### PR TITLE
fix(plutus): fallback ad allocation total + source metadata [gpt]

### DIFF
--- a/apps/plutus/app/api/plutus/settlements/[id]/ads-allocation/route.ts
+++ b/apps/plutus/app/api/plutus/settlements/[id]/ads-allocation/route.ts
@@ -12,9 +12,24 @@ export const runtime = 'nodejs';
 const ADS_REPORT_TYPE = 'SP_ADVERTISED_PRODUCT';
 const WEIGHT_SOURCE = 'SPONSORED_PRODUCTS_SPEND';
 const WEIGHT_UNIT = 'cents';
+const TOTAL_SOURCE_AUDIT = 'AUDIT_DATA';
+const TOTAL_SOURCE_ADS_REPORT = 'ADS_REPORT';
+const TOTAL_SOURCE_NONE = 'NONE';
+const TOTAL_SOURCE_SAVED = 'SAVED';
 
 type RouteContext = { params: Promise<{ id: string }> };
 type AllocationLine = { sku: string; weight: number; allocatedCents: number };
+type AdsDataUploadSelection = { id: string; filename: string; startDate: string; endDate: string; uploadedAt: Date };
+type AdsTotalSource =
+  | typeof TOTAL_SOURCE_AUDIT
+  | typeof TOTAL_SOURCE_ADS_REPORT
+  | typeof TOTAL_SOURCE_NONE
+  | typeof TOTAL_SOURCE_SAVED;
+type ResolvedAdsTotal = {
+  totalAdsCents: number;
+  totalSource: AdsTotalSource;
+  adsDataUpload: AdsDataUploadSelection | null;
+};
 
 class AllocationApiError extends Error {
   status: number;
@@ -122,24 +137,12 @@ async function loadSettlementAdsTotalCents(input: { invoiceId: string; marketpla
   return typeof total === 'number' && Number.isInteger(total) ? total : 0;
 }
 
-async function computeAllocation(input: {
+async function findBestCoveringUpload(input: {
   marketplace: 'amazon.com' | 'amazon.co.uk';
-  invoiceId: string;
   invoiceStartDate: string;
   invoiceEndDate: string;
-  totalAdsCents: number;
-}): Promise<{
-  adsDataUpload: null | { id: string; filename: string; startDate: string; endDate: string; uploadedAt: Date };
-  lines: AllocationLine[];
-}> {
-  if (input.totalAdsCents === 0) {
-    return {
-      adsDataUpload: null,
-      lines: [],
-    };
-  }
-
-  const coveringUploads = await db.adsDataUpload.findMany({
+}): Promise<AdsDataUploadSelection | null> {
+  const fullCoverageUploads = await db.adsDataUpload.findMany({
     where: {
       reportType: ADS_REPORT_TYPE,
       marketplace: input.marketplace,
@@ -156,22 +159,130 @@ async function computeAllocation(input: {
     orderBy: { uploadedAt: 'desc' },
   });
 
-  if (coveringUploads.length === 0) {
-    throw new AllocationApiError(
-      `No Ads Data upload covers ${input.marketplace} ${input.invoiceId} (${input.invoiceStartDate}–${input.invoiceEndDate}). Upload a Sponsored Products report for that full range.`,
-      400,
-    );
+  if (fullCoverageUploads.length > 0) {
+    return chooseBestUpload(fullCoverageUploads);
   }
 
-  const best = chooseBestUpload(coveringUploads);
-  if (!best) {
-    throw new Error('Failed to select Ads Data upload');
+  const overlappingUploads = await db.adsDataUpload.findMany({
+    where: {
+      reportType: ADS_REPORT_TYPE,
+      marketplace: input.marketplace,
+      startDate: { lte: input.invoiceEndDate },
+      endDate: { gte: input.invoiceStartDate },
+    },
+    select: {
+      id: true,
+      filename: true,
+      startDate: true,
+      endDate: true,
+      uploadedAt: true,
+    },
+    orderBy: { uploadedAt: 'desc' },
+  });
+
+  return chooseBestUpload(overlappingUploads);
+}
+
+async function loadAdsReportSpendCents(input: { uploadId: string; startDate: string; endDate: string }): Promise<number> {
+  const grouped = await db.adsDataRow.aggregate({
+    where: {
+      uploadId: input.uploadId,
+      date: { gte: input.startDate, lte: input.endDate },
+    },
+    _sum: { spendCents: true },
+  });
+  const total = grouped._sum.spendCents ?? 0;
+  return Number.isInteger(total) ? total : 0;
+}
+
+async function resolveSettlementAdsTotal(input: {
+  marketplace: 'amazon.com' | 'amazon.co.uk';
+  invoiceId: string;
+  invoiceStartDate: string;
+  invoiceEndDate: string;
+}): Promise<ResolvedAdsTotal> {
+  const auditTotal = await loadSettlementAdsTotalCents({
+    marketplace: input.marketplace,
+    invoiceId: input.invoiceId,
+  });
+
+  if (auditTotal !== 0) {
+    return {
+      totalAdsCents: auditTotal,
+      totalSource: TOTAL_SOURCE_AUDIT,
+      adsDataUpload: null,
+    };
+  }
+
+  const upload = await findBestCoveringUpload({
+    marketplace: input.marketplace,
+    invoiceStartDate: input.invoiceStartDate,
+    invoiceEndDate: input.invoiceEndDate,
+  });
+  if (!upload) {
+    return {
+      totalAdsCents: 0,
+      totalSource: TOTAL_SOURCE_NONE,
+      adsDataUpload: null,
+    };
+  }
+
+  const reportSpendCents = await loadAdsReportSpendCents({
+    uploadId: upload.id,
+    startDate: input.invoiceStartDate,
+    endDate: input.invoiceEndDate,
+  });
+  if (reportSpendCents <= 0) {
+    return {
+      totalAdsCents: 0,
+      totalSource: TOTAL_SOURCE_NONE,
+      adsDataUpload: upload,
+    };
+  }
+
+  return {
+    totalAdsCents: -reportSpendCents,
+    totalSource: TOTAL_SOURCE_ADS_REPORT,
+    adsDataUpload: upload,
+  };
+}
+
+async function computeAllocation(input: {
+  marketplace: 'amazon.com' | 'amazon.co.uk';
+  invoiceId: string;
+  invoiceStartDate: string;
+  invoiceEndDate: string;
+  totalAdsCents: number;
+  adsDataUpload?: AdsDataUploadSelection | null;
+}): Promise<{
+  adsDataUpload: AdsDataUploadSelection | null;
+  lines: AllocationLine[];
+}> {
+  if (input.totalAdsCents === 0) {
+    return {
+      adsDataUpload: input.adsDataUpload ?? null,
+      lines: [],
+    };
+  }
+
+  const bestUpload =
+    input.adsDataUpload ??
+    (await findBestCoveringUpload({
+      marketplace: input.marketplace,
+      invoiceStartDate: input.invoiceStartDate,
+      invoiceEndDate: input.invoiceEndDate,
+    }));
+  if (!bestUpload) {
+    throw new AllocationApiError(
+      `No Ads Data upload overlaps ${input.marketplace} ${input.invoiceId} (${input.invoiceStartDate}–${input.invoiceEndDate}). Upload a Sponsored Products report for this period.`,
+      400,
+    );
   }
 
   const grouped = await db.adsDataRow.groupBy({
     by: ['sku'],
     where: {
-      uploadId: best.id,
+      uploadId: bestUpload.id,
       date: { gte: input.invoiceStartDate, lte: input.invoiceEndDate },
     },
     _sum: { spendCents: true },
@@ -206,7 +317,7 @@ async function computeAllocation(input: {
   });
 
   return {
-    adsDataUpload: best,
+    adsDataUpload: bestUpload,
     lines,
   };
 }
@@ -311,8 +422,15 @@ export async function GET(_req: NextRequest, context: RouteContext) {
     });
 
     const invoiceRange = await loadInvoiceDateRange({ invoiceId, marketplace });
-    const totalAdsCents = await loadSettlementAdsTotalCents({ invoiceId, marketplace });
+    const resolvedTotal = await resolveSettlementAdsTotal({
+      marketplace,
+      invoiceId,
+      invoiceStartDate: invoiceRange.startDate,
+      invoiceEndDate: invoiceRange.endDate,
+    });
     let kind: 'saved' | 'computed';
+    let totalAdsCents: number;
+    let totalSource: AdsTotalSource;
     let weightSource: string;
     let weightUnit: string;
     let adsDataUpload:
@@ -328,6 +446,8 @@ export async function GET(_req: NextRequest, context: RouteContext) {
 
     if (existing) {
       kind = 'saved';
+      totalAdsCents = existing.totalAdsCents;
+      totalSource = TOTAL_SOURCE_SAVED;
       weightSource = existing.weightSource;
       weightUnit = existing.weightUnit;
       lines = existing.lines
@@ -341,6 +461,8 @@ export async function GET(_req: NextRequest, context: RouteContext) {
         : null;
     } else {
       kind = 'computed';
+      totalAdsCents = resolvedTotal.totalAdsCents;
+      totalSource = resolvedTotal.totalSource;
       weightSource = WEIGHT_SOURCE;
       weightUnit = WEIGHT_UNIT;
 
@@ -350,6 +472,7 @@ export async function GET(_req: NextRequest, context: RouteContext) {
         invoiceStartDate: invoiceRange.startDate,
         invoiceEndDate: invoiceRange.endDate,
         totalAdsCents,
+        adsDataUpload: resolvedTotal.adsDataUpload,
       });
 
       lines = computed.lines;
@@ -373,6 +496,7 @@ export async function GET(_req: NextRequest, context: RouteContext) {
       invoiceStartDate: invoiceRange.startDate,
       invoiceEndDate: invoiceRange.endDate,
       totalAdsCents,
+      totalSource,
       weightSource,
       weightUnit,
       adsDataUpload,
@@ -421,24 +545,34 @@ export async function POST(req: NextRequest, context: RouteContext) {
     const invoiceId = processing.invoiceId;
 
     const invoiceRange = await loadInvoiceDateRange({ invoiceId, marketplace });
-    const totalAdsCents = await loadSettlementAdsTotalCents({ invoiceId, marketplace });
+    const resolvedTotal = await resolveSettlementAdsTotal({
+      marketplace,
+      invoiceId,
+      invoiceStartDate: invoiceRange.startDate,
+      invoiceEndDate: invoiceRange.endDate,
+    });
+    const totalAdsCents = resolvedTotal.totalAdsCents;
 
     if (totalAdsCents === 0) {
-      return NextResponse.json({ error: 'No advertising cost found for this invoice' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'No advertising cost found for this invoice in stored Audit Data or Ads Data' },
+        { status: 400 },
+      );
     }
 
-	    const computed = await computeAllocation({
-	      marketplace,
-	      invoiceId,
-	      invoiceStartDate: invoiceRange.startDate,
-	      invoiceEndDate: invoiceRange.endDate,
-	      totalAdsCents,
-	    });
+    const computed = await computeAllocation({
+      marketplace,
+      invoiceId,
+      invoiceStartDate: invoiceRange.startDate,
+      invoiceEndDate: invoiceRange.endDate,
+      totalAdsCents,
+      adsDataUpload: resolvedTotal.adsDataUpload,
+    });
 
-	    const adsUpload = computed.adsDataUpload;
-	    if (!adsUpload) {
-	      return NextResponse.json({ error: 'Missing Ads Data upload' }, { status: 400 });
-	    }
+    const adsUpload = computed.adsDataUpload;
+    if (!adsUpload) {
+      return NextResponse.json({ error: 'Missing Ads Data upload' }, { status: 400 });
+    }
 
     const seen = new Set<string>();
     const normalizedLines: Array<{ sku: string; weight: number }> = [];
@@ -487,28 +621,28 @@ export async function POST(req: NextRequest, context: RouteContext) {
       throw new Error(`Allocated cents do not sum to total (${sumAllocated} vs ${totalAdsCents})`);
     }
 
-	    const saved = await db.$transaction(async (tx) => {
-	      const allocation = await tx.settlementAdsAllocation.upsert({
-	        where: { settlementProcessingId: processing.id },
-	        create: {
-	          settlementProcessingId: processing.id,
-	          weightSource: WEIGHT_SOURCE,
-	          weightUnit: WEIGHT_UNIT,
-	          invoiceStartDate: invoiceRange.startDate,
-	          invoiceEndDate: invoiceRange.endDate,
-	          totalAdsCents,
-	          adsDataUploadId: adsUpload.id,
-	        },
-	        update: {
-	          weightSource: WEIGHT_SOURCE,
-	          weightUnit: WEIGHT_UNIT,
-	          invoiceStartDate: invoiceRange.startDate,
-	          invoiceEndDate: invoiceRange.endDate,
-	          totalAdsCents,
-	          adsDataUploadId: adsUpload.id,
-	        },
-	        select: { id: true },
-	      });
+    const saved = await db.$transaction(async (tx) => {
+      const allocation = await tx.settlementAdsAllocation.upsert({
+        where: { settlementProcessingId: processing.id },
+        create: {
+          settlementProcessingId: processing.id,
+          weightSource: WEIGHT_SOURCE,
+          weightUnit: WEIGHT_UNIT,
+          invoiceStartDate: invoiceRange.startDate,
+          invoiceEndDate: invoiceRange.endDate,
+          totalAdsCents,
+          adsDataUploadId: adsUpload.id,
+        },
+        update: {
+          weightSource: WEIGHT_SOURCE,
+          weightUnit: WEIGHT_UNIT,
+          invoiceStartDate: invoiceRange.startDate,
+          invoiceEndDate: invoiceRange.endDate,
+          totalAdsCents,
+          adsDataUploadId: adsUpload.id,
+        },
+        select: { id: true },
+      });
 
       await tx.settlementAdsAllocationLine.deleteMany({
         where: { settlementAdsAllocationId: allocation.id },
@@ -527,20 +661,21 @@ export async function POST(req: NextRequest, context: RouteContext) {
     });
 
     const user = await getCurrentUser();
-	    await logAudit({
-	      userId: user?.id ?? 'system',
-	      userName: user?.name ?? user?.email ?? 'system',
-	      action: 'SETTLEMENT_ADS_ALLOCATION_SAVED',
-	      entityType: 'SettlementAdsAllocation',
-	      entityId: saved.id,
-	      details: {
-	        marketplace,
-	        invoiceId,
-	        totalAdsCents,
-	        weightSource: WEIGHT_SOURCE,
-	        adsDataUploadId: adsUpload.id,
-	      },
-	    });
+    await logAudit({
+      userId: user?.id ?? 'system',
+      userName: user?.name ?? user?.email ?? 'system',
+      action: 'SETTLEMENT_ADS_ALLOCATION_SAVED',
+      entityType: 'SettlementAdsAllocation',
+      entityId: saved.id,
+      details: {
+        marketplace,
+        invoiceId,
+        totalAdsCents,
+        totalSource: resolvedTotal.totalSource,
+        weightSource: WEIGHT_SOURCE,
+        adsDataUploadId: adsUpload.id,
+      },
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/plutus/app/settlements/[id]/page.tsx
+++ b/apps/plutus/app/settlements/[id]/page.tsx
@@ -176,6 +176,7 @@ type AdsAllocationResponse = {
   invoiceStartDate: string;
   invoiceEndDate: string;
   totalAdsCents: number;
+  totalSource: 'AUDIT_DATA' | 'ADS_REPORT' | 'NONE' | 'SAVED';
   weightSource: string;
   weightUnit: string;
   adsDataUpload: null | { id: string; filename: string; startDate: string; endDate: string; uploadedAt: string };
@@ -1299,6 +1300,16 @@ export default function SettlementDetailPage() {
                           <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                             Invoice <span className="font-mono">{adsAllocation.invoiceId}</span> &middot; {adsAllocation.invoiceStartDate} &rarr; {adsAllocation.invoiceEndDate}
                           </div>
+                          <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                            Total source:{' '}
+                            {adsAllocation.totalSource === 'AUDIT_DATA'
+                              ? 'Audit Data (Amazon Advertising Costs rows)'
+                              : adsAllocation.totalSource === 'ADS_REPORT'
+                                ? 'Ads Data spend fallback'
+                                : adsAllocation.totalSource === 'SAVED'
+                                  ? 'Saved allocation'
+                                  : 'No source data'}
+                          </div>
                           {adsAllocation.adsDataUpload && (
                             <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                               Source: {adsAllocation.adsDataUpload.filename} ({adsAllocation.adsDataUpload.startDate}–{adsAllocation.adsDataUpload.endDate})
@@ -1331,7 +1342,7 @@ export default function SettlementDetailPage() {
 
                       {adsAllocation.totalAdsCents === 0 ? (
                         <div className="text-sm text-slate-500 dark:text-slate-400">
-                          No Amazon Advertising Costs found for this invoice in the stored Audit Data. Nothing to allocate.
+                          No advertising cost found for this invoice in stored Audit Data or Ads Data. Nothing to allocate.
                         </div>
                       ) : (
                         <>

--- a/apps/plutus/lib/plutus/bills/pull-sync.ts
+++ b/apps/plutus/lib/plutus/bills/pull-sync.ts
@@ -24,6 +24,7 @@ const poMemoPatterns = [
   /^P(?:\s*\/\s*)?O\s*(?:#|:|-)\s*(.+)$/i,
   /^P(?:\s*\/\s*)?O\s+(.+)$/i,
 ];
+const directPoCodePattern = /^P(?:\s*\/\s*)?O-[A-Za-z0-9].*$/i;
 
 export function extractPoNumberFromBill(bill: Pick<QboBill, 'PrivateNote' | 'CustomField'>): string {
   const customFieldPo = extractPoNumberFromCustomFields(bill.CustomField);
@@ -65,6 +66,10 @@ function extractPoNumberFromPrivateNote(privateNote: string | undefined): string
     .filter((line) => line !== '');
 
   for (const line of lines) {
+    if (directPoCodePattern.test(line)) {
+      return line;
+    }
+
     for (const pattern of poMemoPatterns) {
       const match = line.match(pattern);
       if (!match) continue;

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -583,6 +583,14 @@ test('extractPoNumberFromBill reads PO from memo when no custom field exists', (
   assert.equal(po, 'US-PO-123');
 });
 
+test('extractPoNumberFromBill preserves direct PO code in memo', () => {
+  const po = extractPoNumberFromBill({
+    PrivateNote: 'PO-19-PDS',
+  });
+
+  assert.equal(po, 'PO-19-PDS');
+});
+
 test('buildBillMappingPullSyncUpdates skips unsynced mappings', () => {
   const updates = buildBillMappingPullSyncUpdates(
     [


### PR DESCRIPTION
Implements settlement-driven ad allocation source fallback and source attribution in API + UI. Uses LMB audit total when present and falls back to SP Ads report spend when missing. Adds deterministic upload selection and shows source in UI. Includes PO memo direct-code extraction fix + tests.