### PR TITLE
fix(hermes): move reviews ingest to marketplace+sku file flow [gpt]

### DIFF
--- a/apps/hermes/README.md
+++ b/apps/hermes/README.md
@@ -113,21 +113,25 @@ Notes:
 
 ---
 
-## ASIN review ingest + weekly insights sync
+## SKU review ingest + insights
 
 Hermes now supports:
 
-1) **Manual product-review ingest** (copy/paste friendly)
+1) **File-based product-review ingest** (no copy/paste)
 - API: `POST /api/reviews/import`
-- You can send either:
-  - `reviews: [{ body, rating?, title?, reviewDate?, externalReviewId?, raw? }]`
-  - or `rawText` with review blocks separated by `---` (or triple blank lines)
-- Reviews are deduplicated by a stable content hash per `(connection_id, marketplace_id, asin)`.
+- Send `multipart/form-data` with:
+  - `connectionId` (string)
+  - `marketplaceId` (string)
+  - `sku` (string)
+  - `file` (`.csv`, `.tsv`, `.txt`, or `.json`)
+- Optional `asin` can be included as a fallback for rows that do not carry ASIN.
+- Reviews are deduplicated by a stable content hash per `(connection_id, marketplace_id, sku)`.
 
-2) **Weekly Customer Feedback API pulls** (ASIN-level topics/trends)
-- Runs inside the existing `orders-sync` worker loop.
-- Pulls for ASINs already seen in `hermes_manual_reviews`.
-- Stores latest snapshots in `hermes_asin_review_insights`.
+2) **Ingested-review insights**
+- API: `GET /api/reviews/manual?connectionId=...&marketplaceId=...&sku=...`
+- API: `GET /api/reviews/insights?connectionId=...&marketplaceId=...&sku=...`
+- API: `GET /api/reviews/export?connectionId=...&marketplaceId=...&sku=...`
+- Metrics are computed from `hermes_manual_reviews` for the selected marketplace + SKU.
 
 Relevant env knobs:
 - `HERMES_REVIEW_INSIGHTS_ENABLED` (default `true`)

--- a/apps/hermes/src/app/api/reviews/export/route.ts
+++ b/apps/hermes/src/app/api/reviews/export/route.ts
@@ -7,6 +7,12 @@ import { listManualReviews } from "@/server/reviews/query";
 
 export const runtime = "nodejs";
 
+function csvEscape(value: string | null): string {
+  if (value === null) return "";
+  const escaped = value.replace(/"/g, "\"\"");
+  return `"${escaped}"`;
+}
+
 async function handleGet(req: Request) {
   await maybeAutoMigrate();
 
@@ -15,14 +21,12 @@ async function handleGet(req: Request) {
     connectionId: z.string().min(1),
     marketplaceId: z.string().min(1),
     sku: z.string().min(1),
-    limit: z.coerce.number().int().min(1).max(500).optional(),
   });
 
   const parsed = schema.safeParse({
     connectionId: url.searchParams.get("connectionId") ?? undefined,
     marketplaceId: url.searchParams.get("marketplaceId") ?? undefined,
     sku: url.searchParams.get("sku") ?? undefined,
-    limit: url.searchParams.get("limit") ?? undefined,
   });
 
   if (!parsed.success) {
@@ -36,10 +40,42 @@ async function handleGet(req: Request) {
     connectionId: parsed.data.connectionId,
     marketplaceId: parsed.data.marketplaceId,
     sku: parsed.data.sku,
-    limit: parsed.data.limit ?? 200,
+    limit: 5000,
   });
 
-  return NextResponse.json({ ok: true, rows });
+  const lines = [
+    ["sku", "asin", "rating", "review_date", "imported_at", "title", "body"]
+      .map((value) => csvEscape(value))
+      .join(","),
+  ];
+
+  for (const row of rows) {
+    lines.push(
+      [
+        row.sku,
+        row.asin,
+        row.rating === null ? "" : row.rating.toString(),
+        row.reviewDate,
+        row.importedAt,
+        row.title,
+        row.body,
+      ]
+        .map((value) => csvEscape(value))
+        .join(",")
+    );
+  }
+
+  const csv = lines.join("\n");
+  const safeSku = parsed.data.sku.trim().toUpperCase().replace(/[^A-Z0-9._-]/g, "_");
+  const fileName = `reviews_${safeSku}.csv`;
+
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "content-type": "text/csv; charset=utf-8",
+      "content-disposition": `attachment; filename=\"${fileName}\"`,
+    },
+  });
 }
 
