### PR TITLE
fix(talos): set tenant search path for prisma clients [claude]

### DIFF
--- a/apps/talos/src/lib/tenant/prisma-factory.ts
+++ b/apps/talos/src/lib/tenant/prisma-factory.ts
@@ -48,15 +48,15 @@ function getTenantDatabaseUrl(tenantCode: TenantCode): string {
 /**
  * Create a new Prisma client for a tenant
  */
-function withSchema(databaseUrl: string, schema: string): string {
-  try {
-    const url = new URL(databaseUrl)
-    url.searchParams.set('schema', schema)
-    return url.toString()
-  } catch {
-    const separator = databaseUrl.includes('?') ? '&' : '?'
-    return `${databaseUrl}${separator}schema=${schema}`
-  }
+function searchPathOption(schema: string): string {
+  return `-csearch_path=${schema},public`
+}
+
+export function buildSchemaScopedDatabaseUrl(databaseUrl: string, schema: string): string {
+  const url = new URL(databaseUrl)
+  url.searchParams.set('schema', schema)
+  url.searchParams.set('options', searchPathOption(schema))
+  return url.toString()
 }
 
 function withApplicationName(databaseUrl: string, applicationName: string): string {
@@ -150,7 +150,7 @@ async function resolveDatasourceUrl(databaseUrl: string, tenantCode: TenantCode)
   const taggedDatabaseUrl = withApplicationName(databaseUrl, `talos-${tenantCode.toLowerCase()}`)
   const schemaOverride = process.env.PRISMA_SCHEMA
   if (schemaOverride) {
-    return withSchema(taggedDatabaseUrl, schemaOverride)
+    return buildSchemaScopedDatabaseUrl(taggedDatabaseUrl, schemaOverride)
   }
 
   let currentSchema: string | null = null
@@ -168,20 +168,20 @@ async function resolveDatasourceUrl(databaseUrl: string, tenantCode: TenantCode)
 
   try {
     const hasRequiredTables = await schemaHasTable(baseConnectionString, currentSchema, 'skus')
-    if (hasRequiredTables) return taggedDatabaseUrl
+    if (hasRequiredTables) return buildSchemaScopedDatabaseUrl(taggedDatabaseUrl, currentSchema)
 
     const bestSchema = await findBestSchemaForTenant(baseConnectionString, tenantCode, currentSchema)
     if (bestSchema && bestSchema !== currentSchema) {
       console.warn(
         `[tenant] Schema "${currentSchema}" missing expected tables for ${tenantCode}; using "${bestSchema}" instead`
       )
-      return withSchema(taggedDatabaseUrl, bestSchema)
+      return buildSchemaScopedDatabaseUrl(taggedDatabaseUrl, bestSchema)
     }
   } catch {
     // Fall back to provided schema URL if we cannot introspect (e.g., network/permissions)
   }
 
-  return taggedDatabaseUrl
+  return buildSchemaScopedDatabaseUrl(taggedDatabaseUrl, currentSchema)
 }
 
 async function createTenantClient(tenantCode: TenantCode): Promise<PrismaClient> {

--- a/apps/talos/tests/unit/prisma-factory.test.ts
+++ b/apps/talos/tests/unit/prisma-factory.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { buildSchemaScopedDatabaseUrl } from '../../src/lib/tenant/prisma-factory'
+
+test('buildSchemaScopedDatabaseUrl preserves schema and sets search_path', () => {
+  const url = buildSchemaScopedDatabaseUrl(
+    'postgresql://portal_talos@localhost:5432/portal_db?schema=main_talos_us',
+    'main_talos_us'
+  )
+
+  const parsed = new URL(url)
+
+  assert.equal(parsed.searchParams.get('schema'), 'main_talos_us')
+  assert.equal(parsed.searchParams.get('options'), '-csearch_path=main_talos_us,public')
+})
+
+test('buildSchemaScopedDatabaseUrl replaces an existing search_path option', () => {
+  const url = buildSchemaScopedDatabaseUrl(
+    'postgresql://portal_talos@localhost:5432/portal_db?schema=dev_talos_us&options=-csearch_path%3Ddev_talos_us,public',
+    'main_talos_us'
+  )
+
+  const parsed = new URL(url)
+
+  assert.equal(parsed.searchParams.get('schema'), 'main_talos_us')
+  assert.equal(parsed.searchParams.get('options'), '-csearch_path=main_talos_us,public')
+})


### PR DESCRIPTION
## Summary
- add a schema-scoped Talos datasource URL builder that sets a Postgres search path
- use it for current, override, and corrected tenant schema URLs in the Prisma factory
- add a unit regression test for the tenant URL builder

## Verification
- pnpm --filter @targon/talos exec tsx --test tests/unit/prisma-factory.test.ts
- node --test scripts/deploy-app.test.cjs
- DATABASE_URL_US=... DATABASE_URL_UK=... pnpm --filter @targon/talos db:migrate:tenant-schema -- --tenant=US
- DATABASE_URL_US=... DATABASE_URL_UK=... pnpm --filter @targon/talos db:migrate:tenant-schema -- --tenant=UK