### PR TITLE
fix(plutus): harden qbo auth runtime [claude]

### DIFF
--- a/apps/plutus/app/api/qbo/callback/route.ts
+++ b/apps/plutus/app/api/qbo/callback/route.ts
@@ -3,7 +3,7 @@ import { cookies } from 'next/headers';
 import { exchangeCodeForTokens } from '@/lib/qbo/client';
 import { createLogger } from '@targon/logger';
 import { z } from 'zod';
-import { saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import type { QboConnection } from '@/lib/qbo/api';
 import { decodePlutusPortalSession, isPlatformAdminPortalSession } from '@/lib/portal-session';
 
@@ -79,6 +79,14 @@ export async function GET(req: NextRequest) {
       expiresAt: new Date(Date.now() + tokens.expiresIn * 1000).toISOString(),
     };
 
+    const previousConnection = await getQboConnection();
+    if (previousConnection !== null && previousConnection.realmId !== connection.realmId) {
+      logger.warn('QBO realm changed during callback', {
+        previousRealmId: previousConnection.realmId,
+        nextRealmId: connection.realmId,
+      });
+    }
+
     // Store full connection server-side only
     await saveServerQboConnection(connection);
 
@@ -93,7 +101,10 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.redirect(new URL(`${basePath}?connected=true`, baseUrl));
   } catch (error) {
-    logger.error('QBO callback failed', error);
+    logger.error('QBO callback failed', {
+      realmId: req.nextUrl.searchParams.get('realmId'),
+      error: error instanceof Error ? error.message : String(error),
+    });
     return NextResponse.redirect(new URL(`${basePath}?error=token_exchange_failed`, baseUrl));
   }
 }

--- a/apps/plutus/app/api/qbo/status/route.ts
+++ b/apps/plutus/app/api/qbo/status/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createLogger } from '@targon/logger';
 import { getApiBaseUrl } from '@/lib/qbo/client';
-import { getValidToken } from '@/lib/qbo/api';
+import { QboAuthError, getValidToken } from '@/lib/qbo/api';
+import { classifyQboVerificationFailure, getQboConnectionErrorMessage } from '@/lib/qbo/connection-feedback';
 import type { QboConnectionStatus, QboCompanyInfoResponse, QboPreferences } from '@/lib/qbo/types';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import { decodePlutusPortalSession, isPlatformAdminPortalSession } from '@/lib/portal-session';
@@ -32,13 +33,23 @@ export async function GET(request: Request) {
       logger.info('QBO token refreshed successfully');
     }
   } catch (refreshError) {
+    if (!(refreshError instanceof QboAuthError)) {
+      throw refreshError;
+    }
+    if (refreshError.code === undefined) {
+      throw new Error('QboAuthError.code is required');
+    }
+
     logger.warn('Token refresh failed', {
-      error: refreshError instanceof Error ? refreshError.message : String(refreshError),
+      realmId: connection.realmId,
+      error: refreshError.details ?? refreshError.message,
+      errorCode: refreshError.code,
     });
     return NextResponse.json<QboConnectionStatus>({
       connected: false,
       canConnect,
-      error: 'Session expired. Please reconnect to QuickBooks.',
+      errorCode: refreshError.code,
+      error: refreshError.message,
     });
   }
 
@@ -56,12 +67,17 @@ export async function GET(request: Request) {
     );
 
     if (response.status === 401 || response.status === 403) {
-      // Token is truly invalid - user needs to reconnect
-      logger.error('QBO authentication failed', { status: response.status });
+      const errorCode = classifyQboVerificationFailure(response.status);
+      logger.error('QBO authentication failed', {
+        realmId: connection.realmId,
+        status: response.status,
+        errorCode,
+      });
       return NextResponse.json<QboConnectionStatus>({
         connected: false,
         canConnect,
-        error: 'Session expired. Please reconnect to QuickBooks.',
+        errorCode,
+        error: getQboConnectionErrorMessage(errorCode),
       });
     }
 

--- a/apps/plutus/app/page.tsx
+++ b/apps/plutus/app/page.tsx
@@ -1,5 +1,9 @@
 import { redirect } from 'next/navigation';
+import { buildPlutusHomeRedirectPath } from '@/lib/qbo/connection-feedback';
 
