### PR TITLE
Add Argus case brief pages

### DIFF
--- a/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx
+++ b/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx
@@ -1,0 +1,551 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  Box,
+  Divider,
+  GlobalStyles,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+import {
+  readCaseReportBundle,
+  type CaseReportBundle,
+  type CaseReportMarketSlug,
+  type CaseReportRow,
+  type CaseReportSection,
+} from '@/lib/cases/reader';
+
+export const dynamic = 'force-dynamic';
+
+type CaseReportPageProps = {
+  params: Promise<{
+    market: string;
+    reportDate: string;
+  }>;
+};
+
+const MARKET_LINKS = [
+  { slug: 'us', label: 'USA - Dust Sheets' },
+  { slug: 'uk', label: 'UK - Dust Sheets' },
+] as const;
+
+function categoryTone(category: string) {
+  if (category === 'Action due') {
+    return {
+      color: '#9f1d12',
+      tint: 'rgba(191, 36, 27, 0.12)',
+      line: 'rgba(191, 36, 27, 0.35)',
+    };
+  }
+
+  if (category === 'Forum watch') {
+    return {
+      color: '#8f5d00',
+      tint: 'rgba(191, 125, 0, 0.12)',
+      line: 'rgba(191, 125, 0, 0.3)',
+    };
+  }
+
+  if (category === 'New case') {
+    return {
+      color: '#005f73',
+      tint: 'rgba(0, 118, 133, 0.12)',
+      line: 'rgba(0, 118, 133, 0.28)',
+    };
+  }
+
+  return {
+    color: '#0b5c58',
+    tint: 'rgba(0, 194, 185, 0.12)',
+    line: 'rgba(0, 194, 185, 0.26)',
+  };
+}
+
+function summarizeRows(sections: CaseReportSection[]) {
+  const rows = sections.flatMap((section) => section.rows);
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    counts.set(row.category, (counts.get(row.category) ?? 0) + 1);
+  }
+  return {
+    totalRows: rows.length,
+    actionDue: counts.get('Action due') ?? 0,
+    watching: counts.get('Watching') ?? 0,
+    forumWatch: counts.get('Forum watch') ?? 0,
+    newCase: counts.get('New case') ?? 0,
+  };
+}
+
+function formatGeneratedAt(value: string | null): string {
+  if (value === null) {
+    return 'Shared drive state available';
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(parsed);
+}
+
+function DetailBlock({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        minWidth: 0,
+        borderLeft: '1px solid',
+        borderColor: accent ? 'rgba(0, 194, 185, 0.34)' : 'divider',
+        pl: 1.5,
+      }}
+    >
+      <Typography
+        variant="overline"
+        sx={{
+          display: 'block',
+          color: accent ? '#0b5c58' : 'text.secondary',
+          fontSize: '0.66rem',
+          letterSpacing: '0.14em',
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.45,
+          fontSize: '0.95rem',
+          lineHeight: 1.7,
+          color: 'text.primary',
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function MetaItem({
+  label,
+  value,
+  monospace,
+}: {
+  label: string;
+  value: string;
+  monospace?: boolean;
+}) {
+  return (
+    <Box>
+      <Typography
+        variant="overline"
+        sx={{
+          display: 'block',
+          color: 'text.secondary',
+          fontSize: '0.62rem',
+          letterSpacing: '0.14em',
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.25,
+          fontSize: '0.9rem',
+          fontFamily: monospace ? 'var(--font-mono), "JetBrains Mono", monospace' : 'inherit',
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+function CaseRow({
+  row,
+  index,
+}: {
+  row: CaseReportRow;
+  index: number;
+}) {
+  const tone = categoryTone(row.category);
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', md: '210px minmax(0, 1fr)' },
+        gap: { xs: 2, md: 3 },
+        py: 2.75,
+        borderTop: '1px solid',
+        borderColor: alpha('#002c51', 0.08),
+        animation: 'caseBriefRise 560ms cubic-bezier(0.18, 0.8, 0.22, 1) both',
+        animationDelay: `${140 + index * 48}ms`,
+      }}
+    >
+      <Stack
+        spacing={1.25}
+        sx={{
+          pr: { md: 2 },
+        }}
+      >
+        <Box
+          sx={{
+            display: 'inline-flex',
+            alignSelf: 'flex-start',
+            px: 1.3,
+            py: 0.6,
+            borderRadius: 999,
+            bgcolor: tone.tint,
+            color: tone.color,
+            fontSize: '0.76rem',
+            fontWeight: 700,
+            letterSpacing: '0.02em',
+          }}
+        >
+          {row.category}
+        </Box>
+        <MetaItem label="Case ID" value={row.caseId} monospace />
+        <MetaItem label="Days ago" value={row.daysAgo} />
+        <MetaItem label="Status" value={row.status} />
+      </Stack>
+
+      <Stack spacing={1.8} sx={{ minWidth: 0 }}>
+        <Typography
+          sx={{
+            fontSize: { xs: '1.12rem', md: '1.42rem' },
+            lineHeight: 1.08,
+            fontWeight: 700,
+            letterSpacing: '-0.045em',
+            maxWidth: '20ch',
+          }}
+        >
+          {row.issue}
+        </Typography>
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', lg: 'repeat(3, minmax(0, 1fr))' },
+            gap: 2,
+          }}
+        >
+          <DetailBlock label="Evidence" value={row.evidence} />
+          <DetailBlock label="Assessment" value={row.assessment} />
+          <DetailBlock label="Next step" value={row.nextStep} accent />
+        </Box>
+      </Stack>
+    </Box>
+  );
+}
+
+function CaseSection({
+  section,
+  rowOffset,
+}: {
+  section: CaseReportSection;
+  rowOffset: number;
+}) {
+  return (
+    <Box sx={{ mb: 4.5 }}>
+      <Box
+        sx={{
+          position: 'sticky',
+          top: { xs: 74, md: 92 },
+          zIndex: 2,
+          py: 1.1,
+          borderTop: '1px solid',
+          borderBottom: '1px solid',
+          borderColor: alpha('#002c51', 0.12),
+          bgcolor: (theme) => alpha(theme.palette.background.default, 0.9),
+          backdropFilter: 'blur(18px)',
+        }}
+      >
+        <Stack direction="row" justifyContent="space-between" alignItems="center">
+          <Typography
+            variant="overline"
+            sx={{
+              color: 'text.secondary',
+              fontSize: '0.68rem',
+              letterSpacing: '0.18em',
+            }}
+          >
+            {section.entity}
+          </Typography>
+          <Typography sx={{ color: 'text.secondary', fontSize: '0.86rem' }}>
+            {section.rows.length} item{section.rows.length === 1 ? '' : 's'}
+          </Typography>
+        </Stack>
+      </Box>
+
+      {section.rows.map((row, index) => (
+        <CaseRow key={`${section.entity}-${row.caseId}-${index}`} row={row} index={rowOffset + index} />
+      ))}
+    </Box>
+  );
+}
+
+function ReportPage({ bundle }: { bundle: CaseReportBundle }) {
+  const summary = summarizeRows(bundle.sections);
+
+  return (
+    <>
+      <GlobalStyles
+        styles={{
+          '@keyframes caseBriefRise': {
+            '0%': { opacity: 0, transform: 'translate3d(0, 18px, 0)' },
+            '100%': { opacity: 1, transform: 'translate3d(0, 0, 0)' },
+          },
+        }}
+      />
+
+      <Box
+        sx={{
+          position: 'relative',
+          overflow: 'hidden',
+          borderBottom: '1px solid',
+          borderColor: alpha('#002c51', 0.12),
+          pb: 4,
+          mb: 4,
+        }}
+      >
+        <Box
+          sx={{
+            position: 'absolute',
+            inset: 0,
+            pointerEvents: 'none',
+            background:
+              'radial-gradient(circle at top right, rgba(0, 194, 185, 0.16), transparent 28%), linear-gradient(180deg, rgba(0, 44, 81, 0.05), rgba(0, 44, 81, 0))',
+          }}
+        />
+
+        <Stack spacing={3} sx={{ position: 'relative' }}>
+          <Stack
+            direction={{ xs: 'column', xl: 'row' }}
+            justifyContent="space-between"
+            spacing={3}
+            sx={{
+              animation: 'caseBriefRise 620ms cubic-bezier(0.18, 0.8, 0.22, 1) both',
+            }}
+          >
+            <Box sx={{ maxWidth: 760 }}>
+              <Typography
+                variant="overline"
+                sx={{
+                  display: 'block',
+                  color: 'text.secondary',
+                  fontSize: '0.72rem',
+                  letterSpacing: '0.16em',
+                }}
+              >
+                {bundle.marketLabel}
+              </Typography>
+              <Typography
+                sx={{
+                  mt: 1.1,
+                  fontSize: { xs: '2.3rem', md: '3.5rem' },
+                  lineHeight: 0.96,
+                  letterSpacing: '-0.07em',
+                  fontWeight: 700,
+                  fontFamily: '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif',
+                }}
+              >
+                {bundle.reportDate}
+              </Typography>
+              <Typography
+                sx={{
+                  mt: 1.6,
+                  maxWidth: '60ch',
+                  color: 'text.secondary',
+                  fontSize: '1rem',
+                  lineHeight: 1.75,
+                }}
+              >
+                Daily Seller Central case brief rendered from the shared-drive markdown report and
+                machine state. Open the brief from Chat, scan the active issues fast, then drop into
+                the tracked case files only when the narrative says it is worth doing.
+              </Typography>
+            </Box>
+
+            <Stack spacing={1.1} sx={{ minWidth: { xl: 260 } }}>
+              {MARKET_LINKS.map((market) => {
+                const active = market.slug === bundle.marketSlug;
+                return (
+                  <Box
+                    key={market.slug}
+                    component={Link}
+                    href={`/cases/${market.slug}`}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      px: 1.5,
+                      py: 1.15,
+                      borderRadius: 999,
+                      textDecoration: 'none',
+                      border: '1px solid',
+                      borderColor: active ? 'rgba(0, 194, 185, 0.34)' : 'divider',
+                      bgcolor: active ? 'rgba(0, 194, 185, 0.08)' : 'transparent',
+                      color: active ? 'text.primary' : 'text.secondary',
+                      transition: 'background-color 160ms ease, border-color 160ms ease',
+                      '&:hover': {
+                        bgcolor: active ? 'rgba(0, 194, 185, 0.12)' : 'action.hover',
+                      },
+                    }}
+                  >
+                    <Typography sx={{ fontWeight: 600 }}>{market.label}</Typography>
+                    <ArrowOutwardIcon sx={{ fontSize: 18 }} />
+                  </Box>
+                );
+              })}
+            </Stack>
+          </Stack>
+
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: { xs: 'repeat(2, minmax(0, 1fr))', lg: 'repeat(5, minmax(0, 1fr))' },
+              gap: 2,
+              pt: 1,
+              animation: 'caseBriefRise 620ms cubic-bezier(0.18, 0.8, 0.22, 1) both',
+              animationDelay: '120ms',
+            }}
+          >
+            <Metric label="Tracked issues" value={String(summary.totalRows)} />
+            <Metric label="Action due" value={String(summary.actionDue)} accent />
+            <Metric label="Watching" value={String(summary.watching)} />
+            <Metric label="Forum watch" value={String(summary.forumWatch)} />
+            <Metric label="State synced" value={formatGeneratedAt(bundle.generatedAt)} detail />
+          </Box>
+
+          <Box
+            sx={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 1,
+              animation: 'caseBriefRise 620ms cubic-bezier(0.18, 0.8, 0.22, 1) both',
+              animationDelay: '180ms',
+            }}
+          >
+            {bundle.availableReportDates.slice(0, 10).map((reportDate) => {
+              const active = reportDate === bundle.reportDate;
+              return (
+                <Box
+                  key={reportDate}
+                  component={Link}
+                  href={`/cases/${bundle.marketSlug}/${reportDate}`}
+                  sx={{
+                    px: 1.25,
+                    py: 0.72,
+                    borderRadius: 999,
+                    border: '1px solid',
+                    borderColor: active ? 'rgba(0, 44, 81, 0.26)' : 'divider',
+                    bgcolor: active ? 'rgba(0, 44, 81, 0.06)' : 'background.paper',
+                    textDecoration: 'none',
+                    color: active ? 'text.primary' : 'text.secondary',
+                    fontSize: '0.84rem',
+                  }}
+                >
+                  {reportDate}
+                </Box>
+              );
+            })}
+          </Box>
+        </Stack>
+      </Box>
+
+      {bundle.sections.map((section, index) => {
+        const rowOffset = bundle.sections
+          .slice(0, index)
+          .reduce((total, currentSection) => total + currentSection.rows.length, 0);
+        return <CaseSection key={section.entity} section={section} rowOffset={rowOffset} />;
+      })}
+
+      <Divider sx={{ mt: 1, mb: 2 }} />
+
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={1.2}
+        justifyContent="space-between"
+        sx={{ color: 'text.secondary' }}
+      >
+        <Typography sx={{ fontSize: '0.88rem' }}>
+          Markdown backend stays in Shared Drives. Argus is only the authenticated reading surface.
+        </Typography>
+        <Typography sx={{ fontSize: '0.88rem' }}>
+          {bundle.trackedCaseIds.length} tracked case ID{bundle.trackedCaseIds.length === 1 ? '' : 's'} in state.
+        </Typography>
+      </Stack>
+    </>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  accent,
+  detail,
+}: {
+  label: string;
+  value: string;
+  accent?: boolean;
+  detail?: boolean;
+}) {
+  return (
+    <Box
+      sx={{
+        pt: 1.1,
+        borderTop: '1px solid',
+        borderColor: accent ? 'rgba(0, 194, 185, 0.34)' : alpha('#002c51', 0.12),
+      }}
+    >
+      <Typography
+        variant="overline"
+        sx={{
+          display: 'block',
+          color: 'text.secondary',
+          fontSize: '0.64rem',
+          letterSpacing: '0.14em',
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          mt: 0.55,
+          fontSize: detail ? '0.95rem' : { xs: '1.55rem', md: '1.85rem' },
+          lineHeight: 1.06,
+          letterSpacing: detail ? '-0.02em' : '-0.06em',
+          fontWeight: detail ? 600 : 700,
+          color: accent ? '#0b5c58' : 'text.primary',
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}
+
+export default async function DatedCaseReportPage({ params }: CaseReportPageProps) {
+  const { market, reportDate } = await params;
+
+  let bundle: CaseReportBundle;
+  try {
+    bundle = await readCaseReportBundle(market as CaseReportMarketSlug, reportDate);
+  } catch {
+    notFound();
+  }
+
+  return <ReportPage bundle={bundle} />;
+}

--- a/apps/argus/app/(app)/cases/[market]/page.tsx
+++ b/apps/argus/app/(app)/cases/[market]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound, redirect } from 'next/navigation';
+import {
+  readCaseReportBundle,
+  type CaseReportMarketSlug,
+} from '@/lib/cases/reader';
+
+export const dynamic = 'force-dynamic';
+
+type MarketLatestPageProps = {
+  params: Promise<{
+    market: string;
+  }>;
+};
+
+export default async function MarketLatestCaseReportPage({ params }: MarketLatestPageProps) {
+  const { market } = await params;
+
+  try {
+    const bundle = await readCaseReportBundle(market as CaseReportMarketSlug);
+    redirect(`/cases/${market}/${bundle.reportDate}`);
+  } catch {
+    notFound();
+  }
+}

--- a/apps/argus/app/(app)/cases/page.tsx
+++ b/apps/argus/app/(app)/cases/page.tsx
@@ -1,0 +1,7 @@
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
+
+export default function CasesIndexPage() {
+  redirect('/cases/us');
+}

--- a/apps/argus/components/layout/app-shell.tsx
+++ b/apps/argus/components/layout/app-shell.tsx
@@ -22,6 +22,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import InsightsIcon from '@mui/icons-material/Insights';
 import AutoGraphIcon from '@mui/icons-material/AutoGraph';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
+import SupportAgentIcon from '@mui/icons-material/SupportAgent';
 import ThemeToggle from './theme-toggle';
 
 const DRAWER_WIDTH = 220;
@@ -55,6 +56,13 @@ const NAV_ITEMS: NavItem[] = [
     description: 'Replica editing and revision control',
     icon: <Inventory2Icon />,
     matchPrefixes: ['/listings'],
+  },
+  {
+    href: '/cases/us',
+    label: 'Cases',
+    description: 'Daily Seller Central support briefs',
+    icon: <SupportAgentIcon />,
+    matchPrefixes: ['/cases'],
   },
 ];
 
@@ -95,6 +103,14 @@ function resolveSectionCopy(pathname: string) {
       eyebrow: 'Argus / Monitoring',
       title: 'Monitoring operations',
       subtitle: 'Track listing change events, source health, and ASIN-level timelines.',
+    };
+  }
+
+  if (pathname.startsWith('/cases')) {
+    return {
+      eyebrow: 'Argus / Cases',
+      title: 'Seller support briefs',
+      subtitle: 'Read the daily US and UK case reports rendered from the shared-drive markdown source.',
     };
   }
 

