### PR TITLE
fix(talos): one shipping mark per cargo line instead of per carton [claude]

### DIFF
--- a/apps/talos/src/lib/services/po-stage-service.ts
+++ b/apps/talos/src/lib/services/po-stage-service.ts
@@ -3319,7 +3319,7 @@ export async function generatePurchaseOrderShippingMarks(params: {
     },
   })
 
-  const labels = activeLines.flatMap(line => {
+  const labels = activeLines.map(line => {
     const cartonRange = resolveLineCartonRange(line)
     const cartonTriplet = resolveDimensionTripletCm({
       side1Cm: line.cartonSide1Cm,
@@ -3338,25 +3338,20 @@ export async function generatePurchaseOrderShippingMarks(params: {
     const grossWeightLabel = formatWeightDisplayFromKg(grossWeightKg, unitSystem, 1)
     const shippingMark = typeof line.lotRef === 'string' ? line.lotRef.trim() : ''
 
-    const perCarton: string[] = []
-    for (let index = cartonRange.start; index <= cartonRange.end; index += 1) {
-      perCarton.push(`
-        <div class="label">
-          <div class="label-header">${escapeHtml(piNumber)}</div>
-          <div class="label-row"><span class="k">Carton</span><span class="v">${index} of ${cartonRange.total}</span></div>
-          <div class="label-row"><span class="k">Shipping Mark</span><span class="v">${escapeHtml(shippingMark)}</span></div>
-          <div class="label-row"><span class="k">Commodity Code</span><span class="v mono">${escapeHtml(commodityLabel)}</span></div>
-          <div class="label-row"><span class="k">Units</span><span class="v">${line.unitsPerCarton} pcs</span></div>
-          <div class="label-row"><span class="k">N/W</span><span class="v">${escapeHtml(netWeightLabel)}</span></div>
-          <div class="label-row"><span class="k">G/W</span><span class="v">${escapeHtml(grossWeightLabel)}</span></div>
-          <div class="label-row"><span class="k">Dims</span><span class="v mono">${escapeHtml(dimsLabel)}</span></div>
-          <div class="label-row"><span class="k">Material</span><span class="v">${escapeHtml(material)}</span></div>
-          <div class="label-footer">MADE IN ${escapeHtml(origin)}</div>
-        </div>
-      `)
-    }
-
-    return perCarton
+    return `
+      <div class="label">
+        <div class="label-header">${escapeHtml(piNumber)}</div>
+        <div class="label-row"><span class="k">Cartons</span><span class="v">${cartonRange.start}–${cartonRange.end} of ${cartonRange.total}</span></div>
+        <div class="label-row"><span class="k">Shipping Mark</span><span class="v">${escapeHtml(shippingMark)}</span></div>
+        <div class="label-row"><span class="k">Commodity Code</span><span class="v mono">${escapeHtml(commodityLabel)}</span></div>
+        <div class="label-row"><span class="k">Units/Carton</span><span class="v">${line.unitsPerCarton} pcs</span></div>
+        <div class="label-row"><span class="k">N/W</span><span class="v">${escapeHtml(netWeightLabel)}</span></div>
+        <div class="label-row"><span class="k">G/W</span><span class="v">${escapeHtml(grossWeightLabel)}</span></div>
+        <div class="label-row"><span class="k">Dims</span><span class="v mono">${escapeHtml(dimsLabel)}</span></div>
+        <div class="label-row"><span class="k">Material</span><span class="v">${escapeHtml(material)}</span></div>
+        <div class="label-footer">MADE IN ${escapeHtml(origin)}</div>
+      </div>
+    `
   })
 
   return `<!doctype html>


### PR DESCRIPTION
## Summary
- Generate one label per cargo line showing carton range (e.g. "Cartons 1–220 of 876") instead of one label per carton
- Shipping marks are a reference document for the supplier, not printable labels — suppliers use their own label printers
- Reduces a 876-label (878KB) document to a 4-label (~4KB) reference sheet

## Test plan
- [ ] Go to PO-2-PDS > Issued stage > click Shipping Marks
- [ ] Verify only 4 labels appear (one per cargo line) instead of 876
- [ ] Each label shows carton range, not individual carton number

🤖 Generated with [Claude Code](https://claude.com/claude-code)