### PR TITLE
fix(xplan): allow deleting default strategies [gpt]

### DIFF
--- a/apps/xplan/app/api/v1/xplan/strategies/route.ts
+++ b/apps/xplan/app/api/v1/xplan/strategies/route.ts
@@ -358,10 +358,6 @@ export const DELETE = withXPlanAuth(async (request: Request, session) => {
     return NextResponse.json({ error: 'No access to strategy' }, { status: 403 });
   }
 
-  if (existing.isDefault) {
-    return NextResponse.json({ error: 'Default strategy cannot be deleted' }, { status: 400 });
-  }
-
   // Avoid runtime crashes caused by legacy DB constraints lacking cascades.
   await prismaAny.$transaction(async (tx: any) => {
     await tx.batchTableRow.deleteMany({

--- a/apps/xplan/app/api/v1/xplan/strategies/route.ts
+++ b/apps/xplan/app/api/v1/xplan/strategies/route.ts
@@ -329,6 +329,8 @@ export const DELETE = withXPlanAuth(async (request: Request, session) => {
       where: { id },
       select: {
         id: true,
+        name: true,
+        region: true,
         isDefault: true,
         createdById: true,
         createdByEmail: true,
@@ -357,6 +359,30 @@ export const DELETE = withXPlanAuth(async (request: Request, session) => {
   if (!actorCanAccess) {
     return NextResponse.json({ error: 'No access to strategy' }, { status: 403 });
   }
+
+  const requestMeta = {
+    userAgent: request.headers.get('user-agent'),
+    xForwardedFor: request.headers.get('x-forwarded-for'),
+    cfConnectingIp: request.headers.get('cf-connecting-ip'),
+    cfRay: request.headers.get('cf-ray'),
+  };
+
+  console.log(
+    JSON.stringify({
+      event: 'xplan.strategy.delete',
+      actor,
+      strategy: {
+        id,
+        name: existing.name,
+        region: existing.region,
+        isDefault: existing.isDefault,
+        createdByEmail: existing.createdByEmail,
+        assigneeEmail: existing.assigneeEmail,
+      },
+      request: requestMeta,
+      at: new Date().toISOString(),
+    }),
+  );
 
   // Avoid runtime crashes caused by legacy DB constraints lacking cascades.
   await prismaAny.$transaction(async (tx: any) => {

--- a/apps/xplan/plans/strategy-audit-logging.md
+++ b/apps/xplan/plans/strategy-audit-logging.md
@@ -12,6 +12,13 @@ Nginx access logs confirmed the HTTP `DELETE /xplan/api/v1/xplan/strategies` cal
 - the real client IP is not visible (requests arrive via `cloudflared` → `nginx`, so `$remote_addr`
   is `127.0.0.1`)
 
+## Current status
+
+- Implemented: app-level console audit log for strategy deletes (includes actor + request metadata).
+- Implemented: manual Sellerboard sync routes log actor + strategyId + duration + update counts.
+- Missing: nginx access log format that captures forwarded client IP + CF request id.
+- Missing: DB-backed audit table (optional).
+
 ## Goals
 
 Be able to answer “who deleted strategy X?” quickly and confidently, with:
@@ -67,4 +74,3 @@ Add a retention policy (e.g. 90 days) and index by `(strategyId, createdAt)`.
 
 - After a delete, we can identify the actor email and strategy id from logs within ~1 minute.
 - Nginx access logs show the real client IP (via CF/XFF), not only `127.0.0.1`.
-


### PR DESCRIPTION
- Allows deleting strategies marked as default (removes API guard).
- Adds a structured audit log line for strategy deletes (actor + request metadata).
- Treats users with X-Plan department `admin` / `super-admin` as super admins for strategy access/deletes.
