### PR TITLE
test(sso): add hosted cross-app auth smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,24 @@ jobs:
           pnpm --filter @targon/auth test
           node --test ecosystem.topology.test.cjs
           pnpm run test:auth-topology
+      - name: Run SSO auth smoke tests
+        run: pnpm --filter @targon/sso test:auth-smoke
+      - name: Run hosted cross-app auth smoke
+        if: runner.os == 'macOS' && vars.USE_SELF_HOSTED == 'true'
+        env:
+          PORTAL_BASE_URL: https://dev-os.targonglobal.com
+          E2E_PORTAL_USER_ID: user-jarrar
+          E2E_PORTAL_EMAIL: jarrar@targonglobal.com
+          E2E_PORTAL_NAME: Jarrar Amjad
+          E2E_ACTIVE_TENANT: US
+        run: |
+          PM2_RUNTIME_JSON="$(pm2 jlist)"
+          NEXTAUTH_SECRET="$(printf '%s' "$PM2_RUNTIME_JSON" | node -e "const fs=require('fs'); const processes=JSON.parse(fs.readFileSync(0,'utf8')); const app=processes.find((entry)=>entry.name==='dev-targonos'); if (!app) { throw new Error('dev-targonos pm2 process not found'); } const secret=app.pm2_env?.NEXTAUTH_SECRET; if (typeof secret !== 'string' || secret.trim() === '') { throw new Error('dev-targonos NEXTAUTH_SECRET is missing'); } process.stdout.write(secret.trim());")"
+          PORTAL_DB_URL="$(printf '%s' "$PM2_RUNTIME_JSON" | node -e "const fs=require('fs'); const processes=JSON.parse(fs.readFileSync(0,'utf8')); const app=processes.find((entry)=>entry.name==='dev-targonos'); if (!app) { throw new Error('dev-targonos pm2 process not found'); } const value=app.pm2_env?.PORTAL_DB_URL; if (typeof value !== 'string' || value.trim() === '') { throw new Error('dev-targonos PORTAL_DB_URL is missing'); } process.stdout.write(value.trim());")"
+          export NEXTAUTH_SECRET
+          export PORTAL_DB_URL
+          pnpm exec tsx apps/sso/scripts/ensure-hosted-smoke-user.ts
+          pnpm --filter @targon/sso test:hosted-smoke
       - name: Assert portal build/runtime topology
         run: |
           pnpm --filter @targon/sso build

--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,6 +8,9 @@
     "build": "next build",
     "start": "next start -p 3200",
     "type-check": "tsc --noEmit",
