### PR TITLE
feat(talos): add multiple freight lines and BL surrender date [claude]

### DIFF
--- a/apps/talos/src/app/api/purchase-orders/[id]/freight-cost/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/freight-cost/route.ts
@@ -25,9 +25,9 @@ const FreightCostSchema = z.object({
 })
 
 const FreightLineSchema = z.object({
-  costName: z.string().min(1, 'Cost name is required').max(200),
+  costName: z.string().trim().min(1, 'Cost name is required').max(200),
   amount: AmountSchema,
-  notes: z.string().max(500).optional(),
+  notes: z.string().trim().max(500).optional(),
 })
 
 function readParam(params: Record<string, unknown> | undefined, key: string): string | undefined {
@@ -268,12 +268,12 @@ export const POST = withAuthAndParams(async (request: NextRequest, params, sessi
       purchaseOrderId: id,
       warehouseId: resolvedWarehouseId,
       costRateId: null,
-      costName: parsed.data.costName.trim(),
+      costName: parsed.data.costName,
       quantity: new Prisma.Decimal(1),
       unitRate: new Prisma.Decimal(normalizedAmount),
       totalCost: new Prisma.Decimal(normalizedAmount),
       currency: null,
-      notes: parsed.data.notes?.trim() || null,
+      notes: parsed.data.notes ? parsed.data.notes : null,
       createdById: session.user.id,
       createdByName,
     },

--- a/apps/talos/src/app/api/purchase-orders/[id]/freight-cost/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/freight-cost/route.ts
@@ -24,6 +24,12 @@ const FreightCostSchema = z.object({
   amount: AmountSchema,
 })
 
+const FreightLineSchema = z.object({
+  costName: z.string().min(1, 'Cost name is required').max(200),
+  amount: AmountSchema,
+  notes: z.string().max(500).optional(),
+})
+
 function readParam(params: Record<string, unknown> | undefined, key: string): string | undefined {
   const value = params?.[key]
   if (typeof value === 'string') return value
@@ -185,4 +191,189 @@ export const PATCH = withAuthAndParams(async (request: NextRequest, params, sess
     createdAt: updated.createdAt.toISOString(),
     updatedAt: updated.updatedAt.toISOString(),
   })
+})
+
+export const POST = withAuthAndParams(async (request: NextRequest, params, session) => {
+  const id = readParam(params, 'id')
+  if (!id) {
+    return ApiResponses.badRequest('Purchase order ID is required')
+  }
+
+  const canEdit = await hasPermission(session.user.id, 'po.edit')
+  if (!canEdit) {
+    return ApiResponses.forbidden('Insufficient permissions')
+  }
+
+  const payload = await request.json().catch(() => null)
+  const parsed = FreightLineSchema.safeParse(payload)
+  if (!parsed.success) {
+    return ApiResponses.validationError(parsed.error.flatten().fieldErrors)
+  }
+
+  const prisma = await getTenantPrisma()
+
+  const order = await prisma.purchaseOrder.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      status: true,
+      warehouseCode: true,
+      receivedDate: true,
+    },
+  })
+
+  if (!order) {
+    return ApiResponses.notFound('Purchase order not found')
+  }
+
+  const crossTenantGuard = await enforceCrossTenantManufacturingOnlyForPurchaseOrder({
+    prisma,
+    purchaseOrderId: id,
+    purchaseOrderStatus: order.status,
+  })
+  if (crossTenantGuard) {
+    return crossTenantGuard
+  }
+
+  if (order.status !== PurchaseOrderStatus.OCEAN && order.status !== PurchaseOrderStatus.WAREHOUSE) {
+    return ApiResponses.conflict('Freight cost can be added during OCEAN or WAREHOUSE stages')
+  }
+
+  const warehouse =
+    typeof order.warehouseCode === 'string' && order.warehouseCode.trim().length > 0
+      ? await prisma.warehouse.findUnique({
+          where: { code: order.warehouseCode.trim() },
+          select: { id: true },
+        })
+      : null
+
+  const fallbackWarehouse = warehouse
+    ? null
+    : await prisma.warehouse.findFirst({
+        where: { isActive: true },
+        select: { id: true },
+        orderBy: [{ code: 'asc' }],
+      })
+
+  const resolvedWarehouseId = warehouse?.id ?? fallbackWarehouse?.id
+  if (!resolvedWarehouseId) {
+    return ApiResponses.conflict('No active warehouse found')
+  }
+
+  const normalizedAmount = Number(parsed.data.amount.toFixed(2))
+  const createdByName = session.user.name ?? session.user.email ?? null
+
+  const created = await prisma.purchaseOrderForwardingCost.create({
+    data: {
+      purchaseOrderId: id,
+      warehouseId: resolvedWarehouseId,
+      costRateId: null,
+      costName: parsed.data.costName.trim(),
+      quantity: new Prisma.Decimal(1),
+      unitRate: new Prisma.Decimal(normalizedAmount),
+      totalCost: new Prisma.Decimal(normalizedAmount),
+      currency: null,
+      notes: parsed.data.notes?.trim() || null,
+      createdById: session.user.id,
+      createdByName,
+    },
+    select: {
+      id: true,
+      purchaseOrderId: true,
+      costRateId: true,
+      costName: true,
+      quantity: true,
+      unitRate: true,
+      totalCost: true,
+      currency: true,
+      notes: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  })
+
+  if (order.status === PurchaseOrderStatus.WAREHOUSE && order.receivedDate && createdByName) {
+    await syncPurchaseOrderForwardingCostLedger({
+      purchaseOrderId: id,
+      createdByName,
+    })
+  }
+
+  return ApiResponses.success({
+    ...created,
+    quantity: Number(created.quantity),
+    unitRate: Number(created.unitRate),
+    totalCost: Number(created.totalCost),
+    createdAt: created.createdAt.toISOString(),
+    updatedAt: created.updatedAt.toISOString(),
+  })
+})
+
+export const DELETE = withAuthAndParams(async (request: NextRequest, params, session) => {
+  const id = readParam(params, 'id')
+  if (!id) {
+    return ApiResponses.badRequest('Purchase order ID is required')
+  }
+
+  const canEdit = await hasPermission(session.user.id, 'po.edit')
+  if (!canEdit) {
+    return ApiResponses.forbidden('Insufficient permissions')
+  }
+
+  const url = new URL(request.url)
+  const costId = url.searchParams.get('costId')
+  if (!costId) {
+    return ApiResponses.badRequest('costId query parameter is required')
+  }
+
+  const prisma = await getTenantPrisma()
+
+  const order = await prisma.purchaseOrder.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      status: true,
+      receivedDate: true,
+    },
+  })
+
+  if (!order) {
+    return ApiResponses.notFound('Purchase order not found')
+  }
+
+  const crossTenantGuard = await enforceCrossTenantManufacturingOnlyForPurchaseOrder({
+    prisma,
+    purchaseOrderId: id,
+    purchaseOrderStatus: order.status,
+  })
+  if (crossTenantGuard) {
+    return crossTenantGuard
+  }
+
+  if (order.status !== PurchaseOrderStatus.OCEAN && order.status !== PurchaseOrderStatus.WAREHOUSE) {
+    return ApiResponses.conflict('Freight cost can be removed during OCEAN or WAREHOUSE stages')
+  }
+
+  const costRow = await prisma.purchaseOrderForwardingCost.findUnique({
+    where: { id: costId },
+    select: { id: true, purchaseOrderId: true },
+  })
+
+  if (!costRow || costRow.purchaseOrderId !== id) {
+    return ApiResponses.notFound('Freight cost entry not found')
+  }
+
+  await prisma.purchaseOrderForwardingCost.delete({
+    where: { id: costId },
+  })
+
+  const createdByName = session.user.name ?? session.user.email ?? null
+  if (order.status === PurchaseOrderStatus.WAREHOUSE && order.receivedDate && createdByName) {
+    await syncPurchaseOrderForwardingCostLedger({
+      purchaseOrderId: id,
+      createdByName,
+    })
+  }
+
+  return ApiResponses.success({ deleted: true })
 })

