### PR TITLE
ci: PR-only (dev/main) + concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,13 @@
 name: CI
 on:
-  push:
-    branches:
-      - '**'
   pull_request:
     branches:
-      - '**'
+      - dev
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-test:


### PR DESCRIPTION
- Remove push trigger to avoid duplicate CI on merge\n- Keep CI on pull_request to dev/main\n- Add concurrency to cancel superseded runs\n- Scope remains website-only build/lint/typecheck