### PR TITLE
feat(talos): add warehouse creation button and enable POST endpoint [claude]

### DIFF
--- a/apps/talos/src/app/config/warehouses/warehouses-panel.tsx
+++ b/apps/talos/src/app/config/warehouses/warehouses-panel.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import {
   Building2,
   Edit,
+  Plus,
   Search,
 } from '@/lib/lucide-icons'
 import { fetchWithCSRF } from '@/lib/fetch-with-csrf'
@@ -146,6 +147,12 @@ export default function WarehousesPanel() {
               />
             </div>
           </div>
+          <Button asChild size="sm" className="gap-2">
+            <Link href="/config/warehouses/new">
+              <Plus className="h-4 w-4" />
+              Add Warehouse
+            </Link>
+          </Button>
         </div>
 
         {loading ? (


### PR DESCRIPTION
## Summary
- Enable the previously disabled `POST /api/warehouses` endpoint with Zod validation and case-insensitive duplicate checks for code/name
- Add an **Add Warehouse** button to the warehouses config panel, linking to the existing `/config/warehouses/new` form

## Test plan
- [ ] Navigate to Config > Warehouses - verify Add Warehouse button appears next to search
- [ ] Click button - verify it navigates to the create warehouse form
- [ ] Fill form and submit - verify warehouse is created successfully
- [ ] Try duplicate code/name - verify proper error message

Generated with [Claude Code](https://claude.com/claude-code)