--- a/apps/argus/lib/cases/reader-core.ts
+++ b/apps/argus/lib/cases/reader-core.ts
@@ -1,0 +1,229 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const CASE_REPORT_HEADER =
+  '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |';
+const REPORT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
+
+const CASE_MARKETS = {
+  us: {
+    marketCode: 'US',
+    label: 'USA - Dust Sheets',
+    caseRoot:
+      '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/cases',
+  },
+  uk: {
+    marketCode: 'UK',
+    label: 'UK - Dust Sheets',
+    caseRoot:
+      '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - UK/Cases',
+  },
+} as const;
+
+export type CaseReportMarketSlug = keyof typeof CASE_MARKETS;
+
+export type CaseReportRow = {
+  category: string;
+  issue: string;
+  caseId: string;
+  daysAgo: string;
+  status: string;
+  evidence: string;
+  assessment: string;
+  nextStep: string;
+};
+
+export type CaseReportSection = {
+  entity: string;
+  rows: CaseReportRow[];
+};
+
+export type ParsedCaseReport = {
+  reportDate: string;
+  marketCode: string;
+  sections: CaseReportSection[];
+};
+
+export type CaseReportBundle = ParsedCaseReport & {
+  marketSlug: CaseReportMarketSlug;
+  marketLabel: string;
+  caseRoot: string;
+  reportPath: string;
+  caseJsonPath: string;
+  availableReportDates: string[];
+  trackedCaseIds: string[];
+  generatedAt: string | null;
+};
+
+function resolveMarketConfig(marketSlug: CaseReportMarketSlug) {
+  const market = CASE_MARKETS[marketSlug];
+  if (market === undefined) {
+    throw new Error(`Unsupported case report market: ${marketSlug}`);
+  }
+  return market;
+}
+
+function parseReportHeading(line: string): { reportDate: string; marketCode: string } {
+  const match = /^## Case Report - (\d{4}-\d{2}-\d{2}) \(([A-Z]{2})\)$/u.exec(line.trim());
+  if (match === null) {
+    throw new Error(`Invalid case report heading: ${line}`);
+  }
+  return {
+    reportDate: match[1],
+    marketCode: match[2],
+  };
+}
+
+function parseTableCells(line: string): string[] {
+  return line
+    .trim()
+    .replace(/^\|/u, '')
+    .replace(/\|$/u, '')
+    .split('|')
+    .map((cell) => cell.trim());
+}
+
+export function parseCaseReportMarkdown(markdown: string): ParsedCaseReport {
+  const lines = markdown.split(/\r?\n/u);
+  const headingLine = lines.find((line) => line.startsWith('## Case Report - '));
+  if (headingLine === undefined) {
+    throw new Error('Case report heading not found.');
+  }
+
+  const { reportDate, marketCode } = parseReportHeading(headingLine);
+  const sections: CaseReportSection[] = [];
+  let currentSection: CaseReportSection | null = null;
+  let readingTable = false;
+
+  for (const line of lines) {
+    if (line.startsWith('### ')) {
+      if (currentSection !== null) {
+        sections.push(currentSection);
+      }
+      currentSection = {
+        entity: line.replace(/^### /u, '').trim(),
+        rows: [],
+      };
+      readingTable = false;
+      continue;
+    }
+
+    if (currentSection === null) {
+      continue;
+    }
+
+    if (line.startsWith(CASE_REPORT_HEADER)) {
+      readingTable = true;
+      continue;
+    }
+
+    if (readingTable && line.startsWith('|---')) {
+      continue;
+    }
+
+    if (readingTable && line.trim().startsWith('|')) {
+      const cells = parseTableCells(line);
+      if (cells.length !== 8) {
+        throw new Error(`Unexpected case report row: ${line}`);
+      }
+      currentSection.rows.push({
+        category: cells[0],
+        issue: cells[1],
+        caseId: cells[2],
+        daysAgo: cells[3],
+        status: cells[4],
+        evidence: cells[5],
+        assessment: cells[6],
+        nextStep: cells[7],
+      });
+      continue;
+    }
+  }
+
+  if (currentSection !== null) {
+    sections.push(currentSection);
+  }
+
+  if (sections.length === 0) {
+    throw new Error('Case report contains no entity sections.');
+  }
+
+  return {
+    reportDate,
+    marketCode,
+    sections,
+  };
+}
+
+async function listAvailableReportDates(caseRoot: string): Promise<string[]> {
+  const reportsDir = path.join(caseRoot, 'reports');
+  const entries = await fs.readdir(reportsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((fileName) => fileName.endsWith('.md'))
+    .map((fileName) => fileName.replace(/\.md$/u, ''))
+    .filter((reportDate) => REPORT_DATE_PATTERN.test(reportDate))
+    .sort((left, right) => right.localeCompare(left));
+}
+
+export async function readCaseReportBundleFromCaseRoot(
+  caseRoot: string,
+  marketSlug: CaseReportMarketSlug,
+  requestedReportDate?: string,
+): Promise<CaseReportBundle> {
+  const market = resolveMarketConfig(marketSlug);
+  const availableReportDates = await listAvailableReportDates(caseRoot);
+  if (availableReportDates.length === 0) {
+    throw new Error(`No case reports found in ${caseRoot}`);
+  }
+
+  const reportDate = requestedReportDate ?? availableReportDates[0];
+  if (REPORT_DATE_PATTERN.test(reportDate) === false) {
+    throw new Error(`Invalid case report date: ${reportDate}`);
+  }
+
+  const reportPath = path.join(caseRoot, 'reports', `${reportDate}.md`);
+  const caseJsonPath = path.join(caseRoot, 'case.json');
+  const [markdown, caseJsonRaw] = await Promise.all([
+    fs.readFile(reportPath, 'utf8'),
+    fs.readFile(caseJsonPath, 'utf8'),
+  ]);
+
+  const parsedReport = parseCaseReportMarkdown(markdown);
+  if (parsedReport.marketCode !== market.marketCode) {
+    throw new Error(
+      `Case report market mismatch: expected ${market.marketCode}, got ${parsedReport.marketCode}`,
+    );
+  }
+
+  const caseState = JSON.parse(caseJsonRaw) as {
+    market: string;
+    generated_at?: string;
+    tracked_case_ids?: string[];
+  };
+
+  if (caseState.market !== market.marketCode) {
+    throw new Error(`case.json market mismatch: expected ${market.marketCode}, got ${caseState.market}`);
+  }
+
+  return {
+    ...parsedReport,
+    marketSlug,
+    marketLabel: market.label,
+    caseRoot,
+    reportPath,
+    caseJsonPath,
+    availableReportDates,
+    trackedCaseIds: Array.isArray(caseState.tracked_case_ids) ? caseState.tracked_case_ids : [],
+    generatedAt: typeof caseState.generated_at === 'string' ? caseState.generated_at : null,
+  };
+}
+
+export async function readCaseReportBundle(
+  marketSlug: CaseReportMarketSlug,
+  requestedReportDate?: string,
+): Promise<CaseReportBundle> {
+  const market = resolveMarketConfig(marketSlug);
+  return readCaseReportBundleFromCaseRoot(market.caseRoot, marketSlug, requestedReportDate);
+}

--- a/apps/argus/lib/cases/reader.test.ts
+++ b/apps/argus/lib/cases/reader.test.ts
@@ -1,0 +1,99 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import {
+  parseCaseReportMarkdown,
+  readCaseReportBundleFromCaseRoot,
+} from './reader-core'
+
+test('parseCaseReportMarkdown extracts entity sections and case rows', () => {
+  const report = parseCaseReportMarkdown(
+    [
+      '## Case Report - 2026-04-08 (UK)',
+      '',
+      '### TARGON',
+      '',
+      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
+      '|---|---|---|---|---|---|---|---|',
+      '| Action due | Account verification status / failed verification | 12339319152 | 0 days ago | Answered | Amazon replied on Apr 8. | Seller action is required now. | Reply from the primary inbox. |',
+      '',
+      '### NIGS LTD',
+      '',
+      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
+      '|---|---|---|---|---|---|---|---|',
+      '| Watching | Weights and dimensions review | 12006221712 | 21 days ago | Transferred / locked | No new case reply. | Keep monitoring. | None. |',
+      '',
+    ].join('\n'),
+  )
+
+  assert.equal(report.reportDate, '2026-04-08')
+  assert.equal(report.marketCode, 'UK')
+  assert.equal(report.sections.length, 2)
+  assert.equal(report.sections[0]?.entity, 'TARGON')
+  assert.equal(report.sections[0]?.rows[0]?.caseId, '12339319152')
+  assert.equal(report.sections[1]?.entity, 'NIGS LTD')
+  assert.equal(report.sections[1]?.rows[0]?.issue, 'Weights and dimensions review')
+})
+
+test('readCaseReportBundleFromCaseRoot resolves the latest dated report and tracked cases', async () => {
+  const caseRoot = mkdtempSync(path.join(tmpdir(), 'argus-cases-'))
+  const reportsDir = path.join(caseRoot, 'reports')
+  mkdirSync(reportsDir, { recursive: true })
+
+  writeFileSync(
+    path.join(caseRoot, 'case.json'),
+    JSON.stringify(
+      {
+        market: 'US',
+        generated_at: '2026-04-08T04:15:00-05:00',
+        tracked_case_ids: ['19550165441'],
+        cases: {
+          '19550165441': {
+            case_id: '19550165441',
+            entity: 'TARGON',
+            title: 'Shipping label refund ($2,583.96)',
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  )
+
+  writeFileSync(
+    path.join(reportsDir, '2026-04-07.md'),
+    [
+      '## Case Report - 2026-04-07 (US)',
+      '',
+      '### TARGON',
+      '',
+      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
+      '|---|---|---|---|---|---|---|---|',
+      '| Watching | Old issue | 19550165441 | 1 day ago | Work in progress | Old evidence. | Old assessment. | Old next step. |',
+      '',
+    ].join('\n'),
+  )
+
+  writeFileSync(
+    path.join(reportsDir, '2026-04-08.md'),
+    [
+      '## Case Report - 2026-04-08 (US)',
+      '',
+      '### TARGON',
+      '',
+      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
+      '|---|---|---|---|---|---|---|---|',
+      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
+      '',
+    ].join('\n'),
+  )
+
+  const bundle = await readCaseReportBundleFromCaseRoot(caseRoot, 'us')
+
+  assert.equal(bundle.reportDate, '2026-04-08')
+  assert.deepEqual(bundle.availableReportDates, ['2026-04-08', '2026-04-07'])
+  assert.deepEqual(bundle.trackedCaseIds, ['19550165441'])
+  assert.equal(bundle.sections[0]?.rows[0]?.caseId, '19550165441')
+})

--- a/apps/argus/lib/cases/reader.ts
+++ b/apps/argus/lib/cases/reader.ts
@@ -1,0 +1,3 @@
+import 'server-only';
+
+export * from './reader-core';


### PR DESCRIPTION
## Summary
- add authenticated Argus case brief routes for US and UK daily Seller Central reports
- add a shared-drive markdown reader and tests for the case report format
- expose the new Cases section in the Argus navigation shell

## Verification
- `cd /Users/jarraramjad/dev/targonos-main/apps/argus && pnpm exec tsx --test lib/cases/reader.test.ts`
- `cd /Users/jarraramjad/dev/targonos-main/apps/argus && pnpm lint`
- `cd /Users/jarraramjad/dev/targonos-main/apps/argus && pnpm type-check`
- `cd /Users/jarraramjad/dev/targonos-main/apps/argus && pnpm build`
- `pm2 restart main-argus`
- `curl -I https://os.targonglobal.com/argus/cases/us/2026-04-08`

## Rollout
- production Argus is already serving the new cases routes from the local main checkout
- case-agent Chat posts were corrected to `https://os.targonglobal.com/argus/cases/...` links