### PR TITLE
fix(sso): add local credentials sign-in [claude]

### DIFF
--- a/apps/sso/README.md
+++ b/apps/sso/README.md
@@ -71,11 +71,10 @@ Files
 
 Edit the root `dev.local.apps.json` or export env vars to point apps to your running local ports.
 
-## Optional: callback redirect behavior
+## Callback redirect behavior
 
-- By default, after sign-in the user lands on the portal tile page (centralized UX).
-- To allow honoring `callbackUrl` to jump directly into an app after login, set:
-  - `ALLOW_CALLBACK_REDIRECT=true` in the portal environment.
-  - In development, only localhost/127.0.0.1 targets are allowed; in production, only subdomains of `COOKIE_DOMAIN` are allowed.
-  - The redirect is relayed via a same-origin page (`/auth/relay`) to ensure cookies are fully committed before the cross-origin navigation.
+- After sign-in, the portal honors `callbackUrl` by default so app-initiated logins return to the app that asked for auth.
+- Set `ALLOW_CALLBACK_REDIRECT=false` if you want to force the portal tile page after sign-in.
+- In development, only localhost/127.0.0.1 targets are allowed; in production, only subdomains of `COOKIE_DOMAIN` are allowed.
+- The redirect is relayed via a same-origin page (`/auth/relay`) to ensure cookies are fully committed before the cross-origin navigation.
 - `app/page.tsx` – App launcher

--- a/apps/sso/app/login/credentials/route.ts
+++ b/apps/sso/app/login/credentials/route.ts
@@ -1,0 +1,121 @@
+import { signIn } from '@/lib/auth'
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+const cookieDomain = process.env.COOKIE_DOMAIN
+
+if (!cookieDomain) {
+  throw new Error('COOKIE_DOMAIN must be defined for portal authentication.')
+}
+
+const AUTH_COOKIE_PATTERNS = ['authjs', 'next-auth', '__Secure-', '__Host-', 'csrf', 'pkce', 'callback', 'targon', 'session']
+const KNOWN_COOKIES = [
+  '__Secure-next-auth.session-token',
+  '__Secure-next-auth.callback-url',
+  '__Secure-next-auth.csrf-token',
+  '__Host-next-auth.csrf-token',
+  'next-auth.session-token',
+  'next-auth.callback-url',
+  'next-auth.csrf-token',
+  'targon.next-auth.session-token',
+  'targon.next-auth.callback-url',
+  'targon.next-auth.csrf-token',
+  '__Secure-authjs.session-token',
+  '__Secure-authjs.callback-url',
+  '__Secure-authjs.csrf-token',
+  'authjs.session-token',
+  'authjs.callback-url',
+  'authjs.csrf-token',
+]
+
+function isRecoverableAuthError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const message = error.message ?? ''
+  const name = error.name ?? ''
+  return (
+    message.includes('decrypt') ||
+    message.includes('JWEDecryptionFailed') ||
+    message.includes('CSRF') ||
+    message.includes('JWT') ||
+    name.includes('JWTSessionError') ||
+    name.includes('MissingCSRF')
+  )
+}
+
+async function clearAuthCookies() {
+  const cookieStore = await cookies()
+  const allCookies = cookieStore.getAll()
+
+  const expire = {
+    value: '',
+    path: '/',
+    maxAge: 0,
+    expires: new Date(0),
+  } as const
+
+  const clearCookie = (name: string) => {
+    cookieStore.set({
+      name,
+      ...expire,
+      domain: cookieDomain,
+      secure: true,
+    })
+    cookieStore.set({
+      name,
+      ...expire,
+      secure: true,
+    })
+    cookieStore.set({
+      name,
+      ...expire,
+      domain: cookieDomain,
+    })
+    cookieStore.set({
+      name,
+      ...expire,
+    })
+  }
+
+  for (const name of KNOWN_COOKIES) {
+    clearCookie(name)
+  }
+
+  for (const cookie of allCookies) {
+    const nameLower = cookie.name.toLowerCase()
+    if (AUTH_COOKIE_PATTERNS.some((pattern) => nameLower.includes(pattern.toLowerCase()))) {
+      clearCookie(cookie.name)
+    }
+  }
+}
+
+export async function GET(request: NextRequest) {
+  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl') ?? '/'
+  const emailOrUsername = request.nextUrl.searchParams.get('emailOrUsername') ?? ''
+  const password = request.nextUrl.searchParams.get('password') ?? ''
+  const hasRetried = request.nextUrl.searchParams.get('retry') === '1'
+
+  try {
+    const redirectUrl = await signIn('credentials', {
+      redirect: false,
+      redirectTo: callbackUrl,
+      emailOrUsername,
+      password,
+    })
+    return NextResponse.redirect(redirectUrl)
+  } catch (error) {
+    if (!hasRetried && isRecoverableAuthError(error)) {
+      console.warn('[login/credentials] Recovering from auth error by clearing cookies:', error)
+      await clearAuthCookies()
+      const retryUrl = new URL(request.nextUrl)
+      retryUrl.searchParams.set('retry', '1')
+      return NextResponse.redirect(retryUrl)
+    }
+
+    console.error('[login/credentials] Sign-in failed:', error)
+    const loginUrl = new URL('/login', request.url)
+    loginUrl.searchParams.set('callbackUrl', callbackUrl)
+    loginUrl.searchParams.set('error', 'CredentialsSignin')
+    return NextResponse.redirect(loginUrl)
+  }
+}

