### PR TITLE
feat(plutus): align all UI colors to brand palette [claude]

### DIFF
--- a/apps/plutus/app/ads-data/page.tsx
+++ b/apps/plutus/app/ads-data/page.tsx
@@ -140,7 +140,7 @@ const tdSx = {
 
 /** Shared sx for table header section */
 const theadSx = {
-  bgcolor: 'rgba(248, 250, 252, 0.8)',
+  bgcolor: 'rgba(245, 245, 245, 0.8)',
   '[data-mui-color-scheme="dark"] &, .dark &': {
     bgcolor: 'rgba(255, 255, 255, 0.05)',
   },
@@ -159,7 +159,7 @@ const trSx = {
   transition: 'background-color 0.15s',
   '&:hover': { bgcolor: 'action.hover' },
   '&[data-state="selected"]': {
-    bgcolor: 'rgba(69, 179, 212, 0.08)',
+    bgcolor: 'rgba(0, 194, 185, 0.08)',
   },
 } as const;
 
@@ -379,8 +379,8 @@ export default function AdsDataPage() {
                 py: 5,
                 transition: 'all 0.2s',
                 ...(isDragging
-                  ? { borderColor: '#45B3D4', bgcolor: 'rgba(69, 179, 212, 0.05)' }
-                  : { borderColor: 'divider', '&:hover': { borderColor: '#45B3D4' } }),
+                  ? { borderColor: '#00C2B9', bgcolor: 'rgba(0, 194, 185, 0.05)' }
+                  : { borderColor: 'divider', '&:hover': { borderColor: '#00C2B9' } }),
               }}
               onDragOver={(e: React.DragEvent) => {
                 e.preventDefault();
@@ -400,7 +400,7 @@ export default function AdsDataPage() {
                       borderRadius: '50%',
                       border: 4,
                       borderColor: 'divider',
-                      borderTopColor: '#45B3D4',
+                      borderTopColor: '#00C2B9',
                       animation: 'spin 1s linear infinite',
                       '@keyframes spin': { to: { transform: 'rotate(360deg)' } },
                     }}
@@ -418,8 +418,8 @@ export default function AdsDataPage() {
                       alignItems: 'center',
                       justifyContent: 'center',
                       borderRadius: 3,
-                      bgcolor: 'rgba(69, 179, 212, 0.08)',
-                      color: '#45B3D4',
+                      bgcolor: 'rgba(0, 194, 185, 0.08)',
+                      color: '#00C2B9',
                     }}
                   >
                     <UploadIcon sx={{ fontSize: 28 }} />
