### PR TITLE
fix(talos): seed permissions catalog in tenant schema

### DIFF
--- a/apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts
+++ b/apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts
@@ -7,6 +7,10 @@ import { fileURLToPath } from 'node:url'
 import type { PrismaClient } from '@targon/prisma-talos'
 import { getTenantPrismaClient } from '../../src/lib/tenant/prisma-factory'
 import type { TenantCode } from '../../src/lib/tenant/constants'
+import {
+  TALOS_PERMISSION_CATALOG,
+  buildPermissionCatalogUpsertSql,
+} from '../../src/lib/permissions/catalog'
 
 type ScriptOptions = {
   tenants: TenantCode[]
@@ -224,7 +228,73 @@ function buildRequiredEnumValuesCheck(
   }
 }
 
+function buildRequiredTextValuesCheck(
+  label: string,
+  table: string,
+  column: string,
+  values: string[]
+): SchemaCheck {
+  const requiredValues = values
+    .map((value) => `(${sqlString(value)})`)
+    .join(',\n          ')
+
+  return {
+    label,
+    sql: `
+      SELECT NOT EXISTS (
+        SELECT required.value
+        FROM (
+          VALUES
+          ${requiredValues}
+        ) AS required(value)
+        WHERE NOT EXISTS (
+          SELECT 1
+          FROM ${table} t
+          WHERE t.${column} = required.value
+        )
+      ) AS value
+    `,
+  }
+}
+
 const baselineChecks: SchemaCheck[] = [
+  buildTableExistsCheck('permissions table', 'permissions'),
+  buildRequiredColumnsCheck('permissions columns', 'permissions', [
+    'id',
+    'code',
+    'name',
+    'description',
+    'category',
+    'created_at',
+    'updated_at',
+  ]),
+  buildRequiredIndexesCheck('permissions indexes', [
+    'permissions_code_key',
+    'permissions_category_idx',
+  ]),
+  buildTableExistsCheck('user_permissions table', 'user_permissions'),
+  buildRequiredColumnsCheck('user_permissions columns', 'user_permissions', [
+    'id',
+    'user_id',
+    'permission_id',
+    'granted_by_id',
+    'granted_at',
+  ]),
+  buildRequiredIndexesCheck('user_permissions indexes', [
+    'user_permissions_userId_permissionId_key',
+    'user_permissions_user_id_idx',
+    'user_permissions_permission_id_idx',
+  ]),
+  buildRequiredConstraintsCheck('user_permissions constraints', [
+    'user_permissions_user_id_fkey',
+    'user_permissions_permission_id_fkey',
+  ]),
+  buildRequiredTextValuesCheck(
+    'permission catalog seed',
+    '"permissions"',
+    '"code"',
+    TALOS_PERMISSION_CATALOG.map((permission) => permission.code)
+  ),
   buildTableExistsCheck('suppliers table', 'suppliers'),
   buildRequiredColumnsCheck('suppliers columns', 'suppliers', [
     'id',
@@ -412,6 +482,72 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
   console.info(`\n[${tenant}] Ensuring baseline schema is present`)
 
   const ddlStatements: string[] = [
+    // RBAC catalog and direct permission grants
+    `
+      CREATE TABLE IF NOT EXISTS "permissions" (
+        "id" text NOT NULL,
+        "code" text NOT NULL,
+        "name" text NOT NULL,
+        "description" text,
+        "category" text NOT NULL,
+        "created_at" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "permissions_pkey" PRIMARY KEY ("id")
+      )
+    `,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "permissions_code_key" ON "permissions"("code")`,
+    `CREATE INDEX IF NOT EXISTS "permissions_category_idx" ON "permissions"("category")`,
+    `
+      CREATE TABLE IF NOT EXISTS "user_permissions" (
+        "id" text NOT NULL,
+        "user_id" text NOT NULL,
+        "permission_id" text NOT NULL,
+        "granted_by_id" text NOT NULL,
+        "granted_at" timestamp(3) without time zone NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "user_permissions_pkey" PRIMARY KEY ("id")
+      )
+    `,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "user_permissions_userId_permissionId_key" ON "user_permissions"("user_id", "permission_id")`,
+    `CREATE INDEX IF NOT EXISTS "user_permissions_user_id_idx" ON "user_permissions"("user_id")`,
+    `CREATE INDEX IF NOT EXISTS "user_permissions_permission_id_idx" ON "user_permissions"("permission_id")`,
+    `
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          WHERE c.conname = 'user_permissions_user_id_fkey'
+            AND n.nspname = current_schema()
+        ) THEN
+          ALTER TABLE "user_permissions"
+            ADD CONSTRAINT "user_permissions_user_id_fkey"
+            FOREIGN KEY ("user_id") REFERENCES "users"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+        END IF;
+      END $$;
+    `,
+    `
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint c
+          JOIN pg_class t ON t.oid = c.conrelid
+          JOIN pg_namespace n ON n.oid = t.relnamespace
+          WHERE c.conname = 'user_permissions_permission_id_fkey'
+            AND n.nspname = current_schema()
+        ) THEN
+          ALTER TABLE "user_permissions"
+            ADD CONSTRAINT "user_permissions_permission_id_fkey"
+            FOREIGN KEY ("permission_id") REFERENCES "permissions"("id")
+            ON DELETE CASCADE ON UPDATE CASCADE;
+        END IF;
+      END $$;
+    `,
+    buildPermissionCatalogUpsertSql(),
+
     // suppliers table (missing in some schemas)
     `
       CREATE TABLE IF NOT EXISTS "suppliers" (

--- a/apps/talos/src/lib/permissions/catalog.ts
+++ b/apps/talos/src/lib/permissions/catalog.ts
@@ -1,0 +1,116 @@
+export type TalosPermissionCatalogEntry = {
+  code: string
+  name: string
+  description: string
+  category: string
+}
+
+export const TALOS_PERMISSION_CATALOG: readonly TalosPermissionCatalogEntry[] = [
+  {
+    code: 'fo.create',
+    name: 'Create Fulfillment Orders',
+    description: 'Permission to create fulfillment orders.',
+    category: 'fulfillment_order',
+  },
+  {
+    code: 'fo.edit',
+    name: 'Edit Fulfillment Orders',
+    description: 'Permission to edit fulfillment order details.',
+    category: 'fulfillment_order',
+  },
+  {
+    code: 'fo.stage',
+    name: 'Advance Fulfillment Order Stage',
+    description: 'Permission to advance fulfillment orders through stage transitions.',
+    category: 'fulfillment_order',
+  },
+  {
+    code: 'permission.manage',
+    name: 'Manage Permissions',
+    description: 'Permission to grant and revoke Talos permissions.',
+    category: 'user_management',
+  },
+  {
+    code: 'po.approve.draft_to_manufacturing',
+    name: 'Approve Draft To Manufacturing',
+    description: 'Permission to approve purchase orders from draft to manufacturing.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.approve.manufacturing_to_ocean',
+    name: 'Approve Manufacturing To Ocean',
+    description: 'Permission to approve purchase orders from manufacturing to ocean.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.approve.ocean_to_warehouse',
+    name: 'Approve Ocean To Warehouse',
+    description: 'Permission to approve purchase orders from ocean to warehouse.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.approve.warehouse_to_shipped',
+    name: 'Approve Warehouse To Shipped',
+    description: 'Permission to approve purchase orders from warehouse to shipped.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.cancel',
+    name: 'Cancel Purchase Orders',
+    description: 'Permission to cancel purchase orders.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.create',
+    name: 'Create Purchase Orders',
+    description: 'Permission to create purchase orders.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.edit',
+    name: 'Edit Purchase Orders',
+    description: 'Permission to edit purchase order details.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'po.view',
+    name: 'View Purchase Order Costs',
+    description: 'Permission to view purchase-order cost details and landed-cost data.',
+    category: 'purchase_order',
+  },
+  {
+    code: 'user.manage',
+    name: 'Manage Users',
+    description: 'Permission to create, edit, and manage Talos users.',
+    category: 'user_management',
+  },
+] as const
+
+function sqlString(value: string) {
+  return `'${value.replaceAll("'", "''")}'`
+}
+
+export function buildPermissionCatalogUpsertSql(): string {
+  const values = TALOS_PERMISSION_CATALOG.map((permission) => {
+    return `(
+      md5(${sqlString(`talos_permission:${permission.code}`)}),
+      ${sqlString(permission.code)},
+      ${sqlString(permission.name)},
+      ${sqlString(permission.description)},
+      ${sqlString(permission.category)},
+      CURRENT_TIMESTAMP,
+      CURRENT_TIMESTAMP
+    )`
+  }).join(',\n        ')
+
+  return `
+    INSERT INTO "permissions" ("id", "code", "name", "description", "category", "created_at", "updated_at")
+    VALUES
+        ${values}
+    ON CONFLICT ("code") DO UPDATE SET
+      "name" = EXCLUDED."name",
+      "description" = EXCLUDED."description",
+      "category" = EXCLUDED."category",
+      "updated_at" = CURRENT_TIMESTAMP
+  `
+}

--- a/apps/talos/tests/unit/permission-catalog.test.ts
+++ b/apps/talos/tests/unit/permission-catalog.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  TALOS_PERMISSION_CATALOG,
+  buildPermissionCatalogUpsertSql,
+} from '../../src/lib/permissions/catalog'
+
+test('permission catalog covers every live Talos authorization code', () => {
+  assert.deepEqual(
+    TALOS_PERMISSION_CATALOG.map((permission) => permission.code),
+    [
+      'fo.create',
+      'fo.edit',
+      'fo.stage',
+      'permission.manage',
+      'po.approve.draft_to_manufacturing',
+      'po.approve.manufacturing_to_ocean',
+      'po.approve.ocean_to_warehouse',
+      'po.approve.warehouse_to_shipped',
+      'po.cancel',
+      'po.create',
+      'po.edit',
+      'po.view',
+      'user.manage',
+    ]
+  )
+})
+
+test('permission catalog upsert SQL seeds the full catalog idempotently', () => {
+  const sql = buildPermissionCatalogUpsertSql()
+
+  assert.match(sql, /INSERT INTO "permissions"/)
+  assert.match(sql, /ON CONFLICT \("code"\) DO UPDATE SET/)
+
+  for (const permission of TALOS_PERMISSION_CATALOG) {
+    assert.match(sql, new RegExp(`'${permission.code.replaceAll('.', '\\.')}'`))
+  }
+})


### PR DESCRIPTION
## Summary
- add a shared Talos permission catalog covering the live authorization codes
- extend the tenant schema baseline script to create and seed permissions tables idempotently
- add a regression test for the seeded permission catalog

## Verification
- pnpm --dir apps/talos exec tsx --test tests/unit/permission-catalog.test.ts tests/unit/permissions-view-model.test.ts
- env NODE_ENV=production DATABASE_URL_US=postgresql://portal_talos@localhost:5432/portal_db?schema=main_talos_us DATABASE_URL_UK=postgresql://portal_talos@localhost:5432/portal_db?schema=main_talos_uk pnpm --dir apps/talos exec tsx scripts/migrations/ensure-talos-tenant-schema.ts --tenant=US --dry-run
- pnpm --dir apps/talos type-check:app
- live verification on https://os.targonglobal.com/talos/config/permissions after seeding main_talos_us and main_talos_uk