### PR TITLE
fix(xplan): equalise primary strategy card heights across groups [claude]

### DIFF
--- a/apps/xplan/components/sheets/strategy-group-card.tsx
+++ b/apps/xplan/components/sheets/strategy-group-card.tsx
@@ -520,11 +520,9 @@ export function StrategyGroupCard({
                       ) : null}
                     </span>
 
-                    {strategy.description ? (
-                      <p className="mt-1 mb-3 line-clamp-2 text-xs text-muted-foreground">
-                        {strategy.description}
-                      </p>
-                    ) : null}
+                    <p className="mt-1 mb-3 line-clamp-2 text-xs text-muted-foreground">
+                      {strategy.description ?? '\u00A0'}
+                    </p>
 
                     <div className="mt-auto flex items-center gap-2 pt-2">
                       {isActive ? (


### PR DESCRIPTION
## Summary
- Always render the description area in primary strategy cards (non-breaking space when empty)
- This ensures cards have uniform height regardless of whether they have a description

## Test plan
- [ ] Verify Demo Strategy card (with description) and Q1 2026 - PDS - UK card (no description) are the same height
- [ ] Verify all primary cards across US/UK columns align vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)