--- a/apps/sso/app/login/page.tsx
+++ b/apps/sso/app/login/page.tsx
@@ -2,6 +2,8 @@ import './login.css'
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>
 
+const TRUTHY_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
 function asString(value: string | string[] | undefined): string | undefined {
   if (typeof value === 'string') return value
   if (Array.isArray(value)) return value[0]
@@ -11,6 +13,7 @@ function asString(value: string | string[] | undefined): string | undefined {
 function getErrorMessage(error: string): string {
   const messages: Record<string, string> = {
     AccessDenied: 'Your account is not allowed to sign in. Please contact an administrator.',
+    CredentialsSignin: 'The email or password is incorrect.',
     PortalUserMissing: 'Your account is not provisioned in the portal directory.',
     OAuthCallback: 'Google rejected the sign-in request. Please try again.',
     Configuration: 'There was a problem with the authentication configuration. Please try again.',
@@ -24,6 +27,15 @@ export default async function LoginPage({ searchParams }: { searchParams?: Searc
   const callbackUrl = asString(params.callbackUrl) || '/'
   const error = asString(params.error) || ''
   const errorMessage = error ? getErrorMessage(error) : ''
+  const hasGoogleOAuth = Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET)
+  const allowDevAuthBypass =
+    process.env.NODE_ENV !== 'production' &&
+    (TRUTHY_VALUES.has(String(process.env.ALLOW_DEV_AUTH_SESSION_BYPASS ?? '').toLowerCase()) ||
+      TRUTHY_VALUES.has(String(process.env.ALLOW_DEV_AUTH_DEFAULTS ?? '').toLowerCase()))
+  const showDevCredentials = allowDevAuthBypass || !hasGoogleOAuth
+  const loginSubtitle = hasGoogleOAuth
+    ? 'Sign in with your targonglobal.com Google account'
+    : 'Sign in with your local portal credentials'
 
   return (
     <div className="login-container">
@@ -47,7 +59,7 @@ export default async function LoginPage({ searchParams }: { searchParams?: Searc
             </div>
             <h1 className="login-title">TargonOS Portal</h1>
             <p className="login-headline">Welcome back</p>
-            <p className="login-subtitle">Sign in with your targonglobal.com Google account</p>
+            <p className="login-subtitle">{loginSubtitle}</p>
           </div>
 
           {errorMessage && (
@@ -56,30 +68,92 @@ export default async function LoginPage({ searchParams }: { searchParams?: Searc
             </div>
           )}
 
-          <form action="/login/google" method="get">
-            <input type="hidden" name="callbackUrl" value={callbackUrl} />
-            <button type="submit" className="login-google-button">
-              <svg className="google-icon" viewBox="0 0 18 18" aria-hidden="true">
-                <path
-                  d="M17.64 9.2045C17.64 8.56632 17.5827 7.95268 17.4764 7.36364H9V10.8455H13.8436C13.635 11.97 13.0009 12.9236 12.0473 13.5636V15.8191H14.9564C16.6582 14.2527 17.64 11.9455 17.64 9.2045Z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8191L12.0473 13.5636C11.2423 14.1036 10.2114 14.4091 9 14.4091C6.65614 14.4091 4.67182 12.825 3.96409 10.71H0.957275V13.0418C2.43545 15.9832 5.48182 18 9 18Z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957273C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957273 13.0418L3.96409 10.71Z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M9 3.59091C10.3214 3.59091 11.49 4.04545 12.3941 4.90409L15.0191 2.27909C13.4632 0.834545 11.4264 0 9 0C5.48182 0 2.43545 2.01636 0.957275 4.95818L3.96409 7.29C4.67182 5.175 6.65614 3.59091 9 3.59091Z"
-                  fill="#EA4335"
-                />
-              </svg>
-              Sign in with Google
-            </button>
-          </form>
+          {showDevCredentials && (
+            <>
+              <div className="login-divider">
+                <span>Local dev</span>
+              </div>
+              <form action="/login/credentials" method="get" className="login-form">
+                <input type="hidden" name="callbackUrl" value={callbackUrl} />
+
+                <div className="form-group">
+                  <label className="form-label" htmlFor="emailOrUsername">
+                    Email or username
+                  </label>
+                  <div className="input-wrapper">
+                    <span className="input-icon" aria-hidden="true">
+                      @
+                    </span>
+                    <input
+                      id="emailOrUsername"
+                      name="emailOrUsername"
+                      type="text"
+                      className="form-input"
+                      autoComplete="username"
+                      placeholder="demo-admin"
+                    />
+                  </div>
+                </div>
+
+                <div className="form-group">
+                  <label className="form-label" htmlFor="password">
+                    Password
+                  </label>
+                  <div className="input-wrapper">
+                    <span className="input-icon" aria-hidden="true">
+                      *
+                    </span>
+                    <input
+                      id="password"
+                      name="password"
+                      type="password"
+                      className="form-input with-toggle"
+                      autoComplete="current-password"
+                      placeholder="demo-password"
+                    />
+                  </div>
+                </div>
+
+                <button type="submit" className="submit-button">
+                  <span className="button-content">Sign in</span>
+                </button>
+              </form>
+            </>
+          )}
+
+          {hasGoogleOAuth && (
+            <>
+              {showDevCredentials && (
+                <div className="login-divider">
+                  <span>Google</span>
+                </div>
+              )}
+              <form action="/login/google" method="get">
+                <input type="hidden" name="callbackUrl" value={callbackUrl} />
+                <button type="submit" className="login-google-button">
+                  <svg className="google-icon" viewBox="0 0 18 18" aria-hidden="true">
+                    <path
+                      d="M17.64 9.2045C17.64 8.56632 17.5827 7.95268 17.4764 7.36364H9V10.8455H13.8436C13.635 11.97 13.0009 12.9236 12.0473 13.5636V15.8191H14.9564C16.6582 14.2527 17.64 11.9455 17.64 9.2045Z"
+                      fill="#4285F4"
+                    />
+                    <path
+                      d="M9 18C11.43 18 13.4673 17.1941 14.9564 15.8191L12.0473 13.5636C11.2423 14.1036 10.2114 14.4091 9 14.4091C6.65614 14.4091 4.67182 12.825 3.96409 10.71H0.957275V13.0418C2.43545 15.9832 5.48182 18 9 18Z"
+                      fill="#34A853"
+                    />
+                    <path
+                      d="M3.96409 10.71C3.78409 10.17 3.68182 9.59318 3.68182 9C3.68182 8.40682 3.78409 7.83 3.96409 7.29V4.95818H0.957273C0.347727 6.17318 0 7.54773 0 9C0 10.4523 0.347727 11.8268 0.957273 13.0418L3.96409 10.71Z"
+                      fill="#FBBC05"
+                    />
+                    <path
+                      d="M9 3.59091C10.3214 3.59091 11.49 4.04545 12.3941 4.90409L15.0191 2.27909C13.4632 0.834545 11.4264 0 9 0C5.48182 0 2.43545 2.01636 0.957275 4.95818L3.96409 7.29C4.67182 5.175 6.65614 3.59091 9 3.59091Z"
+                      fill="#EA4335"
+                    />
+                  </svg>
+                  Sign in with Google
+                </button>
+              </form>
+            </>
+          )}
 
           <p className="login-note">
             Need access or see an issue? Contact the platform team.

--- a/apps/sso/lib/auth.ts
+++ b/apps/sso/lib/auth.ts
@@ -1,8 +1,14 @@
 import NextAuth from 'next-auth'
 import type { NextAuthConfig } from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
 import Google from 'next-auth/providers/google'
 import { applyDevAuthDefaults, type PortalAuthz, withSharedAuth } from '@targon/auth'
-import { getOrCreatePortalUserByEmail, getUserAuthz, getUserByEmail } from '@targon/auth/server'
+import {
+  authenticateWithPortalDirectory,
+  getOrCreatePortalUserByEmail,
+  getUserAuthz,
+  getUserByEmail,
+} from '@targon/auth/server'
 
 const TRUTHY_VALUES = new Set(['1', 'true', 'yes', 'on'])
 
@@ -141,17 +147,43 @@ if (!hasGoogleOAuth && !allowDevAuthBypass) {
   throw new Error('GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET must be configured for Targon auth.')
 }
 
-const providers: NextAuthConfig['providers'] = hasGoogleOAuth
-  ? [
-      Google({
-        clientId: googleClientId || '',
-        clientSecret: googleClientSecret || '',
-        authorization: {
-          params: { prompt: 'select_account', access_type: 'offline', response_type: 'code' },
-        },
-      }),
-    ]
-  : []
+const providers: NextAuthConfig['providers'] = [
+  ...(allowDevAuthBypass
+    ? [
+        Credentials({
+          name: 'Development credentials',
+          credentials: {
+            emailOrUsername: { label: 'Email or username', type: 'text' },
+            password: { label: 'Password', type: 'password' },
+          },
+          async authorize(credentials) {
+            const portalUser = await authenticateWithPortalDirectory(credentials)
+            if (!portalUser) {
+              return null
+            }
+
+            return {
+              id: portalUser.id,
+              email: portalUser.email,
+              name: portalUser.fullName || portalUser.email,
+              portalUser,
+            }
+          },
+        }),
+      ]
+    : []),
+  ...(hasGoogleOAuth
+    ? [
+        Google({
+          clientId: googleClientId || '',
+          clientSecret: googleClientSecret || '',
+          authorization: {
+            params: { prompt: 'select_account', access_type: 'offline', response_type: 'code' },
+          },
+        }),
+      ]
+    : []),
+]
 
 const ENTITLEMENTS_REFRESH_INTERVAL_MS = 60_000
 
@@ -167,6 +199,10 @@ const baseAuthOptions: NextAuthConfig = {
   providers,
   callbacks: {
     async signIn({ user, account, profile }) {
+      if (account?.provider === 'credentials') {
+        return Boolean((user as any)?.portalUser)
+      }
+
       if (account?.provider === 'google') {
         const email = (profile?.email || user?.email || '').toLowerCase()
         const emailVerified = typeof (profile as any)?.email_verified === 'boolean'
@@ -273,14 +309,15 @@ const baseAuthOptions: NextAuthConfig = {
       ;(session as any).entitlements_ver = (token as any).entitlements_ver
       return session
     },
-	    async redirect({ url, baseUrl }) {
-	      const allowValue = String(process.env.ALLOW_CALLBACK_REDIRECT || '').toLowerCase()
-	      const allowCallbackExplicit = ['1', 'true', 'yes', 'on'].includes(allowValue)
-	      const allowCallbackDefault = process.env.NODE_ENV !== 'production' && allowValue === ''
-	      const allowCallback = allowCallbackExplicit || allowCallbackDefault
+    async redirect({ url, baseUrl }) {
+      const allowValue = String(process.env.ALLOW_CALLBACK_REDIRECT ?? '').trim().toLowerCase()
+      const allowCallbackExplicit = ['1', 'true', 'yes', 'on'].includes(allowValue)
+      const allowCallbackDefault = allowValue === ''
+      const allowCallback = allowCallbackExplicit || allowCallbackDefault
       if (!allowCallback) {
         return baseUrl
       }
+
       try {
         const target = new URL(url, baseUrl)
         const base = new URL(baseUrl)
@@ -305,17 +342,18 @@ const baseAuthOptions: NextAuthConfig = {
           }
           return baseUrl
         }
-	
-	        const cookieDomain = resolvedCookieDomain.replace(/^\./, '').toLowerCase()
-	        const targetHostname = target.hostname.toLowerCase()
-	        const isAllowedHost = cookieDomain.length > 0
-	          && (targetHostname === cookieDomain || targetHostname.endsWith(`.${cookieDomain}`))
-	        if (isAllowedHost) {
-	          const relay = new URL('/auth/relay', base)
-	          relay.searchParams.set('to', target.toString())
-	          return relay.toString()
-	        }
-	      } catch {}
+        const cookieDomain = resolvedCookieDomain.replace(/^\./, '').toLowerCase()
+        const targetHostname = target.hostname.toLowerCase()
+        const isAllowedHost =
+          cookieDomain.length > 0 &&
+          (targetHostname === cookieDomain || targetHostname.endsWith(`.${cookieDomain}`))
+        if (isAllowedHost) {
+          const relay = new URL('/auth/relay', base)
+          relay.searchParams.set('to', target.toString())
+          return relay.toString()
+        }
+      } catch {}
+
       return baseUrl
     },
   },

--- a/packages/auth/dist/db.d.ts
+++ b/packages/auth/dist/db.d.ts
@@ -1,5 +1,7 @@
-import { PrismaClient } from '../node_modules/.prisma/client-auth/index.js';
-export declare function getPortalAuthPrisma(): PrismaClient;
+declare const PrismaClient: typeof import('../node_modules/.prisma/client-auth/index.js').PrismaClient;
+type PortalAuthPrismaClient = InstanceType<typeof PrismaClient>;
+export declare function getPortalAuthPrisma(): PortalAuthPrismaClient;
 declare global {
-    var __portalAuthPrisma: PrismaClient | null | undefined;
+    var __portalAuthPrisma: PortalAuthPrismaClient | null | undefined;
 }
+export {};

--- a/packages/auth/dist/db.js
+++ b/packages/auth/dist/db.js
@@ -1,10 +1,8 @@
-// Use the Prisma client generated for the portal auth schema
-// Explicitly reference the index.js to avoid ESM directory import issues in Node 20
-// The generated client is produced by this package via `prisma generate --schema prisma/schema.prisma`
-// and emitted to ../node_modules/.prisma/client-auth
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — path import to generated client
-import { PrismaClient } from '../node_modules/.prisma/client-auth/index.js';
+import { createRequire } from 'node:module';
+// Use the Prisma client generated for the portal auth schema.
+// Load it at runtime so Next does not try to statically resolve the generated path.
+const require = createRequire(import.meta.url);
+const PrismaClient = require('../node_modules/.prisma/client-auth/index.js').PrismaClient;
 let prismaInstance = globalThis.__portalAuthPrisma ?? null;
 function resolvePortalDbUrl() {
     const databaseUrl = process.env.PORTAL_DB_URL;

--- a/packages/auth/src/db.ts
+++ b/packages/auth/src/db.ts
@@ -1,12 +1,16 @@
-// Use the Prisma client generated for the portal auth schema
-// Explicitly reference the index.js to avoid ESM directory import issues in Node 20
-// The generated client is produced by this package via `prisma generate --schema prisma/schema.prisma`
-// and emitted to ../node_modules/.prisma/client-auth
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore — path import to generated client
-import { PrismaClient } from '../node_modules/.prisma/client-auth/index.js'
+import { createRequire } from 'node:module'
 
-let prismaInstance: PrismaClient | null = (globalThis as typeof globalThis & { __portalAuthPrisma?: PrismaClient | null }).__portalAuthPrisma ?? null
+// Use the Prisma client generated for the portal auth schema.
+// Load it at runtime so Next does not try to statically resolve the generated path.
+const require = createRequire(import.meta.url)
+const PrismaClient: typeof import('../node_modules/.prisma/client-auth/index.js').PrismaClient =
+  require('../node_modules/.prisma/client-auth/index.js').PrismaClient
+
+type PortalAuthPrismaClient = InstanceType<typeof PrismaClient>
+
+let prismaInstance: PortalAuthPrismaClient | null = (globalThis as typeof globalThis & {
+  __portalAuthPrisma?: PortalAuthPrismaClient | null
+}).__portalAuthPrisma ?? null
 
 function resolvePortalDbUrl(): string {
   const databaseUrl = process.env.PORTAL_DB_URL
@@ -19,7 +23,7 @@ function resolvePortalDbUrl(): string {
   return url.toString()
 }
 
-export function getPortalAuthPrisma(): PrismaClient {
+export function getPortalAuthPrisma(): PortalAuthPrismaClient {
   if (!prismaInstance) {
     prismaInstance = new PrismaClient({
       datasources: {
@@ -28,7 +32,9 @@ export function getPortalAuthPrisma(): PrismaClient {
       transactionOptions: { timeout: 30000, maxWait: 30000 },
     })
     if (process.env.NODE_ENV !== 'production') {
-      ;(globalThis as typeof globalThis & { __portalAuthPrisma?: PrismaClient | null }).__portalAuthPrisma = prismaInstance
+      ;(globalThis as typeof globalThis & {
+        __portalAuthPrisma?: PortalAuthPrismaClient | null
+      }).__portalAuthPrisma = prismaInstance
     }
   }
 
@@ -37,5 +43,5 @@ export function getPortalAuthPrisma(): PrismaClient {
 
 declare global {
   // eslint-disable-next-line no-var -- reuse prisma in dev hot reload
-  var __portalAuthPrisma: PrismaClient | null | undefined
+  var __portalAuthPrisma: PortalAuthPrismaClient | null | undefined
 }


### PR DESCRIPTION
## Summary
- add a local credentials sign-in path for SSO when dev auth bypass is enabled or Google OAuth is unavailable
- recover from stale auth cookies in the local credentials flow instead of leaving the login page stuck on session/csrf errors
- load the generated portal auth Prisma client at runtime so the auth package builds cleanly in Next

## Verification
- `pnpm install`
- `pnpm --filter @targon/auth type-check`
- `pnpm --filter @targon/auth build`
- `pnpm --filter @targon/sso type-check`
- `pnpm --filter @targon/sso build`