### PR TITLE
fix(plutus): deterministic settlement cash posting + FX reuse [claude]

### DIFF
--- a/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
@@ -41,6 +41,7 @@ export type UkSettlementDraft = {
   eventGroupId: string;
   timeZone: string;
   originalTotalCents: number;
+  fundTransferStatus: string;
   segments: UkSettlementSegmentDraft[];
 };
 
@@ -363,6 +364,21 @@ function requireEventGroupField(value: string | undefined, field: string, settle
   return value;
 }
 
+function requireFundTransferStatus(value: unknown, settlementId: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing FundTransferStatus for settlement ${settlementId}`);
+  }
+  return value.trim();
+}
+
+function normalizeFundTransferStatus(value: string, settlementId: string): 'Succeeded' | 'Failed' | 'Unknown' {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'succeeded') return 'Succeeded';
+  if (normalized === 'failed') return 'Failed';
+  if (normalized === 'unknown') return 'Unknown';
+  throw new Error(`Unhandled FundTransferStatus for settlement ${settlementId}: ${value}`);
+}
+
 export function buildUkSettlementDraftFromSpApiFinances(input: {
   settlementId: string;
   eventGroupId: string;
@@ -388,6 +404,10 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
     throw new Error(`Missing OriginalTotal for settlement ${input.settlementId}`);
   }
   const originalTotalCents = moneyToCents(originalTotalMoney, 'event group OriginalTotal');
+  const fundTransferStatus = normalizeFundTransferStatus(
+    requireFundTransferStatus(input.eventGroup.FundTransferStatus, input.settlementId),
+    input.settlementId,
+  );
 
   const segments: UkSettlementSegmentDraft[] = splitByMonth
     ? buildMonthlySettlementSegments<UkSettlementAuditRowDraft>({
@@ -944,6 +964,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
     eventGroupId: input.eventGroupId,
     timeZone,
     originalTotalCents,
+    fundTransferStatus,
     segments,
   };
 }
@@ -971,6 +992,7 @@ function postingForNonBank(cents: number): { postingType: 'Debit' | 'Credit'; am
 export function buildQboJournalEntriesFromUkSettlementDraft(input: {
   draft: UkSettlementDraft;
   privateNote: string;
+  settlementControlAccountId: string;
   bankAccountId: string;
   paymentAccountId: string;
   accountIdByMemo: Map<string, string>;
@@ -1003,13 +1025,28 @@ export function buildQboJournalEntriesFromUkSettlementDraft(input: {
       const abs = Math.abs(cents);
       const amount = abs / 100;
 
+      // Amazon uses FundTransferStatus to describe payout success for positive settlements.
+      // Negative settlements are charged to the payment method and typically show FundTransferStatus=Unknown,
+      // but still need a "Payment to Amazon" line so the charge can be matched in QBO.
+      const transferSucceeded = input.draft.fundTransferStatus === 'Succeeded';
+
       if (cents > 0) {
-        lines.push({
-          accountId: input.bankAccountId,
-          postingType: 'Debit',
-          amount,
-          description: 'Transfer to Bank',
-        });
+        if (transferSucceeded) {
+          lines.push({
+            accountId: input.bankAccountId,
+            postingType: 'Debit',
+            amount,
+            description: 'Transfer to Bank',
+          });
+        } else {
+          const description = `Settlement Control (FundTransferStatus=${input.draft.fundTransferStatus})`;
+          lines.push({
+            accountId: input.settlementControlAccountId,
+            postingType: 'Debit',
+            amount,
+            description,
+          });
+        }
       } else {
         lines.push({
           accountId: input.paymentAccountId,

--- a/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
@@ -379,7 +379,7 @@ async function validateUkSettlementCashAccountCurrencies(input: {
   bankAccountId: string;
   paymentAccountId: string;
   homeCurrencyCode: string;
-}): Promise<{ updatedConnection?: QboConnection }> {
+}): Promise<{ updatedConnection?: QboConnection; settlementControlAccountId: string }> {
   const accountsResult = await fetchAccounts(input.connection, { includeInactive: true });
   const accountById = new Map(accountsResult.accounts.map((a) => [a.Id, a]));
 
@@ -411,7 +411,27 @@ async function validateUkSettlementCashAccountCurrencies(input: {
     requireAccountCurrency(input.paymentAccountId, 'Payment to Amazon', expected);
   }
 
-  return { updatedConnection: accountsResult.updatedConnection };
+  const settlementControlMatches = accountsResult.accounts.filter(
+    (account) => account.Name.trim().toLowerCase() === 'plutus settlement control',
+  );
+  if (settlementControlMatches.length !== 1) {
+    throw new Error(
+      `Missing or ambiguous QBO account for settlement control (expected exactly one named \"Plutus Settlement Control\", found ${settlementControlMatches.length})`,
+    );
+  }
+
+  const settlementControl = settlementControlMatches[0]!;
+  const settlementControlCurrency = settlementControl.CurrencyRef?.value
+    ? settlementControl.CurrencyRef.value.trim().toUpperCase()
+    : '';
+  const expectedControlCurrency = input.homeCurrencyCode.trim().toUpperCase();
+  if (settlementControlCurrency === '' || settlementControlCurrency !== expectedControlCurrency) {
+    throw new Error(
+      `Settlement control account currency mismatch: expected ${expectedControlCurrency}, got ${settlementControlCurrency} (${settlementControl.Name} / ${settlementControl.Id})`,
+    );
+  }
+
+  return { updatedConnection: accountsResult.updatedConnection, settlementControlAccountId: settlementControl.Id };
 }
 
 export async function syncUkSettlementsFromSpApiFinances(input: UkSpApiSettlementSyncInput): Promise<UkSpApiSettlementSyncResult> {
@@ -524,7 +544,7 @@ export async function syncUkSettlementsFromSpApiFinances(input: UkSpApiSettlemen
       splitByMonth,
     });
 
