### PR TITLE
CD: remove legacy PM2 apps before website start

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -173,6 +173,9 @@
         cd {{ app_base }}/repo
         # Kill any rogue process on the website port
         lsof -ti:{{ website_port }} | xargs -r kill -9 || true
+        # Remove any legacy PM2 apps that could be served by nginx (landing)
+        pm2 delete targon-frontend || true
+        pm2 delete targon || true
         # Rebuild website cleanly
         rm -rf apps/website/.next
         pnpm --filter @ecom-os/website build


### PR DESCRIPTION
- pm2 delete targon-frontend/targon before restart\n- Prevent nginx from serving old landing process\n- Keep hard verification and nginx cleanup