+    "test:auth-smoke": "playwright test --grep \"portal login|stale encrypted session|authenticated launcher\"",
+    "test:e2e": "playwright test",
+    "test:hosted-smoke": "PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",
     "postinstall": "node ../../scripts/link-prisma-client-auth.js"
   },
   "dependencies": {

--- a/apps/sso/playwright.config.ts
+++ b/apps/sso/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from '@playwright/test'
 
-const localPortalBaseUrl = 'http://127.0.0.1:3200'
+const localPortalBaseUrl = 'http://127.0.0.1:3320'
 const localPortalAuthSecret = 'playwright-portal-auth-secret-000000000000'
+const runHostedSmokeOnly = process.env.PLAYWRIGHT_HOSTED_ONLY === '1'
 
 export default defineConfig({
   testDir: './tests',
@@ -14,31 +15,33 @@ export default defineConfig({
     viewport: { width: 1440, height: 900 },
     trace: 'retain-on-failure',
   },
-  webServer: [
-    {
-      command: 'pnpm exec next dev -p 3200 --hostname 127.0.0.1',
-      cwd: __dirname,
-      url: `${localPortalBaseUrl}/login`,
-      reuseExistingServer: !process.env.CI,
-      env: {
-        ...process.env,
-        NEXTAUTH_URL: localPortalBaseUrl,
-        PORTAL_AUTH_URL: localPortalBaseUrl,
-        NEXT_PUBLIC_PORTAL_AUTH_URL: localPortalBaseUrl,
-        NEXT_PUBLIC_APP_URL: localPortalBaseUrl,
-        COOKIE_DOMAIN: '127.0.0.1',
-        NEXTAUTH_SECRET: localPortalAuthSecret,
-        PORTAL_AUTH_SECRET: localPortalAuthSecret,
-        PORTAL_DB_URL: '',
-        GOOGLE_CLIENT_ID: 'playwright-google-client-id',
-        GOOGLE_CLIENT_SECRET: 'playwright-google-client-secret',
+  webServer: runHostedSmokeOnly
+    ? undefined
+    : [
+      {
+        command: 'pnpm exec next dev -p 3320 --hostname 127.0.0.1',
+        cwd: __dirname,
+        url: `${localPortalBaseUrl}/login`,
+        reuseExistingServer: false,
+        env: {
+          ...process.env,
+          NEXTAUTH_URL: localPortalBaseUrl,
+          PORTAL_AUTH_URL: localPortalBaseUrl,
+          NEXT_PUBLIC_PORTAL_AUTH_URL: localPortalBaseUrl,
+          NEXT_PUBLIC_APP_URL: localPortalBaseUrl,
+          COOKIE_DOMAIN: '127.0.0.1',
+          NEXTAUTH_SECRET: localPortalAuthSecret,
+          PORTAL_AUTH_SECRET: localPortalAuthSecret,
+          PORTAL_DB_URL: '',
+          GOOGLE_CLIENT_ID: 'playwright-google-client-id',
+          GOOGLE_CLIENT_SECRET: 'playwright-google-client-secret',
+        },
       },
-    },
-    {
-      command: 'node tests/fixtures/callback-target-server.mjs',
-      cwd: __dirname,
-      url: 'http://127.0.0.1:3201/operations/purchase-orders',
-      reuseExistingServer: !process.env.CI,
-    },
-  ],
+      {
+        command: 'node tests/fixtures/callback-target-server.mjs',
+        cwd: __dirname,
+        url: 'http://127.0.0.1:3321/operations/purchase-orders',
+        reuseExistingServer: false,
+      },
+    ],
 })

--- a/apps/sso/scripts/ensure-hosted-smoke-user.ts
+++ b/apps/sso/scripts/ensure-hosted-smoke-user.ts
@@ -1,0 +1,59 @@
+import { upsertManualUserAppGrant } from '@targon/auth/server'
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (typeof value !== 'string') {
+    throw new Error(`${name} must be defined.`)
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    throw new Error(`${name} must be defined.`)
+  }
+
+  return trimmed
+}
+
+async function main() {
+  process.env.PORTAL_DB_URL = requireEnv('PORTAL_DB_URL')
+
+  const userId = requireEnv('E2E_PORTAL_USER_ID')
+  const email = requireEnv('E2E_PORTAL_EMAIL').toLowerCase()
+
+  const updatedUser = await upsertManualUserAppGrant({
+    userId,
+    appSlug: 'talos',
+    appName: 'Talos',
+    departments: ['Ops'],
+    tenantMemberships: ['US', 'UK'],
+    locked: false,
+  })
+
+  if (updatedUser.id !== userId) {
+    throw new Error(`Hosted smoke user id mismatch: expected ${userId}, received ${updatedUser.id}.`)
+  }
+
+  if (updatedUser.email.toLowerCase() !== email) {
+    throw new Error(`Hosted smoke user email mismatch: expected ${email}, received ${updatedUser.email}.`)
+  }
+
+  const talosGrant = updatedUser.entitlements.talos
+  if (!talosGrant) {
+    throw new Error('Hosted smoke user is missing Talos entitlements after grant update.')
+  }
+
+  if (!talosGrant.tenantMemberships.includes('US')) {
+    throw new Error('Hosted smoke user is missing Talos US tenant membership after grant update.')
+  }
+
+  if (!talosGrant.tenantMemberships.includes('UK')) {
+    throw new Error('Hosted smoke user is missing Talos UK tenant membership after grant update.')
+  }
+
+  console.log(`Ensured hosted smoke Talos grant for ${updatedUser.email}.`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/sso/tests/fixtures/callback-target-server.mjs
+++ b/apps/sso/tests/fixtures/callback-target-server.mjs
@@ -1,7 +1,7 @@
 import http from 'node:http'
 
 const host = '127.0.0.1'
-const port = 3201
+const port = 3321
 
 const routes = new Map([
   [

--- a/apps/sso/tests/fixtures/dev-login.ts
+++ b/apps/sso/tests/fixtures/dev-login.ts
@@ -1,8 +1,8 @@
 import type { Page } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
 
-export const portalBaseUrl = 'http://127.0.0.1:3200'
-export const talosBaseUrl = 'http://localhost:3201/operations/purchase-orders'
+export const portalBaseUrl = 'http://127.0.0.1:3320'
+export const talosBaseUrl = 'http://localhost:3321/operations/purchase-orders'
 export const demoEmail = 'e2e@targonglobal.com'
 export const sessionCookieName = 'targon.next-auth.session-token'
 const portalAuthSecret = 'playwright-portal-auth-secret-000000000000'
@@ -51,8 +51,7 @@ export async function seedPortalSession(page: Page) {
     {
       name: sessionCookieName,
       value: token,
-      domain: '127.0.0.1',
-      path: '/',
+      url: portalBaseUrl,
       httpOnly: true,
       secure: false,
       sameSite: 'Lax',

--- a/apps/sso/tests/fixtures/hosted-auth.ts
+++ b/apps/sso/tests/fixtures/hosted-auth.ts
@@ -1,8 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { Page } from '@playwright/test'
+import { expect, type Page, type Response } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
+
+type CriticalResponseRecord = {
+  method: string
+  resourceType: string
+  status: number
+  url: string
+}
+
+const criticalStatusCodes = new Set([401, 403, 500, 502])
+const trackedResourceTypes = new Set(['document', 'fetch', 'xhr'])
+const hostedErrorMarkers = [
+  'Bad gateway',
+  'Error code 502',
+  "Unexpected token '<'",
+] as const
 
 function requireEnv(name: string): string {
   const value = process.env[name]
@@ -18,18 +33,12 @@ function requireEnv(name: string): string {
   return trimmed
 }
 
-function requireSharedSecret(): string {
-  const nextAuthSecret = process.env.NEXTAUTH_SECRET
-  if (typeof nextAuthSecret === 'string' && nextAuthSecret.trim() !== '') {
-    return nextAuthSecret.trim()
-  }
+function getHostedPortalBaseUrl() {
+  return requireEnv('PORTAL_BASE_URL')
+}
 
-  const portalAuthSecret = process.env.PORTAL_AUTH_SECRET
-  if (typeof portalAuthSecret === 'string' && portalAuthSecret.trim() !== '') {
-    return portalAuthSecret.trim()
-  }
-
-  throw new Error('NEXTAUTH_SECRET or PORTAL_AUTH_SECRET must be defined for hosted portal smoke tests.')
+function getHostedPortalOrigin() {
+  return new URL(getHostedPortalBaseUrl()).origin
 }
 
 function buildPortalAuthz() {
@@ -50,8 +59,7 @@ function buildPortalAuthz() {
 }
 
 function buildScreenshotDirectory(): string {
-  const portalBaseUrl = requireEnv('PORTAL_BASE_URL')
-  const portalHost = new URL(portalBaseUrl).hostname
+  const portalHost = new URL(getHostedPortalBaseUrl()).hostname
   const outputDir = path.join(process.cwd(), '.codex-artifacts', 'hosted-smoke', portalHost)
   fs.mkdirSync(outputDir, { recursive: true })
   return outputDir
@@ -60,7 +68,7 @@ function buildScreenshotDirectory(): string {
 async function buildSessionCookie(portalBaseUrl: string) {
   const authz = buildPortalAuthz()
   const sessionCookieName = '__Secure-next-auth.session-token'
-  const secret = requireSharedSecret()
+  const secret = requireEnv('NEXTAUTH_SECRET')
   const activeTenant = requireEnv('E2E_ACTIVE_TENANT')
   const domain = new URL(portalBaseUrl).hostname
   const token = await encode({
@@ -93,7 +101,7 @@ async function buildSessionCookie(portalBaseUrl: string) {
 async function buildActiveTenantCookie(portalBaseUrl: string) {
   const appId = 'talos'
   const cookieName = `__Secure-targon.active-tenant.${appId}`
-  const secret = requireSharedSecret()
+  const secret = requireEnv('NEXTAUTH_SECRET')
   const domain = new URL(portalBaseUrl).hostname
   const value = await encode({
     token: { activeTenant: requireEnv('E2E_ACTIVE_TENANT') },
@@ -125,17 +133,91 @@ function buildTalosTenantCookie(portalBaseUrl: string) {
 }
 
 export async function loginToHostedPortal(page: Page) {
-  const portalBaseUrl = requireEnv('PORTAL_BASE_URL')
   const context = page.context()
   await context.clearCookies()
   await context.addCookies([
-    await buildSessionCookie(portalBaseUrl),
-    await buildActiveTenantCookie(portalBaseUrl),
-    buildTalosTenantCookie(portalBaseUrl),
+    await buildSessionCookie(getHostedPortalBaseUrl()),
+    await buildActiveTenantCookie(getHostedPortalBaseUrl()),
+    buildTalosTenantCookie(getHostedPortalBaseUrl()),
   ])
-  await page.goto(`${portalBaseUrl}/`, { waitUntil: 'domcontentloaded' })
+  await page.goto(`${getHostedPortalBaseUrl()}/`, { waitUntil: 'domcontentloaded' })
 }
 
 export function hostedScreenshotPath(routeName: string): string {
   return path.join(buildScreenshotDirectory(), `${routeName}.png`)
+}
+
+export function hostedRoute(pathname: string): string {
+  return new URL(pathname, getHostedPortalBaseUrl()).toString()
+}
+
+export function hostedPortalBaseUrl() {
+  return getHostedPortalBaseUrl()
+}
+
+export function hostedVersionBadge(page: Page) {
+  return page.getByRole('link', { name: /v\d+\.\d+\.\d+/i }).first()
+}
+
+export async function assertHostedVersionBadge(page: Page) {
+  await expect(hostedVersionBadge(page)).toBeVisible({ timeout: 20_000 })
+}
+
+export async function assertNoHostedErrorMarkers(page: Page) {
+  const bodyText = await page.locator('body').innerText()
+  for (const marker of hostedErrorMarkers) {
+    expect(bodyText).not.toContain(marker)
+  }
+}
+
+export async function assertNoHostedAuthRedirect(page: Page) {
+  const currentUrl = page.url()
+  expect(currentUrl).not.toContain('/login')
+  expect(currentUrl).not.toContain('/no-access')
+}
+
+export function installHostedResponseTracker(page: Page) {
+  const criticalResponses: CriticalResponseRecord[] = []
+
+  const handleResponse = (response: Response) => {
+    const request = response.request()
+    const resourceType = request.resourceType()
+    if (!trackedResourceTypes.has(resourceType)) {
+      return
+    }
+
+    const responseUrl = new URL(response.url())
+    if (responseUrl.origin !== getHostedPortalOrigin()) {
+      return
+    }
+
+    const status = response.status()
+    if (!criticalStatusCodes.has(status)) {
+      return
+    }
+
+    criticalResponses.push({
+      method: request.method(),
+      resourceType,
+      status,
+      url: response.url(),
+    })
+  }
+
+  page.on('response', handleResponse)
+
+  return {
+    assertNone() {
+      expect(
+        criticalResponses,
+        `Hosted app returned critical responses: ${JSON.stringify(criticalResponses, null, 2)}`,
+      ).toEqual([])
+    },
+    reset() {
+      criticalResponses.length = 0
+    },
+    dispose() {
+      page.off('response', handleResponse)
+    },
+  }
 }

--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -1,33 +1,126 @@
-import { test, expect, type Page } from '@playwright/test'
+import { expect, test, type BrowserContext, type Page, type TestInfo } from '@playwright/test'
 
-import { hostedScreenshotPath, loginToHostedPortal } from './fixtures/hosted-auth'
+import {
+  assertHostedVersionBadge,
+  assertNoHostedAuthRedirect,
+  assertNoHostedErrorMarkers,
+  hostedPortalBaseUrl,
+  hostedRoute,
+  hostedScreenshotPath,
+  installHostedResponseTracker,
+  loginToHostedPortal,
+} from './fixtures/hosted-auth'
 
-const portalBaseUrl = process.env.PORTAL_BASE_URL
-if (typeof portalBaseUrl !== 'string' || portalBaseUrl.trim() === '') {
-  throw new Error('PORTAL_BASE_URL must be defined for hosted portal smoke tests.')
+type HostedRouteCheck = {
+  name: string
+  path: string
+  visibleText: string
 }
 
-const routes = [
-  { name: 'portal', url: `${portalBaseUrl}/`, visible: 'TargonOS Portal' },
-  { name: 'talos', url: `${portalBaseUrl}/talos/operations/purchase-orders`, visible: 'Purchase Orders' },
-  { name: 'atlas', url: `${portalBaseUrl}/atlas/employees`, visible: 'Employees' },
-  { name: 'kairos', url: `${portalBaseUrl}/kairos/forecasts`, visible: 'Forecasts' },
-  { name: 'xplan', url: `${portalBaseUrl}/xplan/1-setup`, visible: 'Setup' },
-  { name: 'plutus', url: `${portalBaseUrl}/plutus/settlements`, visible: 'Settlements' },
-  { name: 'hermes', url: `${portalBaseUrl}/hermes/insights`, visible: 'Insights' },
-  { name: 'argus', url: `${portalBaseUrl}/argus/wpr`, visible: 'Weekly performance reporting' },
-] as const
+const hostedRouteChecks: HostedRouteCheck[] = [
+  { name: 'portal', path: '/', visibleText: 'TargonOS Portal' },
+  { name: 'atlas', path: '/atlas/employees', visibleText: 'Employees' },
+  { name: 'kairos', path: '/kairos/forecasts', visibleText: 'Forecasts' },
+  { name: 'xplan', path: '/xplan/1-setup', visibleText: 'Setup' },
+  { name: 'plutus', path: '/plutus/settlements', visibleText: 'Settlements' },
+  { name: 'hermes', path: '/hermes/insights', visibleText: 'Insights' },
+  { name: 'argus', path: '/argus/wpr', visibleText: 'Weekly performance reporting' },
+]
 
-function versionBadge(page: Page) {
-  return page.getByRole('link', { name: /v\d+\.\d+\.\d+/i }).first()
-}
+test.describe('hosted cross-app auth smoke', () => {
+  test.describe.configure({ mode: 'serial' })
 
-for (const route of routes) {
-  test(`${route.name} deep link renders visible screen`, async ({ page }) => {
+  let context: BrowserContext
+  let page: Page
+  let responseTracker: ReturnType<typeof installHostedResponseTracker>
+
+  async function captureFailure(routeName: string, testInfo: TestInfo, run: () => Promise<void>) {
+    try {
+      await run()
+    } catch (error) {
+      await page.screenshot({
+        path: hostedScreenshotPath(`${routeName}-${testInfo.retry}`),
+        fullPage: true,
+      })
+      throw error
+    }
+  }
+
+  async function assertHostedRoute(check: HostedRouteCheck) {
+    const targetUrl = hostedRoute(check.path)
+    await page.goto(targetUrl, { waitUntil: 'domcontentloaded' })
+
+    const currentPath = new URL(page.url()).pathname
+    if (check.path === '/') {
+      expect(currentPath).toBe('/')
+    } else {
+      expect(
+        currentPath === check.path || currentPath.startsWith(`${check.path}/`),
+        `Expected hosted path ${check.path}, got ${currentPath}`,
+      ).toBe(true)
+    }
+
+    await expect(page.getByText(check.visibleText, { exact: false }).first()).toBeVisible({ timeout: 20_000 })
+    await assertNoHostedAuthRedirect(page)
+    await assertNoHostedErrorMarkers(page)
+    await assertHostedVersionBadge(page)
+    responseTracker.assertNone()
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext()
+    page = await context.newPage()
+    responseTracker = installHostedResponseTracker(page)
     await loginToHostedPortal(page)
-    await page.goto(route.url, { waitUntil: 'domcontentloaded' })
-    await expect(page.getByText(route.visible, { exact: false }).first()).toBeVisible({ timeout: 20_000 })
-    await page.screenshot({ path: hostedScreenshotPath(route.name), fullPage: true })
-    await expect(versionBadge(page)).toBeVisible({ timeout: 20_000 })
   })
-}
+
+  test.beforeEach(async () => {
+    responseTracker.reset()
+  })
+
+  test.afterAll(async () => {
+    responseTracker.dispose()
+    await context.close()
+  })
+
+  for (const check of hostedRouteChecks) {
+    test(`${check.name} deep link renders a real screen`, async ({}, testInfo) => {
+      await captureFailure(check.name, testInfo, async () => {
+        await assertHostedRoute(check)
+      })
+    })
+  }
+
+  test('talos region selection reaches dashboard', async ({}, testInfo) => {
+    await captureFailure('talos-region-selection', testInfo, async () => {
+      await page.goto(hostedRoute('/talos'), { waitUntil: 'domcontentloaded' })
+      await expect(page.getByText('Select your region to continue', { exact: false })).toBeVisible({
+        timeout: 20_000,
+      })
+
+      const tenantSelectResponsePromise = page.waitForResponse((response) => {
+        if (response.request().method() !== 'POST') {
+          return false
+        }
+
+        const responseUrl = new URL(response.url())
+        return responseUrl.origin === new URL(hostedPortalBaseUrl()).origin &&
+          responseUrl.pathname === '/talos/api/tenant/select'
+      })
+
+      await page.getByRole('button', { name: /\bUS\b/i }).first().click()
+
+      const tenantSelectResponse = await tenantSelectResponsePromise
+      expect(tenantSelectResponse.ok()).toBe(true)
+
+      await page.waitForURL(new RegExp(`^${hostedRoute('/talos/dashboard').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), {
+        timeout: 20_000,
+      })
+      await expect(page.getByText('Dashboard', { exact: false }).first()).toBeVisible({ timeout: 20_000 })
+      await assertNoHostedAuthRedirect(page)
+      await assertNoHostedErrorMarkers(page)
+      await assertHostedVersionBadge(page)
+      responseTracker.assertNone()
+    })
+  })
+})

--- a/apps/sso/tests/login.spec.ts
+++ b/apps/sso/tests/login.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { encode } from 'next-auth/jwt'
 
-import { portalBaseUrl } from './fixtures/dev-login'
+import { portalBaseUrl, sessionCookieName } from './fixtures/dev-login'
+
+const staleSessionSecret = 'playwright-stale-session-secret-111111111111'
 
 test('portal login only offers Google sign-in', async ({ page }) => {
   await page.goto(`${portalBaseUrl}/login`, { waitUntil: 'domcontentloaded' })
@@ -18,4 +21,57 @@ test('portal login preserves the requested callback target for Google sign-in', 
   )
 
   await expect(page.locator('input[name="callbackUrl"]')).toHaveValue(callbackUrl)
+})
+
+test('portal recovers from a stale encrypted session cookie and still redirects to Google auth', async ({ page }) => {
+  const staleToken = await encode({
+    token: {
+      sub: 'stale-e2e-user',
+      email: 'stale-e2e@targonglobal.com',
+      name: 'Stale E2E User',
+    },
+    secret: staleSessionSecret,
+    salt: sessionCookieName,
+  })
+
+  await page.context().clearCookies()
+  await page.context().addCookies([
+    {
+      name: sessionCookieName,
+      value: staleToken,
+      url: portalBaseUrl,
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ])
+
+  const response = await page.request.get(
+    `${portalBaseUrl}/login/google?callbackUrl=${encodeURIComponent('/talos/operations/purchase-orders')}`,
+    {
+      maxRedirects: 0,
+    },
+  )
+
+  expect(response.status()).toBe(307)
+  expect(response.headers().location).toContain('https://accounts.google.com/o/oauth2/v2/auth')
+
+  const setCookieHeader = response.headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value)
+    .join('\n')
+
+  expect(setCookieHeader).toContain('authjs.pkce.code_verifier=')
+
+  const sessionResponse = await page.request.get(`${portalBaseUrl}/api/auth/session`)
+
+  expect(sessionResponse.status()).toBe(200)
+  expect(await sessionResponse.json()).toBe(null)
+
+  const sessionSetCookieHeader = sessionResponse.headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value)
+    .join('\n')
+
+  expect(sessionSetCookieHeader).toContain(`${sessionCookieName}=;`)
 })


### PR DESCRIPTION
## Summary
- add a hosted cross-app Playwright smoke that deep-links into portal, Talos, Atlas, Kairos, xPlan, Plutus, Hermes, and Argus
- add a hosted smoke user grant script and CI wiring so the dev hosted lane can seed Talos access before testing
- harden the local SSO smoke harness with dedicated ports and stale-session coverage

## Test Plan
- CI=1 pnpm --filter @targon/sso test:auth-smoke
- pnpm --dir apps/sso exec tsc --noEmit
- PORTAL_BASE_URL=https://dev-os.targonglobal.com ... pnpm exec tsx apps/sso/scripts/ensure-hosted-smoke-user.ts
- PORTAL_BASE_URL=https://dev-os.targonglobal.com ... pnpm --filter @targon/sso test:hosted-smoke