### PR TITLE
fix(atlas): fix atlas and argus UI artifacts [claude]

### DIFF
--- a/apps/argus/app/(app)/cases/[market]/page.tsx
+++ b/apps/argus/app/(app)/cases/[market]/page.tsx
@@ -14,11 +14,14 @@ type MarketLatestPageProps = {
 
 export default async function MarketLatestCaseReportPage({ params }: MarketLatestPageProps) {
   const { market } = await params;
+  let reportDate: string;
 
   try {
     const bundle = await readCaseReportBundle(market as CaseReportMarketSlug);
-    redirect(`/cases/${market}/${bundle.reportDate}`);
+    reportDate = bundle.reportDate;
   } catch {
     notFound();
   }
+
+  redirect(`/cases/${market}/${reportDate}`);
 }

--- a/apps/atlas/lib/permissions.ts
+++ b/apps/atlas/lib/permissions.ts
@@ -215,19 +215,22 @@ export async function canManageEmployee(
 // Get all employees that a user can manage
 export async function getManageableEmployees(currentUserId: string) {
   const actor = await getUserPermissionInfo(currentUserId)
+  const manageableEmployeeSelect = {
+    id: true,
+    employeeId: true,
+    firstName: true,
+    lastName: true,
+    email: true,
+    avatar: true,
+    department: true,
+    position: true,
+  } as const
 
   // HR/Admin can manage all employees except self
   if (actor?.isHROrAbove) {
     return prisma.employee.findMany({
       where: { id: { not: currentUserId }, status: 'ACTIVE' },
-      select: {
-        id: true,
-        employeeId: true,
-        firstName: true,
-        lastName: true,
-        department: true,
-        position: true,
-      },
+      select: manageableEmployeeSelect,
       orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
     })
   }
@@ -235,14 +238,7 @@ export async function getManageableEmployees(currentUserId: string) {
   // Get direct reports
   const directReports = await prisma.employee.findMany({
     where: { reportsToId: currentUserId, status: 'ACTIVE' },
-    select: {
-      id: true,
-      employeeId: true,
-      firstName: true,
-      lastName: true,
-      department: true,
-      position: true,
-    },
+    select: manageableEmployeeSelect,
   })
 
   const allReports = new Map<string, typeof directReports[0]>()
@@ -256,14 +252,7 @@ export async function getManageableEmployees(currentUserId: string) {
     const managerId = queue.shift()!
     const indirectReports = await prisma.employee.findMany({
       where: { reportsToId: managerId, status: 'ACTIVE' },
-      select: {
-        id: true,
-        employeeId: true,
-        firstName: true,
-        lastName: true,
-        department: true,
-        position: true,
-      },
+      select: manageableEmployeeSelect,
     })
     for (const report of indirectReports) {
       if (!allReports.has(report.id)) {
@@ -286,14 +275,7 @@ export async function getManageableEmployees(currentUserId: string) {
         id: { not: currentUserId },
         status: 'ACTIVE',
       },
-      select: {
-        id: true,
-        employeeId: true,
-        firstName: true,
-        lastName: true,
-        department: true,
-        position: true,
-      },
+      select: manageableEmployeeSelect,
     })
     for (const emp of deptEmployees) {
       allReports.set(emp.id, emp)


### PR DESCRIPTION
## Summary
- fix the Argus latest-case redirect so `/argus/cases/us` stops swallowing the Next redirect and returning 404
- return the employee fields Atlas hiring schedule already renders so interviewer rows stop showing literal `undefined`
- ship the verified fixes found during the live screenshot/snapshot browser sweep

## Verification
- `pnpm --dir /Users/jarraramjad/.config/superpowers/worktrees/targonos-main/atlas-argus-fix-ui-artifacts --filter @targon/atlas db:generate`
- `pnpm --dir /Users/jarraramjad/.config/superpowers/worktrees/targonos-main/atlas-argus-fix-ui-artifacts --filter @targon/atlas type-check`
- `pnpm --dir /Users/jarraramjad/.config/superpowers/worktrees/targonos-main/atlas-argus-fix-ui-artifacts --filter @targon/atlas build`
- `pnpm --dir /Users/jarraramjad/.config/superpowers/worktrees/targonos-main/atlas-argus-fix-ui-artifacts --filter @targon/argus type-check`
- `pnpm --dir /Users/jarraramjad/.config/superpowers/worktrees/targonos-main/atlas-argus-fix-ui-artifacts --filter @targon/argus build`

## Evidence
- Atlas hiring schedule showed raw `undefined` interviewer fields in the live screenshot sweep
- Argus cases root redirected into `/argus/cases/us`, which rendered a 404 because the redirect exception was caught and converted into `notFound()`