### PR TITLE
fix(kairos): harden Kairos ML watchdog health checks [claude]

### DIFF
--- a/scripts/targonos-host-watchdog.sh
+++ b/scripts/targonos-host-watchdog.sh
@@ -121,6 +121,27 @@ ensure_pm2_processes_healthy() {
   done
 }
 
+ensure_pm2_http_endpoint_healthy() {
+  local pm_name="$1"
+  local url="$2"
+
+  if check_http_not_5xx "$url"; then
+    return 0
+  fi
+
+  log "pm2 restarting: ${pm_name} (endpoint unhealthy: ${url})"
+  pm2 restart "$pm_name" --update-env >/dev/null
+
+  sleep 3
+
+  check_http_not_5xx "$url"
+}
+
+ensure_internal_services_healthy() {
+  ensure_pm2_http_endpoint_healthy "main-kairos-ml" "http://127.0.0.1:3011/healthz" || exit 1
+  ensure_pm2_http_endpoint_healthy "dev-kairos-ml" "http://127.0.0.1:3111/healthz" || exit 1
+}
+
 check_http_not_5xx() {
   local url="$1"
   local code rc
@@ -246,6 +267,7 @@ main() {
   ensure_pm2_alive
   ensure_no_deploy_lock
   ensure_pm2_processes_healthy
+  ensure_internal_services_healthy
   check_nginx_routes
 }
 


### PR DESCRIPTION
This change hardens the host watchdog so Kairos ML is treated as a real health dependency instead of only trusting PM2 process state.

The issue behind this work was that `main-kairos-ml` could appear `online` in PM2 while the service was not actually listening on `127.0.0.1:3011`. In that state, the main Kairos app was up, but forecast runs that depend on the Python ML backend could fail even though the usual app-level checks still looked healthy.

The root cause was that our watchdog only verified PM2 status for the internal ML process and then checked nginx-backed Next.js routes. It never made an HTTP request to the Kairos ML service itself, so a missing or broken runtime could slip through without an automatic restart.

This fix adds an internal service health check path for both `main-kairos-ml` and `dev-kairos-ml`. The watchdog now probes each service's `/healthz` endpoint, restarts the PM2 process when that endpoint is unhealthy, waits briefly, and verifies the endpoint again before continuing. That closes the gap between "PM2 says online" and "the service is actually serving requests."

I validated the change by syntax-checking the watchdog script with `bash -n scripts/targonos-host-watchdog.sh`, running the watchdog end to end with `bash scripts/targonos-host-watchdog.sh`, and rechecking the local main app ports afterward. I also verified that `http://127.0.0.1:3011/healthz` returned `200` once the Kairos ML runtime was restored.
