### PR TITLE
fix(xplan): restore dark-mode rendering across portal apps [claude]

### DIFF
--- a/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx
+++ b/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx
@@ -7,7 +7,6 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { alpha } from '@mui/material/styles';
 import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 import {
   readCaseReportBundle,
@@ -16,6 +15,14 @@ import {
   type CaseReportRow,
   type CaseReportSection,
 } from '@/lib/cases/reader';
+import {
+  getCaseAccentTextColor,
+  getCaseActiveDateBackgroundColor,
+  getCaseActiveDateBorderColor,
+  getCaseDividerColor,
+  getCaseDividerStrongColor,
+  getCaseTone,
+} from '@/lib/cases/theme';
 
 export const dynamic = 'force-dynamic';
 
@@ -30,38 +37,6 @@ const MARKET_LINKS = [
   { slug: 'us', label: 'USA - Dust Sheets' },
   { slug: 'uk', label: 'UK - Dust Sheets' },
 ] as const;
-
-function categoryTone(category: string) {
-  if (category === 'Action due') {
-    return {
-      color: '#9f1d12',
-      tint: 'rgba(191, 36, 27, 0.12)',
-      line: 'rgba(191, 36, 27, 0.35)',
-    };
-  }
-
-  if (category === 'Forum watch') {
-    return {
-      color: '#8f5d00',
-      tint: 'rgba(191, 125, 0, 0.12)',
-      line: 'rgba(191, 125, 0, 0.3)',
-    };
-  }
-
-  if (category === 'New case') {
-    return {
-      color: '#005f73',
-      tint: 'rgba(0, 118, 133, 0.12)',
-      line: 'rgba(0, 118, 133, 0.28)',
-    };
-  }
-
-  return {
-    color: '#0b5c58',
-    tint: 'rgba(0, 194, 185, 0.12)',
-    line: 'rgba(0, 194, 185, 0.26)',
-  };
-}
 
 function summarizeRows(sections: CaseReportSection[]) {
   const rows = sections.flatMap((section) => section.rows);
@@ -105,21 +80,21 @@ function DetailBlock({
 }) {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         minWidth: 0,
         borderLeft: '1px solid',
-        borderColor: accent ? 'rgba(0, 194, 185, 0.34)' : 'divider',
+        borderColor: accent ? getCaseTone('Watching', theme.palette.mode).line : 'divider',
         pl: 1.5,
-      }}
+      })}
     >
       <Typography
         variant="overline"
-        sx={{
+        sx={(theme) => ({
           display: 'block',
-          color: accent ? '#0b5c58' : 'text.secondary',
+          color: accent ? getCaseAccentTextColor(theme.palette.mode) : 'text.secondary',
           fontSize: '0.66rem',
           letterSpacing: '0.14em',
-        }}
+        })}
       >
         {label}
       </Typography>
