### PR TITLE
fix(website): prevent email text overflow on support page card [claude]

### DIFF
--- a/apps/website/src/app/support/page.tsx
+++ b/apps/website/src/app/support/page.tsx
@@ -152,9 +152,9 @@ export default async function SupportPage({ searchParams }: { searchParams: Prom
                   The fastest way to reach us. We typically respond within 24 hours.
                 </p>
                 <div className="mt-auto pt-8">
-                  <Button asChild variant="accent" size="lg" className="cs-btn-glow w-full">
+                  <Button asChild variant="accent" size="lg" className="cs-btn-glow w-full overflow-hidden">
                     <a href={`mailto:${site.contactEmail}`}>
-                      {site.contactEmail} <ArrowUpRight className="h-4 w-4" />
+                      <span className="truncate">{site.contactEmail}</span> <ArrowUpRight className="h-4 w-4 shrink-0" />
                     </a>
                   </Button>
                   <p className="mt-3 text-center text-xs text-white/35">


### PR DESCRIPTION
## Summary
- Added `overflow-hidden` to the email button and `truncate` to the email text on the support page to prevent the long email address from overflowing its container
- Added `shrink-0` to the arrow icon so it doesn't get squeezed

## Test plan
- [ ] Visit the support page and verify the email button text stays within bounds on all screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)