### PR TITLE
fix(website): swap 1 Pack and 3 Pack product images [claude]

### DIFF
--- a/apps/website/src/content/products.ts
+++ b/apps/website/src/content/products.ts
@@ -177,7 +177,7 @@ export const products: Product[] = [
       { label: 'Durability', value: 'Strong' },
       { label: 'Material', value: 'LDPE (plastic sheeting)' }
     ],
-    image: { src: '/images/products/dust-core-1pk.webp', alt: 'CS 1 Pack Extra Large Dust Sheet by Caelum Star' },
+    image: { src: '/images/products/dust-basic-3pk.webp', alt: 'CS 1 Pack Extra Large Dust Sheet by Caelum Star' },
     gallery: [
       {
         src: '/images/amazon/uk/1pk-strong-lifestyle.webp',
@@ -216,7 +216,7 @@ export const products: Product[] = [
       { label: 'Durability', value: 'Standard' },
       { label: 'Material', value: 'LDPE (plastic sheeting)' }
     ],
-    image: { src: '/images/products/dust-basic-3pk.webp', alt: 'CS 3 Pack Extra Large Dust Sheets by Caelum Star' },
+    image: { src: '/images/products/dust-core-1pk.webp', alt: 'CS 3 Pack Extra Large Dust Sheets by Caelum Star' },
     gallery: [
       {
         src: '/images/amazon/uk/3pk-standard-lifestyle.webp',
@@ -341,7 +341,7 @@ export const productsUK: Product[] = [
       { label: 'Durability', value: 'Strong' },
       { label: 'Material', value: 'LDPE (plastic sheeting)' }
     ],
-    image: { src: '/images/products/dust-core-1pk.webp', alt: 'CS 1 Pack Extra Large Dust Sheet by Caelum Star' },
+    image: { src: '/images/products/dust-basic-3pk.webp', alt: 'CS 1 Pack Extra Large Dust Sheet by Caelum Star' },
     gallery: [
       {
         src: '/images/amazon/uk/1pk-strong-lifestyle.webp',
@@ -377,7 +377,7 @@ export const productsUK: Product[] = [
       { label: 'Durability', value: 'Standard' },
       { label: 'Material', value: 'LDPE (plastic sheeting)' }
     ],
-    image: { src: '/images/products/dust-basic-3pk.webp', alt: 'CS 3 Pack Extra Large Dust Sheets by Caelum Star' },
+    image: { src: '/images/products/dust-core-1pk.webp', alt: 'CS 3 Pack Extra Large Dust Sheets by Caelum Star' },
     gallery: [
       {
         src: '/images/amazon/uk/3pk-standard-lifestyle.webp',


### PR DESCRIPTION
## Summary
- 1 Pack card was showing the 3 Pack box image and vice versa
- Swapped image sources between the two products in both US and UK arrays

## Test plan
- [ ] Check /caelum-star/products — 1 Pack shows single sheet box, 3 Pack shows 3-sheet box
- [ ] Check /caelum-star/where-to-buy — same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)