@@ -179,19 +154,24 @@ function CaseRow({
   row: CaseReportRow;
   index: number;
 }) {
-  const tone = categoryTone(row.category);
-
   return (
     <Box
-      sx={{
-        display: 'grid',
-        gridTemplateColumns: { xs: '1fr', md: '210px minmax(0, 1fr)' },
-        gap: { xs: 2, md: 3 },
-        py: 2.75,
-        borderTop: '1px solid',
-        borderColor: alpha('#002c51', 0.08),
-        animation: 'caseBriefRise 560ms cubic-bezier(0.18, 0.8, 0.22, 1) both',
-        animationDelay: `${140 + index * 48}ms`,
+      sx={(theme) => {
+        const tone = getCaseTone(row.category, theme.palette.mode);
+        return {
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '210px minmax(0, 1fr)' },
+          gap: { xs: 2, md: 3 },
+          py: 2.75,
+          borderTop: '1px solid',
+          borderColor: getCaseDividerColor(theme.palette.mode),
+          animation: 'caseBriefRise 560ms cubic-bezier(0.18, 0.8, 0.22, 1) both',
+          animationDelay: `${140 + index * 48}ms`,
+          '& .case-row-category': {
+            bgcolor: tone.tint,
+            color: tone.color,
+          },
+        };
       }}
     >
       <Stack
@@ -201,14 +181,13 @@ function CaseRow({
         }}
       >
         <Box
+          className="case-row-category"
           sx={{
             display: 'inline-flex',
             alignSelf: 'flex-start',
             px: 1.3,
             py: 0.6,
             borderRadius: 999,
-            bgcolor: tone.tint,
-            color: tone.color,
             fontSize: '0.76rem',
             fontWeight: 700,
             letterSpacing: '0.02em',
@@ -260,17 +239,17 @@ function CaseSection({
   return (
     <Box sx={{ mb: 4.5 }}>
       <Box
-        sx={{
+        sx={(theme) => ({
           position: 'sticky',
           top: { xs: 74, md: 92 },
           zIndex: 2,
           py: 1.1,
           borderTop: '1px solid',
           borderBottom: '1px solid',
-          borderColor: alpha('#002c51', 0.12),
+          borderColor: getCaseDividerStrongColor(theme.palette.mode),
           bgcolor: 'background.paper',
           backdropFilter: 'blur(18px)',
-        }}
+        })}
       >
         <Stack direction="row" justifyContent="space-between" alignItems="center">
           <Typography
@@ -311,23 +290,24 @@ function ReportPage({ bundle }: { bundle: CaseReportBundle }) {
       />
 
       <Box
-        sx={{
+        sx={(theme) => ({
           position: 'relative',
           overflow: 'hidden',
           borderBottom: '1px solid',
-          borderColor: alpha('#002c51', 0.12),
+          borderColor: getCaseDividerStrongColor(theme.palette.mode),
           pb: 4,
           mb: 4,
-        }}
+        })}
       >
         <Box
-          sx={{
+          sx={(theme) => ({
             position: 'absolute',
             inset: 0,
             pointerEvents: 'none',
-            background:
-              'radial-gradient(circle at top right, rgba(0, 194, 185, 0.16), transparent 28%), linear-gradient(180deg, rgba(0, 44, 81, 0.05), rgba(0, 44, 81, 0))',
-          }}
+            background: theme.palette.mode === 'dark'
+              ? 'radial-gradient(circle at top right, rgba(0, 194, 185, 0.16), transparent 28%), linear-gradient(180deg, rgba(0, 194, 185, 0.04), rgba(0, 194, 185, 0))'
+              : 'radial-gradient(circle at top right, rgba(0, 194, 185, 0.16), transparent 28%), linear-gradient(180deg, rgba(0, 44, 81, 0.05), rgba(0, 44, 81, 0))',
+          })}
         />
 
         <Stack spacing={3} sx={{ position: 'relative' }}>
@@ -389,21 +369,21 @@ function ReportPage({ bundle }: { bundle: CaseReportBundle }) {
                   >
                     <Box
                       sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      px: 1.5,
-                      py: 1.15,
-                      borderRadius: 999,
-                      textDecoration: 'none',
-                      border: '1px solid',
-                      borderColor: active ? 'rgba(0, 194, 185, 0.34)' : 'divider',
-                      bgcolor: active ? 'rgba(0, 194, 185, 0.08)' : 'transparent',
-                      color: active ? 'text.primary' : 'text.secondary',
-                      transition: 'background-color 160ms ease, border-color 160ms ease',
-                      '&:hover': {
-                        bgcolor: active ? 'rgba(0, 194, 185, 0.12)' : 'action.hover',
-                      },
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        px: 1.5,
+                        py: 1.15,
+                        borderRadius: 999,
+                        textDecoration: 'none',
+                        border: '1px solid',
+                        borderColor: active ? 'rgba(0, 194, 185, 0.34)' : 'divider',
+                        bgcolor: active ? 'rgba(0, 194, 185, 0.08)' : 'transparent',
+                        color: active ? 'text.primary' : 'text.secondary',
+                        transition: 'background-color 160ms ease, border-color 160ms ease',
+                        '&:hover': {
+                          bgcolor: active ? 'rgba(0, 194, 185, 0.12)' : 'action.hover',
+                        },
                       }}
                     >
                       <Typography sx={{ fontWeight: 600 }}>{market.label}</Typography>
@@ -450,17 +430,17 @@ function ReportPage({ bundle }: { bundle: CaseReportBundle }) {
                   style={{ textDecoration: 'none' }}
                 >
                   <Box
-                    sx={{
-                    px: 1.25,
-                    py: 0.72,
-                    borderRadius: 999,
-                    border: '1px solid',
-                    borderColor: active ? 'rgba(0, 44, 81, 0.26)' : 'divider',
-                    bgcolor: active ? 'rgba(0, 44, 81, 0.06)' : 'background.paper',
-                    textDecoration: 'none',
-                    color: active ? 'text.primary' : 'text.secondary',
-                    fontSize: '0.84rem',
-                    }}
+                    sx={(theme) => ({
+                      px: 1.25,
+                      py: 0.72,
+                      borderRadius: 999,
+                      border: '1px solid',
+                      borderColor: active ? getCaseActiveDateBorderColor(theme.palette.mode) : 'divider',
+                      bgcolor: active ? getCaseActiveDateBackgroundColor(theme.palette.mode) : 'background.paper',
+                      textDecoration: 'none',
+                      color: active ? 'text.primary' : 'text.secondary',
+                      fontSize: '0.84rem',
+                    })}
                   >
                     {reportDate}
                   </Box>
@@ -510,11 +490,11 @@ function Metric({
 }) {
   return (
     <Box
-      sx={{
+      sx={(theme) => ({
         pt: 1.1,
         borderTop: '1px solid',
-        borderColor: accent ? 'rgba(0, 194, 185, 0.34)' : alpha('#002c51', 0.12),
-      }}
+        borderColor: accent ? getCaseTone('Watching', theme.palette.mode).line : getCaseDividerStrongColor(theme.palette.mode),
+      })}
     >
       <Typography
         variant="overline"
@@ -528,14 +508,14 @@ function Metric({
         {label}
       </Typography>
       <Typography
-        sx={{
+        sx={(theme) => ({
           mt: 0.55,
           fontSize: detail ? '0.95rem' : { xs: '1.55rem', md: '1.85rem' },
           lineHeight: 1.06,
           letterSpacing: detail ? '-0.02em' : '-0.06em',
           fontWeight: detail ? 600 : 700,
-          color: accent ? '#0b5c58' : 'text.primary',
-        }}
+          color: accent ? getCaseAccentTextColor(theme.palette.mode) : 'text.primary',
+        })}
       >
         {value}
       </Typography>

--- a/apps/argus/lib/cases/theme.test.ts
+++ b/apps/argus/lib/cases/theme.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  getCaseAccentTextColor,
+  getCaseActiveDateBackgroundColor,
+  getCaseActiveDateBorderColor,
+  getCaseDividerColor,
+  getCaseDividerStrongColor,
+  getCaseTone,
+} from './theme'
+
+test('getCaseTone returns brighter dark-mode accents', () => {
+  assert.deepEqual(getCaseTone('Action due', 'dark'), {
+    color: '#ff8f80',
+    tint: 'rgba(255, 143, 128, 0.14)',
+    line: 'rgba(255, 143, 128, 0.34)',
+  })
+  assert.deepEqual(getCaseTone('Watching', 'dark'), {
+    color: '#63ddd7',
+    tint: 'rgba(99, 221, 215, 0.14)',
+    line: 'rgba(99, 221, 215, 0.28)',
+  })
+})
+
+test('case brief chrome colors stay theme-aware', () => {
+  assert.equal(getCaseAccentTextColor('light'), '#0b5c58')
+  assert.equal(getCaseAccentTextColor('dark'), '#7ce7e0')
+  assert.equal(getCaseDividerColor('light'), 'rgba(0, 44, 81, 0.08)')
+  assert.equal(getCaseDividerColor('dark'), 'rgba(255, 255, 255, 0.08)')
+  assert.equal(getCaseDividerStrongColor('light'), 'rgba(0, 44, 81, 0.12)')
+  assert.equal(getCaseDividerStrongColor('dark'), 'rgba(255, 255, 255, 0.12)')
+  assert.equal(getCaseActiveDateBorderColor('light'), 'rgba(0, 44, 81, 0.26)')
+  assert.equal(getCaseActiveDateBorderColor('dark'), 'rgba(127, 232, 225, 0.28)')
+  assert.equal(getCaseActiveDateBackgroundColor('light'), 'rgba(0, 44, 81, 0.06)')
+  assert.equal(getCaseActiveDateBackgroundColor('dark'), 'rgba(255, 255, 255, 0.05)')
+})

--- a/apps/argus/lib/cases/theme.ts
+++ b/apps/argus/lib/cases/theme.ts
@@ -1,0 +1,95 @@
+type CaseThemeMode = 'light' | 'dark';
+
+type CaseTone = {
+  color: string;
+  tint: string;
+  line: string;
+};
+
+function lightTone(category: string): CaseTone {
+  if (category === 'Action due') {
+    return {
+      color: '#9f1d12',
+      tint: 'rgba(191, 36, 27, 0.12)',
+      line: 'rgba(191, 36, 27, 0.35)',
+    };
+  }
+
+  if (category === 'Forum watch') {
+    return {
+      color: '#8f5d00',
+      tint: 'rgba(191, 125, 0, 0.12)',
+      line: 'rgba(191, 125, 0, 0.3)',
+    };
+  }
+
+  if (category === 'New case') {
+    return {
+      color: '#005f73',
+      tint: 'rgba(0, 118, 133, 0.12)',
+      line: 'rgba(0, 118, 133, 0.28)',
+    };
+  }
+
+  return {
+    color: '#0b5c58',
+    tint: 'rgba(0, 194, 185, 0.12)',
+    line: 'rgba(0, 194, 185, 0.26)',
+  };
+}
+
+function darkTone(category: string): CaseTone {
+  if (category === 'Action due') {
+    return {
+      color: '#ff8f80',
+      tint: 'rgba(255, 143, 128, 0.14)',
+      line: 'rgba(255, 143, 128, 0.34)',
+    };
+  }
+
+  if (category === 'Forum watch') {
+    return {
+      color: '#f3cc74',
+      tint: 'rgba(243, 204, 116, 0.14)',
+      line: 'rgba(243, 204, 116, 0.28)',
+    };
+  }
+
+  if (category === 'New case') {
+    return {
+      color: '#78dce8',
+      tint: 'rgba(120, 220, 232, 0.14)',
+      line: 'rgba(120, 220, 232, 0.28)',
+    };
+  }
+
+  return {
+    color: '#63ddd7',
+    tint: 'rgba(99, 221, 215, 0.14)',
+    line: 'rgba(99, 221, 215, 0.28)',
+  };
+}
+
+export function getCaseTone(category: string, mode: CaseThemeMode): CaseTone {
+  return mode === 'dark' ? darkTone(category) : lightTone(category);
+}
+
+export function getCaseAccentTextColor(mode: CaseThemeMode): string {
+  return mode === 'dark' ? '#7ce7e0' : '#0b5c58';
+}
+
+export function getCaseDividerColor(mode: CaseThemeMode): string {
+  return mode === 'dark' ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 44, 81, 0.08)';
+}
+
+export function getCaseDividerStrongColor(mode: CaseThemeMode): string {
+  return mode === 'dark' ? 'rgba(255, 255, 255, 0.12)' : 'rgba(0, 44, 81, 0.12)';
+}
+
+export function getCaseActiveDateBorderColor(mode: CaseThemeMode): string {
+  return mode === 'dark' ? 'rgba(127, 232, 225, 0.28)' : 'rgba(0, 44, 81, 0.26)';
+}
+
+export function getCaseActiveDateBackgroundColor(mode: CaseThemeMode): string {
+  return mode === 'dark' ? 'rgba(255, 255, 255, 0.05)' : 'rgba(0, 44, 81, 0.06)';
+}

--- a/apps/plutus/components/providers.tsx
+++ b/apps/plutus/components/providers.tsx
@@ -5,10 +5,11 @@ import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { SnackbarProvider } from 'notistack';
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
 import { lightTheme, darkTheme } from '@/lib/mui-theme';
 import { NavigationHistoryProvider } from '@/lib/navigation-history';
+import { resolveMuiThemeMode } from '@/lib/theme-mode';
 
 type ProvidersProps = {
   children?: ReactNode;
@@ -16,7 +17,14 @@ type ProvidersProps = {
 
 function MuiThemeSync({ children }: { children: ReactNode }) {
   const { resolvedTheme } = useTheme();
-  const muiTheme = resolvedTheme === 'dark' ? darkTheme : lightTheme;
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const themeMode = resolveMuiThemeMode(mounted, resolvedTheme);
+  const muiTheme = themeMode === 'dark' ? darkTheme : lightTheme;
 
   return (
     <ThemeProvider theme={muiTheme}>

--- a/apps/plutus/lib/theme-mode.ts
+++ b/apps/plutus/lib/theme-mode.ts
@@ -1,0 +1,7 @@
+export function resolveMuiThemeMode(
+  mounted: boolean,
+  resolvedTheme: string | undefined,
+): 'light' | 'dark' {
+  if (!mounted) return 'light';
+  return resolvedTheme === 'dark' ? 'dark' : 'light';
+}

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -85,6 +85,7 @@ import {
   buildLegacySettlementPagePath,
   remapLegacySettlementPath,
 } from '../lib/plutus/legacy-settlement-routes';
+import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
 import type { QboAccount, QboBill, QboRecurringTransaction } from '../lib/qbo/api';
 
@@ -104,6 +105,13 @@ test('normalizeAuditMarketToMarketplaceId maps common values', () => {
   assert.equal(normalizeAuditMarketToMarketplaceId('US'), 'amazon.com');
   assert.equal(normalizeAuditMarketToMarketplaceId('UK'), 'amazon.co.uk');
   assert.equal(normalizeAuditMarketToMarketplaceId('unknown'), null);
+});
+
+test('resolveMuiThemeMode waits for mount before applying dark mode', () => {
+  assert.equal(resolveMuiThemeMode(false, 'dark'), 'light');
+  assert.equal(resolveMuiThemeMode(true, 'dark'), 'dark');
+  assert.equal(resolveMuiThemeMode(true, 'light'), 'light');
+  assert.equal(resolveMuiThemeMode(true, undefined), 'light');
 });
 
 test('normalizeSettlementDocNumber extracts embedded settlement ids', () => {

--- a/apps/xplan/components/providers.tsx
+++ b/apps/xplan/components/providers.tsx
@@ -1,14 +1,15 @@
 'use client';
 
+import { useEffect, useState, type ComponentProps, type ReactElement, type ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider as NextThemeProvider, useTheme } from 'next-themes';
 import { ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { Toaster } from 'sonner';
-import { useState, type ComponentProps, type ReactElement, type ReactNode } from 'react';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { lightTheme, darkTheme } from '@/lib/mui-theme';
+import { resolveMuiThemeMode } from '@/lib/theme-mode';
 
 type ProvidersProps = {
   // Accept any React tree so we can bridge the React 18/19 type mismatch in this workspace
@@ -25,7 +26,14 @@ const NextTheme = NextThemeProvider as unknown as (props: ThemeProviderProps) =>
 
 function MuiThemeSync({ children }: { children: ReactNode }) {
   const { resolvedTheme } = useTheme();
-  const muiTheme = resolvedTheme === 'dark' ? darkTheme : lightTheme;
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const themeMode = resolveMuiThemeMode(mounted, resolvedTheme);
+  const muiTheme = themeMode === 'dark' ? darkTheme : lightTheme;
 
   return (
     <ThemeProvider theme={muiTheme}>

--- a/apps/xplan/lib/theme-mode.ts
+++ b/apps/xplan/lib/theme-mode.ts
@@ -1,0 +1,7 @@
+export function resolveMuiThemeMode(
+  mounted: boolean,
+  resolvedTheme: string | undefined,
+): 'light' | 'dark' {
+  if (!mounted) return 'light';
+  return resolvedTheme === 'dark' ? 'dark' : 'light';
+}

--- a/apps/xplan/tests/unit/theme-mode.test.ts
+++ b/apps/xplan/tests/unit/theme-mode.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMuiThemeMode } from '@/lib/theme-mode'
+
+describe('resolveMuiThemeMode', () => {
+  it('keeps the light theme until the client mounts', () => {
+    expect(resolveMuiThemeMode(false, 'dark')).toBe('light')
+  })
+
+  it('switches to dark mode after mount when next-themes resolves dark', () => {
+    expect(resolveMuiThemeMode(true, 'dark')).toBe('dark')
+  })
+
+  it('falls back to light mode for non-dark resolved themes', () => {
+    expect(resolveMuiThemeMode(true, 'light')).toBe('light')
+    expect(resolveMuiThemeMode(true, undefined)).toBe('light')
+  })
+})


### PR DESCRIPTION
## Summary
- restore xplan and plutus MUI theme sync after the client mount so dark mode surfaces follow the active theme
- add small theme-mode tests in xplan and plutus to lock the provider behavior
- tune argus case-brief palette tokens for readable dark-mode contrast and cover them with node tests

## Verification
- pnpm --filter @targon/xplan test -- tests/unit/theme-mode.test.ts
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/argus exec tsx --test lib/cases/theme.test.ts
- pnpm --filter @targon/xplan type-check
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/argus type-check
- pnpm --filter @targon/xplan build
- pnpm --filter @targon/plutus build
- pnpm --filter @targon/argus build
- pnpm --filter @targon/xplan lint
- pnpm --filter @targon/plutus lint
- pnpm --filter @targon/argus lint