### PR TITLE
fix(hermes): harden dry-run + fix insights all range [gpt]

### DIFF
--- a/apps/hermes/src/app/api/dispatches/requeue/route.ts
+++ b/apps/hermes/src/app/api/dispatches/requeue/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { withApiLogging } from "@/server/api-logging";
 import { maybeAutoMigrate } from "@/server/db/migrate";
 import { getPgPool } from "@/server/db/pool";
+import { isHermesDryRun } from "@/server/env/flags";
 
 export const runtime = "nodejs";
 
@@ -16,7 +17,7 @@ export const runtime = "nodejs";
  * - Expired dispatches cannot be requeued (worker will ignore them).
  */
 async function handlePost(req: Request) {
-  if (process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true") {
+  if (isHermesDryRun()) {
     return NextResponse.json(
       { ok: false, error: "Hermes is in dry-run mode. Requeue is disabled." },
       { status: 403 }
@@ -86,4 +87,3 @@ async function handlePost(req: Request) {
 }
 
 export const POST = withApiLogging("POST /api/dispatches/requeue", handlePost);
-

--- a/apps/hermes/src/app/api/health/route.ts
+++ b/apps/hermes/src/app/api/health/route.ts
@@ -1,9 +1,10 @@
 import { NextResponse } from "next/server";
 
 import { withApiLogging } from "@/server/api-logging";
+import { isHermesDryRun } from "@/server/env/flags";
 
 async function handleGet(_req: Request) {
-  const dryRun = process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true";
+  const dryRun = isHermesDryRun();
   return NextResponse.json({
     ok: true,
     app: "hermes",

--- a/apps/hermes/src/app/api/messaging/send/route.ts
+++ b/apps/hermes/src/app/api/messaging/send/route.ts
@@ -7,6 +7,7 @@ import { queueBuyerMessage } from "@/server/dispatch/ledger";
 import { processBuyerMessageDispatch } from "@/server/messaging/dispatcher";
 import { MESSAGING_KINDS } from "@/server/sp-api/messaging";
 import { withApiLogging } from "@/server/api-logging";
+import { isHermesDryRun } from "@/server/env/flags";
 
 export const runtime = "nodejs";
 
@@ -130,7 +131,7 @@ async function loadDispatchById(id: string) {
  * - optional immediate send runs through the same claim+attempt recording as the worker
  */
 async function handlePost(req: Request) {
-  if (process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true") {
+  if (isHermesDryRun()) {
     return NextResponse.json(
       { ok: false, error: "Hermes is in dry-run mode. Messaging is disabled." },
       { status: 403 }

--- a/apps/hermes/src/app/api/solicitations/request-review/route.ts
+++ b/apps/hermes/src/app/api/solicitations/request-review/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { maybeAutoMigrate } from "@/server/db/migrate";
 import { queueRequestReview } from "@/server/dispatch/ledger";
 import { withApiLogging } from "@/server/api-logging";
+import { isHermesDryRun } from "@/server/env/flags";
 
 export const runtime = "nodejs";
 
@@ -28,7 +29,7 @@ export const runtime = "nodejs";
  * - mark sent + append audit attempts
  */
 async function handlePost(req: Request) {
-  if (process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true") {
+  if (isHermesDryRun()) {
     return NextResponse.json(
       { ok: false, error: "Hermes is in dry-run mode. Dispatch queueing is disabled." },
       { status: 403 }

--- a/apps/hermes/src/components/app-shell/app-shell.tsx
+++ b/apps/hermes/src/components/app-shell/app-shell.tsx
@@ -2,8 +2,9 @@ import * as React from "react";
 
 import { AppHeader } from "@/components/app-shell/app-header";
 import { AppSidebar } from "@/components/app-shell/app-sidebar";
+import { isHermesDryRun } from "@/server/env/flags";
 
-const isDryRun = process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true";
+const isDryRun = isHermesDryRun();
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   return (

--- a/apps/hermes/src/server/analytics/overview.ts
+++ b/apps/hermes/src/server/analytics/overview.ts
@@ -81,6 +81,7 @@ export async function getAnalyticsOverview(params: {
   const pool = getPgPool();
 
   const to = new Date();
+  const toDay = startOfUtcDay(to);
 
   let rangeDays: number;
   let from: Date;
@@ -99,16 +100,16 @@ export async function getAnalyticsOverview(params: {
     const earliest = (earliestRow.rows[0] as any)?.earliest;
     if (earliest) {
       from = startOfUtcDay(new Date(earliest));
-      rangeDays = Math.max(1, Math.ceil((to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)) + 1);
+      rangeDays = Math.max(1, Math.floor((toDay.getTime() - from.getTime()) / (24 * 60 * 60 * 1000)) + 1);
     } else {
       // No dispatches sent yet — fall back to 30 days
       rangeDays = 30;
-      from = startOfUtcDay(addUtcDays(to, -(rangeDays - 1)));
+      from = startOfUtcDay(addUtcDays(toDay, -(rangeDays - 1)));
     }
   } else {
     rangeDays = Math.max(1, Math.min(params.rangeDays, 3650));
     // Inclusive day range (e.g. 30d => today + previous 29 days)
-    from = startOfUtcDay(addUtcDays(to, -(rangeDays - 1)));
+    from = startOfUtcDay(addUtcDays(toDay, -(rangeDays - 1)));
   }
 
   const connectionId = params.connectionId;

--- a/apps/hermes/src/server/env/flags.ts
+++ b/apps/hermes/src/server/env/flags.ts
@@ -1,0 +1,14 @@
+function normalizeEnvValue(value: string | undefined): string {
+  if (typeof value !== "string") return "";
+  return value.trim().toLowerCase();
+}
+
+export function envFlag(name: string): boolean {
+  const v = normalizeEnvValue(process.env[name]);
+  return v === "1" || v === "true" || v === "yes";
+}
+
+export function isHermesDryRun(): boolean {
+  return envFlag("HERMES_DRY_RUN");
+}
+

--- a/apps/hermes/src/server/jobs/buyer-message-dispatcher.ts
+++ b/apps/hermes/src/server/jobs/buyer-message-dispatcher.ts
@@ -19,6 +19,7 @@ import {
   processBuyerMessageDispatch,
   requeueStuckBuyerMessages,
 } from "../messaging/dispatcher";
+import { isHermesDryRun } from "../env/flags";
 import { loadHermesEnv } from "./load-env";
 
 function sleep(ms: number) {
@@ -39,7 +40,7 @@ function getInt(name: string, fallback: number): number {
 async function main() {
   loadHermesEnv();
 
-  if (process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true") {
+  if (isHermesDryRun()) {
     console.log(`[${nowIso()}] HERMES_DRY_RUN is enabled — buyer-message dispatcher will not process dispatches.`);
     setInterval(() => {}, 60_000);
     return;

--- a/apps/hermes/src/server/jobs/orders-sync-hourly.ts
+++ b/apps/hermes/src/server/jobs/orders-sync-hourly.ts
@@ -88,7 +88,7 @@ function buildScheduleFromEnv(): ScheduleConfig {
     endHour,
     spreadEnabled,
     spreadMaxMinutes,
-    timezone: process.env.HERMES_DEFAULT_TIMEZONE || undefined,
+    timezone: process.env.HERMES_DEFAULT_TIMEZONE,
   };
 }
 

--- a/apps/hermes/src/server/jobs/request-review-dispatcher.ts
+++ b/apps/hermes/src/server/jobs/request-review-dispatcher.ts
@@ -34,6 +34,7 @@ import {
   createProductReviewAndSellerFeedbackSolicitation,
   getSolicitationActionsForOrder,
 } from "../sp-api/solicitations";
+import { isHermesDryRun } from "../env/flags";
 import { loadHermesEnv } from "./load-env";
 
 function sleep(ms: number) {
@@ -387,7 +388,7 @@ async function processDispatch(row: DispatchRow, opts: {
 async function main() {
   loadHermesEnv();
 
-  if (process.env.HERMES_DRY_RUN === "1" || process.env.HERMES_DRY_RUN === "true") {
+  if (isHermesDryRun()) {
     console.log(`[${nowIso()}] HERMES_DRY_RUN is enabled — request-review dispatcher will not process dispatches.`);
     // Keep the process alive so monitoring sees it as running, but do nothing.
     setInterval(() => {}, 60_000);

--- a/apps/hermes/src/server/sp-api/client.ts
+++ b/apps/hermes/src/server/sp-api/client.ts
@@ -17,6 +17,7 @@ import { Hash } from "@aws-sdk/hash-node";
 import { AssumeRoleCommand, STSClient } from "@aws-sdk/client-sts";
 import { getAwsSigningRegion, getSpApiHost, type SpApiRegion } from "./regions";
 import { spApiLimiter, type TokenBucketConfig } from "./rate-limiter";
+import { isHermesDryRun } from "../env/flags";
 
 class Sha256 extends Hash {
   constructor(secret?: any) {
@@ -127,11 +128,6 @@ const lwaCache = g.__hermesLwaCache ?? (g.__hermesLwaCache = new Map());
 const stsCache = g.__hermesStsCache ?? (g.__hermesStsCache = new Map());
 
 // -------------------------------------------------------------------------
-
-function isDryRun(): boolean {
-  const v = process.env.HERMES_DRY_RUN;
-  return v === "1" || v === "true";
-}
 
 export class SpApiClient {
   constructor(private config: SpApiConfig) {}
@@ -323,10 +319,10 @@ export class SpApiClient {
 
   async request(opts: SpApiRequestOpts): Promise<SpApiResponse> {
     // Safety net: block all POST requests in dry-run mode.
-    if (isDryRun() && opts.method === "POST") {
+    if (isHermesDryRun() && opts.method === "POST") {
       console.log(`[hermes:dry-run] BLOCKED ${opts.method} ${opts.path}`);
       return {
-        status: 200,
+        status: 499,
         body: { dryRun: true, blocked: `${opts.method} ${opts.path}` },
         headers: {},
       };

--- a/apps/hermes/src/server/sp-api/connection-config.ts
+++ b/apps/hermes/src/server/sp-api/connection-config.ts
@@ -45,15 +45,15 @@ export function loadSpApiConfigForConnection(connectionId: string): SpApiConfig 
     region,
     sandbox,
     endpointOverride:
-      (mapping?.endpointOverride ?? process.env.SPAPI_ENDPOINT_OVERRIDE) || undefined,
+      mapping?.endpointOverride ?? process.env.SPAPI_ENDPOINT_OVERRIDE,
     awsRegionOverride:
-      (mapping?.awsRegionOverride ?? process.env.SPAPI_AWS_REGION_OVERRIDE) || undefined,
+      mapping?.awsRegionOverride ?? process.env.SPAPI_AWS_REGION_OVERRIDE,
     lwaClientId: getEnvOrThrow("SPAPI_LWA_CLIENT_ID"),
     lwaClientSecret: getEnvOrThrow("SPAPI_LWA_CLIENT_SECRET"),
     lwaRefreshToken: mapping?.lwaRefreshToken ?? getEnvOrThrow("SPAPI_LWA_REFRESH_TOKEN"),
     awsAccessKeyId: getEnvOrThrow("SPAPI_AWS_ACCESS_KEY_ID"),
     awsSecretAccessKey: getEnvOrThrow("SPAPI_AWS_SECRET_ACCESS_KEY"),
-    awsRoleArn: (mapping?.awsRoleArn ?? process.env.SPAPI_AWS_ROLE_ARN) || undefined,
+    awsRoleArn: mapping?.awsRoleArn ?? process.env.SPAPI_AWS_ROLE_ARN,
     userAgent: mapping?.userAgent ?? process.env.SPAPI_USER_AGENT ?? "targon-hermes/0.1",
   };
 }


### PR DESCRIPTION
Fixes Insights 'All' off-by-one day bucketing (avoid trailing future day). Centralizes HERMES_DRY_RUN parsing (case-insensitive) and uses it across workers/API/UI. Dry-run SP-API POST safety net now returns non-2xx (499) so it can't be mistaken as success. Removes || undefined fallbacks per repo style.

Validation: pnpm -C apps/hermes lint && pnpm -C apps/hermes build