### PR TITLE
feat(sso): register argus in portal app manifest [claude]

### DIFF
--- a/app-manifest.json
+++ b/app-manifest.json
@@ -8,6 +8,7 @@
     "xplan": { "lifecycle": "active" },
     "plutus": { "lifecycle": "active" },
     "hermes": { "lifecycle": "active" },
+    "argus": { "lifecycle": "active" },
     "legal-suite": { "lifecycle": "archived" },
     "jason": { "lifecycle": "archived" }
   }

--- a/apps/sso/lib/apps.ts
+++ b/apps/sso/lib/apps.ts
@@ -142,6 +142,15 @@ const BASE_APPS: AppBase[] = [
     devPath: '/hermes',
     devUrl: 'http://localhost:3014',
   },
+  {
+    id: 'argus',
+    name: 'Argus',
+    description: 'Amazon listing version control and monitoring.',
+    url: joinBaseUrl(PORTAL_BASE_URL, '/argus'),
+    category: 'Account / Listing',
+    devPath: '/argus',
+    devUrl: 'http://localhost:3016',
+  },
 ]
 
 let manifestCache: AppManifest | null | undefined


### PR DESCRIPTION
## Summary
- Add argus to `BASE_APPS` array in `apps/sso/lib/apps.ts` with category "Account / Listing"
- Add `"argus": { "lifecycle": "active" }` to `app-manifest.json`
- This makes Argus visible on the SSO portal dashboard

## Test plan
- [ ] Verify Argus tile appears on the portal dashboard at dev-os.targonglobal.com
- [ ] Verify clicking the tile navigates to /argus

🤖 Generated with [Claude Code](https://claude.com/claude-code)