### PR TITLE
infra(cd): drop warn flag from cleanup shell

### DIFF
--- a/infra/ansible/deploy-monorepo.yml
+++ b/infra/ansible/deploy-monorepo.yml
@@ -228,8 +228,6 @@
 
     - name: Run housekeeping cleanup now
       shell: /usr/local/bin/ecomos-cleanup.sh
-      args:
-        warn: false
   handlers:
     - name: restart nginx
       systemd: { name: nginx, state: restarted }


### PR DESCRIPTION
## Summary
- remove unsupported warn flag now that shell module is used

## Testing
- ansible-lint not run (deployment config change only)