### PR TITLE
fix(sso): enable Argus for all users and wire portal/cd config [gpt]

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -431,6 +431,7 @@ jobs:
             [[ "${{ needs.detect-changes.outputs.atlas }}" == "true" ]] && apps+=(atlas)
             [[ "${{ needs.detect-changes.outputs.plutus }}" == "true" ]] && apps+=(plutus)
             [[ "${{ needs.detect-changes.outputs.hermes }}" == "true" ]] && apps+=(hermes)
+            [[ "${{ needs.detect-changes.outputs.argus }}" == "true" ]] && apps+=(argus)
           fi
 
           if [[ ${#apps[@]} -eq 0 ]]; then

--- a/apps/sso/dev.apps.json
+++ b/apps/sso/dev.apps.json
@@ -7,6 +7,7 @@
     "website": "https://dev.targonglobal.com",
     "xplan": "/xplan/1-strategies",
     "plutus": "/plutus",
-    "hermes": "/hermes"
+    "hermes": "/hermes",
+    "argus": "/argus"
   }
 }

--- a/apps/sso/dev.local.apps.json
+++ b/apps/sso/dev.local.apps.json
@@ -7,6 +7,7 @@
     "xplan": 3008,
     "kairos": 3010,
     "plutus": 3012,
-    "hermes": 3014
+    "hermes": 3014,
+    "argus": 3016
   }
 }

--- a/apps/sso/lib/apps.ts
+++ b/apps/sso/lib/apps.ts
@@ -147,6 +147,7 @@ const BASE_APPS: AppBase[] = [
     name: 'Argus',
     description: 'Amazon listing version control and monitoring.',
     url: joinBaseUrl(PORTAL_BASE_URL, '/argus'),
+    entryPolicy: 'public',
     category: 'Account / Listing',
     devPath: '/argus',
     devUrl: 'http://localhost:3016',

--- a/apps/sso/prod.apps.json
+++ b/apps/sso/prod.apps.json
@@ -7,6 +7,7 @@
     "website": "https://www.targonglobal.com",
     "xplan": "/xplan/1-strategies",
     "plutus": "/plutus",
-    "hermes": "/hermes"
+    "hermes": "/hermes",
+    "argus": "/argus"
   }
 }

--- a/apps/sso/worktree.apps.json
+++ b/apps/sso/worktree.apps.json
@@ -7,6 +7,7 @@
     "website": "https://worktree.website.targonglobal.com",
     "xplan": "/xplan/1-strategies",
     "plutus": "/plutus",
-    "hermes": "/hermes"
+    "hermes": "/hermes",
+    "argus": "/argus"
   }
 }


### PR DESCRIPTION
## Summary\n- set Argus app entry policy to public in SSO app registry\n- add Argus to SSO app override configs for dev/prod/worktree/local so it appears in portal links\n- include Argus in CD manual deploy changed-app collection path\n\n## Validation\n- pnpm --filter @targon/sso type-check\n- JSON parse validation for SSO app config files