--- a/apps/talos/src/components/purchase-orders/purchase-order-flow.tsx
+++ b/apps/talos/src/components/purchase-orders/purchase-order-flow.tsx
@@ -1557,7 +1557,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
         body: JSON.stringify({
           costName,
           amount: parsed,
-          notes: freightLineDraft.notes.trim() || undefined,
+          notes: freightLineDraft.notes.trim() ? freightLineDraft.notes.trim() : undefined,
         }),
         tenantOverride,
       })
@@ -5267,7 +5267,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                             </tbody>
                             <tfoot>
                               <tr className="border-t-2 border-slate-200 dark:border-slate-600 bg-slate-50/50 dark:bg-slate-700/50">
-                                <td colSpan={canEditFreightCost ? 4 : 3} className="px-3 py-2 text-right font-medium text-muted-foreground">
+                                <td colSpan={3} className="px-3 py-2 text-right font-medium text-muted-foreground">
                                   Freight Subtotal
                                 </td>
                                 <td className="px-3 py-2 text-right tabular-nums font-semibold">
@@ -5275,6 +5275,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                                     ? `${tenantCurrency} ${forwardingSubtotal.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
                                     : '—'}
                                 </td>
+                                {canEditFreightCost && <td />}
                               </tr>
                             </tfoot>
                           </table>


### PR DESCRIPTION
## Summary
- Replace single Freight Total input with multi-line add/delete for individual freight cost entries (e.g., Ocean Freight, Destination Charges, Documentation Fee)
- Add POST and DELETE API endpoints for creating and removing individual freight lines
- Add BL Surrender date field to the Transit section UI

Rebased on latest dev. Supersedes #4132.

## Test plan
- [ ] Open a PO in OCEAN stage on US Talos
- [ ] Verify BL Surrender date field appears in Transit section and can be edited/saved
- [ ] Click + Add Freight, enter cost name + amount + optional notes, save
- [ ] Add second freight line, verify subtotal sums correctly
- [ ] Delete a line with trash icon, verify subtotal updates
- [ ] Navigate away and return, verify lines persist

Generated with [Claude Code](https://claude.com/claude-code)