### PR TITLE
CD: fix PM2 website start path (final)

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -163,6 +163,8 @@
         cd {{ app_base }}/repo
         rm -rf apps/website/.next
         pnpm --filter @ecom-os/website build
+        rm -rf apps/website/.next
+        pnpm --filter @ecom-os/website build
         pm2 delete website || true
         PORT={{ website_port }} NODE_ENV=production pm2 start apps/website/server.js --name website --cwd {{ app_base }}/repo/apps/website --update-env
         pm2 save


### PR DESCRIPTION
Use pm2 start server.js with --cwd apps/website and rebuild .next to avoid stale content.