-export const GET = withApiLogging("GET /api/reviews/manual", handleGet);
+export const GET = withApiLogging("GET /api/reviews/export", handleGet);

--- a/apps/hermes/src/server/reviews/file-parser.ts
+++ b/apps/hermes/src/server/reviews/file-parser.ts
@@ -1,0 +1,237 @@
+import { type ManualReviewInput, parseManualReviewText } from "./manual-ingest";
+
+type Row = Record<string, string>;
+
+function cleanText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  return trimmed;
+}
+
+function normalizeHeader(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+/, "")
+    .replace(/_+$/, "");
+}
+
+function parseDelimitedRows(content: string, delimiter: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < content.length; index += 1) {
+    const char = content[index];
+    if (char === "\"") {
+      const next = content[index + 1];
+      if (inQuotes && next === "\"") {
+        field += "\"";
+        index += 1;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+
+    if (!inQuotes && char === delimiter) {
+      row.push(field);
+      field = "";
+      continue;
+    }
+
+    if (!inQuotes && (char === "\n" || char === "\r")) {
+      if (char === "\r" && content[index + 1] === "\n") {
+        index += 1;
+      }
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+      continue;
+    }
+
+    field += char;
+  }
+
+  row.push(field);
+  rows.push(row);
+  return rows;
+}
+
+function rowToObject(headers: string[], values: string[]): Row {
+  const out: Row = {};
+  for (let index = 0; index < headers.length; index += 1) {
+    const key = headers[index];
+    if (!key) continue;
+    out[key] = values[index] ?? "";
+  }
+  return out;
+}
+
+const BODY_KEYS = ["body", "review", "review_text", "text", "content", "comment"];
+const TITLE_KEYS = ["title", "headline", "subject"];
+const DATE_KEYS = ["review_date", "date", "created_at", "created"];
+const RATING_KEYS = ["rating", "stars", "star_rating", "score"];
+const ID_KEYS = ["external_review_id", "review_id", "id"];
+const ASIN_KEYS = ["asin", "product_asin"];
+
+function getField(row: Row, keys: string[]): string | null {
+  for (const key of keys) {
+    const value = cleanText(row[key]);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function getRating(row: Row): number | undefined {
+  const raw = getField(row, RATING_KEYS);
+  if (raw === null) return undefined;
+
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) return undefined;
+  if (parsed < 0 || parsed > 5) return undefined;
+  return parsed;
+}
+
+function looksLikeHeader(row: string[]): boolean {
+  const normalized = row.map((value) => normalizeHeader(value));
+  for (const key of BODY_KEYS) {
+    if (normalized.includes(key)) return true;
+  }
+  for (const key of RATING_KEYS) {
+    if (normalized.includes(key)) return true;
+  }
+  return false;
+}
+
+function parseTabular(content: string, delimiter: string): ManualReviewInput[] {
+  const rows = parseDelimitedRows(content, delimiter)
+    .map((row) => row.map((value) => value.trim()))
+    .filter((row) => row.some((value) => value.length > 0));
+  if (rows.length === 0) return [];
+
+  const hasHeader = looksLikeHeader(rows[0] ?? []);
+  const headers = hasHeader
+    ? (rows[0] ?? []).map((value, index) => {
+        const normalized = normalizeHeader(value);
+        if (normalized.length > 0) return normalized;
+        return `column_${index + 1}`;
+      })
+    : (rows[0] ?? []).map((_, index) => `column_${index + 1}`);
+  const startIndex = hasHeader ? 1 : 0;
+
+  const out: ManualReviewInput[] = [];
+  for (let index = startIndex; index < rows.length; index += 1) {
+    const row = rowToObject(headers, rows[index] ?? []);
+
+    const bodyValue = getField(row, BODY_KEYS);
+    const body = bodyValue ? bodyValue : cleanText(row.column_1);
+    if (body === null) continue;
+
+    const title = getField(row, TITLE_KEYS) ?? undefined;
+    const reviewDate = getField(row, DATE_KEYS) ?? undefined;
+    const externalReviewId = getField(row, ID_KEYS) ?? undefined;
+    const asin = getField(row, ASIN_KEYS) ?? undefined;
+    const rating = getRating(row);
+
+    out.push({
+      asin,
+      externalReviewId,
+      reviewDate,
+      rating,
+      title,
+      body,
+      raw: row,
+    });
+  }
+
+  return out;
+}
+
+function parseJson(content: string): ManualReviewInput[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return [];
+  }
+
+  const rows =
+    Array.isArray(parsed)
+      ? parsed
+      : parsed && typeof parsed === "object" && "reviews" in parsed
+        ? (parsed as { reviews?: unknown }).reviews
+        : null;
+  if (!Array.isArray(rows)) return [];
+
+  const out: ManualReviewInput[] = [];
+  for (const row of rows) {
+    if (!row || typeof row !== "object") continue;
+    const obj = row as Record<string, unknown>;
+
+    const body =
+      cleanText(obj.body) ??
+      cleanText(obj.review) ??
+      cleanText(obj.text) ??
+      cleanText(obj.comment);
+    if (body === null) continue;
+
+    const ratingValue = obj.rating ?? obj.stars ?? obj.star_rating ?? obj.score;
+    const ratingParsed = typeof ratingValue === "number" ? ratingValue : Number.parseFloat(String(ratingValue ?? ""));
+    const rating =
+      Number.isFinite(ratingParsed) && ratingParsed >= 0 && ratingParsed <= 5
+        ? ratingParsed
+        : undefined;
+
+    out.push({
+      asin: cleanText(obj.asin) ?? undefined,
+      externalReviewId: cleanText(obj.externalReviewId) ?? cleanText(obj.reviewId) ?? cleanText(obj.id) ?? undefined,
+      reviewDate: cleanText(obj.reviewDate) ?? cleanText(obj.date) ?? cleanText(obj.createdAt) ?? undefined,
+      rating,
+      title: cleanText(obj.title) ?? cleanText(obj.headline) ?? undefined,
+      body,
+      raw: row,
+    });
+  }
+  return out;
+}
+
+function pickDelimiter(fileName: string, content: string): string {
+  const lowerName = fileName.toLowerCase();
+  if (lowerName.endsWith(".tsv")) return "\t";
+  if (lowerName.endsWith(".csv")) return ",";
+
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? "";
+  const commaCount = (firstLine.match(/,/g) ?? []).length;
+  const tabCount = (firstLine.match(/\t/g) ?? []).length;
+  if (tabCount > commaCount) return "\t";
+  return ",";
+}
+
+export function parseReviewsFile(params: { fileName: string; content: string }): ManualReviewInput[] {
+  const content = params.content.replace(/^\uFEFF/, "").trim();
+  if (content.length === 0) return [];
+
+  const lowerName = params.fileName.toLowerCase();
+  if (lowerName.endsWith(".json")) {
+    const jsonRows = parseJson(content);
+    if (jsonRows.length > 0) return jsonRows;
+  }
+
+  if (lowerName.endsWith(".txt")) {
+    return parseManualReviewText(content);
+  }
+
+  const delimiter = pickDelimiter(params.fileName, content);
+  const tabularRows = parseTabular(content, delimiter);
+  if (tabularRows.length > 0) return tabularRows;
+
+  const jsonRows = parseJson(content);
+  if (jsonRows.length > 0) return jsonRows;
+
+  return parseManualReviewText(content);
+}


### PR DESCRIPTION
## Summary
- replace copy/paste review ingest with file upload flow keyed by marketplace + SKU
- add file parser support for CSV/TSV/TXT/JSON and SKU-aware dedupe
- replace review endpoints/UI to query and export by marketplace + SKU
- compute insights from ingested reviews (total, avg, five-star, 30-day change, 90-day series)
- update schema migration for `sku` column + indexes and docs

## Validation
- `pnpm --filter @targon/hermes lint`
- `pnpm --filter @targon/hermes exec tsc --noEmit`
- `pnpm --filter @targon/hermes build`
- integration check via `tsx` using `dev_hermes` schema for import/list/insights
- applied `db/schema.sql` as `portal_talos` on both `main_hermes` and `dev_hermes`

## Ops notes
- ensured ownership for `hermes_manual_reviews` and `hermes_asin_review_insights` is `portal_talos` in both schemas to avoid auto-migrate permission errors
