### PR TITLE
chore(repo): promote dev to main [claude]

### DIFF
--- a/apps/talos/src/lib/tenant/prisma-factory.ts
+++ b/apps/talos/src/lib/tenant/prisma-factory.ts
@@ -7,6 +7,7 @@ import { PrismaClient } from '@targon/prisma-talos'
 import { Client } from 'pg'
 import { logger } from '@/lib/logger'
 import { TenantCode, TENANTS, isValidTenantCode } from './constants'
+import { resolveTenantSchema } from './schema'
 
 // Global cache for Prisma clients per tenant
 const globalForPrisma = global as unknown as {
@@ -148,21 +149,11 @@ async function findBestSchemaForTenant(
 
 async function resolveDatasourceUrl(databaseUrl: string, tenantCode: TenantCode): Promise<string> {
   const taggedDatabaseUrl = withApplicationName(databaseUrl, `talos-${tenantCode.toLowerCase()}`)
-  const schemaOverride = process.env.PRISMA_SCHEMA
-  if (schemaOverride) {
-    return buildSchemaScopedDatabaseUrl(taggedDatabaseUrl, schemaOverride)
-  }
-
-  let currentSchema: string | null = null
-  try {
-    currentSchema = new URL(databaseUrl).searchParams.get('schema')
-  } catch {
-    currentSchema = null
-  }
-
-  if (!currentSchema) {
+  const resolvedSchema = resolveTenantSchema(databaseUrl, process.env.PRISMA_SCHEMA)
+  if (!resolvedSchema) {
     return taggedDatabaseUrl
   }
+  const currentSchema = resolvedSchema.schema
 
   const baseConnectionString = withoutSchema(taggedDatabaseUrl)
 

--- a/apps/talos/src/lib/tenant/schema.ts
+++ b/apps/talos/src/lib/tenant/schema.ts
@@ -1,0 +1,34 @@
+export type ResolvedTenantSchema = {
+  schema: string
+  source: 'database-url' | 'override'
+}
+
+export function getSchemaFromDatabaseUrl(databaseUrl: string): string | null {
+  try {
+    return new URL(databaseUrl).searchParams.get('schema')
+  } catch {
+    return null
+  }
+}
+
+export function resolveTenantSchema(
+  databaseUrl: string,
+  schemaOverride: string | undefined | null
+): ResolvedTenantSchema | null {
+  const schemaFromUrl = getSchemaFromDatabaseUrl(databaseUrl)
+  if (schemaFromUrl) {
+    return {
+      schema: schemaFromUrl,
+      source: 'database-url',
+    }
+  }
+
+  if (schemaOverride) {
+    return {
+      schema: schemaOverride,
+      source: 'override',
+    }
+  }
+
+  return null
+}

--- a/apps/talos/src/lib/tenant/server.ts
+++ b/apps/talos/src/lib/tenant/server.ts
@@ -10,6 +10,7 @@ import {
 import { getTenantPrismaClient } from './prisma-factory'
 import { PrismaClient } from '@targon/prisma-talos'
 import { resolveTenantCodeFromState } from './session'
+import { resolveTenantSchema } from './schema'
 
 function assertSafePgIdentifier(value: string, label: string): asserts value is string {
   if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
@@ -18,25 +19,15 @@ function assertSafePgIdentifier(value: string, label: string): asserts value is 
 }
 
 function getSchemaFromDatabaseUrl(databaseUrl: string, tenantCode: TenantCode): string {
-  const override = process.env.PRISMA_SCHEMA
-  if (override) {
-    assertSafePgIdentifier(override, 'PRISMA_SCHEMA')
-    return override
-  }
-
-  let schema: string | null = null
-  try {
-    schema = new URL(databaseUrl).searchParams.get('schema')
-  } catch {
-    schema = null
-  }
-
-  if (!schema) {
+  const resolvedSchema = resolveTenantSchema(databaseUrl, process.env.PRISMA_SCHEMA)
+  if (!resolvedSchema) {
     throw new Error(`Missing schema for tenant ${tenantCode}. Add ?schema=... to ${TENANTS[tenantCode].envKey}.`)
   }
-
-  assertSafePgIdentifier(schema, `${TENANTS[tenantCode].envKey} schema`)
-  return schema
+  const label = resolvedSchema.source === 'override'
+    ? 'PRISMA_SCHEMA'
+    : `${TENANTS[tenantCode].envKey} schema`
+  assertSafePgIdentifier(resolvedSchema.schema, label)
+  return resolvedSchema.schema
 }
 
 /**

--- a/apps/talos/tests/unit/prisma-factory.test.ts
+++ b/apps/talos/tests/unit/prisma-factory.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import { buildSchemaScopedDatabaseUrl } from '../../src/lib/tenant/prisma-factory'
+import { resolveTenantSchema } from '../../src/lib/tenant/schema'
 
 test('buildSchemaScopedDatabaseUrl preserves schema and sets search_path', () => {
   const url = buildSchemaScopedDatabaseUrl(
@@ -24,4 +25,28 @@ test('buildSchemaScopedDatabaseUrl replaces an existing search_path option', () 
 
   assert.equal(parsed.searchParams.get('schema'), 'main_talos_us')
   assert.equal(parsed.searchParams.get('options'), '-csearch_path=main_talos_us,public')
+})
+
+test('resolveTenantSchema prefers the schema embedded in the tenant URL', () => {
+  const resolved = resolveTenantSchema(
+    'postgresql://portal_talos@localhost:5432/portal_db?schema=main_talos_us',
+    'dev_talos_us'
+  )
+
+  assert.deepEqual(resolved, {
+    schema: 'main_talos_us',
+    source: 'database-url',
+  })
+})
+
+test('resolveTenantSchema uses PRISMA_SCHEMA when the tenant URL has no schema', () => {
+  const resolved = resolveTenantSchema(
+    'postgresql://portal_talos@localhost:5432/portal_db',
+    'dev_talos_us'
+  )
+
+  assert.deepEqual(resolved, {
+    schema: 'dev_talos_us',
+    source: 'override',
+  })
 })


### PR DESCRIPTION
## Summary\n- promote the merged Talos tenant schema precedence fix from dev to main\n\n## Included fixes\n- prefer the schema embedded in DATABASE_URL_US/DATABASE_URL_UK over PRISMA_SCHEMA overrides\n- keep PRISMA_SCHEMA only for single-url setups without a schema in the URL\n- preserve the Argus deploy env precedence fix already merged earlier\n\n## Verification\n- GitHub CI on #4973\n- talos production-style migration repro commands from the feature branch