### PR TITLE
fix(talos): expose hidden amazon tools in the app shell [claude]

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -17,6 +17,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { EmptyState } from '@/components/ui/empty-state'
 import { PageContainer, PageContent, PageHeaderSection } from '@/components/layout/page-container'
+import { AmazonWorkspaceSwitcher } from '@/components/amazon/amazon-workspace-switcher'
 import {
   AlertTriangle,
   CheckCircle2,
@@ -450,8 +451,9 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
         title="FBA Fee Discrepancies"
         description="Amazon"
         icon={DollarSign}
-        backHref="/config/products"
-        backLabel="Products"
+        backHref="/amazon"
+        backLabel="Amazon Workspace"
+        metadata={<AmazonWorkspaceSwitcher currentHref="/amazon/fba-fee-discrepancies" />}
       />
 
       <PageContent className="space-y-6">

--- a/apps/talos/src/app/amazon/fba-fee-tables/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-tables/page.tsx
@@ -19,6 +19,7 @@ import {
 
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { PageContainer, PageContent, PageHeaderSection } from '@/components/layout/page-container'
+import { AmazonWorkspaceSwitcher } from '@/components/amazon/amazon-workspace-switcher'
 import { DollarSign, Loader2 } from '@/lib/lucide-icons'
 
 const ALLOWED_ROLES = ['admin', 'staff'] as const
@@ -173,8 +174,9 @@ export default function FbaFeeTablesPage() {
             title="FBA Fee Tables"
             description="Amazon UK Rate Card 2026"
             icon={DollarSign}
-            backHref="/config/products"
-            backLabel="Products"
+            backHref="/amazon"
+            backLabel="Amazon Workspace"
+            metadata={<AmazonWorkspaceSwitcher currentHref="/amazon/fba-fee-tables" />}
           />
 
           <PageContent className="space-y-8">
@@ -438,8 +440,9 @@ export default function FbaFeeTablesPage() {
           title="FBA Fee Tables"
           description="Amazon US Rate Card 2026 (after Jan 15, 2026)"
           icon={DollarSign}
-          backHref="/config/products"
-          backLabel="Products"
+          backHref="/amazon"
+          backLabel="Amazon Workspace"
+          metadata={<AmazonWorkspaceSwitcher currentHref="/amazon/fba-fee-tables" />}
         />
 
         <PageContent className="space-y-8">

--- a/apps/talos/src/app/amazon/page.tsx
+++ b/apps/talos/src/app/amazon/page.tsx
@@ -1,5 +1,173 @@
-import { redirect } from 'next/navigation'
+'use client'
+
+import Link from 'next/link'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { toast } from 'react-hot-toast'
+import { useSession } from '@/hooks/usePortalSession'
+import { redirectToPortal } from '@/lib/portal'
+import { withBasePath } from '@/lib/utils/base-path'
+import { AMAZON_WORKSPACE_TOOLS } from '@/lib/amazon/workspace'
+import { PageContainer, PageContent, PageHeaderSection } from '@/components/layout/page-container'
+import { AmazonWorkspaceSwitcher } from '@/components/amazon/amazon-workspace-switcher'
+import {
+  ArrowRight,
+  LayoutGrid,
+  Loader2,
+  Sparkles,
+} from '@/lib/lucide-icons'
+
+const ALLOWED_ROLES = ['admin', 'staff'] as const
 
 export default function AmazonPage() {
-  redirect('/amazon/fba-fee-discrepancies')
+  const router = useRouter()
+  const { data: session, status } = useSession()
+  const workspaceTools = AMAZON_WORKSPACE_TOOLS.filter((tool) => tool.href !== '/amazon')
+
+  const isAllowed =
+    session !== null &&
+    ALLOWED_ROLES.includes(session.user.role as (typeof ALLOWED_ROLES)[number])
+
+  useEffect(() => {
+    if (status === 'loading') return
+
+    if (!session) {
+      redirectToPortal('/login', `${window.location.origin}${withBasePath('/amazon')}`)
+      return
+    }
+
+    if (!isAllowed) {
+      toast.error('You are not authorised to view this page')
+      router.push('/dashboard')
+    }
+  }, [isAllowed, router, session, status])
+
+  if (status === 'loading') {
+    return (
+      <PageContainer>
+        <div className="flex h-full items-center justify-center">
+          <div className="flex flex-col items-center gap-3">
+            <Loader2 className="h-8 w-8 animate-spin text-cyan-600" />
+            <span className="text-sm text-slate-500">Loading...</span>
+          </div>
+        </div>
+      </PageContainer>
+    )
+  }
+
+  if (!session || !isAllowed) return null
+
+  const tenantCode = session.user.region
+
+  return (
+    <PageContainer>
+      <PageHeaderSection
+        title="Amazon Workspace"
+        description="Live fee and replenishment controls"
+        icon={LayoutGrid}
+        metadata={<AmazonWorkspaceSwitcher currentHref="/amazon" />}
+      />
+
+      <PageContent className="space-y-6">
+        <section className="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(320px,0.95fr)]">
+          <div className="rounded-[28px] border border-slate-200/80 bg-white px-6 py-6 shadow-soft dark:border-slate-700/80 dark:bg-slate-900">
+            <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.14em] text-cyan-700/75 dark:text-cyan-400/75">
+              <span>{tenantCode} marketplace</span>
+              <span className="h-1 w-1 rounded-full bg-cyan-500/60" />
+              <span>{workspaceTools.length} live tools</span>
+            </div>
+
+            <div className="mt-5 grid gap-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(240px,0.8fr)]">
+              <div className="space-y-4">
+                <h2 className="max-w-2xl text-[clamp(2rem,3.2vw,3.25rem)] font-semibold leading-[0.96] tracking-[-0.06em] text-slate-950 dark:text-slate-50">
+                  Cost intelligence, fee references, and shipment planning in one Talos surface.
+                </h2>
+                <p className="max-w-[64ch] text-sm leading-7 text-slate-600 dark:text-slate-300">
+                  The Amazon section now exposes the live tools that operators actually use. Jump
+                  between rate cards, fee audits, and replenishment planning without bouncing
+                  through unrelated areas like Products or memorising route paths.
+                </p>
+              </div>
+
+              <div className="rounded-3xl border border-slate-200/80 bg-slate-50 px-5 py-5 dark:border-slate-700/80 dark:bg-slate-950/70">
+                <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                  <Sparkles className="h-4 w-4 text-cyan-600 dark:text-cyan-400" />
+                  Recommended flow
+                </div>
+                <ol className="mt-4 space-y-3 text-sm leading-6 text-slate-700 dark:text-slate-300">
+                  <li>1. Audit fee mismatches when Amazon inputs drift from your reference package data.</li>
+                  <li>2. Check the fee tables before updating reference costs or reviewing rate-card changes.</li>
+                  <li>3. Use shipment planning to turn low-stock risk into an actual replenishment move.</li>
+                </ol>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4">
+            <div className="rounded-[24px] border border-slate-200/80 bg-white px-5 py-5 shadow-soft dark:border-slate-700/80 dark:bg-slate-900">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                Workspace coverage
+              </p>
+              <div className="mt-4 flex items-end gap-3">
+                <span className="text-5xl font-semibold tracking-[-0.08em] text-slate-950 dark:text-slate-50">
+                  {workspaceTools.length}
+                </span>
+                <span className="pb-2 text-sm text-slate-500 dark:text-slate-400">
+                  surfaced tools
+                </span>
+              </div>
+              <p className="mt-3 text-sm leading-7 text-slate-600 dark:text-slate-300">
+                The sidebar now exposes live Amazon workflows directly instead of leaving them behind
+                unlinked URLs.
+              </p>
+            </div>
+
+            <div className="rounded-[24px] border border-slate-200/80 bg-slate-50 px-5 py-5 dark:border-slate-700/80 dark:bg-slate-950/70">
+              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                What stays hidden
+              </p>
+              <p className="mt-3 text-sm leading-7 text-slate-600 dark:text-slate-300">
+                Under-construction routes like Market Orders and Reorder stay out of the primary nav
+                until they are ready for real operator use.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_repeat(2,minmax(0,1fr))]">
+          {workspaceTools.map((tool) => (
+            <Link
+              key={tool.href}
+              href={tool.href}
+              className="group rounded-[28px] border border-slate-200/80 bg-white px-5 py-5 shadow-soft transition-all hover:-translate-y-0.5 hover:border-cyan-300/70 hover:bg-slate-50 dark:border-slate-700/80 dark:bg-slate-900 dark:hover:border-cyan-500/40 dark:hover:bg-slate-900/90"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-cyan-700/75 dark:text-cyan-400/75">
+                    {tool.note}
+                  </p>
+                  <h3 className="mt-3 text-2xl font-semibold tracking-[-0.05em] text-slate-950 dark:text-slate-50">
+                    {tool.name}
+                  </h3>
+                </div>
+                <div className="rounded-2xl border border-slate-200/80 bg-slate-50 p-3 text-slate-700 dark:border-slate-700/80 dark:bg-slate-950/70 dark:text-slate-200">
+                  <tool.icon className="h-5 w-5" />
+                </div>
+              </div>
+
+              <p className="mt-4 max-w-[34ch] text-sm leading-7 text-slate-600 dark:text-slate-300">
+                {tool.description}
+              </p>
+              <p className="mt-3 text-sm text-slate-500 dark:text-slate-400">{tool.note}</p>
+
+              <div className="mt-6 inline-flex items-center gap-2 text-sm font-medium text-cyan-700 dark:text-cyan-400">
+                Open tool
+                <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+              </div>
+            </Link>
+          ))}
+        </section>
+      </PageContent>
+    </PageContainer>
+  )
 }

--- a/apps/talos/src/app/config/permissions/page.tsx
+++ b/apps/talos/src/app/config/permissions/page.tsx
@@ -10,12 +10,7 @@ import { Shield } from '@/lib/lucide-icons'
 import PermissionsPanel from './permissions-panel'
 import { redirectToPortal } from '@/lib/portal'
 import { withBasePath } from '@/lib/utils/base-path'
-
-const SUPER_ADMIN_EMAILS = ['jarrar@targonglobal.com']
-
-function isSuperAdmin(email: string): boolean {
-  return SUPER_ADMIN_EMAILS.includes(email?.toLowerCase() ?? '')
-}
+import { isSuperAdminEmail } from '@/lib/auth/super-admin'
 
 export default function PermissionsPage() {
   const router = useRouter()
@@ -29,7 +24,7 @@ export default function PermissionsPage() {
       return
     }
 
-    if (!isSuperAdmin(session.user.email)) {
+    if (!isSuperAdminEmail(session.user.email)) {
       toast.error('Only super admins can access this page')
       router.push('/dashboard')
     }
@@ -48,7 +43,7 @@ export default function PermissionsPage() {
     )
   }
 
-  if (!session || !isSuperAdmin(session.user.email)) {
+  if (!session || !isSuperAdminEmail(session.user.email)) {
     return null
   }
 

--- a/apps/talos/src/app/market/shipment-planning/page.tsx
+++ b/apps/talos/src/app/market/shipment-planning/page.tsx
@@ -11,6 +11,7 @@ import { useSession } from '@/hooks/usePortalSession'
 	} from '@/lib/lucide-icons'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
+import { AmazonWorkspaceSwitcher } from '@/components/amazon/amazon-workspace-switcher'
 import { toast } from 'react-hot-toast'
 import Link from 'next/link'
 import { 
@@ -319,6 +320,7 @@ try {
  title="Shipment Planning"
  description="Marketplace"
  icon={Truck}
+ metadata={<AmazonWorkspaceSwitcher currentHref="/market/shipment-planning" />}
  actions={
  <div className="flex items-center gap-2">
  <button

--- a/apps/talos/src/components/amazon/amazon-workspace-switcher.tsx
+++ b/apps/talos/src/components/amazon/amazon-workspace-switcher.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { AMAZON_WORKSPACE_TOOLS } from '@/lib/amazon/workspace'
+import { isNavigationItemActive } from '@/lib/navigation/main-nav'
+import { cn } from '@/lib/utils'
+
+type AmazonWorkspaceSwitcherProps = {
+  currentHref: string
+  className?: string
+}
+
+export function AmazonWorkspaceSwitcher({
+  currentHref,
+  className,
+}: AmazonWorkspaceSwitcherProps) {
+  return (
+    <div
+      className={cn(
+        'inline-flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/80 bg-white/85 p-1.5 shadow-soft dark:border-slate-700/80 dark:bg-slate-900/85',
+        className
+      )}
+    >
+      {AMAZON_WORKSPACE_TOOLS.map((tool) => {
+        const isActive = isNavigationItemActive(currentHref, tool)
+
+        return (
+          <Link
+            key={tool.href}
+            href={tool.href}
+            className={cn(
+              'rounded-xl px-3 py-2 text-sm font-medium transition-colors',
+              isActive
+                ? 'bg-cyan-600 text-white shadow-soft'
+                : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-white'
+            )}
+          >
+            {tool.name}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/talos/src/components/layout/main-nav.tsx
+++ b/apps/talos/src/components/layout/main-nav.tsx
@@ -5,18 +5,9 @@ import Image from 'next/image'
 import { usePathname } from 'next/navigation'
 import { useSession } from '@/hooks/usePortalSession'
 import {
-  Home,
-  Package,
-  FileText,
-  Truck,
   LogOut,
   Menu,
   X,
-  BarChart3,
-  DollarSign,
-  Building,
-  BookOpen,
-  Users,
   ChevronRight,
 } from '@/lib/lucide-icons'
 import { useState, useEffect, useCallback } from 'react'
@@ -25,6 +16,11 @@ import { portalUrl } from '@/lib/portal'
 import { withBasePath } from '@/lib/utils/base-path'
 import { TenantIndicator } from '@/components/tenant/TenantIndicator'
 import { ThemeToggle } from '@/components/ui/theme-toggle'
+import {
+  buildMainNavigation,
+  isNavigationItemActive,
+  type NavSection,
+} from '@/lib/navigation/main-nav'
 
 const assetBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? ''
 
@@ -48,47 +44,6 @@ function TargonWordmark({ className }: { className?: string }) {
     </div>
   )
 }
-
-interface NavSection {
-  title: string
-  items: Array<{
-    name: string
-    href: string
-    icon: React.ComponentType<{ className?: string }>
-  }>
-}
-
-const baseNavigation: NavSection[] = [
-  {
-    title: '',
-    items: [
-      { name: 'Dashboard', href: '/dashboard', icon: Home },
-    ]
-  },
-  {
-    title: 'Amazon',
-    items: [
-      { name: 'FBA Fee Discrepancies', href: '/amazon/fba-fee-discrepancies', icon: DollarSign },
-    ]
-  },
-  {
-    title: 'Operations',
-    items: [
-      { name: 'Purchase Orders', href: '/operations/purchase-orders', icon: FileText },
-      { name: 'Fulfillment Orders', href: '/operations/fulfillment-orders', icon: Truck },
-      { name: 'Inventory Ledger', href: '/operations/inventory', icon: BookOpen },
-      { name: 'Financial Ledger', href: '/operations/financial-ledger', icon: BarChart3 },
-    ]
-  },
-  {
-    title: 'Configuration',
-    items: [
-      { name: 'Products', href: '/config/products', icon: Package },
-      { name: 'Suppliers', href: '/config/suppliers', icon: Users },
-      { name: 'Warehouses', href: '/config/warehouses', icon: Building },
-    ]
-  },
-]
 
 // LocalStorage key for persisting collapsed sections
 const COLLAPSED_SECTIONS_KEY = 'talos-nav-collapsed-sections'
@@ -127,19 +82,19 @@ export function MainNav() {
 
   if (!session) return null
 
-  // Use base navigation for all users
-  const userNavigation = baseNavigation
+  const userNavigation: NavSection[] = buildMainNavigation({
+    role: session.user.role,
+    email: session.user.email,
+  })
 
   // Get current page name for mobile header
-  const matchesPath = (href: string) => {
-    const [targetPath] = href.split('?')
-    return pathname.startsWith(targetPath)
-  }
+  const matchesPath = (href: string, matchMode: 'prefix' | 'exact') =>
+    isNavigationItemActive(pathname, { href, matchMode })
 
   const getCurrentPageName = () => {
     for (const section of userNavigation) {
       for (const item of section.items) {
-        if (matchesPath(item.href)) {
+        if (matchesPath(item.href, item.matchMode)) {
           return item.name
         }
       }
@@ -184,7 +139,9 @@ export function MainNav() {
                 <ul role="list" className="-mx-2 space-y-3">
                   {userNavigation.map((section, sectionIdx) => {
                     const isCollapsed = section.title ? collapsedSections[section.title] : false
-                    const hasActiveItem = section.items.some(item => matchesPath(item.href))
+                    const hasActiveItem = section.items.some((item) =>
+                      matchesPath(item.href, item.matchMode)
+                    )
 
                     return (
                       <li key={sectionIdx}>
@@ -220,7 +177,7 @@ export function MainNav() {
                                 scroll={false}
                                 prefetch={false}
                                 className={cn(
-                                  matchesPath(item.href)
+                                  matchesPath(item.href, item.matchMode)
                                     ? 'bg-cyan-50 dark:bg-cyan-900/20 text-cyan-900 dark:text-cyan-300'
                                     : 'text-slate-700 dark:text-slate-300 hover:text-cyan-700 dark:hover:text-cyan-400 hover:bg-slate-50 dark:hover:bg-slate-800',
                                   'group flex gap-x-3 rounded-lg py-2 px-3 text-sm leading-5 font-medium transition-all duration-200'
@@ -228,7 +185,7 @@ export function MainNav() {
                               >
                                 <item.icon
                                   className={cn(
-                                    matchesPath(item.href)
+                                    matchesPath(item.href, item.matchMode)
                                       ? 'text-cyan-600 dark:text-cyan-400'
                                       : 'text-slate-400 dark:text-slate-500 group-hover:text-cyan-600 dark:group-hover:text-cyan-400',
                                     'h-5 w-5 shrink-0'
@@ -354,7 +311,7 @@ export function MainNav() {
                                     scroll={false}
                                     prefetch={false}
                                     className={cn(
-                                      matchesPath(item.href)
+                                      matchesPath(item.href, item.matchMode)
                                         ? 'bg-cyan-50 dark:bg-cyan-900/20 text-cyan-900 dark:text-cyan-300'
                                         : 'text-slate-700 dark:text-slate-300 hover:text-cyan-700 dark:hover:text-cyan-400 hover:bg-slate-50 dark:hover:bg-slate-800',
                                       'group flex gap-x-3 rounded-lg py-2 px-3 text-sm leading-5 font-medium transition-all duration-200'
@@ -363,7 +320,7 @@ export function MainNav() {
                                   >
                                     <item.icon
                                       className={cn(
-                                        matchesPath(item.href)
+                                        matchesPath(item.href, item.matchMode)
                                           ? 'text-cyan-600 dark:text-cyan-400'
                                           : 'text-slate-400 dark:text-slate-500 group-hover:text-cyan-600 dark:group-hover:text-cyan-400',
                                         'h-5 w-5 shrink-0'

--- a/apps/talos/src/lib/amazon/workspace.ts
+++ b/apps/talos/src/lib/amazon/workspace.ts
@@ -1,0 +1,53 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  Activity,
+  Calculator,
+  LayoutGrid,
+  Truck,
+} from '@/lib/lucide-icons'
+
+export type NavigationMatchMode = 'prefix' | 'exact'
+
+export type AmazonWorkspaceTool = {
+  name: string
+  href: string
+  description: string
+  note: string
+  icon: LucideIcon
+  matchMode: NavigationMatchMode
+}
+
+export const AMAZON_WORKSPACE_TOOLS: AmazonWorkspaceTool[] = [
+  {
+    name: 'Workspace',
+    href: '/amazon',
+    description: 'Amazon workspace entry point for live cost, fee, and planning tools.',
+    note: 'Workspace',
+    icon: LayoutGrid,
+    matchMode: 'exact',
+  },
+  {
+    name: 'FBA Fee Discrepancies',
+    href: '/amazon/fba-fee-discrepancies',
+    description: 'Compare reference packaging against Amazon fee inputs and isolate mismatches fast.',
+    note: 'Audit',
+    icon: Activity,
+    matchMode: 'prefix',
+  },
+  {
+    name: 'FBA Fee Tables',
+    href: '/amazon/fba-fee-tables',
+    description: 'Reference the live Amazon rate cards without leaving Talos.',
+    note: 'Reference',
+    icon: Calculator,
+    matchMode: 'prefix',
+  },
+  {
+    name: 'Shipment Planning',
+    href: '/market/shipment-planning',
+    description: 'Prioritize FBA replenishment using days-of-stock and suggested carton moves.',
+    note: 'Planning',
+    icon: Truck,
+    matchMode: 'prefix',
+  },
+] as const

--- a/apps/talos/src/lib/auth/super-admin.ts
+++ b/apps/talos/src/lib/auth/super-admin.ts
@@ -1,0 +1,5 @@
+const SUPER_ADMIN_EMAILS = ['jarrar@targonglobal.com']
+
+export function isSuperAdminEmail(email: string): boolean {
+  return SUPER_ADMIN_EMAILS.includes(email.toLowerCase())
+}

--- a/apps/talos/src/lib/navigation/main-nav.ts
+++ b/apps/talos/src/lib/navigation/main-nav.ts
@@ -1,0 +1,99 @@
+import type { LucideIcon } from 'lucide-react'
+import {
+  BarChart3,
+  BookOpen,
+  Building,
+  FileText,
+  Home,
+  Package,
+  Shield,
+  Truck,
+  Users,
+} from '@/lib/lucide-icons'
+import { AMAZON_WORKSPACE_TOOLS, type NavigationMatchMode } from '@/lib/amazon/workspace'
+import { isSuperAdminEmail } from '@/lib/auth/super-admin'
+
+export type NavItem = {
+  name: string
+  href: string
+  icon: LucideIcon
+  matchMode: NavigationMatchMode
+}
+
+export type NavSection = {
+  title: string
+  items: NavItem[]
+}
+
+type NavigationContext = {
+  role: string
+  email: string
+}
+
+function createItem(
+  name: string,
+  href: string,
+  icon: LucideIcon,
+  matchMode: NavigationMatchMode = 'prefix'
+): NavItem {
+  return {
+    name,
+    href,
+    icon,
+    matchMode,
+  }
+}
+
+export function buildMainNavigation(context: NavigationContext): NavSection[] {
+  const amazonItems = AMAZON_WORKSPACE_TOOLS.map((tool) =>
+    createItem(tool.name, tool.href, tool.icon, tool.matchMode)
+  )
+
+  const configurationItems = [
+    createItem('Products', '/config/products', Package),
+    createItem('Suppliers', '/config/suppliers', Users),
+    createItem('Warehouses', '/config/warehouses', Building),
+  ]
+
+  if (context.role === 'admin' && isSuperAdminEmail(context.email)) {
+    configurationItems.push(createItem('Permissions', '/config/permissions', Shield))
+  }
+
+  return [
+    {
+      title: '',
+      items: [createItem('Dashboard', '/dashboard', Home)],
+    },
+    {
+      title: 'Amazon',
+      items: amazonItems,
+    },
+    {
+      title: 'Operations',
+      items: [
+        createItem('Purchase Orders', '/operations/purchase-orders', FileText),
+        createItem('Fulfillment Orders', '/operations/fulfillment-orders', Truck),
+        createItem('Inventory Ledger', '/operations/inventory', BookOpen),
+        createItem('Storage Ledger', '/operations/storage-ledger', Building),
+        createItem('Financial Ledger', '/operations/financial-ledger', BarChart3),
+      ],
+    },
+    {
+      title: 'Configuration',
+      items: configurationItems,
+    },
+  ]
+}
+
+export function isNavigationItemActive(
+  pathname: string,
+  item: Pick<NavItem, 'href' | 'matchMode'>
+): boolean {
+  const [targetPath] = item.href.split('?')
+
+  if (item.matchMode === 'exact') {
+    return pathname === targetPath
+  }
+
+  return pathname === targetPath || pathname.startsWith(`${targetPath}/`)
+}

--- a/apps/talos/tests/unit/navigation.test.ts
+++ b/apps/talos/tests/unit/navigation.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { AMAZON_WORKSPACE_TOOLS } from '../../src/lib/amazon/workspace'
+import { buildMainNavigation, isNavigationItemActive } from '../../src/lib/navigation/main-nav'
+
+test('amazon workspace exposes the live tool surfaces in Talos', () => {
+  assert.deepEqual(
+    AMAZON_WORKSPACE_TOOLS.map((tool) => tool.href),
+    [
+      '/amazon',
+      '/amazon/fba-fee-discrepancies',
+      '/amazon/fba-fee-tables',
+      '/market/shipment-planning',
+    ]
+  )
+
+  assert.equal(
+    AMAZON_WORKSPACE_TOOLS.find((tool) => tool.href === '/amazon')?.matchMode,
+    'exact'
+  )
+})
+
+test('main navigation surfaces live Talos pages and keeps super-admin routes gated', () => {
+  const staffNavigation = buildMainNavigation({
+    role: 'staff',
+    email: 'ops@targonglobal.com',
+  })
+
+  const amazonSection = staffNavigation.find((section) => section.title === 'Amazon')
+  assert.ok(amazonSection)
+  assert.deepEqual(
+    amazonSection.items.map((item) => item.href),
+    [
+      '/amazon',
+      '/amazon/fba-fee-discrepancies',
+      '/amazon/fba-fee-tables',
+      '/market/shipment-planning',
+    ]
+  )
+
+  const operationsSection = staffNavigation.find((section) => section.title === 'Operations')
+  assert.ok(operationsSection)
+  assert.ok(
+    operationsSection.items.some((item) => item.href === '/operations/storage-ledger')
+  )
+
+  const configurationSection = staffNavigation.find((section) => section.title === 'Configuration')
+  assert.ok(configurationSection)
+  assert.equal(
+    configurationSection.items.some((item) => item.href === '/config/permissions'),
+    false
+  )
+
+  const superAdminNavigation = buildMainNavigation({
+    role: 'admin',
+    email: 'jarrar@targonglobal.com',
+  })
+  const superAdminConfiguration = superAdminNavigation.find(
+    (section) => section.title === 'Configuration'
+  )
+  assert.ok(superAdminConfiguration)
+  assert.equal(
+    superAdminConfiguration.items.some((item) => item.href === '/config/permissions'),
+    true
+  )
+})
+
+test('navigation matching keeps the Amazon overview exact while child tools stay highlighted', () => {
+  assert.equal(
+    isNavigationItemActive('/amazon/fba-fee-tables', {
+      href: '/amazon',
+      matchMode: 'exact',
+    }),
+    false
+  )
+
+  assert.equal(
+    isNavigationItemActive('/amazon/fba-fee-tables', {
+      href: '/amazon/fba-fee-tables',
+      matchMode: 'prefix',
+    }),
+    true
+  )
+
+  assert.equal(
+    isNavigationItemActive('/operations/purchase-orders/123', {
+      href: '/operations/purchase-orders',
+      matchMode: 'prefix',
+    }),
+    true
+  )
+})


### PR DESCRIPTION
## Summary
- expose the working Amazon tools in the Talos app shell and add an Amazon workspace landing page
- surface shipment planning and storage ledger in the appropriate nav sections while keeping permissions gated to super admins
- add a pure navigation model test and fix the Amazon page headers so they route back to the workspace

## Verification
- PR #4952 merged into dev after CI passed
- pnpm exec tsx --test tests/unit/navigation.test.ts
- pnpm type-check
- pnpm lint
- set -a && source /Users/jarraramjad/dev/targonos-main/apps/talos/.env.local && set +a && pnpm build