### PR TITLE
[codex] preserve talos owner grants during hardening

### DIFF
--- a/scripts/db/portal-hardening.sql
+++ b/scripts/db/portal-hardening.sql
@@ -5,7 +5,6 @@ SELECT set_config('portal.external_role', :'external_role', false);
 DO $do$
 DECLARE
   external_role text := current_setting('portal.external_role');
-  talos_role text := 'portal_talos';
   schema_record record;
   relation_record record;
   type_record record;
@@ -105,28 +104,13 @@ BEGIN
       );
     END LOOP;
 
+    -- FK checks can execute under the owning role; keep owner access explicit.
+    EXECUTE format('GRANT USAGE ON SCHEMA %I TO %I', schema_record.schema_name, schema_record.owner_role);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I TO %I', schema_record.schema_name, schema_record.owner_role);
+    EXECUTE format('GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I TO %I', schema_record.schema_name, schema_record.owner_role);
+    EXECUTE format('GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA %I TO %I', schema_record.schema_name, schema_record.owner_role);
     EXECUTE format('REVOKE CREATE ON SCHEMA %I FROM %I', schema_record.schema_name, external_role);
   END LOOP;
-
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = talos_role) THEN
-    FOR schema_record IN
-      SELECT m.schema_name
-      FROM (
-        VALUES
-          ('dev_talos_us'),
-          ('dev_talos_uk'),
-          ('main_talos_us'),
-          ('main_talos_uk')
-      ) AS m(schema_name)
-      JOIN pg_namespace n ON n.nspname = m.schema_name
-    LOOP
-      EXECUTE format('REVOKE USAGE ON SCHEMA %I FROM %I', schema_record.schema_name, talos_role);
-      EXECUTE format('REVOKE CREATE ON SCHEMA %I FROM %I', schema_record.schema_name, talos_role);
-      EXECUTE format('REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I FROM %I', schema_record.schema_name, talos_role);
-      EXECUTE format('REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I FROM %I', schema_record.schema_name, talos_role);
-      EXECUTE format('REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA %I FROM %I', schema_record.schema_name, talos_role);
-    END LOOP;
-  END IF;
 
   EXECUTE format('REVOKE CREATE ON DATABASE %I FROM %I', current_database(), external_role);
   EXECUTE format('REVOKE CREATE ON SCHEMA public FROM %I', external_role);


### PR DESCRIPTION
This fixes a Talos dev-database hardening regression that was breaking UK warehouse configuration writes.

The user-visible effect was that authenticated Talos requests against `dev_talos_uk` could read data, but inserts into `cost_rates` and `warehouse_sku_storage_configs`, plus deletes on `users`, failed during foreign-key checks with `permission denied for schema/table` errors. In practice this blocked Ahmad's warehouse creation and related config work in the UK tenant.

The root cause was in `scripts/db/portal-hardening.sql`. The script correctly normalized Talos object ownership to `portal_talos`, but then explicitly revoked schema, table, sequence, and function privileges from that same owner role for Talos schemas. PostgreSQL foreign-key checks were executing in that owner context, so the owner-role privilege removal caused FK validation to fail even though `portal_dev_external` had direct DML grants.

The fix keeps explicit owner access in place for each schema after ownership normalization by granting the owner role usage on the schema, all privileges on tables and sequences, and execute on functions. It also removes the special-case block that revoked Talos privileges from `portal_talos`, since that block was the regression source.

Validation was done in three layers. First, I reapplied the hardening SQL to `portal_db_dev` and ran the portal ownership audit successfully. Second, I reproduced the previously failing database operations as `portal_dev_external` and confirmed they now succeed: insert into `dev_talos_uk.cost_rates`, insert into `dev_talos_uk.warehouse_sku_storage_configs`, and delete from `dev_talos_uk.users`. Third, I verified the live Talos app flow on a local bypass-auth dev server in the UK tenant by calling `/api/warehouses/uk-warehouse-001/storage-config`, updating a real SKU storage config, confirming the new values persisted, and then reverting them cleanly.
