### PR TITLE
fix(talos): resolve auth redirect origin from request headers instead of env vars [claude]

### DIFF
--- a/apps/talos/src/app/auth/login/page.tsx
+++ b/apps/talos/src/app/auth/login/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import { headers } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { portalOrigin } from '@/lib/portal'
 import { withoutBasePath } from '@/lib/utils/base-path'
@@ -25,7 +26,7 @@ export default async function LoginPage({ searchParams }: { searchParams?: Searc
  redirect(desired)
  }
  const portalAuth = portalOrigin()
- const resolvedAppBase = resolveAppBase()
+ const resolvedAppBase = await resolveAppBase()
  if (!resolvedAppBase) {
   throw new Error('Unable to determine Talos application base URL. Configure BASE_PATH or NEXT_PUBLIC_APP_URL.')
  }
@@ -44,7 +45,7 @@ const { baseUrl, basePath, originHostname } = resolvedAppBase
  redirect(url.toString())
 }
 
-function resolveAppBase(): { baseUrl: string; basePath: string; originHostname: string } | null {
+async function resolveAppBase(): Promise<{ baseUrl: string; basePath: string; originHostname: string } | null> {
  const normalizeBasePath = (value?: string | null) => {
  if (!value) return ''
  let normalized = value.trim()
@@ -69,19 +70,73 @@ function resolveAppBase(): { baseUrl: string; basePath: string; originHostname: 
 
  const appUrlFromEnv = parseUrl(process.env.NEXT_PUBLIC_APP_URL)
  const portalUrl = parseUrl(process.env.PORTAL_AUTH_URL)
+ const headerList = await headers()
+ const requestUrlFromHeaders = resolveUrlFromHeaders(headerList)
 
- const basePath =
- normalizeBasePath(process.env.BASE_PATH) ||
- normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH) ||
- normalizeBasePath(appUrlFromEnv?.pathname ?? '')
+ const basePathCandidates = [
+  normalizeBasePath(process.env.BASE_PATH),
+  normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH),
+  normalizeBasePath(requestUrlFromHeaders?.pathname ?? ''),
+  normalizeBasePath(appUrlFromEnv?.pathname ?? ''),
+ ]
 
- const originUrl = appUrlFromEnv ?? portalUrl
+ let basePath = ''
+ for (const candidate of basePathCandidates) {
+  if (!candidate) continue
+  basePath = candidate
+  break
+ }
+
+ let originUrl = requestUrlFromHeaders
+ if (!originUrl) {
+  originUrl = appUrlFromEnv
+ }
+ if (!originUrl) {
+  originUrl = portalUrl
+ }
  if (!originUrl) {
   throw new Error('NEXT_PUBLIC_APP_URL or PORTAL_AUTH_URL must be configured for Talos login redirect.')
  }
 
  const baseUrl = `${originUrl.origin}${basePath}`
  return { baseUrl, basePath, originHostname: originUrl.hostname }
+}
+
+function resolveUrlFromHeaders(headerList: { get(name: string): string | null }): URL | null {
+ const parseUrl = (value?: string | null) => {
+  if (!value) return null
+  try {
+   return new URL(value)
+  } catch {
+   return null
+  }
+ }
+
+ const forwardedOriginRaw = headerList.get('x-forwarded-origin')
+ const forwardedOrigin = forwardedOriginRaw ? forwardedOriginRaw.split(',')[0].trim() : ''
+ if (forwardedOrigin) {
+  const parsed = parseUrl(forwardedOrigin)
+  if (parsed) return parsed
+ }
+
+ const forwardedHostRaw = headerList.get('x-forwarded-host')
+ const forwardedHost = forwardedHostRaw ? forwardedHostRaw.split(',')[0].trim() : ''
+ const forwardedProtoRaw = headerList.get('x-forwarded-proto')
+ const forwardedProto = forwardedProtoRaw ? forwardedProtoRaw.split(',')[0].trim() : 'https'
+
+ if (forwardedHost) {
+  const parsed = parseUrl(`${forwardedProto}://${forwardedHost}`)
+  if (parsed) return parsed
+ }
+
+ const hostRaw = headerList.get('host')
+ const host = hostRaw ? hostRaw.trim() : ''
+ if (host) {
+  const parsed = parseUrl(`${forwardedProto}://${host}`)
+  if (parsed) return parsed
+ }
+
+ return null
 }
 
 function buildCallback(appBase: string, basePath: string, target: string): string {

--- a/apps/talos/src/middleware.ts
+++ b/apps/talos/src/middleware.ts
@@ -11,12 +11,23 @@ applyDevAuthDefaults({
   appId: 'targon',
 })
 
-function resolveAppOrigin(): string {
-  const candidates = [
-    process.env.NEXT_PUBLIC_APP_URL,
-    process.env.BASE_URL,
-    process.env.NEXTAUTH_URL,
-  ]
+function resolveAppOrigin(request: NextRequest): string {
+  const candidates: Array<string | undefined> = []
+
+  const forwardedHostRaw = request.headers.get('x-forwarded-host')
+  const forwardedHost = forwardedHostRaw ? forwardedHostRaw.split(',')[0].trim() : ''
+  const forwardedProtoRaw = request.headers.get('x-forwarded-proto')
+  const forwardedProto = forwardedProtoRaw ? forwardedProtoRaw.split(',')[0].trim() : 'https'
+
+  if (forwardedHost) {
+    candidates.push(`${forwardedProto}://${forwardedHost}`)
+  }
+
+  candidates.push(request.nextUrl.origin)
+  candidates.push(request.url)
+  candidates.push(process.env.NEXT_PUBLIC_APP_URL)
+  candidates.push(process.env.BASE_URL)
+  candidates.push(process.env.NEXTAUTH_URL)
 
   for (const candidate of candidates) {
     if (!candidate) continue
@@ -130,7 +141,7 @@ export async function middleware(request: NextRequest) {
         return NextResponse.redirect(url)
       }
 
-      const origin = resolveAppOrigin()
+      const origin = resolveAppOrigin(request)
 
       const rawBasePath = (process.env.BASE_PATH ?? '').trim()
       const normalizedBasePath = rawBasePath && rawBasePath !== '/'


### PR DESCRIPTION
## Summary
- Talos auth redirects (middleware + `/auth/login`) were building callback URLs from env vars (`NEXT_PUBLIC_APP_URL`, etc.), which on the deployed dev server resolved to localhost
- Both `resolveAppOrigin` in middleware and `resolveAppBase` in the login page now prefer `x-forwarded-host`/`x-forwarded-proto` request headers (set by the reverse proxy) before falling back to env vars
- Adds a `resolveUrlFromHeaders` helper in the login page that checks `x-forwarded-origin`, `x-forwarded-host`, and `host` headers in priority order

## Test plan
- [ ] Navigate to `https://dev-os.targonglobal.com/talos` while unauthenticated
- [ ] Confirm the login redirect callback URL stays on `dev-os.targonglobal.com` (not localhost)
- [ ] Confirm login completes and returns to Talos on the correct host
- [ ] Verify local dev still works (env vars used as fallback when no proxy headers present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)