### PR TITLE
chore(repo): promote dev to main [claude]

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -769,7 +769,7 @@ ensure_database_url() {
   if [[ "$environment" == "dev" ]]; then
     candidates=("$app_dir/.env.local" "$app_dir/.env.dev" "$app_dir/.env.dev.ci" "$app_dir/.env")
   else
-    candidates=("$app_dir/.env.local" "$app_dir/.env.production" "$app_dir/.env")
+    candidates=("$app_dir/.env.production" "$app_dir/.env.local" "$app_dir/.env")
   fi
 
   for file in "${candidates[@]}"; do
@@ -796,7 +796,7 @@ ensure_portal_db_url() {
   if [[ "$environment" == "dev" ]]; then
     candidates=("$sso_dir/.env.local" "$sso_dir/.env.dev" "$sso_dir/.env.dev.ci" "$sso_dir/.env")
   else
-    candidates=("$sso_dir/.env.local" "$sso_dir/.env.production" "$sso_dir/.env")
+    candidates=("$sso_dir/.env.production" "$sso_dir/.env.local" "$sso_dir/.env")
   fi
   local file
 
@@ -880,7 +880,7 @@ resolve_portal_shared_secret() {
   if [[ "$environment" == "dev" ]]; then
     candidates=("$sso_dir/.env.local" "$sso_dir/.env.dev" "$sso_dir/.env.dev.ci" "$sso_dir/.env")
   else
-    candidates=("$sso_dir/.env.local" "$sso_dir/.env.production" "$sso_dir/.env")
+    candidates=("$sso_dir/.env.production" "$sso_dir/.env.local" "$sso_dir/.env")
   fi
 
   local file
@@ -1087,7 +1087,7 @@ ensure_app_env_loaded() {
   if [[ "$environment" == "dev" ]]; then
     candidates=("$app_dir/.env.local" "$app_dir/.env.dev" "$app_dir/.env.dev.ci" "$app_dir/.env")
   else
-    candidates=("$app_dir/.env.local" "$app_dir/.env.production" "$app_dir/.env")
+    candidates=("$app_dir/.env.production" "$app_dir/.env.local" "$app_dir/.env")
   fi
 
   local file

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -73,3 +73,22 @@ test('atlas dev deploy no longer falls back to db push on migrate errors', () =>
     /Prisma migrate deploy failed for atlas dev; falling back to non-destructive db push/,
   )
 })
+
+test('production deploys prefer .env.production before .env.local', () => {
+  assert.match(
+    deployScript,
+    /ensure_database_url\(\)[\s\S]*?else[\s\S]*?candidates=\("\$app_dir\/.env.production" "\$app_dir\/.env.local" "\$app_dir\/.env"\)/,
+  )
+  assert.match(
+    deployScript,
+    /ensure_portal_db_url\(\)[\s\S]*?else[\s\S]*?candidates=\("\$sso_dir\/.env.production" "\$sso_dir\/.env.local" "\$sso_dir\/.env"\)/,
+  )
+  assert.match(
+    deployScript,
+    /resolve_portal_shared_secret\(\)[\s\S]*?else[\s\S]*?candidates=\("\$sso_dir\/.env.production" "\$sso_dir\/.env.local" "\$sso_dir\/.env"\)/,
+  )
+  assert.match(
+    deployScript,
+    /ensure_app_env_loaded\(\)[\s\S]*?else[\s\S]*?candidates=\("\$app_dir\/.env.production" "\$app_dir\/.env.local" "\$app_dir\/.env"\)/,
+  )
+})


### PR DESCRIPTION
## Summary
- promote the deploy env precedence fix from `dev` to `main`
- keep production deploys loading `.env.production` before `.env.local`

## Verification
- CI on #4969 passed before merge to dev
- CI must pass on this promotion PR before merge