-    if (draft.originalTotalCents > 0) needBankAccount = true;
+    if (draft.originalTotalCents > 0 && draft.fundTransferStatus === 'Succeeded') needBankAccount = true;
     if (draft.originalTotalCents < 0) needPaymentAccount = true;
 
     for (const segment of draft.segments) {
@@ -584,6 +604,7 @@ export async function syncUkSettlementsFromSpApiFinances(input: UkSpApiSettlemen
   if (currencyValidation.updatedConnection) {
     activeConnection = currencyValidation.updatedConnection;
   }
+  const settlementControlAccountId = currencyValidation.settlementControlAccountId;
 
   const exchangeRateByTxnDate = new Map<string, number>();
   if (homeCurrencyCode !== 'GBP') {
@@ -670,6 +691,7 @@ export async function syncUkSettlementsFromSpApiFinances(input: UkSpApiSettlemen
     const jeDrafts = buildQboJournalEntriesFromUkSettlementDraft({
       draft: bundle.draft,
       privateNote: `Plutus (SP-API Finances) | Region: UK | Settlement: ${bundle.settlementId} | Group: ${bundle.eventGroupId}${upload ? ` | Upload: ${upload.id}` : ''}`,
+      settlementControlAccountId,
       bankAccountId: mapping.bankAccountId,
       paymentAccountId: mapping.paymentAccountId,
       accountIdByMemo: mapping.accountIdByMemo,

--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -41,6 +41,7 @@ export type UsSettlementDraft = {
   eventGroupId: string;
   timeZone: string;
   originalTotalCents: number;
+  fundTransferStatus: string;
   segments: UsSettlementSegmentDraft[];
 };
 
@@ -72,6 +73,21 @@ function requirePostedDate(value: string | undefined, context: string): string {
     throw new Error(`Missing PostedDate for ${context}`);
   }
   return value;
+}
+
+function requireFundTransferStatus(value: unknown, settlementId: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing FundTransferStatus for settlement ${settlementId}`);
+  }
+  return value.trim();
+}
+
+function normalizeFundTransferStatus(value: string, settlementId: string): 'Succeeded' | 'Failed' | 'Unknown' {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'succeeded') return 'Succeeded';
+  if (normalized === 'failed') return 'Failed';
+  if (normalized === 'unknown') return 'Unknown';
+  throw new Error(`Unhandled FundTransferStatus for settlement ${settlementId}: ${value}`);
 }
 
 function brandNameForSku(skuRaw: string, skuToBrandName: Map<string, string>): string {
@@ -232,6 +248,10 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
     throw new Error(`Missing OriginalTotal for settlement ${input.settlementId}`);
   }
   const originalTotalCents = moneyToCents(originalTotalMoney, 'event group OriginalTotal');
+  const fundTransferStatus = normalizeFundTransferStatus(
+    requireFundTransferStatus(input.eventGroup.FundTransferStatus, input.settlementId),
+    input.settlementId,
+  );
 
   const segments: UsSettlementSegmentDraft[] = splitByMonth
     ? buildMonthlySettlementSegments<UsSettlementAuditRowDraft>({
@@ -650,6 +670,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
     eventGroupId: input.eventGroupId,
     timeZone,
     originalTotalCents,
+    fundTransferStatus,
     segments,
   };
 }
@@ -677,6 +698,7 @@ function postingForNonBank(cents: number): { postingType: 'Debit' | 'Credit'; am
 export function buildQboJournalEntriesFromUsSettlementDraft(input: {
   draft: UsSettlementDraft;
   privateNote: string;
+  settlementControlAccountId: string;
   bankAccountId: string;
   paymentAccountId: string;
   accountIdByMemo: Map<string, string>;
@@ -709,13 +731,28 @@ export function buildQboJournalEntriesFromUsSettlementDraft(input: {
       const abs = Math.abs(cents);
       const amount = abs / 100;
 
+      // Amazon uses FundTransferStatus to describe payout success for positive settlements.
+      // Negative settlements are charged to the payment method and typically show FundTransferStatus=Unknown,
+      // but still need a "Payment to Amazon" line so the charge can be matched in QBO.
+      const transferSucceeded = input.draft.fundTransferStatus === 'Succeeded';
+
       if (cents > 0) {
-        lines.push({
-          accountId: input.bankAccountId,
-          postingType: 'Debit',
-          amount,
-          description: 'Transfer to Bank',
-        });
+        if (transferSucceeded) {
+          lines.push({
+            accountId: input.bankAccountId,
+            postingType: 'Debit',
+            amount,
+            description: 'Transfer to Bank',
+          });
+        } else {
+          const description = `Settlement Control (FundTransferStatus=${input.draft.fundTransferStatus})`;
+          lines.push({
+            accountId: input.settlementControlAccountId,
+            postingType: 'Debit',
+            amount,
+            description,
+          });
+        }
       } else {
         lines.push({
           accountId: input.paymentAccountId,

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -374,7 +374,7 @@ async function validateUsSettlementCashAccountCurrencies(input: {
   needPaymentAccount: boolean;
   bankAccountId: string;
   paymentAccountId: string;
-}): Promise<{ updatedConnection?: QboConnection }> {
+}): Promise<{ updatedConnection?: QboConnection; settlementControlAccountId: string }> {
   const accountsResult = await fetchAccounts(input.connection, { includeInactive: true });
   const accountById = new Map(accountsResult.accounts.map((a) => [a.Id, a]));
 
@@ -402,7 +402,26 @@ async function validateUsSettlementCashAccountCurrencies(input: {
     requireAccountCurrency(input.paymentAccountId, 'Payment to Amazon');
   }
 
-  return { updatedConnection: accountsResult.updatedConnection };
+  const settlementControlMatches = accountsResult.accounts.filter(
+    (account) => account.Name.trim().toLowerCase() === 'plutus settlement control',
+  );
+  if (settlementControlMatches.length !== 1) {
+    throw new Error(
+      `Missing or ambiguous QBO account for settlement control (expected exactly one named \"Plutus Settlement Control\", found ${settlementControlMatches.length})`,
+    );
+  }
+
+  const settlementControl = settlementControlMatches[0]!;
+  const settlementControlCurrency = settlementControl.CurrencyRef?.value
+    ? settlementControl.CurrencyRef.value.trim().toUpperCase()
+    : '';
+  if (settlementControlCurrency === '' || settlementControlCurrency !== 'USD') {
+    throw new Error(
+      `Settlement control account currency mismatch: expected USD, got ${settlementControlCurrency} (${settlementControl.Name} / ${settlementControl.Id})`,
+    );
+  }
+
+  return { updatedConnection: accountsResult.updatedConnection, settlementControlAccountId: settlementControl.Id };
 }
 
 export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlementSyncInput): Promise<UsSpApiSettlementSyncResult> {
@@ -505,7 +524,7 @@ export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlemen
       splitByMonth,
     });
 
-    if (draft.originalTotalCents > 0) needBankAccount = true;
+    if (draft.originalTotalCents > 0 && draft.fundTransferStatus === 'Succeeded') needBankAccount = true;
     if (draft.originalTotalCents < 0) needPaymentAccount = true;
 
     for (const segment of draft.segments) {
@@ -552,6 +571,7 @@ export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlemen
   if (currencyValidation.updatedConnection) {
     activeConnection = currencyValidation.updatedConnection;
   }
+  const settlementControlAccountId = currencyValidation.settlementControlAccountId;
 
   const segments: UsSpApiSettlementSyncSegmentResult[] = [];
 
@@ -617,6 +637,7 @@ export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlemen
     const jeDrafts = buildQboJournalEntriesFromUsSettlementDraft({
       draft: bundle.draft,
       privateNote: `Plutus (SP-API Finances) | Settlement: ${bundle.settlementId} | Group: ${bundle.eventGroupId}${upload ? ` | Upload: ${upload.id}` : ''}`,
+      settlementControlAccountId,
       bankAccountId: mapping.bankAccountId,
       paymentAccountId: mapping.paymentAccountId,
       accountIdByMemo: mapping.accountIdByMemo,

--- a/apps/plutus/lib/plutus/settlement-processing.ts
+++ b/apps/plutus/lib/plutus/settlement-processing.ts
@@ -4,7 +4,6 @@ import {
   deleteJournalEntry,
   fetchAccounts,
   fetchBills,
-  fetchExchangeRate,
   fetchJournalEntryById,
   fetchPreferences,
 } from '@/lib/qbo/api';
@@ -82,6 +81,7 @@ async function resolveExchangeRateForJournalPosting(input: {
   connection: QboConnection;
   txnDate: string;
   currencyCode: 'USD' | 'GBP';
+  preferredExchangeRate?: number;
 }): Promise<{ exchangeRate?: number; updatedConnection?: QboConnection }> {
   const preferencesResult = await fetchPreferences(input.connection);
   let activeConnection = preferencesResult.updatedConnection ? preferencesResult.updatedConnection : input.connection;
@@ -98,17 +98,22 @@ async function resolveExchangeRateForJournalPosting(input: {
     return { updatedConnection: activeConnection === input.connection ? undefined : activeConnection };
   }
 
-  const rateResult = await fetchExchangeRate(activeConnection, {
-    sourceCurrencyCode: txnCurrencyCode,
-    targetCurrencyCode: homeCurrencyCode,
-    asOfDate: input.txnDate,
-  });
-  if (rateResult.updatedConnection) {
-    activeConnection = rateResult.updatedConnection;
+  // Deterministic posting: for foreign currency settlements we must reuse the settlement JE's ExchangeRate.
+  // Otherwise the P&L reclass won't net to zero in home currency (FX drift between JEs).
+  if (input.preferredExchangeRate === undefined) {
+    throw new Error(
+      `Missing ExchangeRate for ${txnCurrencyCode}->${homeCurrencyCode} posting on ${input.txnDate}. Settlement JE ExchangeRate is required.`,
+    );
+  }
+
+  if (!Number.isFinite(input.preferredExchangeRate) || input.preferredExchangeRate <= 0) {
+    throw new Error(
+      `Invalid ExchangeRate for ${txnCurrencyCode}->${homeCurrencyCode} posting on ${input.txnDate}: ${String(input.preferredExchangeRate)}`,
+    );
   }
 
   return {
-    exchangeRate: rateResult.exchangeRate.Rate,
+    exchangeRate: input.preferredExchangeRate,
     updatedConnection: activeConnection === input.connection ? undefined : activeConnection,
   };
 }
@@ -126,6 +131,7 @@ function buildEmptyPreview(input: {
   settlementJournalEntryId: string;
   settlementDocNumber: string;
   settlementPostedDate: string;
+  settlementExchangeRate?: number;
   invoiceId: string;
   processingHash: string;
   minDate: string;
@@ -153,6 +159,7 @@ function buildEmptyPreview(input: {
     settlementJournalEntryId: input.settlementJournalEntryId,
     settlementDocNumber: input.settlementDocNumber,
     settlementPostedDate: input.settlementPostedDate,
+    settlementExchangeRate: input.settlementExchangeRate,
     invoiceId: input.invoiceId,
     processingHash: input.processingHash,
     minDate: input.minDate,
@@ -454,6 +461,7 @@ export async function computeSettlementPreview(input: {
         settlementJournalEntryId: settlement.Id,
         settlementDocNumber: settlement.DocNumber,
         settlementPostedDate: settlement.TxnDate,
+        settlementExchangeRate: settlement.ExchangeRate,
         invoiceId,
         processingHash,
         minDate,
@@ -546,6 +554,7 @@ export async function computeSettlementPreview(input: {
         settlementJournalEntryId: settlement.Id,
         settlementDocNumber: settlement.DocNumber,
         settlementPostedDate: settlement.TxnDate,
+        settlementExchangeRate: settlement.ExchangeRate,
         invoiceId,
         processingHash,
         minDate,
@@ -1132,6 +1141,7 @@ export async function computeSettlementPreview(input: {
     settlementJournalEntryId: settlement.Id,
     settlementDocNumber: settlement.DocNumber,
     settlementPostedDate: settlement.TxnDate,
+    settlementExchangeRate: settlement.ExchangeRate,
     invoiceId,
     processingHash,
     minDate,
@@ -1174,6 +1184,7 @@ export async function processSettlement(input: {
     connection: postingConnection,
     txnDate: computed.preview.settlementPostedDate,
     currencyCode: settlementCurrencyCode,
+    preferredExchangeRate: computed.preview.settlementExchangeRate,
   });
   if (postingRate.updatedConnection) {
     postingConnection = postingRate.updatedConnection;

--- a/apps/plutus/lib/plutus/settlement-types.ts
+++ b/apps/plutus/lib/plutus/settlement-types.ts
@@ -86,6 +86,9 @@ export type SettlementProcessingPreview = {
   settlementJournalEntryId: string;
   settlementDocNumber: string;
   settlementPostedDate: string;
+  // The ExchangeRate from the settlement JE in QBO (when the settlement currency is not the QBO home currency).
+  // We reuse this for posting P&L/COGS JEs so parent-account reclasses net to zero in home currency.
+  settlementExchangeRate?: number;
 
   invoiceId: string;
   processingHash: string;

--- a/apps/plutus/scripts/us-settlement-ingest-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-ingest-spapi.ts
@@ -9,7 +9,15 @@ import {
 import { fromCents } from '@/lib/inventory/money';
 import { stripPlutusDocPrefix } from '@/lib/plutus/settlement-doc-number';
 import { normalizeSku } from '@/lib/plutus/settlement-validation';
-import { createJournalEntry, fetchJournalEntries, fetchJournalEntryById, type QboConnection, type QboJournalEntry } from '@/lib/qbo/api';
+import {
+  createJournalEntry,
+  fetchAccounts,
+  fetchJournalEntries,
+  fetchJournalEntryById,
+  type QboAccount,
+  type QboConnection,
+  type QboJournalEntry,
+} from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 
 type CliOptions = {
@@ -348,6 +356,27 @@ async function main(): Promise<void> {
     paymentAccountId = found.accountId;
   }
 
+  const accountsResult = await fetchAccounts(connection, { includeInactive: true });
+  if (accountsResult.updatedConnection) connection = accountsResult.updatedConnection;
+  const settlementControlMatches = accountsResult.accounts.filter(
+    (account: QboAccount) => account.Name.trim().toLowerCase() === 'plutus settlement control',
+  );
+  if (settlementControlMatches.length !== 1) {
+    throw new Error(
+      `Missing or ambiguous QBO account for settlement control (expected exactly one named \"Plutus Settlement Control\", found ${settlementControlMatches.length})`,
+    );
+  }
+  const settlementControlAccount = settlementControlMatches[0]!;
+  const settlementControlCurrency = settlementControlAccount.CurrencyRef?.value
+    ? settlementControlAccount.CurrencyRef.value.trim().toUpperCase()
+    : '';
+  if (settlementControlCurrency === '' || settlementControlCurrency !== 'USD') {
+    throw new Error(
+      `Settlement control account currency mismatch: expected USD, got ${settlementControlCurrency} (${settlementControlAccount.Name} / ${settlementControlAccount.Id})`,
+    );
+  }
+  const settlementControlAccountId = settlementControlAccount.Id;
+
   const postedAfterIso = `${options.startDate}T00:00:00.000Z`;
   const postedBeforeIso = new Date(Date.now() - 5 * 60 * 1000).toISOString();
 
@@ -393,6 +422,7 @@ async function main(): Promise<void> {
     const jeDrafts = buildQboJournalEntriesFromUsSettlementDraft({
       draft,
       privateNote: `Plutus (SP-API Finances) | Settlement: ${settlementId} | Group: ${eventGroupId}`,
+      settlementControlAccountId,
       bankAccountId,
       paymentAccountId,
       accountIdByMemo: templateMapping.accountIdByMemo,

--- a/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
@@ -9,7 +9,7 @@ import {
 import type { SpApiFinancialEvents } from '@/lib/amazon-finances/types';
 import { normalizeSku } from '@/lib/plutus/settlement-validation';
 import { isSettlementDocNumber, parseSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
-import { fetchJournalEntries, fetchJournalEntryById, type QboConnection, type QboJournalEntry } from '@/lib/qbo/api';
+import { fetchAccounts, fetchJournalEntries, fetchJournalEntryById, type QboAccount, type QboConnection, type QboJournalEntry } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 
 type CliOptions = {
@@ -472,6 +472,7 @@ async function main(): Promise<void> {
       const accountIdByMemo = new Map<string, string>();
       let bankAccountId = '';
       let paymentAccountId = '';
+      let settlementControlAccountId = '';
 
       for (const line of actualLines) {
         if (line.description === 'Transfer to Bank') {
@@ -482,15 +483,35 @@ async function main(): Promise<void> {
           paymentAccountId = line.accountId;
           continue;
         }
+        if (line.description.startsWith('Settlement Control (FundTransferStatus=')) {
+          settlementControlAccountId = line.accountId;
+          continue;
+        }
         if (!accountIdByMemo.has(line.description)) {
           accountIdByMemo.set(line.description, line.accountId);
         }
       }
 
+      if (settlementControlAccountId === '') {
+        // Resolve via chart of accounts in case the settlement didn't use it.
+        const accountsResult = await fetchAccounts(connection, { includeInactive: true });
+        if (accountsResult.updatedConnection) connection = accountsResult.updatedConnection;
+        const matches = accountsResult.accounts.filter(
+          (a: QboAccount) => a.Name.trim().toLowerCase() === 'plutus settlement control',
+        );
+        if (matches.length !== 1) {
+          throw new Error(
+            `Missing or ambiguous QBO account for settlement control (expected exactly one named \"Plutus Settlement Control\", found ${matches.length})`,
+          );
+        }
+        settlementControlAccountId = matches[0]!.Id;
+      }
+
       const isLast = segmentIdx === draft.segments.length - 1;
       const originalTotalCents = isLast ? draft.originalTotalCents : 0;
+      const transferSucceeded = draft.fundTransferStatus === 'Succeeded';
 
-      if (isLast && originalTotalCents > 0 && bankAccountId === '') {
+      if (isLast && transferSucceeded && originalTotalCents > 0 && bankAccountId === '') {
         throw new Error(`Missing 'Transfer to Bank' line in ${segment.docNumber}`);
       }
       if (isLast && originalTotalCents < 0 && paymentAccountId === '') {
@@ -504,6 +525,7 @@ async function main(): Promise<void> {
           segments: [segment],
         },
         privateNote: 'Plutus reconcile (SP-API Finances)',
+        settlementControlAccountId,
         bankAccountId,
         paymentAccountId,
         accountIdByMemo,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -360,6 +360,7 @@ test('buildUsSettlementDraftFromSpApiFinances preserves cross-month settlement p
     eventGroup: {
       FinancialEventGroupStart: '2025-12-19T08:00:00.000Z',
       FinancialEventGroupEnd: '2026-01-02T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
       OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -1 },
     },
     events: {
@@ -391,6 +392,7 @@ test('buildUsSettlementDraftFromSpApiFinances can split multi-month settlements 
     eventGroup: {
       FinancialEventGroupStart: '2025-12-19T08:00:00.000Z',
       FinancialEventGroupEnd: '2026-02-02T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
       OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -3 },
     },
     events: {
@@ -448,6 +450,7 @@ test('buildUkSettlementDraftFromSpApiFinances can split multi-month settlements 
     eventGroup: {
       FinancialEventGroupStart: '2025-12-19T00:00:00.000Z',
       FinancialEventGroupEnd: '2026-02-02T00:00:00.000Z',
+      FundTransferStatus: 'Unknown',
       OriginalTotal: { CurrencyCode: 'GBP', CurrencyAmount: -3 },
     },
     events: {
@@ -505,6 +508,7 @@ test('buildUkSettlementDraftFromSpApiFinances validates marketplace VAT at order
     eventGroup: {
       FinancialEventGroupStart: '2026-01-16T00:00:00.000Z',
       FinancialEventGroupEnd: '2026-01-16T23:59:59.000Z',
+      FundTransferStatus: 'Unknown',
       OriginalTotal: { CurrencyCode: 'GBP', CurrencyAmount: 30 },
     },
     events: {
@@ -560,6 +564,7 @@ test('buildUkSettlementDraftFromSpApiFinances validates marketplace VAT at order
     eventGroup: {
       FinancialEventGroupStart: '2026-01-16T00:00:00.000Z',
       FinancialEventGroupEnd: '2026-01-16T23:59:59.000Z',
+      FundTransferStatus: 'Unknown',
       OriginalTotal: { CurrencyCode: 'GBP', CurrencyAmount: -30 },
     },
     events: {
@@ -616,6 +621,7 @@ test('buildUkSettlementDraftFromSpApiFinances still fails aggregate VAT mismatch
       eventGroup: {
         FinancialEventGroupStart: '2026-01-16T00:00:00.000Z',
         FinancialEventGroupEnd: '2026-01-16T23:59:59.000Z',
+        FundTransferStatus: 'Unknown',
         OriginalTotal: { CurrencyCode: 'GBP', CurrencyAmount: 20 },
       },
       events: {


### PR DESCRIPTION
## What
- Require and normalize SP-API `FundTransferStatus` for settlements.
- Only debit the bank account for positive settlements when `FundTransferStatus=Succeeded`; otherwise debit **Plutus Settlement Control** (prevents fake bank transfers for pending/failed payouts).
- Reuse the settlement JE `ExchangeRate` when posting the P&L/COGS processing JEs to eliminate FX drift between related JEs.
- Validate **Plutus Settlement Control** account exists exactly once and has the expected currency (fail hard on ambiguity/mismatch).

## Why
- Keeps settlement postings matchable/reconcilable in QBO and prevents silent inconsistencies.
- Ensures deterministic financial outputs (no exchange-rate lookup fallbacks).

## Tests
- pnpm -C apps/plutus lint
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus test
