### PR TITLE
fix(argus): auto-sync WPR workspace after weekly collectors [claude]

### DIFF
--- a/apps/argus/scripts/api/weekly-sources/run.sh
+++ b/apps/argus/scripts/api/weekly-sources/run.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG="/tmp/weekly-api-sources.log"
 RUN_LOG_WRITER="$SCRIPT_DIR/../../lib/write-monitoring-run-log.mjs"
+WPR_SYNC_SCRIPT="$SCRIPT_DIR/../../lib/sync-wpr-workspace.sh"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 DRY_FLAG=""
@@ -110,6 +111,10 @@ run_optional_step "Datadive API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-datadive.m
 run_optional_step "Datadive format repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-datadive-formats.mjs\" $DRY_FLAG"
 run_step "Sellerboard API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-sellerboard.mjs\" $DRY_FLAG $DATE_FLAGS"
 run_step "Weekly label repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-week-labels.mjs\" $DRY_FLAG"
+
+if [ -z "$DRY_FLAG" ] && [ "$FAILED" -eq 0 ]; then
+  run_step "WPR workspace sync" "bash \"$WPR_SYNC_SCRIPT\" --trigger weekly-api-sources"
+fi
 
 log "=== Weekly API Sources run done (failures=$FAILED) ==="
 

--- a/apps/argus/scripts/browser/run-weekly.sh
+++ b/apps/argus/scripts/browser/run-weekly.sh
@@ -12,6 +12,7 @@ source "$SCRIPT_DIR/common.sh"
 
 LOG="/tmp/weekly-browser-sources.log"
 RUN_LOG_WRITER="$REPO_ROOT/apps/argus/scripts/lib/write-monitoring-run-log.mjs"
+WPR_SYNC_SCRIPT="$REPO_ROOT/apps/argus/scripts/lib/sync-wpr-workspace.sh"
 RUN_STARTED_AT_MS="$("$NODE_BIN" -e 'process.stdout.write(String(Date.now()))')"
 RUN_STARTED_AT_ISO="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 BRAND_METRICS_SOURCE_LIMIT_NOTE="$("$NODE_BIN" "$SCRIPT_DIR/brand-metrics-availability.mjs" source-limit-note)"
@@ -72,6 +73,18 @@ run_script "Product Opportunity Explorer" "$SCRIPT_DIR/weekly-poe/collect.sh" "/
 run_script "ScaleInsights" "$SCRIPT_DIR/weekly-scaleinsights/collect.sh" "/tmp/weekly-scaleinsights.log"
 log "Brand Metrics note: $BRAND_METRICS_SOURCE_LIMIT_NOTE"
 run_script "Brand Metrics" "$SCRIPT_DIR/weekly-brand-metrics/collect.sh" "/tmp/weekly-brand-metrics.log"
+
+if [ "$FAILED" -eq 0 ]; then
+  log "Running: WPR workspace sync"
+  if bash "$WPR_SYNC_SCRIPT" --trigger weekly-browser-sources >> "$LOG" 2>&1; then
+    log "OK: WPR workspace sync"
+  else
+    local_exit_code=$?
+    log "FAILED: WPR workspace sync (exit $local_exit_code)"
+    FAILED_STEPS+=("WPR workspace sync")
+    FAILED=$((FAILED + 1))
+  fi
+fi
 
 log "=== Weekly Master Run Done ($FAILED failures) ==="
 

--- a/apps/argus/scripts/lib/sync-wpr-workspace.sh
+++ b/apps/argus/scripts/lib/sync-wpr-workspace.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+LOCK_FILE="/tmp/argus-wpr-workspace.lock"
+
+if [ "${1:-}" != "--locked" ]; then
+  exec /usr/bin/lockf "$LOCK_FILE" /bin/bash "$SCRIPT_PATH" --locked "$@"
+fi
+shift
+
+TRIGGER="manual"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --trigger)
+      TRIGGER="${2:-}"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+PYTHON_BIN="$(command -v python3)"
+export PYTHON_BIN
+
+source "$(cd "$(dirname "$0")/../browser" && pwd)/common.sh"
+load_monitoring_env
+
+WPR_DATA_DIR="$(require_env WPR_DATA_DIR)"
+WPR_WORKSPACE="$(cd "$(dirname "$WPR_DATA_DIR")" && pwd)"
+REBUILD_SCRIPT="$WPR_WORKSPACE/rebuild_wpr.py"
+BUILD_SCRIPT="$WPR_WORKSPACE/build_intent_cluster_dashboard.py"
+
+if [ ! -f "$REBUILD_SCRIPT" ]; then
+  echo "Missing rebuild script: $REBUILD_SCRIPT" >&2
+  exit 1
+fi
+
+if [ ! -f "$BUILD_SCRIPT" ]; then
+  echo "Missing dashboard build script: $BUILD_SCRIPT" >&2
+  exit 1
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') — WPR workspace sync starting (trigger=$TRIGGER)"
+echo "$(date '+%Y-%m-%d %H:%M:%S') — WPR workspace: $WPR_WORKSPACE"
+
+"$PYTHON_BIN" "$REBUILD_SCRIPT"
+"$PYTHON_BIN" "$BUILD_SCRIPT"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') — WPR workspace sync completed"


### PR DESCRIPTION
## Summary
- add a shared WPR workspace sync script that rebuilds the workspace and dashboard outputs under a lock
- trigger the sync automatically after successful weekly API collection
- trigger the sync automatically after successful weekly browser collection

## Why
The weekly collectors were writing fresh Monitoring data, but Argus serves the generated WPR workspace output. Without an automatic rebuild/build step after collection, live WPR data could stay stale until someone ran the workspace rebuild manually.

## Verification
- `bash -n apps/argus/scripts/lib/sync-wpr-workspace.sh`
- `bash -n apps/argus/scripts/api/weekly-sources/run.sh`
- `bash -n apps/argus/scripts/browser/run-weekly.sh`
- `WPR_DATA_DIR='…/wpr-workspace/output' bash apps/argus/scripts/lib/sync-wpr-workspace.sh --trigger manual-verification`
