### PR TITLE
CD: fix PM2 website start path

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -164,7 +164,7 @@
         rm -rf apps/website/.next
         pnpm --filter @ecom-os/website build
         pm2 delete website || true
-        PORT={{ website_port }} NODE_ENV=production pm2 start apps/website/server.js --name website --cwd {{ app_base }}/repo/apps/website --update-env
+        PORT={{ website_port }} NODE_ENV=production pm2 start server.js --name website --cwd {{ app_base }}/repo/apps/website --update-env
         pm2 save
       args: { chdir: "{{ app_base }}/repo" }
   handlers:


### PR DESCRIPTION
Use pm2 start server.js with --cwd apps/website to avoid wrong path and stale content. Rebuild .next before restart remains in place.