-export default function HomePage() {
-  redirect('/settlements');
+type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
+
+export default async function HomePage({ searchParams }: { searchParams?: SearchParams } = {}) {
+  const resolvedSearchParams = searchParams === undefined ? {} : await searchParams;
+  redirect(buildPlutusHomeRedirectPath(resolvedSearchParams));
 }

--- a/apps/plutus/lib/qbo/api.ts
+++ b/apps/plutus/lib/qbo/api.ts
@@ -2,6 +2,8 @@ import { getApiBaseUrl, refreshAccessToken } from './client';
 import { createLogger } from '@targon/logger';
 import { getCached, setCache, invalidateCache } from './cache';
 import { loadServerQboConnection, saveServerQboConnection } from './connection-store';
+import { classifyQboRefreshFailure, getQboConnectionErrorMessage } from './connection-feedback';
+import type { QboConnectionErrorCode } from './types';
 
 const logger = createLogger({ name: 'qbo-api' });
 
@@ -21,6 +23,14 @@ function escapeSoql(value: string): string {
 
 export class QboAuthError extends Error {
   name = 'QboAuthError';
+  readonly code?: QboConnectionErrorCode;
+  readonly details?: string;
+
+  constructor(message: string, options?: { code?: QboConnectionErrorCode; details?: string }) {
+    super(message);
+    this.code = options?.code;
+    this.details = options?.details;
+  }
 }
 
 /**
@@ -686,9 +696,17 @@ export async function getValidToken(
       const updatedConnection = await refreshConnectionSingleFlight(connection);
       return { accessToken: updatedConnection.accessToken, updatedConnection };
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      logger.warn('QBO token refresh failed', { realmId: connection.realmId, error: message });
-      throw new QboAuthError('Session expired. Please reconnect to QuickBooks.');
+      const details = error instanceof Error ? error.message : String(error);
+      const errorCode = classifyQboRefreshFailure(error);
+      logger.warn('QBO token refresh failed', {
+        realmId: connection.realmId,
+        error: details,
+        errorCode,
+      });
+      throw new QboAuthError(getQboConnectionErrorMessage(errorCode), {
+        code: errorCode,
+        details,
+      });
     }
   }
 

--- a/apps/plutus/lib/qbo/client.ts
+++ b/apps/plutus/lib/qbo/client.ts
@@ -20,10 +20,18 @@ function requireEnv(name: string): string {
   return value;
 }
 
+function requireQboOAuthEnv(name: 'QBO_CLIENT_ID' | 'QBO_CLIENT_SECRET'): string {
+  const value = requireEnv(name);
+  if (value === 'ci-placeholder') {
+    throw new Error(`${name} cannot use ci-placeholder`);
+  }
+  return value;
+}
+
 export function getQboClientConfig(): QboClientConfig {
   return {
-    clientId: requireEnv('QBO_CLIENT_ID'),
-    clientSecret: requireEnv('QBO_CLIENT_SECRET'),
+    clientId: requireQboOAuthEnv('QBO_CLIENT_ID'),
+    clientSecret: requireQboOAuthEnv('QBO_CLIENT_SECRET'),
     redirectUri: requireEnv('QBO_REDIRECT_URI'),
     environment: (process.env.QBO_SANDBOX === 'true' ? 'sandbox' : 'production') as QboEnvironment,
   };

--- a/apps/plutus/lib/qbo/connection-feedback.ts
+++ b/apps/plutus/lib/qbo/connection-feedback.ts
@@ -1,0 +1,103 @@
+import type { QboConnectionErrorCode } from './types';
+
+type SearchParamValue = string | string[] | undefined;
+
+function readErrorText(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return String(error);
+}
+
+function firstSearchParamValue(value: SearchParamValue): string | null {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const firstValue = value[0];
+    if (firstValue === undefined) {
+      return null;
+    }
+    return firstValue;
+  }
+  return null;
+}
+
+export function classifyQboRefreshFailure(error: unknown): QboConnectionErrorCode {
+  const normalized = readErrorText(error).trim().toLowerCase();
+
+  if (normalized.includes('ci-placeholder')) {
+    return 'oauth_client_mismatch';
+  }
+
+  if (normalized.includes('invalid_client')) {
+    return 'oauth_client_mismatch';
+  }
+
+  if (normalized.includes('invalid_grant')) {
+    return 'refresh_token_invalid';
+  }
+
+  if (normalized.includes('refresh token is invalid')) {
+    return 'refresh_token_invalid';
+  }
+
+  if (normalized.includes('authorize again')) {
+    return 'refresh_token_invalid';
+  }
+
+  return 'session_expired';
+}
+
+export function classifyQboVerificationFailure(status: number): QboConnectionErrorCode {
+  if (status === 403) {
+    return 'qbo_company_forbidden';
+  }
+
+  return 'session_expired';
+}
+
+export function getQboConnectionErrorMessage(code: QboConnectionErrorCode): string {
+  switch (code) {
+    case 'connect_failed':
+      return 'Plutus could not start the QuickBooks connection flow. Please try again.';
+    case 'invalid_params':
+      return 'QuickBooks returned incomplete connection parameters. Please try again.';
+    case 'invalid_state':
+      return 'Security check failed. Please try connecting to QuickBooks again.';
+    case 'oauth_client_mismatch':
+      return 'Plutus cannot authenticate with QuickBooks because the server OAuth client is invalid. Ask a platform admin to fix the QuickBooks app credentials before reconnecting.';
+    case 'qbo_company_forbidden':
+      return 'QuickBooks rejected access to this company. Reconnect as a QuickBooks Company Admin and make sure you authorize the correct company.';
+    case 'refresh_token_invalid':
+      return 'The saved QuickBooks authorization is no longer valid. Reconnect QuickBooks to continue.';
+    case 'session_expired':
+      return 'Session expired. Please reconnect to QuickBooks.';
+    case 'token_exchange_failed':
+      return 'QuickBooks did not complete the connection. Please try again.';
+  }
+}
+
+export function buildPlutusHomeRedirectPath(searchParams: Record<string, SearchParamValue>): string {
+  const params = new URLSearchParams();
+
+  const connected = firstSearchParamValue(searchParams.connected);
+  if (connected !== null) {
+    params.set('connected', connected);
+  }
+
+  const error = firstSearchParamValue(searchParams.error);
+  if (error !== null) {
+    params.set('error', error);
+  }
+
+  const query = params.toString();
+  if (query === '') {
+    return '/settlements';
+  }
+
+  return `/settlements?${query}`;
+}

--- a/apps/plutus/lib/qbo/types.ts
+++ b/apps/plutus/lib/qbo/types.ts
@@ -1,3 +1,13 @@
+export type QboConnectionErrorCode =
+  | 'connect_failed'
+  | 'invalid_params'
+  | 'invalid_state'
+  | 'oauth_client_mismatch'
+  | 'qbo_company_forbidden'
+  | 'refresh_token_invalid'
+  | 'session_expired'
+  | 'token_exchange_failed';
+
 // QBO OAuth Token
 export interface QboToken {
   accessToken: string;
@@ -175,5 +185,6 @@ export interface QboConnectionStatus {
   partnerTaxEnabled?: boolean;
   subscription?: string;
   lastSyncAt?: Date;
+  errorCode?: QboConnectionErrorCode;
   error?: string;
 }

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -85,6 +85,11 @@ import {
   buildLegacySettlementPagePath,
   remapLegacySettlementPath,
 } from '../lib/plutus/legacy-settlement-routes';
+import {
+  buildPlutusHomeRedirectPath,
+  classifyQboRefreshFailure,
+  classifyQboVerificationFailure,
+} from '../lib/qbo/connection-feedback';
 import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
 import type { QboAccount, QboBill, QboRecurringTransaction } from '../lib/qbo/api';
@@ -112,6 +117,41 @@ test('resolveMuiThemeMode waits for mount before applying dark mode', () => {
   assert.equal(resolveMuiThemeMode(true, 'dark'), 'dark');
   assert.equal(resolveMuiThemeMode(true, 'light'), 'light');
   assert.equal(resolveMuiThemeMode(true, undefined), 'light');
+});
+
+test('classifyQboRefreshFailure maps invalid_client to oauth client mismatch', () => {
+  assert.equal(classifyQboRefreshFailure(new Error('invalid_client')), 'oauth_client_mismatch');
+});
+
+test('classifyQboRefreshFailure maps ci-placeholder config errors to oauth client mismatch', () => {
+  assert.equal(
+    classifyQboRefreshFailure(new Error('QBO_CLIENT_ID cannot use ci-placeholder')),
+    'oauth_client_mismatch',
+  );
+});
+
+test('classifyQboRefreshFailure maps invalid refresh token messages to refresh token invalid', () => {
+  assert.equal(
+    classifyQboRefreshFailure(new Error('The Refresh token is invalid, please Authorize again.')),
+    'refresh_token_invalid',
+  );
+});
+
+test('classifyQboVerificationFailure maps 403 to forbidden company and 401 to session expired', () => {
+  assert.equal(classifyQboVerificationFailure(403), 'qbo_company_forbidden');
+  assert.equal(classifyQboVerificationFailure(401), 'session_expired');
+});
+
+test('buildPlutusHomeRedirectPath preserves qbo callback query params', () => {
+  assert.equal(buildPlutusHomeRedirectPath({ connected: 'true' }), '/settlements?connected=true');
+  assert.equal(
+    buildPlutusHomeRedirectPath({ error: 'token_exchange_failed', ignored: 'x' }),
+    '/settlements?error=token_exchange_failed',
+  );
+  assert.equal(
+    buildPlutusHomeRedirectPath({ connected: ['true', 'false'], error: ['invalid_state'] }),
+    '/settlements?connected=true&error=invalid_state',
+  );
 });
 
 test('normalizeSettlementDocNumber extracts embedded settlement ids', () => {

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -24,7 +24,8 @@ function loadEnvFile(filePath) {
   } catch { return {}; }
 }
 
-function envFilenamesFor(environment, includeLocal = true) {
+function envFilenamesFor(environment, includeLocal = true, options = {}) {
+  const preferLocal = options.preferLocal === undefined ? true : options.preferLocal;
   if (environment === 'dev') {
     const filenames = ['.env', '.env.dev.ci', '.env.dev'];
     if (includeLocal) {
@@ -33,8 +34,12 @@ function envFilenamesFor(environment, includeLocal = true) {
     return filenames;
   }
 
-  const filenames = ['.env', '.env.production'];
-  if (includeLocal) {
+  const filenames = ['.env'];
+  if (includeLocal && !preferLocal) {
+    filenames.push('.env.local');
+  }
+  filenames.push('.env.production');
+  if (includeLocal && preferLocal) {
     filenames.push('.env.local');
   }
   return filenames;
@@ -42,9 +47,10 @@ function envFilenamesFor(environment, includeLocal = true) {
 
 function loadAppEnv(appDir, environment, options = {}) {
   const includeLocal = options.includeLocal === undefined ? true : options.includeLocal;
+  const preferLocal = options.preferLocal === undefined ? true : options.preferLocal;
   const env = {};
 
-  for (const filename of envFilenamesFor(environment, includeLocal)) {
+  for (const filename of envFilenamesFor(environment, includeLocal, { preferLocal })) {
     Object.assign(env, loadEnvFile(path.join(appDir, filename)));
   }
 
@@ -66,6 +72,20 @@ function createNextAppEnv(rootDir, appName, environment, runtimeEnv) {
   return {
     ...loadAppEnv(path.join(rootDir, `apps/${appName}`), environment),
     ...runtimeEnv,
+  };
+}
+
+function getHostedEnvLoadOptions(environment) {
+  if (environment === 'production') {
+    return {
+      includeLocal: true,
+      preferLocal: false,
+    };
+  }
+
+  return {
+    includeLocal: true,
+    preferLocal: true,
   };
 }
 
@@ -138,18 +158,29 @@ function omitHostedManagedAppEnv(appEnv) {
 
 function createPortalRuntimeEnv(rootDir, environment, runtimeEnv) {
   const portalBaseUrl = getPortalHostedUrl(environment);
-  const portalEnv = loadAppEnv(path.join(rootDir, 'apps/sso'), environment);
+  const hostedLoadOptions = getHostedEnvLoadOptions(environment);
+  const portalEnv = loadAppEnv(path.join(rootDir, 'apps/sso'), environment, hostedLoadOptions);
+  const portalProcessEnv = pickProcessEnv(['PORTAL_AUTH_SECRET', 'NEXTAUTH_SECRET', 'PORTAL_DB_URL']);
   const sharedSecret = getHostedSharedSecret({
     ...portalEnv,
-    ...pickProcessEnv(['PORTAL_AUTH_SECRET', 'NEXTAUTH_SECRET']),
+    ...portalProcessEnv,
   });
   const buildMetadataEnv = getHostedBuildMetadataEnv();
+  let portalDatabaseUrl = portalEnv.PORTAL_DB_URL;
+  if (portalProcessEnv.PORTAL_DB_URL !== undefined) {
+    portalDatabaseUrl = portalProcessEnv.PORTAL_DB_URL;
+  }
+  if (!portalDatabaseUrl) {
+    throw new Error(`Missing PORTAL_DB_URL for hosted portal ${environment} runtime.`);
+  }
+
   return {
     ...portalEnv,
     ...runtimeEnv,
     ...buildMetadataEnv,
     PORTAL_AUTH_SECRET: sharedSecret,
     NEXTAUTH_SECRET: sharedSecret,
+    PORTAL_DB_URL: portalDatabaseUrl,
     COOKIE_DOMAIN: getHostedCookieDomain(environment),
     PORTAL_APPS_BASE_URL: portalBaseUrl,
     NEXT_PUBLIC_PORTAL_APPS_BASE_URL: portalBaseUrl,
@@ -215,7 +246,10 @@ function resolveHostedBasePath(appEnv, runtimeEnv) {
 
 function createNextAppEnvWithPortal(rootDir, appName, environment, runtimeEnv) {
   const portalEnv = createPortalRuntimeEnv(rootDir, environment, {});
-  const appEnv = omitHostedManagedAppEnv(loadAppEnv(path.join(rootDir, `apps/${appName}`), environment));
+  const hostedLoadOptions = getHostedEnvLoadOptions(environment);
+  const appEnv = omitHostedManagedAppEnv(
+    loadAppEnv(path.join(rootDir, `apps/${appName}`), environment, hostedLoadOptions),
+  );
   const portalBaseUrl = portalEnv.PORTAL_AUTH_URL;
   if (!portalBaseUrl) {
     throw new Error(`Missing PORTAL_AUTH_URL for ${appName} ${environment} runtime.`);
@@ -398,12 +432,13 @@ module.exports = {
       args: 'scripts/cashflow-refresh-worker.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: {
-        ...loadEnvFile(path.join(DEV_DIR, 'apps/plutus/.env.local')),
+      env: createNextAppEnvWithPortal(DEV_DIR, 'plutus', 'dev', {
         NODE_ENV: 'production',
         PLUTUS_CASHFLOW_REFRESH_WORKER_ENABLED: '0',
-        PLUTUS_QBO_CONNECTION_PATH: DEV_PLUTUS_QBO_CONNECTION_PATH
-      },
+        PLUTUS_QBO_CONNECTION_PATH: DEV_PLUTUS_QBO_CONNECTION_PATH,
+        BASE_PATH: '/plutus',
+        NEXT_PUBLIC_BASE_PATH: '/plutus',
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -415,14 +450,15 @@ module.exports = {
       args: 'scripts/settlement-sync-worker.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: {
-        ...loadEnvFile(path.join(DEV_DIR, 'apps/plutus/.env.local')),
+      env: createNextAppEnvWithPortal(DEV_DIR, 'plutus', 'dev', {
         NODE_ENV: 'production',
         PLUTUS_SETTLEMENT_SYNC_WORKER_ENABLED: '0',
         PLUTUS_SETTLEMENT_SYNC_INTERVAL_MINUTES: '60',
         PLUTUS_SETTLEMENT_SYNC_LOOKBACK_DAYS: '45',
-        PLUTUS_QBO_CONNECTION_PATH: DEV_PLUTUS_QBO_CONNECTION_PATH
-      },
+        PLUTUS_QBO_CONNECTION_PATH: DEV_PLUTUS_QBO_CONNECTION_PATH,
+        BASE_PATH: '/plutus',
+        NEXT_PUBLIC_BASE_PATH: '/plutus',
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -619,12 +655,13 @@ module.exports = {
       args: 'scripts/cashflow-refresh-worker.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: {
-        ...loadEnvFile(path.join(MAIN_DIR, 'apps/plutus/.env.local')),
+      env: createNextAppEnvWithPortal(MAIN_DIR, 'plutus', 'production', {
         NODE_ENV: 'production',
         PLUTUS_CASHFLOW_REFRESH_WORKER_ENABLED: '1',
-        PLUTUS_QBO_CONNECTION_PATH: MAIN_PLUTUS_QBO_CONNECTION_PATH
-      },
+        PLUTUS_QBO_CONNECTION_PATH: MAIN_PLUTUS_QBO_CONNECTION_PATH,
+        BASE_PATH: '/plutus',
+        NEXT_PUBLIC_BASE_PATH: '/plutus',
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -636,14 +673,15 @@ module.exports = {
       args: 'scripts/settlement-sync-worker.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: {
-        ...loadEnvFile(path.join(MAIN_DIR, 'apps/plutus/.env.local')),
+      env: createNextAppEnvWithPortal(MAIN_DIR, 'plutus', 'production', {
         NODE_ENV: 'production',
         PLUTUS_SETTLEMENT_SYNC_WORKER_ENABLED: '1',
         PLUTUS_SETTLEMENT_SYNC_INTERVAL_MINUTES: '60',
         PLUTUS_SETTLEMENT_SYNC_LOOKBACK_DAYS: '45',
-        PLUTUS_QBO_CONNECTION_PATH: MAIN_PLUTUS_QBO_CONNECTION_PATH
-      },
+        PLUTUS_QBO_CONNECTION_PATH: MAIN_PLUTUS_QBO_CONNECTION_PATH,
+        BASE_PATH: '/plutus',
+        NEXT_PUBLIC_BASE_PATH: '/plutus',
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -708,7 +746,6 @@ module.exports = {
     },
   ]
 };
-
 module.exports.createPortalRuntimeEnv = createPortalRuntimeEnv;
 module.exports.createNextAppEnvWithPortal = createNextAppEnvWithPortal;
 module.exports.buildHostedAppUrl = buildHostedAppUrl;

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -1080,7 +1080,6 @@ prepare_owner_migration_env() {
       ;;
   esac
 }
-
 ensure_app_env_loaded() {
   local candidates=()
 
@@ -1099,6 +1098,41 @@ ensure_app_env_loaded() {
   done
 
   return 1
+}
+
+validate_plutus_qbo_env() {
+  local expected_redirect
+  expected_redirect="$(hosted_portal_origin)/plutus/api/qbo/callback"
+
+  if [[ -z "${QBO_CLIENT_ID:-}" ]]; then
+    error "QBO_CLIENT_ID is required for plutus deployments"
+    exit 1
+  fi
+
+  if [[ -z "${QBO_CLIENT_SECRET:-}" ]]; then
+    error "QBO_CLIENT_SECRET is required for plutus deployments"
+    exit 1
+  fi
+
+  if [[ "${QBO_CLIENT_ID}" == "ci-placeholder" ]]; then
+    error "QBO_CLIENT_ID cannot use ci-placeholder for plutus deployments"
+    exit 1
+  fi
+
+  if [[ "${QBO_CLIENT_SECRET}" == "ci-placeholder" ]]; then
+    error "QBO_CLIENT_SECRET cannot use ci-placeholder for plutus deployments"
+    exit 1
+  fi
+
+  if [[ -z "${QBO_REDIRECT_URI:-}" ]]; then
+    error "QBO_REDIRECT_URI is required for plutus deployments"
+    exit 1
+  fi
+
+  if [[ "${QBO_REDIRECT_URI}" != "$expected_redirect" ]]; then
+    error "QBO_REDIRECT_URI must be $expected_redirect for plutus deployments"
+    exit 1
+  fi
 }
 
 require_non_empty_env_var() {
@@ -1367,6 +1401,10 @@ fi
 
 apply_build_metadata_env
 apply_hosted_env_overrides
+
+if [[ "$app_key" == "plutus" ]]; then
+  validate_plutus_qbo_env
+fi
 
 if [[ "$app_key" == "argus" ]]; then
   run_argus_prebuild_checks


### PR DESCRIPTION
## Summary
- classify QBO auth failures so Plutus surfaces the actual reconnect cause and preserves callback feedback into `/settlements`
- reject placeholder QBO OAuth credentials and log realm changes during reconnects
- harden Plutus hosted runtime and deploy config so production portal values win over poisoned `.env.local`, including the Plutus workers

## Root cause
A manual restart of `main-plutus` picked up hosted auth values from poisoned `.env.local` files instead of production portal config. That put Plutus on the wrong portal auth secret and kicked valid users back to `/login`. The same deploy/runtime path also let placeholder QBO credentials and wrong hosted callback values survive longer than they should.

## Validation
- `pnpm --filter @targon/plutus test`
- `pnpm --filter @targon/plutus type-check`
- `pnpm --filter @targon/plutus lint`
- `bash -n scripts/deploy-app.sh`
- synthetic `ecosystem.config.js` check proving production portal env overrides poisoned `.env.local` for `main-targonos`, `main-plutus`, and `main-plutus-settlement-sync`