@@ -433,7 +433,7 @@ export default function AdsDataPage() {
                     sx={{
                       mt: 2,
                       borderRadius: 2,
-                      bgcolor: '#45B3D4',
+                      bgcolor: '#00C2B9',
                       px: 2,
                       py: 1,
                       fontSize: '0.875rem',
@@ -443,7 +443,7 @@ export default function AdsDataPage() {
                       transition: 'background-color 0.2s',
                       border: 'none',
                       cursor: 'pointer',
-                      '&:hover': { bgcolor: '#2fa3c7' },
+                      '&:hover': { bgcolor: '#00a89f' },
                     }}
                   >
                     Choose File
@@ -625,7 +625,7 @@ export default function AdsDataPage() {
                             '& .MuiOutlinedInput-root': {
                               borderRadius: '8px',
                               '&:hover .MuiOutlinedInput-notchedOutline': {
-                                borderColor: '#45B3D4',
+                                borderColor: '#00C2B9',
                               },
                               '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
                                 borderColor: '#00C2B9',
@@ -659,7 +659,7 @@ export default function AdsDataPage() {
                             '& .MuiOutlinedInput-root': {
                               borderRadius: '8px',
                               '&:hover .MuiOutlinedInput-notchedOutline': {
-                                borderColor: '#45B3D4',
+                                borderColor: '#00C2B9',
                               },
                               '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
                                 borderColor: '#00C2B9',
@@ -753,10 +753,10 @@ export default function AdsDataPage() {
                 height: 36,
                 px: 2,
                 fontSize: '0.875rem',
-                bgcolor: '#45B3D4',
+                bgcolor: '#00C2B9',
                 color: '#fff',
-                '&:hover': { bgcolor: '#2fa3c7' },
-                '&:active': { bgcolor: '#2384a1' },
+                '&:hover': { bgcolor: '#00a89f' },
+                '&:active': { bgcolor: '#008f87' },
                 '&.Mui-disabled': { opacity: 0.4, pointerEvents: 'none' },
               }}
             >

--- a/apps/plutus/app/audit-data/page.tsx
+++ b/apps/plutus/app/audit-data/page.tsx
@@ -106,7 +106,7 @@ const rowSx = {
 
 /* ---- shared table head section sx ---- */
 const theadSx = {
-  bgcolor: 'rgba(248, 250, 252, 0.8)',
+  bgcolor: 'rgba(245, 245, 245, 0.8)',
   '[data-mui-color-scheme="dark"] &, .dark &': {
     bgcolor: 'rgba(255, 255, 255, 0.05)',
   },
@@ -227,8 +227,8 @@ export default function AuditDataPage() {
                 py: 6,
                 transition: 'all 0.2s',
                 ...(isDragging
-                  ? { borderColor: '#45B3D4', bgcolor: 'rgba(69, 179, 212, 0.05)' }
-                  : { borderColor: 'divider', '&:hover': { borderColor: '#45B3D4' } }),
+                  ? { borderColor: '#00C2B9', bgcolor: 'rgba(0, 194, 185, 0.05)' }
+                  : { borderColor: 'divider', '&:hover': { borderColor: '#00C2B9' } }),
               }}
               onDragOver={(e: React.DragEvent) => {
                 e.preventDefault();
@@ -254,7 +254,7 @@ export default function AuditDataPage() {
                       borderRadius: '50%',
                       border: 4,
                       borderColor: 'divider',
-                      borderTopColor: '#45B3D4',
+                      borderTopColor: '#00C2B9',
                       animation: 'spin 1s linear infinite',
                       '@keyframes spin': { to: { transform: 'rotate(360deg)' } },
                     }}
@@ -272,8 +272,8 @@ export default function AuditDataPage() {
                       alignItems: 'center',
                       justifyContent: 'center',
                       borderRadius: 3,
-                      bgcolor: 'rgba(69, 179, 212, 0.08)',
-                      color: '#45B3D4',
+                      bgcolor: 'rgba(0, 194, 185, 0.08)',
+                      color: '#00C2B9',
                     }}
                   >
                     <UploadIcon sx={{ fontSize: 28 }} />
@@ -291,7 +291,7 @@ export default function AuditDataPage() {
                     sx={{
                       mt: 2,
                       borderRadius: 2,
-                      bgcolor: '#45B3D4',
+                      bgcolor: '#00C2B9',
                       px: 2,
                       py: 1,
                       fontSize: '0.875rem',
@@ -301,7 +301,7 @@ export default function AuditDataPage() {
                       transition: 'background-color 0.2s',
                       border: 'none',
                       cursor: 'pointer',
-                      '&:hover': { bgcolor: '#2fa3c7' },
+                      '&:hover': { bgcolor: '#00a89f' },
                     }}
                   >
                     Choose File
@@ -402,7 +402,7 @@ export default function AuditDataPage() {
             <Box sx={{ overflowX: 'auto' }}>
               <Table sx={tableSx}>
                 <TableHead sx={theadSx}>
-                  <TableRow sx={{ ...rowSx, bgcolor: 'rgba(248, 250, 252, 0.8)' }}>
+                  <TableRow sx={{ ...rowSx, bgcolor: 'rgba(245, 245, 245, 0.8)' }}>
                     <TableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Filename</TableCell>
                     <TableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Uploaded</TableCell>
                     <TableCell component="th" sx={{ ...thSx, fontWeight: 600, textAlign: 'right' }}>Settlements</TableCell>

--- a/apps/plutus/app/cashflow/page.tsx
+++ b/apps/plutus/app/cashflow/page.tsx
@@ -920,7 +920,7 @@ export default function CashflowPage() {
           </Button>
           <Button
             variant="contained"
-            sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }}
+            sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }}
             onClick={() => saveConfigMutation.mutate(configForm)}
             disabled={saveConfigMutation.isPending}
           >
@@ -977,7 +977,7 @@ export default function CashflowPage() {
                   type="button"
                   variant={adjustmentForm.direction === 'inflow' ? 'contained' : 'outlined'}
                   sx={adjustmentForm.direction === 'inflow'
-                    ? { bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }
+                    ? { bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }
                     : { borderColor: 'divider', color: 'text.primary' }
                   }
                   onClick={() => setAdjustmentForm((current) => ({ ...current, direction: 'inflow' }))}
@@ -988,7 +988,7 @@ export default function CashflowPage() {
                   type="button"
                   variant={adjustmentForm.direction === 'outflow' ? 'contained' : 'outlined'}
                   sx={adjustmentForm.direction === 'outflow'
-                    ? { bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }
+                    ? { bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }
                     : { borderColor: 'divider', color: 'text.primary' }
                   }
                   onClick={() => setAdjustmentForm((current) => ({ ...current, direction: 'outflow' }))}
@@ -1026,7 +1026,7 @@ export default function CashflowPage() {
           </Button>
           <Button
             variant="contained"
-            sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }}
+            sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }}
             onClick={() => {
               try {
                 const absCents = parseAmountToCents(adjustmentForm.amount);

--- a/apps/plutus/app/chart-of-accounts/page.tsx
+++ b/apps/plutus/app/chart-of-accounts/page.tsx
@@ -197,7 +197,7 @@ function ColumnFilterDropdown({
           cursor: 'pointer',
           p: 0,
           ...(isActive
-            ? { color: '#45B3D4' }
+            ? { color: '#00C2B9' }
             : { color: 'text.secondary', '&:hover': { color: 'text.primary' } }),
         }}
       >
@@ -246,7 +246,7 @@ function ColumnFilterDropdown({
                 px: 1,
                 py: 0.75,
                 fontSize: '0.875rem',
-                color: '#45B3D4',
+                color: '#00C2B9',
                 '&:hover': { bgcolor: 'action.hover' },
                 borderRadius: 1,
                 border: 'none',
@@ -290,7 +290,7 @@ function ColumnFilterDropdown({
                     borderRadius: 0.5,
                     border: 1,
                     ...(selectedValues.has(option)
-                      ? { borderColor: '#45B3D4', bgcolor: '#45B3D4', color: '#fff' }
+                      ? { borderColor: '#00C2B9', bgcolor: '#00C2B9', color: '#fff' }
                       : { borderColor: 'divider' }),
                   }}
                 >
@@ -480,7 +480,7 @@ export default function ChartOfAccountsPage() {
                       fontWeight: 600,
                       textTransform: 'uppercase',
                       letterSpacing: '0.05em',
-                      color: '#45B3D4',
+                      color: '#00C2B9',
                     }}
                   >
                     Search
@@ -541,7 +541,7 @@ export default function ChartOfAccountsPage() {
               <Box sx={{ overflowX: 'auto' }}>
                 <MuiTable>
                   <TableHead>
-                    <TableRow sx={{ bgcolor: 'rgba(248, 250, 252, 0.8)' }}>
+                    <TableRow sx={{ bgcolor: 'rgba(245, 245, 245, 0.8)' }}>
                       <TableCell sx={{ fontWeight: 600, width: 80 }}>Code</TableCell>
                       <TableCell sx={{ fontWeight: 600 }}>Name</TableCell>
                       <TableCell sx={{ fontWeight: 600 }}>
@@ -610,7 +610,7 @@ export default function ChartOfAccountsPage() {
                       !isCheckingConnection &&
                       !error &&
                       filteredAccounts.map((account) => (
-                        <TableRow key={account.id} sx={{ transition: 'background-color 0.15s', cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' }, '& td:first-of-type': { position: 'relative' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#45B3D4' } }}>
+                        <TableRow key={account.id} sx={{ transition: 'background-color 0.15s', cursor: 'pointer', '&:hover': { bgcolor: 'action.hover' }, '& td:first-of-type': { position: 'relative' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#00C2B9' } }}>
                           {/* Code */}
                           <TableCell sx={{ fontFamily: 'monospace', fontSize: '0.875rem', color: 'text.secondary' }}>
                             {account.acctNum ? account.acctNum : '—'}

--- a/apps/plutus/app/data-sources/page.tsx
+++ b/apps/plutus/app/data-sources/page.tsx
@@ -118,7 +118,7 @@ function readApiError(payload: unknown, fallback: string): string {
 /* ---- shared table sx ---- */
 const thSx = { height: 44, px: 1.5, fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary' } as const;
 const tdSx = { px: 1.5, py: 1.5, color: 'text.primary', fontVariantNumeric: 'tabular-nums' } as const;
-const theadSx = { bgcolor: 'rgba(248, 250, 252, 0.8)', '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' }, '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' } } as const;
+const theadSx = { bgcolor: 'rgba(245, 245, 245, 0.8)', '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' }, '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' } } as const;
 const tbodySx = { '& .MuiTableRow-root:last-child': { borderBottom: 0 } } as const;
 const rowSx = { borderBottom: 1, borderColor: 'divider', transition: 'background-color 0.15s', '&:hover': { bgcolor: 'action.hover' } } as const;
 const tableSx = { width: '100%', fontSize: '0.875rem' } as const;
@@ -127,14 +127,14 @@ const selectSx = {
   borderRadius: '8px',
   fontSize: '0.875rem',
   '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+  '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
   '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
 } as const;
 
 const dateFieldSx = {
   '& .MuiOutlinedInput-root': {
     borderRadius: '8px',
-    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
     '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
   },
 } as const;
@@ -386,8 +386,8 @@ export default function DataSourcesPage() {
                   py: 5,
                   transition: 'all 0.2s',
                   ...(isDragging
-                    ? { borderColor: '#45B3D4', bgcolor: 'rgba(69, 179, 212, 0.05)' }
-                    : { borderColor: 'divider', '&:hover': { borderColor: '#45B3D4' } }),
+                    ? { borderColor: '#00C2B9', bgcolor: 'rgba(0, 194, 185, 0.05)' }
+                    : { borderColor: 'divider', '&:hover': { borderColor: '#00C2B9' } }),
                 }}
                 onDragOver={(e: React.DragEvent) => {
                   e.preventDefault();
@@ -406,7 +406,7 @@ export default function DataSourcesPage() {
                         borderRadius: '50%',
                         border: 4,
                         borderColor: 'divider',
-                        borderTopColor: '#45B3D4',
+                        borderTopColor: '#00C2B9',
                         animation: 'spin 1s linear infinite',
                         '@keyframes spin': { to: { transform: 'rotate(360deg)' } },
                       }}
@@ -424,8 +424,8 @@ export default function DataSourcesPage() {
                         alignItems: 'center',
                         justifyContent: 'center',
                         borderRadius: 3,
-                        bgcolor: 'rgba(69, 179, 212, 0.08)',
-                        color: '#45B3D4',
+                        bgcolor: 'rgba(0, 194, 185, 0.08)',
+                        color: '#00C2B9',
                       }}
                     >
                       <UploadIcon sx={{ fontSize: 28 }} />
@@ -439,7 +439,7 @@ export default function DataSourcesPage() {
                       sx={{
                         mt: 2,
                         borderRadius: 2,
-                        bgcolor: '#45B3D4',
+                        bgcolor: '#00C2B9',
                         px: 2,
                         py: 1,
                         fontSize: '0.875rem',
@@ -449,7 +449,7 @@ export default function DataSourcesPage() {
                         transition: 'background-color 0.2s',
                         border: 'none',
                         cursor: 'pointer',
-                        '&:hover': { bgcolor: '#2fa3c7' },
+                        '&:hover': { bgcolor: '#00a89f' },
                       }}
                     >
                       Choose File

--- a/apps/plutus/app/reconciliation/page.tsx
+++ b/apps/plutus/app/reconciliation/page.tsx
@@ -235,7 +235,7 @@ export default function ReconciliationPage() {
             <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>How it works</Typography>
             <Box sx={{ mt: 2, display: 'grid', gap: 2, gridTemplateColumns: { xs: '1fr', sm: 'repeat(3, 1fr)' } }}>
               <Box sx={{ display: 'flex', gap: 1.5 }}>
-                <Box sx={{ display: 'flex', height: 28, width: 28, flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: 99, bgcolor: 'rgba(69, 179, 212, 0.08)', fontSize: '0.75rem', fontWeight: 700, color: '#2384a1' }}>
+                <Box sx={{ display: 'flex', height: 28, width: 28, flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: 99, bgcolor: 'rgba(0, 194, 185, 0.08)', fontSize: '0.75rem', fontWeight: 700, color: '#008f87' }}>
                   1
                 </Box>
                 <Box>
@@ -246,7 +246,7 @@ export default function ReconciliationPage() {
                 </Box>
               </Box>
               <Box sx={{ display: 'flex', gap: 1.5 }}>
-                <Box sx={{ display: 'flex', height: 28, width: 28, flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: 99, bgcolor: 'rgba(69, 179, 212, 0.08)', fontSize: '0.75rem', fontWeight: 700, color: '#2384a1' }}>
+                <Box sx={{ display: 'flex', height: 28, width: 28, flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: 99, bgcolor: 'rgba(0, 194, 185, 0.08)', fontSize: '0.75rem', fontWeight: 700, color: '#008f87' }}>
                   2
                 </Box>
                 <Box>
@@ -257,7 +257,7 @@ export default function ReconciliationPage() {
                 </Box>
               </Box>
               <Box sx={{ display: 'flex', gap: 1.5 }}>
-                <Box sx={{ display: 'flex', height: 28, width: 28, flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: 99, bgcolor: 'rgba(69, 179, 212, 0.08)', fontSize: '0.75rem', fontWeight: 700, color: '#2384a1' }}>
+                <Box sx={{ display: 'flex', height: 28, width: 28, flexShrink: 0, alignItems: 'center', justifyContent: 'center', borderRadius: 99, bgcolor: 'rgba(0, 194, 185, 0.08)', fontSize: '0.75rem', fontWeight: 700, color: '#008f87' }}>
                   3
                 </Box>
                 <Box>
@@ -299,7 +299,7 @@ export default function ReconciliationPage() {
                     '& .MuiOutlinedInput-root': {
                       borderRadius: '8px',
                       '&:hover .MuiOutlinedInput-notchedOutline': {
-                        borderColor: '#45B3D4',
+                        borderColor: '#00C2B9',
                       },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
                         borderColor: '#00C2B9',
@@ -327,7 +327,7 @@ export default function ReconciliationPage() {
                         borderColor: 'divider',
                       },
                       '&:hover .MuiOutlinedInput-notchedOutline': {
-                        borderColor: '#45B3D4',
+                        borderColor: '#00C2B9',
                       },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
                         borderColor: '#00C2B9',
@@ -364,13 +364,13 @@ export default function ReconciliationPage() {
                 justifyContent: 'center',
                 borderRadius: 3,
                 border: '2px dashed',
-                borderColor: isDragging ? '#45B3D4' : 'divider',
-                bgcolor: isDragging ? 'rgba(69, 179, 212, 0.04)' : 'transparent',
+                borderColor: isDragging ? '#00C2B9' : 'divider',
+                bgcolor: isDragging ? 'rgba(0, 194, 185, 0.04)' : 'transparent',
                 px: 3,
                 py: 5,
                 transition: 'all 0.2s',
                 '&:hover': {
-                  borderColor: '#45B3D4',
+                  borderColor: '#00C2B9',
                 },
               }}
               onDragOver={(e: React.DragEvent) => {
@@ -393,14 +393,14 @@ export default function ReconciliationPage() {
                     component="button"
                     type="button"
                     onClick={() => fileInputRef.current?.click()}
-                    sx={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '0.75rem', fontWeight: 500, color: '#2384a1', '&:hover': { color: '#1a6b82' } }}
+                    sx={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '0.75rem', fontWeight: 500, color: '#008f87', '&:hover': { color: '#007069' } }}
                   >
                     Choose a different file
                   </Box>
                 </Box>
               ) : (
                 <>
-                  <Box sx={{ mb: 1.5, display: 'flex', height: 48, width: 48, alignItems: 'center', justifyContent: 'center', borderRadius: 3, bgcolor: 'rgba(69, 179, 212, 0.08)', color: '#2384a1' }}>
+                  <Box sx={{ mb: 1.5, display: 'flex', height: 48, width: 48, alignItems: 'center', justifyContent: 'center', borderRadius: 3, bgcolor: 'rgba(0, 194, 185, 0.08)', color: '#008f87' }}>
                     <UploadIcon sx={{ fontSize: 24 }} />
                   </Box>
                   <Typography sx={{ fontSize: '0.875rem', fontWeight: 500, color: 'text.primary' }}>
@@ -416,7 +416,7 @@ export default function ReconciliationPage() {
                     sx={{
                       mt: 1.5,
                       borderRadius: 2,
-                      bgcolor: '#45B3D4',
+                      bgcolor: '#00C2B9',
                       px: 2,
                       py: 1,
                       fontSize: '0.875rem',
@@ -426,7 +426,7 @@ export default function ReconciliationPage() {
                       cursor: 'pointer',
                       boxShadow: 1,
                       transition: 'background-color 0.2s',
-                      '&:hover': { bgcolor: '#2fa3c7' },
+                      '&:hover': { bgcolor: '#00a89f' },
                     }}
                   >
                     Choose File
@@ -451,10 +451,10 @@ export default function ReconciliationPage() {
                   height: 36,
                   px: 2,
                   fontSize: '0.875rem',
-                  bgcolor: '#45B3D4',
+                  bgcolor: '#00C2B9',
                   color: '#fff',
-                  '&:hover': { bgcolor: '#2fa3c7' },
-                  '&:active': { bgcolor: '#2384a1' },
+                  '&:hover': { bgcolor: '#00a89f' },
+                  '&:active': { bgcolor: '#008f87' },
                   '&.Mui-disabled': { opacity: 0.4, pointerEvents: 'none' },
                 }}
               >
@@ -560,7 +560,7 @@ export default function ReconciliationPage() {
                   <MuiTable sx={{ width: '100%', fontSize: '0.875rem' }}>
                     <MuiTableHead
                       sx={{
-                        bgcolor: 'rgba(248, 250, 252, 0.8)',
+                        bgcolor: 'rgba(245, 245, 245, 0.8)',
                         '[data-mui-color-scheme="dark"] &, .dark &': {
                           bgcolor: 'rgba(255, 255, 255, 0.05)',
                         },

--- a/apps/plutus/app/settings/page.tsx
+++ b/apps/plutus/app/settings/page.tsx
@@ -357,7 +357,7 @@ export default function SettingsPage() {
                     {disconnectMutation.isPending ? 'Disconnecting…' : 'Disconnect'}
                   </Button>
                 ) : (
-                  <Button variant="contained" sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }} onClick={handleConnect}>Connect to QuickBooks</Button>
+                  <Button variant="contained" sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }} onClick={handleConnect}>Connect to QuickBooks</Button>
                 )}
               </Box>
             </CardContent>
@@ -390,7 +390,7 @@ export default function SettingsPage() {
               <Box sx={{ mt: 2.5, display: 'flex', alignItems: 'center', gap: 1.5 }}>
                 <Button
                   variant="contained"
-                  sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }}
+                  sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }}
                   onClick={() => savePrefsMutation.mutate(localPrefs)}
                   disabled={!prefsDirty || savePrefsMutation.isPending}
                 >
@@ -435,7 +435,7 @@ export default function SettingsPage() {
               <Box sx={{ mt: 2 }}>
                 <Button
                   variant="contained"
-                  sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }}
+                  sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }}
                   onClick={handleSaveAutopost}
                   disabled={autopostMutation.isPending}
                 >

--- a/apps/plutus/app/settlement-mapping/page.tsx
+++ b/apps/plutus/app/settlement-mapping/page.tsx
@@ -244,7 +244,7 @@ export default function SettlementMappingPage() {
               onClick={() => saveMutation.mutate()}
               disabled={saveMutation.isPending}
               startIcon={<SaveIcon sx={{ fontSize: 16 }} />}
-              sx={{ borderRadius: 2, textTransform: 'none', bgcolor: '#45B3D4', '&:hover': { bgcolor: '#2fa3c7' } }}
+              sx={{ borderRadius: 2, textTransform: 'none', bgcolor: '#00C2B9', '&:hover': { bgcolor: '#00a89f' } }}
             >
               {saveMutation.isPending ? 'Saving…' : 'Save'}
             </Button>
@@ -263,7 +263,7 @@ export default function SettlementMappingPage() {
 
               <Box sx={{ mt: 2, display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' } }}>
                 <Box>
-                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#45B3D4' }}>
+                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#00C2B9' }}>
                     Transfer to Bank
                   </Typography>
                   <FormControl size="small" fullWidth sx={{ mt: 0.75 }}>
@@ -287,7 +287,7 @@ export default function SettlementMappingPage() {
                 </Box>
 
                 <Box>
-                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#45B3D4' }}>
+                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#00C2B9' }}>
                     Payment to Amazon
                   </Typography>
                   <FormControl size="small" fullWidth sx={{ mt: 0.75 }}>
@@ -337,7 +337,7 @@ export default function SettlementMappingPage() {
 
               <Box sx={{ mt: 2, display: 'grid', gap: 1.5, gridTemplateColumns: { xs: '1fr', md: '1.2fr 1fr auto' }, alignItems: { md: 'end' } }}>
                 <Box>
-                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#45B3D4' }}>
+                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#00C2B9' }}>
                     Add memo
                   </Typography>
                   <TextField
@@ -351,7 +351,7 @@ export default function SettlementMappingPage() {
                 </Box>
 
                 <Box>
-                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#45B3D4' }}>
+                  <Typography sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#00C2B9' }}>
                     Account
                   </Typography>
                   <FormControl size="small" fullWidth sx={{ mt: 0.75 }}>
@@ -389,7 +389,7 @@ export default function SettlementMappingPage() {
 
               <Box sx={{ mt: 2, border: 1, borderColor: 'divider', borderRadius: 2, overflow: 'hidden' }}>
                 <Table size="small">
-                  <TableHead sx={{ bgcolor: 'rgba(248, 250, 252, 0.8)' }}>
+                  <TableHead sx={{ bgcolor: 'rgba(245, 245, 245, 0.8)' }}>
                     <TableRow>
                       <TableCell sx={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary' }}>
                         Memo

--- a/apps/plutus/app/settlements/[id]/page.tsx
+++ b/apps/plutus/app/settlements/[id]/page.tsx
@@ -543,7 +543,7 @@ function ProcessSettlementDialog({
 
   return (
     <>
-      <Button size="small" variant="contained" sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }} onClick={() => setOpen(true)}>Process Settlement</Button>
+      <Button size="small" variant="contained" sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }} onClick={() => setOpen(true)}>Process Settlement</Button>
       <Dialog
         open={open}
         onClose={() => handleOpenChange(false)}
@@ -635,12 +635,12 @@ function ProcessSettlementDialog({
                                 display: 'inline-flex',
                                 alignItems: 'center',
                                 borderRadius: '6px',
-                                bgcolor: 'rgba(69, 179, 212, 0.1)',
+                                bgcolor: 'rgba(0, 194, 185, 0.1)',
                                 px: 0.75,
                                 py: 0.25,
                                 fontSize: '10px',
                                 fontWeight: 500,
-                                color: '#2384a1',
+                                color: '#008f87',
                               }}
                             >
                               Recommended
@@ -683,7 +683,7 @@ function ProcessSettlementDialog({
                       </>
                     )}
                     {selectedMeta.recommended && (
-                      <Chip label="Recommended" size="small" sx={{ fontSize: '10px', bgcolor: 'rgba(69, 179, 212, 0.1)', color: '#2384a1' }} />
+                      <Chip label="Recommended" size="small" sx={{ fontSize: '10px', bgcolor: 'rgba(0, 194, 185, 0.1)', color: '#008f87' }} />
                     )}
                   </Box>
                 )}
@@ -802,7 +802,7 @@ function ProcessSettlementDialog({
                   )}
 
                   {previewBlockingBlocks.length === 0 && (
-                    <Button variant="contained" sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }} onClick={() => void handlePost()} disabled={isPosting}>
+                    <Button variant="contained" sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }} onClick={() => void handlePost()} disabled={isPosting}>
                       {isPosting ? 'Posting...' : 'Post to QBO'}
                     </Button>
                   )}
@@ -1426,12 +1426,12 @@ export default function SettlementDetailPage() {
                                     display: 'inline-flex',
                                     alignItems: 'center',
                                     borderRadius: '6px',
-                                    bgcolor: 'rgba(69, 179, 212, 0.1)',
+                                    bgcolor: 'rgba(0, 194, 185, 0.1)',
                                     px: 0.75,
                                     py: 0.25,
                                     fontSize: '10px',
                                     fontWeight: 500,
-                                    color: '#2384a1',
+                                    color: '#008f87',
                                   }}
                                 >
                                   Recommended
@@ -1596,7 +1596,7 @@ export default function SettlementDetailPage() {
                               <Button
                                 size="small"
                                 variant="contained"
-                                sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' } }}
+                                sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' } }}
                                 onClick={() => saveAdsAllocationMutation.mutate()}
                                 disabled={!adsAllocationPreview.ok || !adsAllocation.adsDataUpload || saveAdsAllocationMutation.isPending}
                               >
@@ -1832,7 +1832,7 @@ export default function SettlementDetailPage() {
                         <Box
                           component={Link}
                           href="/audit-data"
-                          sx={{ color: '#2384a1', '&:hover': { textDecoration: 'underline' } }}
+                          sx={{ color: '#008f87', '&:hover': { textDecoration: 'underline' } }}
                         >
                           Audit Data
                         </Box>{' '}

--- a/apps/plutus/app/settlements/page.tsx
+++ b/apps/plutus/app/settlements/page.tsx
@@ -506,10 +506,10 @@ const outlineSx = {
 
 const defaultBtnSx = {
   ...btnBase,
-  bgcolor: '#45B3D4',
+  bgcolor: '#00C2B9',
   color: '#fff',
-  '&:hover': { bgcolor: '#2fa3c7' },
-  '&:active': { bgcolor: '#2384a1' },
+  '&:hover': { bgcolor: '#00a89f' },
+  '&:active': { bgcolor: '#008f87' },
 } as const;
 
 const smSize = { height: 32, px: 1.5, fontSize: '0.75rem' } as const;
@@ -519,7 +519,7 @@ const defaultSize = { height: 36, px: 2, fontSize: '0.875rem' } as const;
 const textFieldSx = {
   '& .MuiOutlinedInput-root': {
     borderRadius: '8px',
-    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
     '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
   },
 } as const;
@@ -765,7 +765,7 @@ export default function SettlementsPage() {
             <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
               <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { md: '1.4fr 0.55fr 0.55fr auto' }, alignItems: { md: 'end' } }}>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     Search
                   </Typography>
                   <Box sx={{ position: 'relative' }}>
@@ -790,7 +790,7 @@ export default function SettlementsPage() {
                 </Box>
 
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     Start date
                   </Typography>
                   <TextField
@@ -810,7 +810,7 @@ export default function SettlementsPage() {
                 </Box>
 
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     End date
                   </Typography>
                   <TextField
@@ -853,12 +853,12 @@ export default function SettlementsPage() {
                 <MuiTable sx={{ width: '100%', fontSize: '0.875rem' }}>
                   <MuiTableHead
                     sx={{
-                      bgcolor: 'rgba(248, 250, 252, 0.8)',
+                      bgcolor: 'rgba(245, 245, 245, 0.8)',
                       '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' },
                       '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' },
                     }}
                   >
-                    <MuiTableRow sx={{ bgcolor: 'rgba(248, 250, 252, 0.8)' }}>
+                    <MuiTableRow sx={{ bgcolor: 'rgba(245, 245, 245, 0.8)' }}>
                       <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Marketplace</MuiTableCell>
                       <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Period</MuiTableCell>
                       <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Settlement Total</MuiTableCell>
@@ -908,7 +908,7 @@ export default function SettlementsPage() {
                         return (
                           <MuiTableRow
                             key={s.id}
-                            sx={{ ...rowHoverSx, cursor: 'pointer', '& td:first-of-type': { position: 'relative' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#45B3D4' } }}
+                            sx={{ ...rowHoverSx, cursor: 'pointer', '& td:first-of-type': { position: 'relative' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#00C2B9' } }}
                             onClick={() => router.push(`/settlements/${s.id}`)}
                           >
                           <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top' }}>
@@ -986,7 +986,7 @@ export default function SettlementsPage() {
               </Box>
 
               {data && data.pagination.totalPages > 1 && (
-                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 1.5, alignItems: { sm: 'center' }, justifyContent: { sm: 'space-between' }, p: 2, borderTop: 1, borderColor: 'divider', bgcolor: 'rgba(248, 250, 252, 0.5)' }}>
+                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 1.5, alignItems: { sm: 'center' }, justifyContent: { sm: 'space-between' }, p: 2, borderTop: 1, borderColor: 'divider', bgcolor: 'rgba(245, 245, 245, 0.5)' }}>
                   <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}>
                     Page {data.pagination.page} of {data.pagination.totalPages} &middot; {data.pagination.totalCount} settlements
                   </Typography>
@@ -1107,7 +1107,7 @@ export default function SettlementsPage() {
 
               {syncResult && (
                 <Box sx={{ borderRadius: 2, border: 1, borderColor: 'divider', overflow: 'hidden' }}>
-                  <Box sx={{ p: 1.5, borderBottom: 1, borderColor: 'divider', bgcolor: 'rgba(248, 250, 252, 0.5)' }}>
+                  <Box sx={{ p: 1.5, borderBottom: 1, borderColor: 'divider', bgcolor: 'rgba(245, 245, 245, 0.5)' }}>
                     <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
                       Results
                     </Typography>
@@ -1119,7 +1119,7 @@ export default function SettlementsPage() {
                   </Box>
                   <Box sx={{ overflow: 'auto' }}>
                     <MuiTable size="small" sx={{ width: '100%', fontSize: '0.875rem' }}>
-                      <MuiTableHead sx={{ bgcolor: 'rgba(248, 250, 252, 0.8)' }}>
+                      <MuiTableHead sx={{ bgcolor: 'rgba(245, 245, 245, 0.8)' }}>
                         <MuiTableRow sx={{ borderBottom: 1, borderColor: 'divider' }}>
                           <MuiTableCell sx={{ ...thSx, fontWeight: 600 }}>Doc #</MuiTableCell>
                           <MuiTableCell sx={{ ...thSx, fontWeight: 600 }}>QBO</MuiTableCell>

--- a/apps/plutus/app/setup/page.tsx
+++ b/apps/plutus/app/setup/page.tsx
@@ -346,7 +346,7 @@ function Sidebar({
                   ...(item.complete
                     ? { bgcolor: '#10b981', borderColor: '#10b981', color: '#fff' }
                     : isActive
-                      ? { bgcolor: 'background.paper', borderColor: '#45B3D4', color: '#45B3D4' }
+                      ? { bgcolor: 'background.paper', borderColor: '#00C2B9', color: '#00C2B9' }
                       : { bgcolor: 'background.paper', borderColor: 'divider', color: 'text.disabled' }),
                 }}
               >
@@ -421,7 +421,7 @@ function BrandsSection({
               <Table sx={{ width: '100%', fontSize: '0.875rem' }}>
                 <TableHead
                   sx={{
-                    bgcolor: 'rgba(248, 250, 252, 0.8)',
+                    bgcolor: 'rgba(245, 245, 245, 0.8)',
                     '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' },
                     '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' },
                   }}
@@ -485,7 +485,7 @@ function BrandsSection({
                 sx={{
                   '& .MuiOutlinedInput-root': {
                     borderRadius: '8px',
-                    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                     '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                   },
                 }}
@@ -508,7 +508,7 @@ function BrandsSection({
                     borderRadius: '8px',
                     fontSize: '0.875rem',
                     '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                    '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                     '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                   }}
                   MenuProps={{
@@ -549,10 +549,10 @@ function BrandsSection({
                   height: 36,
                   px: 2,
                   fontSize: '0.875rem',
-                  bgcolor: '#45B3D4',
+                  bgcolor: '#00C2B9',
                   color: '#fff',
-                  '&:hover': { bgcolor: '#2fa3c7' },
-                  '&:active': { bgcolor: '#2384a1' },
+                  '&:hover': { bgcolor: '#00a89f' },
+                  '&:active': { bgcolor: '#008f87' },
                 }}
               >
                 Add Brand
@@ -602,9 +602,9 @@ function AccountRow({
               fontSize: '0.875rem',
               bgcolor: 'background.paper',
               '& .MuiOutlinedInput-notchedOutline': {
-                borderColor: selected ? '#45B3D4' : 'divider',
+                borderColor: selected ? '#00C2B9' : 'divider',
               },
-              '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+              '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
               '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
             }}
             MenuProps={{
@@ -766,10 +766,10 @@ function AccountsSection({
                 sx={{
                   width: '100%',
                   borderRadius: 3,
-                  bgcolor: '#45B3D4',
+                  bgcolor: '#00C2B9',
                   color: '#fff',
-                  '&:hover': { bgcolor: '#2fa3c7' },
-                  boxShadow: '0 4px 14px -3px rgba(69,179,212,0.25)',
+                  '&:hover': { bgcolor: '#00a89f' },
+                  boxShadow: '0 4px 14px -3px rgba(0,194,185,0.25)',
                 }}
               >
                 Connect to QuickBooks
@@ -812,7 +812,7 @@ function AccountsSection({
           <Table sx={{ width: '100%', fontSize: '0.875rem' }}>
             <TableHead
               sx={{
-                bgcolor: 'rgba(248, 250, 252, 0.8)',
+                bgcolor: 'rgba(245, 245, 245, 0.8)',
                 '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' },
                 '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' },
               }}
@@ -919,10 +919,10 @@ function AccountsSection({
           height: 36,
           px: 2,
           fontSize: '0.875rem',
-          bgcolor: '#45B3D4',
+          bgcolor: '#00C2B9',
           color: '#fff',
-          '&:hover': { bgcolor: '#2fa3c7' },
-          '&:active': { bgcolor: '#2384a1' },
+          '&:hover': { bgcolor: '#00a89f' },
+          '&:active': { bgcolor: '#008f87' },
           width: '100%',
         }}
       >
@@ -1115,7 +1115,7 @@ function SkusSection({
             <Table sx={{ width: '100%', fontSize: '0.875rem' }}>
               <TableHead
                 sx={{
-                  bgcolor: 'rgba(248, 250, 252, 0.8)',
+                  bgcolor: 'rgba(245, 245, 245, 0.8)',
                   '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' },
                   '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' },
                 }}
@@ -1160,7 +1160,7 @@ function SkusSection({
                             sx={{
                               '& .MuiOutlinedInput-root': {
                                 borderRadius: '8px',
-                                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                                 '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                               },
                             }}
@@ -1190,7 +1190,7 @@ function SkusSection({
                             sx={{
                               '& .MuiOutlinedInput-root': {
                                 borderRadius: '8px',
-                                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                                 '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                               },
                             }}
@@ -1230,7 +1230,7 @@ function SkusSection({
                                 fontSize: '0.875rem',
                                 width: 220,
                                 '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                                '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                                 '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                               }}
                               MenuProps={{
@@ -1297,7 +1297,7 @@ function SkusSection({
                   sx={{
                     '& .MuiOutlinedInput-root': {
                       borderRadius: '8px',
-                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                     },
                   }}
@@ -1323,7 +1323,7 @@ function SkusSection({
                   sx={{
                     '& .MuiOutlinedInput-root': {
                       borderRadius: '8px',
-                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                     },
                   }}
@@ -1349,7 +1349,7 @@ function SkusSection({
                   sx={{
                     '& .MuiOutlinedInput-root': {
                       borderRadius: '8px',
-                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                     },
                   }}
@@ -1370,7 +1370,7 @@ function SkusSection({
                       borderRadius: '8px',
                       fontSize: '0.875rem',
                       '& .MuiOutlinedInput-notchedOutline': { borderColor: 'divider' },
-                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#45B3D4' },
+                      '&:hover .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9' },
                       '&.Mui-focused .MuiOutlinedInput-notchedOutline': { borderColor: '#00C2B9', borderWidth: 2 },
                     }}
                     MenuProps={{
@@ -1409,10 +1409,10 @@ function SkusSection({
                   height: 36,
                   px: 2,
                   fontSize: '0.875rem',
-                  bgcolor: '#45B3D4',
+                  bgcolor: '#00C2B9',
                   color: '#fff',
-                  '&:hover': { bgcolor: '#2fa3c7' },
-                  '&:active': { bgcolor: '#2384a1' },
+                  '&:hover': { bgcolor: '#00a89f' },
+                  '&:active': { bgcolor: '#008f87' },
                 }}
               >
                 Add SKU
@@ -1441,10 +1441,10 @@ function SkusSection({
             height: 36,
             px: 2,
             fontSize: '0.875rem',
-            bgcolor: '#45B3D4',
+            bgcolor: '#00C2B9',
             color: '#fff',
-            '&:hover': { bgcolor: '#2fa3c7' },
-            '&:active': { bgcolor: '#2384a1' },
+            '&:hover': { bgcolor: '#00a89f' },
+            '&:active': { bgcolor: '#008f87' },
           }}
         >
           Save SKUs

--- a/apps/plutus/app/transactions/page.tsx
+++ b/apps/plutus/app/transactions/page.tsx
@@ -1468,7 +1468,7 @@ function CreateBillModal({
             </Box>
 
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-              <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>Memo</Box>
+              <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>Memo</Box>
               <TextField
                 multiline
                 rows={4}
@@ -1481,7 +1481,7 @@ function CreateBillModal({
             </Box>
 
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-              <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>Attachments</Box>
+              <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>Attachments</Box>
               <Box
                 component="input"
                 type="file"
@@ -1531,7 +1531,7 @@ function CreateBillModal({
             onClick={handleSubmit}
             disabled={isContextLoading || !!contextError || createMutation.isPending}
             variant="contained"
-            sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' }, gap: 0.75 }}
+            sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' }, gap: 0.75 }}
           >
             <SaveIcon sx={{ fontSize: 14 }} />
             {createMutation.isPending ? 'Creating...' : 'Save bill'}
@@ -1664,7 +1664,7 @@ function CreatePurchaseModal({
                 component="select"
                 value={createState.paymentAccountId}
                 onChange={(event: React.ChangeEvent<HTMLSelectElement>) => setCreateState((prev) => ({ ...prev, paymentAccountId: event.target.value }))}
-                sx={{ height: 36, width: '100%', borderRadius: 1.5, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1.5, fontSize: '0.875rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 2px rgba(69,179,212,0.4)' } }}
+                sx={{ height: 36, width: '100%', borderRadius: 1.5, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1.5, fontSize: '0.875rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 2px rgba(0,194,185,0.4)' } }}
               >
                 <option value="">{createContextLoading ? 'Loading accounts…' : 'Select payment account'}</option>
                 {paymentAccounts.map((account) => (
@@ -1678,7 +1678,7 @@ function CreatePurchaseModal({
                 component="select"
                 value={createState.vendorId}
                 onChange={(event: React.ChangeEvent<HTMLSelectElement>) => setCreateState((prev) => ({ ...prev, vendorId: event.target.value }))}
-                sx={{ height: 36, width: '100%', borderRadius: 1.5, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1.5, fontSize: '0.875rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 2px rgba(69,179,212,0.4)' } }}
+                sx={{ height: 36, width: '100%', borderRadius: 1.5, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1.5, fontSize: '0.875rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 2px rgba(0,194,185,0.4)' } }}
               >
                 <option value="">{createContextLoading ? 'Loading vendors…' : 'No payee'}</option>
                 {vendors.map((vendor) => (
@@ -1723,7 +1723,7 @@ function CreatePurchaseModal({
                             description: nextAccount ? nextAccount.fullyQualifiedName : '',
                           });
                         }}
-                        sx={{ height: 32, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(69,179,212,0.4)' } }}
+                        sx={{ height: 32, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(0,194,185,0.4)' } }}
                       >
                         <option value="">{createContextLoading ? 'Loading accounts…' : 'Select account'}</option>
                         {lineAccounts.map((account) => (
@@ -1788,7 +1788,7 @@ function CreatePurchaseModal({
             onClick={() => createMutation.mutate()}
             disabled={!canSave || createMutation.isPending || createContextLoading}
             variant="contained"
-            sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' }, gap: 0.75 }}
+            sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' }, gap: 0.75 }}
           >
             <SaveIcon sx={{ fontSize: 14 }} />
             {createMutation.isPending ? 'Creating...' : 'Create Expense'}
@@ -1968,7 +1968,7 @@ function EditBillModal({
               target="_blank"
               rel="noopener noreferrer"
               title="Open in QuickBooks"
-              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, borderRadius: 1.5, px: 1, py: 0.5, fontSize: '0.75rem', fontWeight: 500, color: 'text.secondary', transition: 'background-color 0.15s', '&:hover': { color: '#45B3D4', bgcolor: 'rgba(69,179,212,0.08)' } }}
+              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, borderRadius: 1.5, px: 1, py: 0.5, fontSize: '0.75rem', fontWeight: 500, color: 'text.secondary', transition: 'background-color 0.15s', '&:hover': { color: '#00C2B9', bgcolor: 'rgba(0,194,185,0.08)' } }}
             >
               <OpenInNewIcon sx={{ fontSize: 14 }} />
               QuickBooks
@@ -2003,7 +2003,7 @@ function EditBillModal({
                 component="select"
                 value={editState.brandId}
                 onChange={(event: React.ChangeEvent<HTMLSelectElement>) => handleBrandChange(event.target.value)}
-                sx={{ height: 36, width: '100%', borderRadius: 1.5, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1.5, fontSize: '0.875rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 2px rgba(69,179,212,0.4)' } }}
+                sx={{ height: 36, width: '100%', borderRadius: 1.5, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1.5, fontSize: '0.875rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 2px rgba(0,194,185,0.4)' } }}
               >
                 <option value="">Select brand</option>
                 {brands.map((brand) => (
@@ -2050,7 +2050,7 @@ function EditBillModal({
                                     value={split.sku}
                                     onChange={(event: React.ChangeEvent<HTMLSelectElement>) => updateSplit(trackedLine.lineId, split.id, { sku: event.target.value })}
                                     disabled={editState.brandId === ''}
-                                    sx={{ height: 28, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 0.75, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(69,179,212,0.4)' }, '&:disabled': { opacity: 0.5 } }}
+                                    sx={{ height: 28, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 0.75, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(0,194,185,0.4)' }, '&:disabled': { opacity: 0.5 } }}
                                   >
                                     <option value="">{editState.brandId === '' ? 'Select brand first' : 'Select SKU'}</option>
                                     {filteredSkus.map((sku) => (
@@ -2086,7 +2086,7 @@ function EditBillModal({
                               value={lineState.sku}
                               onChange={(event: React.ChangeEvent<HTMLSelectElement>) => updateLine(trackedLine.lineId, { sku: event.target.value })}
                               disabled={editState.brandId === ''}
-                              sx={{ height: 28, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 0.75, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(69,179,212,0.4)' }, '&:disabled': { opacity: 0.5 } }}
+                              sx={{ height: 28, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 0.75, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(0,194,185,0.4)' }, '&:disabled': { opacity: 0.5 } }}
                             >
                               <option value="">{editState.brandId === '' ? 'Select brand first' : 'Select SKU'}</option>
                               {filteredSkus.map((sku) => (
@@ -2166,7 +2166,7 @@ function EditBillModal({
             onClick={() => saveMutation.mutate()}
             disabled={!canSave || saveMutation.isPending}
             variant="contained"
-            sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' }, gap: 0.75 }}
+            sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' }, gap: 0.75 }}
           >
             <SaveIcon sx={{ fontSize: 14 }} />
             {saveMutation.isPending ? 'Saving...' : 'Save'}
@@ -2345,7 +2345,7 @@ function EditPurchaseModal({
               target="_blank"
               rel="noopener noreferrer"
               title="Open in QuickBooks"
-              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, borderRadius: 1.5, px: 1, py: 0.5, fontSize: '0.75rem', fontWeight: 500, color: 'text.secondary', transition: 'background-color 0.15s', '&:hover': { color: '#45B3D4', bgcolor: 'rgba(69,179,212,0.08)' } }}
+              sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.75, borderRadius: 1.5, px: 1, py: 0.5, fontSize: '0.75rem', fontWeight: 500, color: 'text.secondary', transition: 'background-color 0.15s', '&:hover': { color: '#00C2B9', bgcolor: 'rgba(0,194,185,0.08)' } }}
             >
               <OpenInNewIcon sx={{ fontSize: 14 }} />
               QuickBooks
@@ -2390,7 +2390,7 @@ function EditPurchaseModal({
                         component="select"
                         value={lineState.accountId}
                         onChange={(event: React.ChangeEvent<HTMLSelectElement>) => updateLine(lineState.qboLineId, { accountId: event.target.value })}
-                        sx={{ height: 32, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(69,179,212,0.4)' } }}
+                        sx={{ height: 32, width: '100%', borderRadius: 1, border: 1, borderColor: 'divider', bgcolor: 'background.paper', px: 1, fontSize: '0.75rem', color: 'text.primary', '&:focus': { outline: 'none', boxShadow: '0 0 0 1px rgba(0,194,185,0.4)' } }}
                       >
                         <option value="">Select account</option>
                         {accounts.map((account) => (
@@ -2532,7 +2532,7 @@ function EditPurchaseModal({
             onClick={() => saveMutation.mutate()}
             disabled={!canSave || saveMutation.isPending}
             variant="contained"
-            sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' }, gap: 0.75 }}
+            sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' }, gap: 0.75 }}
           >
             <SaveIcon sx={{ fontSize: 14 }} />
             {saveMutation.isPending ? 'Saving...' : 'Save'}
@@ -2680,7 +2680,7 @@ export default function TransactionsPage() {
                 },
               }}>
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     Search
                   </Box>
                   <Box sx={{ position: 'relative' }}>
@@ -2697,7 +2697,7 @@ export default function TransactionsPage() {
                 </Box>
 
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     Start date
                   </Box>
                   <TextField
@@ -2714,7 +2714,7 @@ export default function TransactionsPage() {
                 </Box>
 
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     End date
                   </Box>
                   <TextField
@@ -2731,7 +2731,7 @@ export default function TransactionsPage() {
                 </Box>
 
                 <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                  <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                     Rows
                   </Box>
                   <FormControl size="small" fullWidth>
@@ -2754,7 +2754,7 @@ export default function TransactionsPage() {
 
                 {tab === 'purchase' && (
                   <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}>
+                    <Box sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
                       Payment account
                     </Box>
                     <FormControl size="small" fullWidth>
@@ -2783,7 +2783,7 @@ export default function TransactionsPage() {
                     <Button
                       onClick={() => setCreateBillOpen(true)}
                       variant="contained"
-                      sx={{ bgcolor: '#45B3D4', color: '#fff', '&:hover': { bgcolor: '#2fa3c7' }, gap: 0.75 }}
+                      sx={{ bgcolor: '#00C2B9', color: '#fff', '&:hover': { bgcolor: '#00a89f' }, gap: 0.75 }}
                     >
                       <AddIcon sx={{ fontSize: 14 }} />
                       New Bill
@@ -2905,7 +2905,7 @@ export default function TransactionsPage() {
                                 rel="noopener noreferrer"
                                 onClick={(event: React.MouseEvent) => event.stopPropagation()}
                                 title="Open in QuickBooks"
-                                sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', height: 28, width: 28, borderRadius: 1, color: 'text.disabled', transition: 'background-color 0.15s', '&:hover': { color: '#45B3D4', bgcolor: 'rgba(69,179,212,0.08)' } }}
+                                sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', height: 28, width: 28, borderRadius: 1, color: 'text.disabled', transition: 'background-color 0.15s', '&:hover': { color: '#00C2B9', bgcolor: 'rgba(0,194,185,0.08)' } }}
                               >
                                 <OpenInNewIcon sx={{ fontSize: 14 }} />
                               </Box>
@@ -2990,7 +2990,7 @@ export default function TransactionsPage() {
 
                         return (
                           <Fragment key={row.id}>
-                            <TableRow sx={{ transition: 'background-color 0.15s', '&:hover': { bgcolor: 'action.hover' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#45B3D4' }, '& td:first-of-type': { position: 'relative' }, '& .show-on-hover': { opacity: 0, transition: 'opacity 0.2s' }, '&:hover .show-on-hover': { opacity: 1 } }}>
+                            <TableRow sx={{ transition: 'background-color 0.15s', '&:hover': { bgcolor: 'action.hover' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#00C2B9' }, '& td:first-of-type': { position: 'relative' }, '& .show-on-hover': { opacity: 0, transition: 'opacity 0.2s' }, '&:hover .show-on-hover': { opacity: 1 } }}>
                               <TableCell sx={{ verticalAlign: 'top' }}>
                                 <Box
                                   component="button"
@@ -3045,7 +3045,7 @@ export default function TransactionsPage() {
                                     aria-label="Open in QuickBooks"
                                     title="Open in QuickBooks"
                                     className="show-on-hover"
-                                    sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', height: 28, width: 28, mt: -0.25, borderRadius: 1, color: 'text.disabled', '&:hover': { color: '#45B3D4', bgcolor: 'rgba(69,179,212,0.08)' }, '&:focus-within': { opacity: 1 } }}
+                                    sx={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', height: 28, width: 28, mt: -0.25, borderRadius: 1, color: 'text.disabled', '&:hover': { color: '#00C2B9', bgcolor: 'rgba(0,194,185,0.08)' }, '&:focus-within': { opacity: 1 } }}
                                   >
                                     <OpenInNewIcon sx={{ fontSize: 16 }} />
                                   </Box>

--- a/apps/plutus/components/app-header.tsx
+++ b/apps/plutus/components/app-header.tsx
@@ -160,7 +160,7 @@ function NavDropdown({ item, pathname }: { item: Extract<NavItem, { items: any[]
           cursor: 'pointer',
           transition: 'all 0.15s',
           position: 'relative',
-          color: anyActive ? '#2384a1' : 'text.secondary',
+          color: anyActive ? '#008f87' : 'text.secondary',
           '&:hover': { color: 'text.primary' },
         }}
       >
@@ -182,7 +182,7 @@ function NavDropdown({ item, pathname }: { item: Extract<NavItem, { items: any[]
               right: 10,
               height: 2,
               borderRadius: 1,
-              bgcolor: '#45B3D4',
+              bgcolor: '#00C2B9',
             }}
           />
         )}
@@ -242,9 +242,9 @@ export function AppHeader() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 borderRadius: 2,
-                background: 'linear-gradient(135deg, #45B3D4, #2fa3c7)',
+                background: 'linear-gradient(135deg, #0b273f, #00C2B9)',
                 color: '#fff',
-                boxShadow: '0 2px 8px rgba(69, 179, 212, 0.25)',
+                boxShadow: '0 2px 8px rgba(11, 39, 63, 0.25)',
               }}
             >
               <LogoIcon />
@@ -278,7 +278,7 @@ export function AppHeader() {
                         fontSize: '13px',
                         fontWeight: 500,
                         transition: 'all 0.15s',
-                        color: isActive ? '#2384a1' : 'text.secondary',
+                        color: isActive ? '#008f87' : 'text.secondary',
                         '&:hover': { color: 'text.primary' },
                       }}
                     >
@@ -292,7 +292,7 @@ export function AppHeader() {
                             right: 10,
                             height: 2,
                             borderRadius: 1,
-                            bgcolor: '#45B3D4',
+                            bgcolor: '#00C2B9',
                           }}
                         />
                       )}
@@ -370,7 +370,7 @@ export function AppHeader() {
       <Box
         sx={{
           height: 1,
-          background: 'linear-gradient(to right, transparent, rgba(69, 179, 212, 0.3), transparent)',
+          background: 'linear-gradient(to right, transparent, rgba(0, 194, 185, 0.3), transparent)',
         }}
       />
 
@@ -416,12 +416,12 @@ export function AppHeader() {
                       fontSize: '0.875rem',
                       fontWeight: 500,
                       transition: 'background-color 0.15s',
-                      color: isActive ? '#2384a1' : 'text.secondary',
-                      bgcolor: isActive ? 'rgba(69, 179, 212, 0.08)' : 'transparent',
+                      color: isActive ? '#008f87' : 'text.secondary',
+                      bgcolor: isActive ? 'rgba(0, 194, 185, 0.08)' : 'transparent',
                       '&:hover': { bgcolor: 'action.hover' },
                     }}
                   >
-                    <Icon sx={{ fontSize: 16, color: isActive ? '#45B3D4' : 'text.disabled' }} />
+                    <Icon sx={{ fontSize: 16, color: isActive ? '#00C2B9' : 'text.disabled' }} />
                     {item.label}
                   </Box>
                 </Link>
@@ -467,8 +467,8 @@ export function AppHeader() {
                           fontSize: '0.875rem',
                           fontWeight: 500,
                           transition: 'background-color 0.15s',
-                          color: isActive ? '#2384a1' : 'text.secondary',
-                          bgcolor: isActive ? 'rgba(69, 179, 212, 0.08)' : 'transparent',
+                          color: isActive ? '#008f87' : 'text.secondary',
+                          bgcolor: isActive ? 'rgba(0, 194, 185, 0.08)' : 'transparent',
                           '&:hover': { bgcolor: 'action.hover' },
                         }}
                       >

--- a/apps/plutus/components/not-connected-screen.tsx
+++ b/apps/plutus/components/not-connected-screen.tsx
@@ -84,7 +84,7 @@ export function NotConnectedScreen({ title, error }: NotConnectedScreenProps) {
 
           <Typography
             variant="caption"
-            sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#2384a1' }}
+            sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}
           >
             QuickBooks Online
           </Typography>
@@ -105,10 +105,10 @@ export function NotConnectedScreen({ title, error }: NotConnectedScreenProps) {
               sx={{
                 width: '100%',
                 borderRadius: 3,
-                background: 'linear-gradient(to right, #45B3D4, #2fa3c7)',
+                background: 'linear-gradient(to right, #00C2B9, #00a89f)',
                 color: '#fff',
-                boxShadow: '0 4px 16px rgba(69, 179, 212, 0.25)',
-                '&:hover': { background: 'linear-gradient(to right, #2fa3c7, #2384a1)' },
+                boxShadow: '0 4px 16px rgba(0, 194, 185, 0.25)',
+                '&:hover': { background: 'linear-gradient(to right, #00a89f, #008f87)' },
               }}
             >
               Connect to QuickBooks

--- a/apps/plutus/components/page-header.tsx
+++ b/apps/plutus/components/page-header.tsx
@@ -49,7 +49,7 @@ export function PageHeader({ title, kicker, description, actions, sx, variant = 
             fontSize: '1.875rem',
             lineHeight: 1,
             letterSpacing: '-0.025em',
-            color: variant === 'accent' ? '#f97316' : 'text.primary',
+            color: variant === 'accent' ? '#00C2B9' : 'text.primary',
           }}
         >
           {title}
@@ -64,7 +64,7 @@ export function PageHeader({ title, kicker, description, actions, sx, variant = 
             mt: 1.5,
             height: 1,
             width: 96,
-            background: 'linear-gradient(to right, rgba(69, 179, 212, 0.5), transparent)',
+            background: 'linear-gradient(to right, rgba(0, 194, 185, 0.5), transparent)',
           }}
         />
       </Box>

--- a/apps/plutus/components/ui/split-button.tsx
+++ b/apps/plutus/components/ui/split-button.tsx
@@ -39,7 +39,7 @@ export function SplitButton({
         <Button
           onClick={onClick}
           sx={{
-            bgcolor: '#45B3D4',
+            bgcolor: '#00C2B9',
             color: '#fff',
             fontSize: '0.75rem',
             fontWeight: 600,
@@ -47,7 +47,7 @@ export function SplitButton({
             letterSpacing: '0.05em',
             px: 2,
             borderRight: '1px solid rgba(255,255,255,0.2) !important',
-            '&:hover': { bgcolor: '#2fa3c7' },
+            '&:hover': { bgcolor: '#00a89f' },
           }}
         >
           {children}
@@ -56,11 +56,11 @@ export function SplitButton({
           size="small"
           onClick={(e) => setAnchorEl(e.currentTarget)}
           sx={{
-            bgcolor: '#2fa3c7',
+            bgcolor: '#00a89f',
             color: '#fff',
             px: 0.5,
             minWidth: 32,
-            '&:hover': { bgcolor: '#2384a1' },
+            '&:hover': { bgcolor: '#008f87' },
           }}
         >
           <ExpandMoreIcon sx={{ fontSize: 18 }} />

--- a/apps/plutus/components/ui/stat-card.tsx
+++ b/apps/plutus/components/ui/stat-card.tsx
@@ -64,7 +64,7 @@ export function StatCard({ label, value, icon, trend, dotColor, sx }: StatCardPr
           position: 'absolute',
           inset: '0 0 auto 0',
           height: 2,
-          background: 'linear-gradient(to right, rgba(69, 179, 212, 0.6), rgba(69, 179, 212, 0.4), transparent)',
+          background: 'linear-gradient(to right, rgba(0, 194, 185, 0.6), rgba(0, 194, 185, 0.4), transparent)',
           opacity: 0,
           transition: 'opacity 0.2s',
         }}
@@ -144,8 +144,8 @@ export function StatCard({ label, value, icon, trend, dotColor, sx }: StatCardPr
               alignItems: 'center',
               justifyContent: 'center',
               borderRadius: 2,
-              bgcolor: 'rgba(69, 179, 212, 0.08)',
-              color: '#2384a1',
+              bgcolor: 'rgba(0, 194, 185, 0.08)',
+              color: '#008f87',
             }}
           >
             {icon}

--- a/apps/plutus/lib/mui-theme.ts
+++ b/apps/plutus/lib/mui-theme.ts
@@ -84,7 +84,7 @@ const shared = {
           '& .MuiOutlinedInput-root': {
             borderRadius: 8,
             '&:hover .MuiOutlinedInput-notchedOutline': {
-              borderColor: '#45B3D4',
+              borderColor: '#00C2B9',
             },
             '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
               borderColor: '#00C2B9',
@@ -100,7 +100,7 @@ const shared = {
           borderRadius: 8,
           fontSize: '0.875rem',
           '&:hover .MuiOutlinedInput-notchedOutline': {
-            borderColor: '#45B3D4',
+            borderColor: '#00C2B9',
           },
           '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
             borderColor: '#00C2B9',
@@ -158,7 +158,7 @@ const shared = {
     MuiTableHead: {
       styleOverrides: {
         root: {
-          backgroundColor: 'rgba(248, 250, 252, 0.8)',
+          backgroundColor: 'rgba(245, 245, 245, 0.8)',
         },
       },
     },
@@ -216,10 +216,10 @@ export const lightTheme = createTheme({
       main: '#0b273f',
     },
     secondary: {
-      main: '#45B3D4',
+      main: '#00C2B9',
     },
     background: {
-      default: '#F8FAFC',
+      default: '#F5F5F5',
       paper: '#FFFFFF',
     },
     divider: 'rgba(0, 0, 0, 0.08)',
@@ -231,10 +231,10 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#45B3D4',
+      main: '#00C2B9',
     },
     secondary: {
-      main: '#00C2B9',
+      main: '#0b273f',
     },
     background: {
       default: '#0B1120',


### PR DESCRIPTION
## Summary

- Replaces off-brand `#45B3D4` (blue-cyan) with brand accent `#00C2B9` (teal) across all Plutus pages and components
- Updates hover/active shade chain: `#2fa3c7` → `#00a89f`, `#2384a1` → `#008f87`
- Sets `background.default` → `#F5F5F5` (brand secondary), theme `secondary.main` → `#00C2B9`
- Fixes `page-header.tsx` accent variant from orange `#f97316` → `#00C2B9`
- Updates logo gradient to use brand primary (`#0b273f`) → accent (`#00C2B9`)
- Converts all `rgba(69, 179, 212, ...)` → `rgba(0, 194, 185, ...)` equivalents

**Brand colors applied:**
| Token | Color |
|-------|-------|
| Primary | `#0b273f` |
| Secondary (bg) | `#F5F5F5` |
| Accent | `#00C2B9` |

## Test plan

- [ ] Visit `/plutus/settlements` — header nav underline, ACTION buttons, page title accent are teal `#00C2B9`
- [ ] Visit `/plutus/transactions` — filter/action buttons use brand accent
- [ ] Visit `/plutus/cashflow` — chart controls use brand accent
- [ ] Visit `/plutus/setup` — wizard buttons and input focus rings use brand accent
- [ ] Dark mode — accent color reads correctly on dark background

🤖 Generated with [Claude Code](https://claude.com/claude-code)