### PR TITLE
feat(plutus): add QBO full-history exception audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,24 @@ jobs:
           pnpm --filter @targon/auth test
           node --test ecosystem.topology.test.cjs
           pnpm run test:auth-topology
+      - name: Run SSO auth smoke tests
+        run: pnpm --filter @targon/sso test:auth-smoke
+      - name: Run hosted cross-app auth smoke
+        if: runner.os == 'macOS' && vars.USE_SELF_HOSTED == 'true'
+        env:
+          PORTAL_BASE_URL: https://dev-os.targonglobal.com
+          E2E_PORTAL_USER_ID: user-jarrar
+          E2E_PORTAL_EMAIL: jarrar@targonglobal.com
+          E2E_PORTAL_NAME: Jarrar Amjad
+          E2E_ACTIVE_TENANT: US
+        run: |
+          PM2_RUNTIME_JSON="$(pm2 jlist)"
+          NEXTAUTH_SECRET="$(printf '%s' "$PM2_RUNTIME_JSON" | node -e "const fs=require('fs'); const processes=JSON.parse(fs.readFileSync(0,'utf8')); const app=processes.find((entry)=>entry.name==='dev-targonos'); if (!app) { throw new Error('dev-targonos pm2 process not found'); } const secret=app.pm2_env?.NEXTAUTH_SECRET; if (typeof secret !== 'string' || secret.trim() === '') { throw new Error('dev-targonos NEXTAUTH_SECRET is missing'); } process.stdout.write(secret.trim());")"
+          PORTAL_DB_URL="$(printf '%s' "$PM2_RUNTIME_JSON" | node -e "const fs=require('fs'); const processes=JSON.parse(fs.readFileSync(0,'utf8')); const app=processes.find((entry)=>entry.name==='dev-targonos'); if (!app) { throw new Error('dev-targonos pm2 process not found'); } const value=app.pm2_env?.PORTAL_DB_URL; if (typeof value !== 'string' || value.trim() === '') { throw new Error('dev-targonos PORTAL_DB_URL is missing'); } process.stdout.write(value.trim());")"
+          export NEXTAUTH_SECRET
+          export PORTAL_DB_URL
+          pnpm exec tsx apps/sso/scripts/ensure-hosted-smoke-user.ts
+          pnpm --filter @targon/sso test:hosted-smoke
       - name: Assert portal build/runtime topology
         run: |
           pnpm --filter @targon/sso build

--- a/apps/plutus/app/settlements/page.tsx
+++ b/apps/plutus/app/settlements/page.tsx
@@ -33,18 +33,17 @@ import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
 import { EmptyState } from '@/components/ui/empty-state';
-import { MarketplaceFlag } from '@/components/ui/marketplace-flag';
 import { PageHeader } from '@/components/page-header';
 import { SplitButton } from '@/components/ui/split-button';
 import { NotConnectedScreen } from '@/components/not-connected-screen';
 import { normalizeSettlementMarketplaceQuery } from '@/lib/plutus/settlement-marketplace-query';
+import { buildSettlementListRowViewModel } from '@/lib/plutus/settlement-review';
 import { useMarketplaceStore, type Marketplace } from '@/lib/store/marketplace';
 import {
   SETTLEMENT_LIST_STATUSES,
   useSettlementsListStore,
   type SettlementListStatus,
 } from '@/lib/store/settlements';
-import { getSettlementDisplayId } from '@/lib/plutus/settlement-display';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 if (basePath === undefined) {
@@ -246,13 +245,6 @@ function PlutusPill({ status }: { status: SettlementRow['plutusStatus'] }) {
 
 function buildParentSettlementHref(settlement: SettlementRow): string {
   return `/settlements/${settlement.marketplace.region}/${encodeURIComponent(settlement.sourceSettlementId)}`;
-}
-
-function buildVisibleSettlementId(settlement: SettlementRow): string {
-  return getSettlementDisplayId({
-    sourceSettlementId: settlement.sourceSettlementId,
-    childDocNumbers: settlement.children.map((child) => child.docNumber),
-  })
 }
 
 async function fetchConnectionStatus(): Promise<ConnectionStatus> {
@@ -601,390 +593,344 @@ export default function SettlementsPage() {
           </Box>
         </Box>
 
-        <Box sx={{ mt: 3, display: 'grid', gap: 2 }}>
-          {/* Filter Bar */}
-          <Card sx={{ border: 1, borderColor: 'divider' }}>
-            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-                {/* Row 1: Search + Date Range */}
-                <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { md: '1.4fr 0.55fr 0.55fr' }, alignItems: { md: 'end' } }}>
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
-                      Search
-                    </Typography>
-                    <Box sx={{ position: 'relative' }}>
-                      <SearchIcon sx={{ pointerEvents: 'none', position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 16, color: 'text.disabled', zIndex: 1 }} />
-                      <TextField
-                        value={searchInput}
-                        onChange={(e) => setSearchInput(e.target.value)}
-                        placeholder="Amazon settlement ID, posting doc number, memo…"
-                        size="small"
-                        variant="outlined"
-                        fullWidth
-                        slotProps={textFieldInputSlotProps}
-                        sx={{
-                          ...textFieldSx,
-                          '& .MuiOutlinedInput-root': {
-                            ...textFieldSx['& .MuiOutlinedInput-root'],
-                            '& input': { pl: 4.5 },
-                          },
-                        }}
-                      />
-                    </Box>
-                  </Box>
+        <Box sx={{ mt: 3, display: 'flex', flexWrap: 'wrap', gap: 1.5, alignItems: 'flex-end' }}>
+          <Box sx={{ flex: '1 1 22rem', display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
+              Search
+            </Typography>
+            <Box sx={{ position: 'relative' }}>
+              <SearchIcon sx={{ pointerEvents: 'none', position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 16, color: 'text.disabled', zIndex: 1 }} />
+              <TextField
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Amazon settlement ID, posting doc number, memo…"
+                size="small"
+                variant="outlined"
+                fullWidth
+                slotProps={textFieldInputSlotProps}
+                sx={{
+                  ...textFieldSx,
+                  '& .MuiOutlinedInput-root': {
+                    ...textFieldSx['& .MuiOutlinedInput-root'],
+                    '& input': { pl: 4.5 },
+                  },
+                }}
+              />
+            </Box>
+          </Box>
 
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
-                      Start date
-                    </Typography>
-                    <TextField
-                      type="date"
-                      value={startDate}
-                      onChange={(e) => {
-                        const value = e.target.value.trim();
-                        setStartDate(value);
-                        setPage(1);
-                      }}
-                      size="small"
-                      variant="outlined"
-                      fullWidth
-                      slotProps={textFieldInputSlotProps}
-                      sx={textFieldSx}
-                    />
-                  </Box>
+          <Box sx={{ width: { xs: '100%', sm: '10rem' }, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
+              Start date
+            </Typography>
+            <TextField
+              type="date"
+              value={startDate}
+              onChange={(e) => {
+                const value = e.target.value.trim();
+                setStartDate(value);
+                setPage(1);
+              }}
+              size="small"
+              variant="outlined"
+              fullWidth
+              slotProps={textFieldInputSlotProps}
+              sx={textFieldSx}
+            />
+          </Box>
 
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
-                      End date
-                    </Typography>
-                    <TextField
-                      type="date"
-                      value={endDate}
-                      onChange={(e) => {
-                        const value = e.target.value.trim();
-                        setEndDate(value);
-                        setPage(1);
-                      }}
-                      size="small"
-                      variant="outlined"
-                      fullWidth
-                      slotProps={textFieldInputSlotProps}
-                      sx={textFieldSx}
-                    />
-                  </Box>
+          <Box sx={{ width: { xs: '100%', sm: '10rem' }, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
+              End date
+            </Typography>
+            <TextField
+              type="date"
+              value={endDate}
+              onChange={(e) => {
+                const value = e.target.value.trim();
+                setEndDate(value);
+                setPage(1);
+              }}
+              size="small"
+              variant="outlined"
+              fullWidth
+              slotProps={textFieldInputSlotProps}
+              sx={textFieldSx}
+            />
+          </Box>
+
+          <Box sx={{ width: { xs: '100%', sm: '14rem' }, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
+              Settlement Total
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              <TextField
+                value={totalMin}
+                onChange={(e) => setTotalMin(e.target.value)}
+                placeholder="Min"
+                size="small"
+                variant="outlined"
+                fullWidth
+                slotProps={textFieldInputSlotProps}
+                sx={textFieldSx}
+              />
+              <TextField
+                value={totalMax}
+                onChange={(e) => setTotalMax(e.target.value)}
+                placeholder="Max"
+                size="small"
+                variant="outlined"
+                fullWidth
+                slotProps={textFieldInputSlotProps}
+                sx={textFieldSx}
+              />
+            </Box>
+          </Box>
+
+          <Box sx={{ width: { xs: '100%', sm: '12rem' }, display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+            <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
+              Settlement Status
+            </Typography>
+            <Box>
+              <MuiButton
+                variant="outlined"
+                disableElevation
+                onClick={(e) => setStatusAnchorEl(statusAnchorEl ? null : e.currentTarget)}
+                sx={{
+                  ...outlineSx,
+                  ...defaultSize,
+                  width: '100%',
+                  justifyContent: 'space-between',
+                }}
+              >
+                <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {statusFilter.length === 0 ? 'All Statuses' : statusFilter.join(', ')}
                 </Box>
-
-                {/* Row 2: Settlement Total + Status + Filter + Clear */}
-                <Box sx={{ display: 'grid', gap: 1.5, gridTemplateColumns: { md: '1fr 1fr auto auto' }, alignItems: { md: 'end' } }}>
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
-                      Settlement Total
-                    </Typography>
-                    <Box sx={{ display: 'flex', gap: 1 }}>
-                      <TextField
-                        value={totalMin}
-                        onChange={(e) => setTotalMin(e.target.value)}
-                        placeholder="Min"
-                        size="small"
-                        variant="outlined"
-                        fullWidth
-                        slotProps={textFieldInputSlotProps}
-                        sx={textFieldSx}
-                      />
-                      <TextField
-                        value={totalMax}
-                        onChange={(e) => setTotalMax(e.target.value)}
-                        placeholder="Max"
-                        size="small"
-                        variant="outlined"
-                        fullWidth
-                        slotProps={textFieldInputSlotProps}
-                        sx={textFieldSx}
-                      />
-                    </Box>
-                  </Box>
-
-                  <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
-                    <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#008f87' }}>
-                      Settlement Status
-                    </Typography>
-                    <Box>
-                      <MuiButton
-                        variant="outlined"
-                        disableElevation
-                        onClick={(e) => setStatusAnchorEl(statusAnchorEl ? null : e.currentTarget)}
-                        sx={{
-                          ...outlineSx,
-                          ...defaultSize,
-                          width: '100%',
-                          justifyContent: 'space-between',
-                        }}
-                      >
-                        <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                          {statusFilter.length === 0 ? 'All Statuses' : statusFilter.join(', ')}
-                        </Box>
-                        <Box component="span" sx={{ fontSize: 10, color: 'text.disabled', ml: 0.5 }}>&#9662;</Box>
-                      </MuiButton>
-                      <Popper open={Boolean(statusAnchorEl)} anchorEl={statusAnchorEl} placement="bottom-start" sx={{ zIndex: 1300 }}>
-                        <ClickAwayListener onClickAway={() => setStatusAnchorEl(null)}>
-                          <Card sx={{ border: 1, borderColor: 'divider', mt: 0.5, minWidth: 200, p: 1 }}>
-                            {SETTLEMENT_LIST_STATUSES.map((status) => (
-                              <FormControlLabel
-                                key={status}
-                                control={
-                                  <Checkbox
-                                    size="small"
-                                    checked={statusFilter.includes(status)}
-                                    onChange={(e) => {
-                                      if (e.target.checked) {
-                                        setStatusFilter([...statusFilter, status]);
-                                      } else {
-                                        setStatusFilter(statusFilter.filter((s) => s !== status));
-                                      }
-                                      setPage(1);
-                                    }}
-                                    sx={{ py: 0.25 }}
-                                  />
-                                }
-                                label={<Typography sx={{ fontSize: '0.875rem' }}>{status === 'RolledBack' ? 'Rolled Back' : status}</Typography>}
-                                sx={{ display: 'flex', mx: 0 }}
-                              />
-                            ))}
-                          </Card>
-                        </ClickAwayListener>
-                      </Popper>
-                    </Box>
-                  </Box>
-
-                  <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
-                    <MuiButton
-                      variant="contained"
-                      disableElevation
-                      onClick={() => {
-                        setPage(1);
-                        queryClient.invalidateQueries({ queryKey: ['plutus-settlements'] });
-                      }}
-                      startIcon={<FilterListIcon sx={{ fontSize: 14 }} />}
-                      sx={{ ...defaultBtnSx, ...defaultSize }}
-                    >
-                      Filter
-                    </MuiButton>
-                  </Box>
-
-                  <Box sx={{ display: 'flex', alignItems: 'flex-end', gap: 1 }}>
-                    <MuiButton
-                      variant="outlined"
-                      disableElevation
-                      onClick={() => {
-                        clear();
-                      }}
-                      disabled={searchInput.trim() === '' && startDate.trim() === '' && endDate.trim() === '' && statusFilter.length === 0 && totalMin.trim() === '' && totalMax.trim() === ''}
-                      sx={{ ...outlineSx, ...defaultSize }}
-                    >
-                      Clear
-                    </MuiButton>
-                  </Box>
-                </Box>
-              </Box>
-            </CardContent>
-          </Card>
-
-          {/* Table */}
-          <Card sx={{ border: 1, borderColor: 'divider', overflow: 'hidden' }}>
-            <CardContent sx={{ p: 0, '&:last-child': { pb: 0 } }}>
-              <Box sx={{ overflow: 'auto' }}>
-                <MuiTable sx={{ width: '100%', fontSize: '0.875rem' }}>
-                  <MuiTableHead
-                    sx={{
-                      bgcolor: 'rgba(245, 245, 245, 0.8)',
-                      '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' },
-                      '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' },
-                    }}
-                  >
-                    <MuiTableRow>
-                      <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Marketplace</MuiTableCell>
-                      <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Period</MuiTableCell>
-                      <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Settlement Total</MuiTableCell>
-                      <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600, textAlign: 'right' }}>Status</MuiTableCell>
-                    </MuiTableRow>
-                  </MuiTableHead>
-                  <MuiTableBody sx={{ '& .MuiTableRow-root:last-child': { borderBottom: 0 } }}>
-                    {isLoading && (
-                      <>
-                        {Array.from({ length: 6 }).map((_, idx) => (
-                          <MuiTableRow key={idx} sx={rowHoverSx}>
-                            <MuiTableCell colSpan={4} sx={{ ...tdSx, py: 2 }}>
-                              <Skeleton variant="rectangular" animation="pulse" sx={{ height: 40, width: '100%', bgcolor: 'action.hover', borderRadius: 1 }} />
-                            </MuiTableCell>
-                          </MuiTableRow>
-                        ))}
-                      </>
-                    )}
-
-                    {!isLoading && error && (
-                      <MuiTableRow sx={rowHoverSx}>
-                        <MuiTableCell colSpan={4} sx={{ ...tdSx, py: 5, textAlign: 'center', fontSize: '0.875rem', color: 'error.main' }}>
-                          {error instanceof Error ? error.message : String(error)}
-                        </MuiTableCell>
-                      </MuiTableRow>
-                    )}
-
-                    {!isLoading && !error && settlements.length === 0 && (
-                      <MuiTableRow sx={rowHoverSx}>
-                        <MuiTableCell colSpan={4} sx={tdSx}>
-                          <EmptyState
-                            icon={<SettlementsEmptyIcon />}
-                            title="No settlements found"
-                            description="No settlements match your current filters. Try adjusting the date range or search terms."
+                <Box component="span" sx={{ fontSize: 10, color: 'text.disabled', ml: 0.5 }}>&#9662;</Box>
+              </MuiButton>
+              <Popper open={Boolean(statusAnchorEl)} anchorEl={statusAnchorEl} placement="bottom-start" sx={{ zIndex: 1300 }}>
+                <ClickAwayListener onClickAway={() => setStatusAnchorEl(null)}>
+                  <Card sx={{ border: 1, borderColor: 'divider', mt: 0.5, minWidth: 200, p: 1 }}>
+                    {SETTLEMENT_LIST_STATUSES.map((status) => (
+                      <FormControlLabel
+                        key={status}
+                        control={
+                          <Checkbox
+                            size="small"
+                            checked={statusFilter.includes(status)}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                setStatusFilter([...statusFilter, status]);
+                              } else {
+                                setStatusFilter(statusFilter.filter((s) => s !== status));
+                              }
+                              setPage(1);
+                            }}
+                            sx={{ py: 0.25 }}
                           />
+                        }
+                        label={<Typography sx={{ fontSize: '0.875rem' }}>{status === 'RolledBack' ? 'Rolled Back' : status}</Typography>}
+                        sx={{ display: 'flex', mx: 0 }}
+                      />
+                    ))}
+                  </Card>
+                </ClickAwayListener>
+              </Popper>
+            </Box>
+          </Box>
+
+          <MuiButton
+            variant="contained"
+            disableElevation
+            onClick={() => {
+              setPage(1);
+              queryClient.invalidateQueries({ queryKey: ['plutus-settlements'] });
+            }}
+            startIcon={<FilterListIcon sx={{ fontSize: 14 }} />}
+            sx={{ ...defaultBtnSx, ...defaultSize }}
+          >
+            Filter
+          </MuiButton>
+
+          <MuiButton
+            variant="outlined"
+            disableElevation
+            onClick={() => {
+              clear();
+            }}
+            disabled={searchInput.trim() === '' && startDate.trim() === '' && endDate.trim() === '' && statusFilter.length === 0 && totalMin.trim() === '' && totalMax.trim() === ''}
+            sx={{ ...outlineSx, ...defaultSize }}
+          >
+            Clear
+          </MuiButton>
+        </Box>
+
+        <Box sx={{ mt: 2, overflow: 'hidden', border: 1, borderColor: 'divider' }}>
+          <Box sx={{ overflow: 'auto' }}>
+            <MuiTable sx={{ width: '100%', fontSize: '0.875rem' }}>
+              <MuiTableHead
+                sx={{
+                  bgcolor: 'rgba(245, 245, 245, 0.8)',
+                  '[data-mui-color-scheme="dark"] &, .dark &': { bgcolor: 'rgba(255, 255, 255, 0.05)' },
+                  '& .MuiTableRow-root': { borderBottom: 1, borderColor: 'divider' },
+                }}
+              >
+                <MuiTableRow>
+                  <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Settlement</MuiTableCell>
+                  <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Period</MuiTableCell>
+                  <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600 }}>Settlement Total</MuiTableCell>
+                  <MuiTableCell component="th" sx={{ ...thSx, fontWeight: 600, textAlign: 'right' }}>Status</MuiTableCell>
+                </MuiTableRow>
+              </MuiTableHead>
+              <MuiTableBody sx={{ '& .MuiTableRow-root:last-child': { borderBottom: 0 } }}>
+                {isLoading && (
+                  <>
+                    {Array.from({ length: 6 }).map((_, idx) => (
+                      <MuiTableRow key={idx} sx={rowHoverSx}>
+                        <MuiTableCell colSpan={4} sx={{ ...tdSx, py: 2 }}>
+                          <Skeleton variant="rectangular" animation="pulse" sx={{ height: 40, width: '100%', bgcolor: 'action.hover', borderRadius: 1 }} />
                         </MuiTableCell>
                       </MuiTableRow>
-                    )}
+                    ))}
+                  </>
+                )}
 
-                    {!isLoading &&
-                      !error &&
-                      settlements.map((s) => {
-                        const settlementHref = buildParentSettlementHref(s);
-                        const visibleSettlementId = buildVisibleSettlementId(s);
+                {!isLoading && error && (
+                  <MuiTableRow sx={rowHoverSx}>
+                    <MuiTableCell colSpan={4} sx={{ ...tdSx, py: 5, textAlign: 'center', fontSize: '0.875rem', color: 'error.main' }}>
+                      {error instanceof Error ? error.message : String(error)}
+                    </MuiTableCell>
+                  </MuiTableRow>
+                )}
 
-                        return (
-                          <MuiTableRow
-                            key={s.parentId}
-                            sx={{ ...rowHoverSx, cursor: 'pointer', '& td:first-of-type': { position: 'relative' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#00C2B9' } }}
-                            onClick={() => router.push(settlementHref)}
-                          >
-                            <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top' }}>
-                              <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.25 }}>
-                                <MarketplaceFlag region={s.marketplace.region} />
-                                <Box sx={{ minWidth: 0 }}>
-                                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75, flexWrap: 'wrap' }}>
-                                    <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.875rem', fontWeight: 500, color: 'text.primary', transition: 'color 0.15s' }}>
-                                      {s.marketplace.label}
-                                    </Box>
-                                    {s.isSplit && (
-                                      <Chip
-                                        label={`Split into ${s.splitCount} month-end postings`}
-                                        size="small"
-                                        variant="outlined"
-                                        sx={{
-                                          ...chipBase,
-                                          borderColor: 'rgba(0, 194, 185, 0.35)',
-                                          bgcolor: 'rgba(0, 194, 185, 0.08)',
-                                          color: '#007d76',
-                                        }}
-                                      />
-                                    )}
-                                  </Box>
-                                  <Box sx={{ mt: 0.35, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontFamily: 'JetBrains Mono, monospace', fontSize: '0.8125rem', color: 'text.secondary' }}>
-                                    {visibleSettlementId}
-                                  </Box>
-                                  <Box sx={{ mt: 0.35, fontSize: '0.75rem', color: 'text.secondary' }}>
-                                    {s.childCount === 1 ? '1 month-end posting' : `${s.childCount} month-end postings`}
-                                  </Box>
-                                  {s.hasInconsistency && (
-                                    <Box sx={{ mt: 0.5, fontSize: '0.75rem', color: 'warning.dark', fontWeight: 600 }}>
-                                      Child posting states need review
-                                    </Box>
-                                  )}
-                                </Box>
-                              </Box>
-                            </MuiTableCell>
-                            <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top', fontSize: '0.875rem' }}>
-                              <Box sx={{ fontWeight: 500, color: 'text.primary' }}>
-                                {formatPeriod(s.periodStart, s.periodEnd)}
-                              </Box>
-                              <Box sx={{ mt: 0.25, fontSize: '0.875rem', color: 'text.secondary' }}>
-                                Posted {new Date(`${s.postedDate}T00:00:00Z`).toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric', year: 'numeric' })}
-                              </Box>
-                            </MuiTableCell>
-                            <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top', fontSize: '0.875rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'text.primary' }}>
-                              {s.settlementTotal === null ? '—' : formatMoney(s.settlementTotal, s.marketplace.currency)}
-                            </MuiTableCell>
-                            <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top', textAlign: 'right' }} onClick={(e) => e.stopPropagation()}>
-                              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 1, flexWrap: 'wrap' }}>
-                                <PlutusPill status={s.plutusStatus} />
-                                <SplitButton
-                                  onClick={() => router.push(settlementHref)}
-                                  dropdownItems={[
-                                    { label: 'Open settlement', onClick: () => router.push(settlementHref) },
-                                    { label: 'History', onClick: () => router.push(`${settlementHref}?tab=history`) },
-                                    {
-                                      label: 'Sync from Amazon',
-                                      onClick: () =>
-                                        openSyncDialog({
-                                          region: s.marketplace.region,
-                                          settlementId: s.sourceSettlementId,
-                                          postedDate: s.postedDate,
-                                        }),
-                                    },
-                                  ]}
-                                >
-                                  Action
-                                </SplitButton>
-                              </Box>
-                            </MuiTableCell>
-                          </MuiTableRow>
-                        );
-                      })}
-                  </MuiTableBody>
-                </MuiTable>
+                {!isLoading && !error && settlements.length === 0 && (
+                  <MuiTableRow sx={rowHoverSx}>
+                    <MuiTableCell colSpan={4} sx={tdSx}>
+                      <EmptyState
+                        icon={<SettlementsEmptyIcon />}
+                        title="No settlements found"
+                        description="No settlements match your current filters. Try adjusting the date range or search terms."
+                      />
+                    </MuiTableCell>
+                  </MuiTableRow>
+                )}
+
+                {!isLoading &&
+                  !error &&
+                  settlements.map((s) => {
+                    const settlementHref = buildParentSettlementHref(s);
+                    const rowView = buildSettlementListRowViewModel(s);
+
+                    return (
+                      <MuiTableRow
+                        key={s.parentId}
+                        sx={{ ...rowHoverSx, cursor: 'pointer', '& td:first-of-type': { position: 'relative' }, '&:hover td:first-of-type::before': { content: '""', position: 'absolute', left: 0, top: 0, bottom: 0, width: 3, borderRadius: '0 4px 4px 0', bgcolor: '#00C2B9' } }}
+                        onClick={() => router.push(settlementHref)}
+                      >
+                        <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top' }}>
+                          <Box>
+                            <Typography sx={{ fontSize: '0.875rem', fontWeight: 500, color: 'text.primary', transition: 'color 0.15s' }}>
+                              {rowView.title}
+                            </Typography>
+                            <Typography sx={{ color: 'text.secondary', fontSize: '0.8125rem', mt: 0.25 }}>
+                              {rowView.subtitle}
+                            </Typography>
+                          </Box>
+                        </MuiTableCell>
+                        <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top', fontSize: '0.875rem' }}>
+                          <Box sx={{ fontWeight: 500, color: 'text.primary' }}>
+                            {formatPeriod(s.periodStart, s.periodEnd)}
+                          </Box>
+                          <Box sx={{ mt: 0.25, fontSize: '0.875rem', color: 'text.secondary' }}>
+                            Posted {new Date(`${s.postedDate}T00:00:00Z`).toLocaleDateString('en-US', { timeZone: 'UTC', month: 'short', day: 'numeric', year: 'numeric' })}
+                          </Box>
+                        </MuiTableCell>
+                        <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top', fontSize: '0.875rem', fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'text.primary' }}>
+                          {s.settlementTotal === null ? '—' : formatMoney(s.settlementTotal, s.marketplace.currency)}
+                        </MuiTableCell>
+                        <MuiTableCell sx={{ ...tdSx, verticalAlign: 'top', textAlign: 'right' }} onClick={(e) => e.stopPropagation()}>
+                          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 1, flexWrap: 'wrap' }}>
+                            <PlutusPill status={s.plutusStatus} />
+                            <SplitButton
+                              onClick={() => router.push(settlementHref)}
+                              dropdownItems={[
+                                { label: 'Open settlement', onClick: () => router.push(settlementHref) },
+                                { label: 'History', onClick: () => router.push(`${settlementHref}?tab=history`) },
+                                {
+                                  label: 'Sync from Amazon',
+                                  onClick: () =>
+                                    openSyncDialog({
+                                      region: s.marketplace.region,
+                                      settlementId: s.sourceSettlementId,
+                                      postedDate: s.postedDate,
+                                    }),
+                                },
+                              ]}
+                            >
+                              Action
+                            </SplitButton>
+                          </Box>
+                        </MuiTableCell>
+                      </MuiTableRow>
+                    );
+                  })}
+              </MuiTableBody>
+            </MuiTable>
+          </Box>
+
+          {data && data.pagination.totalPages > 1 && (
+            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 1.5, alignItems: { sm: 'center' }, justifyContent: { sm: 'space-between' }, p: 2, borderTop: 1, borderColor: 'divider', bgcolor: 'action.hover' }}>
+              <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}>
+                Page {data.pagination.page} of {data.pagination.totalPages} &middot; {data.pagination.totalCount} settlements
+              </Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                <MuiButton
+                  variant="outlined"
+                  disableElevation
+                  disabled={page <= 1}
+                  onClick={() => setPage(page - 1)}
+                  sx={{ ...outlineSx, ...smSize, height: 32, width: 32, p: 0, minWidth: 32 }}
+                >
+                  <ChevronLeftIcon sx={{ fontSize: 16 }} />
+                </MuiButton>
+                {Array.from({ length: Math.min(data.pagination.totalPages, 5) }).map((_, idx) => {
+                  const pageNum = idx + 1;
+                  return (
+                    <MuiButton
+                      key={pageNum}
+                      variant={page === pageNum ? 'contained' : 'outlined'}
+                      disableElevation
+                      onClick={() => setPage(pageNum)}
+                      sx={{
+                        ...(page === pageNum ? defaultBtnSx : outlineSx),
+                        ...smSize,
+                        height: 32,
+                        width: 32,
+                        p: 0,
+                        minWidth: 32,
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
+                      {pageNum}
+                    </MuiButton>
+                  );
+                })}
+                {data.pagination.totalPages > 5 && (
+                  <Box component="span" sx={{ px: 0.5, fontSize: '0.75rem', color: 'text.disabled' }}>…</Box>
+                )}
+                <MuiButton
+                  variant="outlined"
+                  disableElevation
+                  disabled={page >= data.pagination.totalPages}
+                  onClick={() => setPage(page + 1)}
+                  sx={{ ...outlineSx, ...smSize, height: 32, width: 32, p: 0, minWidth: 32 }}
+                >
+                  <ChevronRightIcon sx={{ fontSize: 16 }} />
+                </MuiButton>
               </Box>
-
-              {data && data.pagination.totalPages > 1 && (
-                <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, gap: 1.5, alignItems: { sm: 'center' }, justifyContent: { sm: 'space-between' }, p: 2, borderTop: 1, borderColor: 'divider', bgcolor: 'action.hover' }}>
-                  <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', fontVariantNumeric: 'tabular-nums' }}>
-                    Page {data.pagination.page} of {data.pagination.totalPages} &middot; {data.pagination.totalCount} settlements
-                  </Typography>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-                    <MuiButton
-                      variant="outlined"
-                      disableElevation
-                      disabled={page <= 1}
-                      onClick={() => setPage(page - 1)}
-                      sx={{ ...outlineSx, ...smSize, height: 32, width: 32, p: 0, minWidth: 32 }}
-                    >
-                      <ChevronLeftIcon sx={{ fontSize: 16 }} />
-                    </MuiButton>
-                    {/* Page number buttons */}
-                    {Array.from({ length: Math.min(data.pagination.totalPages, 5) }).map((_, idx) => {
-                      const pageNum = idx + 1;
-                      return (
-                        <MuiButton
-                          key={pageNum}
-                          variant={page === pageNum ? 'contained' : 'outlined'}
-                          disableElevation
-                          onClick={() => setPage(pageNum)}
-                          sx={{
-                            ...(page === pageNum ? defaultBtnSx : outlineSx),
-                            ...smSize,
-                            height: 32,
-                            width: 32,
-                            p: 0,
-                            minWidth: 32,
-                            fontVariantNumeric: 'tabular-nums',
-                          }}
-                        >
-                          {pageNum}
-                        </MuiButton>
-                      );
-                    })}
-                    {data.pagination.totalPages > 5 && (
-                      <Box component="span" sx={{ px: 0.5, fontSize: '0.75rem', color: 'text.disabled' }}>…</Box>
-                    )}
-                    <MuiButton
-                      variant="outlined"
-                      disableElevation
-                      disabled={page >= data.pagination.totalPages}
-                      onClick={() => setPage(page + 1)}
-                      sx={{ ...outlineSx, ...smSize, height: 32, width: 32, p: 0, minWidth: 32 }}
-                    >
-                      <ChevronRightIcon sx={{ fontSize: 16 }} />
-                    </MuiButton>
-                  </Box>
-                </Box>
-              )}
-            </CardContent>
-          </Card>
+            </Box>
+          )}
+        </Box>
 
           <Dialog
             open={syncOpen}
@@ -1115,7 +1061,6 @@ export default function SettlementsPage() {
               </MuiButton>
             </DialogActions>
           </Dialog>
-        </Box>
       </Box>
     </Box>
   );

--- a/apps/plutus/lib/plutus/settlement-review.ts
+++ b/apps/plutus/lib/plutus/settlement-review.ts
@@ -1,0 +1,32 @@
+import { getSettlementDisplayId } from './settlement-display';
+
+export type SettlementListRowViewModel = {
+  title: string;
+  subtitle: string;
+};
+
+export type SettlementListRowInput = {
+  sourceSettlementId: string;
+  marketplace: {
+    label: string;
+  };
+  splitCount: number;
+  isSplit: boolean;
+  children: readonly {
+    docNumber: string;
+  }[];
+};
+
+export function buildSettlementListRowViewModel(row: SettlementListRowInput): SettlementListRowViewModel {
+  const title = getSettlementDisplayId({
+    sourceSettlementId: row.sourceSettlementId,
+    childDocNumbers: row.children.map((child) => child.docNumber),
+  });
+
+  const subtitle = row.isSplit ? `${row.marketplace.label} · ${row.splitCount} month-end postings` : row.marketplace.label;
+
+  return {
+    title,
+    subtitle,
+  };
+}

--- a/apps/plutus/lib/qbo/api.ts
+++ b/apps/plutus/lib/qbo/api.ts
@@ -129,6 +129,10 @@ export interface QboPurchase {
   PaymentType: 'Cash' | 'Check' | 'CreditCard';
   DocNumber?: string;
   PrivateNote?: string;
+  CurrencyRef?: {
+    value: string;
+    name?: string;
+  };
   EntityRef?: {
     value: string;
     name: string;
@@ -1837,6 +1841,7 @@ export async function createPurchase(
     docNumber?: string;
     vendorId?: string;
     privateNote?: string;
+    currencyCode?: string;
     lines: Array<{
       amount: number;
       accountId: string;
@@ -1870,6 +1875,9 @@ export async function createPurchase(
   }
   if (input.privateNote !== undefined) {
     payload.PrivateNote = input.privateNote;
+  }
+  if (input.currencyCode !== undefined) {
+    payload.CurrencyRef = { value: input.currencyCode };
   }
 
   logger.info('Creating purchase in QBO', {

--- a/apps/plutus/lib/qbo/full-history-audit/fetch.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/fetch.ts
@@ -128,39 +128,23 @@ export type ActiveQboConnection = {
   accessToken: string;
 };
 
-export async function getActiveQboConnection(): Promise<ActiveQboConnection> {
-  const connection = await qboFullHistoryAuditDeps.getQboConnection();
-  if (connection === null) {
-    throw new Error('No active QBO connection');
-  }
-
-  const { accessToken, updatedConnection } = await qboFullHistoryAuditDeps.getValidToken(connection);
-  if (updatedConnection !== undefined) {
-    await qboFullHistoryAuditDeps.saveServerQboConnection(updatedConnection);
-  }
-
-  return {
-    connection: updatedConnection ?? connection,
-    accessToken,
-  };
-}
-
-export async function qboQueryAll(
-  activeConnection: ActiveQboConnection,
-  query: string,
-): Promise<{ rows: Record<string, unknown>[]; complete: boolean }> {
-  const baseUrl = getApiBaseUrl();
+async function qboQueryAllByCredentials<T extends Record<string, unknown>>(
+  accessToken: string,
+  realmId: string,
+  baseUrl: string,
+  buildQuery: (startPosition: number, maxResults: number) => string,
+): Promise<{ rows: T[]; complete: boolean }> {
   const maxResults = 1000;
   let startPosition = 1;
-  const rows: Record<string, unknown>[] = [];
+  const rows: T[] = [];
 
   while (true) {
-    const pageQuery = `${query} STARTPOSITION ${startPosition} MAXRESULTS ${maxResults}`;
+    const pageQuery = buildQuery(startPosition, maxResults);
     const response = await fetchWithRetry(
-      `${baseUrl}/v3/company/${activeConnection.connection.realmId}/query?query=${encodeURIComponent(pageQuery)}`,
+      `${baseUrl}/v3/company/${realmId}/query?query=${encodeURIComponent(pageQuery)}`,
       {
         headers: {
-          Authorization: `Bearer ${activeConnection.accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
           Accept: 'application/json',
         },
       },
@@ -187,7 +171,7 @@ export async function qboQueryAll(
       return { rows, complete: true };
     }
 
-    rows.push(...pageRows);
+    rows.push(...(pageRows as T[]));
 
     if (pageRows.length < maxResults) {
       return { rows, complete: true };
@@ -195,4 +179,70 @@ export async function qboQueryAll(
 
     startPosition += maxResults;
   }
+}
+
+export async function getActiveQboConnection(): Promise<ActiveQboConnection> {
+  const connection = await qboFullHistoryAuditDeps.getQboConnection();
+  if (connection === null) {
+    throw new Error('No active QBO connection');
+  }
+
+  const { accessToken, updatedConnection } = await qboFullHistoryAuditDeps.getValidToken(connection);
+  if (updatedConnection !== undefined) {
+    await qboFullHistoryAuditDeps.saveServerQboConnection(updatedConnection);
+  }
+
+  return {
+    connection: updatedConnection ?? connection,
+    accessToken,
+  };
+}
+
+export async function fetchAuditSourceData(accessToken: string, realmId: string, baseUrl: string) {
+  const [purchases, bills, journalEntries, transfers, attachables] = await Promise.all([
+    qboQueryAllByCredentials<any>(
+      accessToken,
+      realmId,
+      baseUrl,
+      (start, max) => `SELECT * FROM Purchase ORDERBY TxnDate STARTPOSITION ${start} MAXRESULTS ${max}`,
+    ),
+    qboQueryAllByCredentials<any>(
+      accessToken,
+      realmId,
+      baseUrl,
+      (start, max) => `SELECT * FROM Bill ORDERBY TxnDate STARTPOSITION ${start} MAXRESULTS ${max}`,
+    ),
+    qboQueryAllByCredentials<any>(
+      accessToken,
+      realmId,
+      baseUrl,
+      (start, max) => `SELECT * FROM JournalEntry ORDERBY TxnDate STARTPOSITION ${start} MAXRESULTS ${max}`,
+    ),
+    qboQueryAllByCredentials<any>(
+      accessToken,
+      realmId,
+      baseUrl,
+      (start, max) => `SELECT * FROM Transfer ORDERBY TxnDate STARTPOSITION ${start} MAXRESULTS ${max}`,
+    ),
+    qboQueryAllByCredentials<any>(
+      accessToken,
+      realmId,
+      baseUrl,
+      (start, max) => `SELECT * FROM Attachable STARTPOSITION ${start} MAXRESULTS ${max}`,
+    ),
+  ]);
+
+  return { purchases, bills, journalEntries, transfers, attachables };
+}
+
+export async function qboQueryAll(
+  activeConnection: ActiveQboConnection,
+  query: string,
+): Promise<{ rows: Record<string, unknown>[]; complete: boolean }> {
+  return qboQueryAllByCredentials<Record<string, unknown>>(
+    activeConnection.accessToken,
+    activeConnection.connection.realmId,
+    getApiBaseUrl(),
+    (startPosition, maxResults) => `${query} STARTPOSITION ${startPosition} MAXRESULTS ${maxResults}`,
+  );
 }

--- a/apps/plutus/lib/qbo/full-history-audit/fetch.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/fetch.ts
@@ -4,7 +4,7 @@ import * as qboApi from '../api';
 import type { QboConnection } from '../api';
 
 export type CoverageRow = {
-  transactionType: 'Purchase' | 'Bill' | 'Transfer' | 'JournalEntry' | 'BillPayment' | 'Invoice';
+  transactionType: 'Purchase' | 'Bill' | 'Transfer' | 'JournalEntry' | 'BillPayment' | 'Invoice' | 'Attachable';
   scannedCount: number;
   complete: boolean;
 };
@@ -31,15 +31,30 @@ function extractArrayKey(queryResponse: Record<string, unknown>): string | null 
 const retryableStatusCodes = new Set([429, 503]);
 const retryMaxAttempts = 3;
 const retryBaseDelayMs = 1000;
+const queryTimeoutMs = 60000;
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number = queryTimeoutMs): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await qboFullHistoryAuditDeps.fetch(url, {
+      ...init,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
   for (let attempt = 0; attempt <= retryMaxAttempts; attempt++) {
     try {
-      const response = await qboFullHistoryAuditDeps.fetch(url, init);
+      const response = await fetchWithTimeout(url, init);
       if (response.ok) {
         return response;
       }

--- a/apps/plutus/lib/qbo/full-history-audit/fetch.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/fetch.ts
@@ -1,0 +1,140 @@
+import { getApiBaseUrl } from '../client';
+import { getQboConnection } from '../connection-store';
+import type { QboConnection } from '../api';
+
+export type CoverageRow = {
+  transactionType: 'Purchase' | 'Bill' | 'Transfer' | 'JournalEntry' | 'BillPayment' | 'Invoice';
+  scannedCount: number;
+  complete: boolean;
+};
+
+export type RawAttachable = {
+  Id: string;
+  FileName?: string;
+  AttachableRef?: Array<{ EntityRef?: { type?: string; value?: string } }>;
+};
+
+export type CoverageSummary = {
+  completeCoverage: boolean;
+  failedTypes: CoverageRow['transactionType'][];
+  scannedCount: number;
+};
+
+function extractArrayKey(queryResponse: Record<string, unknown>): string | null {
+  for (const [key, value] of Object.entries(queryResponse)) {
+    if (Array.isArray(value)) return key;
+  }
+  return null;
+}
+
+export function mergeAttachmentRefs(attachables: RawAttachable[]): Map<string, string[]> {
+  const merged = new Map<string, string[]>();
+
+  for (const attachable of attachables) {
+    const fileName = attachable.FileName;
+    if (fileName === undefined) continue;
+
+    const refs = attachable.AttachableRef;
+    if (refs === undefined) continue;
+
+    for (const ref of refs) {
+      const entityRef = ref.EntityRef;
+      if (entityRef === undefined) continue;
+
+      const entityType = entityRef.type;
+      const entityId = entityRef.value;
+      if (entityType === undefined || entityId === undefined) continue;
+
+      const key = `${entityType}:${entityId}`;
+      const existing = merged.get(key);
+      if (existing === undefined) {
+        merged.set(key, [fileName]);
+        continue;
+      }
+
+      if (!existing.includes(fileName)) {
+        existing.push(fileName);
+      }
+    }
+  }
+
+  return merged;
+}
+
+export function summarizeCoverage(rows: CoverageRow[]): CoverageSummary {
+  let scannedCount = 0;
+  const failedTypes: CoverageSummary['failedTypes'] = [];
+  let completeCoverage = true;
+
+  for (const row of rows) {
+    scannedCount += row.scannedCount;
+    if (row.complete) continue;
+
+    completeCoverage = false;
+    if (!failedTypes.includes(row.transactionType)) {
+      failedTypes.push(row.transactionType);
+    }
+  }
+
+  return {
+    completeCoverage,
+    failedTypes,
+    scannedCount,
+  };
+}
+
+export async function getActiveQboConnection(): Promise<QboConnection> {
+  const connection = await getQboConnection();
+  if (connection === null) {
+    throw new Error('No active QBO connection');
+  }
+  return connection;
+}
+
+export async function qboQueryAll(
+  connection: QboConnection,
+  query: string,
+): Promise<{ rows: Record<string, unknown>[]; complete: boolean }> {
+  const baseUrl = getApiBaseUrl();
+  const maxResults = 1000;
+  let startPosition = 1;
+  const rows: Record<string, unknown>[] = [];
+
+  while (true) {
+    const pageQuery = `${query} STARTPOSITION ${startPosition} MAXRESULTS ${maxResults}`;
+    const response = await fetch(`${baseUrl}/v3/company/${connection.realmId}/query?query=${encodeURIComponent(pageQuery)}`, {
+      headers: {
+        Authorization: `Bearer ${connection.accessToken}`,
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      return { rows, complete: false };
+    }
+
+    const data = (await response.json()) as { QueryResponse?: Record<string, unknown> };
+    const queryResponse = data.QueryResponse;
+    if (queryResponse === undefined) {
+      return { rows, complete: true };
+    }
+
+    const arrayKey = extractArrayKey(queryResponse);
+    if (arrayKey === null) {
+      return { rows, complete: true };
+    }
+
+    const pageRows = queryResponse[arrayKey];
+    if (!Array.isArray(pageRows)) {
+      return { rows, complete: true };
+    }
+
+    rows.push(...pageRows);
+
+    if (pageRows.length < maxResults) {
+      return { rows, complete: true };
+    }
+
+    startPosition += maxResults;
+  }
+}

--- a/apps/plutus/lib/qbo/full-history-audit/fetch.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/fetch.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from '../client';
-import { getQboConnection } from '../connection-store';
+import { getQboConnection, saveServerQboConnection } from '../connection-store';
+import * as qboApi from '../api';
 import type { QboConnection } from '../api';
 
 export type CoverageRow = {
@@ -26,6 +27,45 @@ function extractArrayKey(queryResponse: Record<string, unknown>): string | null 
   }
   return null;
 }
+
+const retryableStatusCodes = new Set([429, 503]);
+const retryMaxAttempts = 3;
+const retryBaseDelayMs = 1000;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+  for (let attempt = 0; attempt <= retryMaxAttempts; attempt++) {
+    try {
+      const response = await qboFullHistoryAuditDeps.fetch(url, init);
+      if (response.ok) {
+        return response;
+      }
+
+      if (!retryableStatusCodes.has(response.status) || attempt === retryMaxAttempts) {
+        return response;
+      }
+    } catch (error) {
+      if (attempt === retryMaxAttempts) {
+        throw error;
+      }
+    }
+
+    await qboFullHistoryAuditDeps.sleep(retryBaseDelayMs * Math.pow(2, attempt));
+  }
+
+  throw new Error('fetchWithRetry: unreachable');
+}
+
+export const qboFullHistoryAuditDeps = {
+  fetch: (url: string, init: RequestInit) => fetch(url, init),
+  getQboConnection,
+  getValidToken: qboApi.getValidToken,
+  saveServerQboConnection,
+  sleep,
+};
 
 export function mergeAttachmentRefs(attachables: RawAttachable[]): Map<string, string[]> {
   const merged = new Map<string, string[]>();
@@ -83,16 +123,30 @@ export function summarizeCoverage(rows: CoverageRow[]): CoverageSummary {
   };
 }
 
-export async function getActiveQboConnection(): Promise<QboConnection> {
-  const connection = await getQboConnection();
+export type ActiveQboConnection = {
+  connection: QboConnection;
+  accessToken: string;
+};
+
+export async function getActiveQboConnection(): Promise<ActiveQboConnection> {
+  const connection = await qboFullHistoryAuditDeps.getQboConnection();
   if (connection === null) {
     throw new Error('No active QBO connection');
   }
-  return connection;
+
+  const { accessToken, updatedConnection } = await qboFullHistoryAuditDeps.getValidToken(connection);
+  if (updatedConnection !== undefined) {
+    await qboFullHistoryAuditDeps.saveServerQboConnection(updatedConnection);
+  }
+
+  return {
+    connection: updatedConnection ?? connection,
+    accessToken,
+  };
 }
 
 export async function qboQueryAll(
-  connection: QboConnection,
+  activeConnection: ActiveQboConnection,
   query: string,
 ): Promise<{ rows: Record<string, unknown>[]; complete: boolean }> {
   const baseUrl = getApiBaseUrl();
@@ -102,15 +156,19 @@ export async function qboQueryAll(
 
   while (true) {
     const pageQuery = `${query} STARTPOSITION ${startPosition} MAXRESULTS ${maxResults}`;
-    const response = await fetch(`${baseUrl}/v3/company/${connection.realmId}/query?query=${encodeURIComponent(pageQuery)}`, {
-      headers: {
-        Authorization: `Bearer ${connection.accessToken}`,
-        Accept: 'application/json',
+    const response = await fetchWithRetry(
+      `${baseUrl}/v3/company/${activeConnection.connection.realmId}/query?query=${encodeURIComponent(pageQuery)}`,
+      {
+        headers: {
+          Authorization: `Bearer ${activeConnection.accessToken}`,
+          Accept: 'application/json',
+        },
       },
-    });
+    );
 
     if (!response.ok) {
-      return { rows, complete: false };
+      const errorText = await response.text();
+      throw new Error(`Failed to fetch QBO query page: ${response.status} ${errorText}`);
     }
 
     const data = (await response.json()) as { QueryResponse?: Record<string, unknown> };

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -79,3 +79,51 @@ export function normalizeJournalEntryForAudit(
     sourceTag: null,
   };
 }
+
+export function normalizeBillForAudit(
+  bill: any,
+  attachmentFileNames: string[],
+): NormalizedAuditTransaction {
+  return {
+    transactionType: 'Bill',
+    transactionId: bill.Id,
+    txnDate: bill.TxnDate,
+    amount: bill.TotalAmt,
+    currency: bill.CurrencyRef?.value || null,
+    counterparty: bill.VendorRef?.name || null,
+    docNumber: bill.DocNumber || null,
+    privateNote: bill.PrivateNote || null,
+    dueDate: bill.DueDate || null,
+    postingAccounts: (bill.Line || [])
+      .map((line: any) => line.AccountBasedExpenseLineDetail?.AccountRef?.name || '')
+      .filter(Boolean),
+    lineDescriptions: (bill.Line || []).map((line: any) => line.Description || ''),
+    attachmentFileNames,
+    isInReconciledPeriod: false,
+    lastUpdatedTime: bill.MetaData?.LastUpdatedTime || null,
+    sourceTag: null,
+  };
+}
+
+export function normalizeTransferForAudit(
+  transfer: any,
+  attachmentFileNames: string[],
+): NormalizedAuditTransaction {
+  return {
+    transactionType: 'Transfer',
+    transactionId: transfer.Id,
+    txnDate: transfer.TxnDate,
+    amount: transfer.Amount,
+    currency: transfer.CurrencyRef?.value || null,
+    counterparty: null,
+    docNumber: transfer.DocNumber || null,
+    privateNote: transfer.PrivateNote || null,
+    dueDate: null,
+    postingAccounts: [transfer.FromAccountRef?.name || '', transfer.ToAccountRef?.name || ''].filter(Boolean),
+    lineDescriptions: [],
+    attachmentFileNames,
+    isInReconciledPeriod: false,
+    lastUpdatedTime: transfer.MetaData?.LastUpdatedTime || null,
+    sourceTag: null,
+  };
+}

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -2,9 +2,20 @@ import type { QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
 import type { NormalizedAuditTransaction } from './types';
 
 function collectPurchasePostingAccounts(purchase: QboPurchase): string[] {
-  return (purchase.Line ?? [])
-    .map((line) => line.AccountBasedExpenseLineDetail?.AccountRef.name ?? '')
-    .filter((account) => account.length > 0);
+  const accounts: string[] = [];
+
+  for (const line of purchase.Line ?? []) {
+    const accountName =
+      line.AccountBasedExpenseLineDetail?.AccountRef.name ??
+      line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
+      null;
+
+    if (accountName !== null) {
+      accounts.push(accountName);
+    }
+  }
+
+  return accounts;
 }
 
 function collectJournalEntryPostingAccounts(journalEntry: QboJournalEntry): string[] {
@@ -12,7 +23,15 @@ function collectJournalEntryPostingAccounts(journalEntry: QboJournalEntry): stri
 }
 
 function collectLineDescriptions(lines: Array<{ Description?: string }>): string[] {
-  return lines.map((line) => line.Description ?? '');
+  const descriptions: string[] = [];
+
+  for (const line of lines) {
+    if (line.Description !== undefined) {
+      descriptions.push(line.Description);
+    }
+  }
+
+  return descriptions;
 }
 
 export function normalizePurchaseForAudit(

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -1,4 +1,4 @@
-import type { QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
+import type { QboBill, QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
 import type { NormalizedAuditTransaction } from './types';
 
 function collectPurchasePostingAccounts(purchase: QboPurchase): string[] {
@@ -20,6 +20,23 @@ function collectPurchasePostingAccounts(purchase: QboPurchase): string[] {
 
 function collectJournalEntryPostingAccounts(journalEntry: QboJournalEntry): string[] {
   return journalEntry.Line.map((line) => line.JournalEntryLineDetail.AccountRef.name ?? '');
+}
+
+function collectBillPostingAccounts(bill: QboBill): string[] {
+  const accounts: string[] = [];
+
+  for (const line of bill.Line ?? []) {
+    const accountName =
+      line.AccountBasedExpenseLineDetail?.AccountRef.name ??
+      line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
+      null;
+
+    if (accountName !== null) {
+      accounts.push(accountName);
+    }
+  }
+
+  return accounts;
 }
 
 function collectLineDescriptions(lines: Array<{ Description?: string }>): string[] {
@@ -81,7 +98,7 @@ export function normalizeJournalEntryForAudit(
 }
 
 export function normalizeBillForAudit(
-  bill: any,
+  bill: QboBill,
   attachmentFileNames: string[],
 ): NormalizedAuditTransaction {
   return {
@@ -89,18 +106,16 @@ export function normalizeBillForAudit(
     transactionId: bill.Id,
     txnDate: bill.TxnDate,
     amount: bill.TotalAmt,
-    currency: bill.CurrencyRef?.value || null,
-    counterparty: bill.VendorRef?.name || null,
-    docNumber: bill.DocNumber || null,
-    privateNote: bill.PrivateNote || null,
-    dueDate: bill.DueDate || null,
-    postingAccounts: (bill.Line || [])
-      .map((line: any) => line.AccountBasedExpenseLineDetail?.AccountRef?.name || '')
-      .filter(Boolean),
-    lineDescriptions: (bill.Line || []).map((line: any) => line.Description || ''),
+    currency: bill.CurrencyRef?.value ?? null,
+    counterparty: bill.VendorRef?.name ?? null,
+    docNumber: bill.DocNumber ?? null,
+    privateNote: bill.PrivateNote ?? null,
+    dueDate: bill.DueDate ?? null,
+    postingAccounts: collectBillPostingAccounts(bill),
+    lineDescriptions: collectLineDescriptions(bill.Line ?? []),
     attachmentFileNames,
     isInReconciledPeriod: false,
-    lastUpdatedTime: bill.MetaData?.LastUpdatedTime || null,
+    lastUpdatedTime: bill.MetaData?.LastUpdatedTime ?? null,
     sourceTag: null,
   };
 }

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -1,6 +1,26 @@
 import type { QboBill, QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
 import type { NormalizedAuditTransaction } from './types';
 
+type QboTransfer = {
+  Id: string;
+  TxnDate: string;
+  Amount: number;
+  CurrencyRef?: {
+    value?: string;
+  };
+  DocNumber?: string;
+  PrivateNote?: string;
+  FromAccountRef?: {
+    name?: string;
+  };
+  ToAccountRef?: {
+    name?: string;
+  };
+  MetaData?: {
+    LastUpdatedTime?: string;
+  };
+};
+
 function collectPurchasePostingAccounts(purchase: QboPurchase): string[] {
   const accounts: string[] = [];
 
@@ -39,6 +59,15 @@ function collectBillPostingAccounts(bill: QboBill): string[] {
   return accounts;
 }
 
+function collectTransferPostingAccounts(transfer: QboTransfer): string[] {
+  const accountNames = [
+    transfer.FromAccountRef?.name ?? null,
+    transfer.ToAccountRef?.name ?? null,
+  ];
+
+  return accountNames.filter((accountName): accountName is string => accountName !== null);
+}
+
 function collectLineDescriptions(lines: Array<{ Description?: string }>): string[] {
   const descriptions: string[] = [];
 
@@ -68,7 +97,7 @@ export function normalizePurchaseForAudit(
     postingAccounts: collectPurchasePostingAccounts(purchase),
     lineDescriptions: collectLineDescriptions(purchase.Line ?? []),
     attachmentFileNames,
-    isInReconciledPeriod: false,
+    isInReconciledPeriod: null,
     lastUpdatedTime: purchase.MetaData?.LastUpdatedTime ?? null,
     sourceTag: null,
   };
@@ -91,7 +120,7 @@ export function normalizeJournalEntryForAudit(
     postingAccounts: collectJournalEntryPostingAccounts(journalEntry),
     lineDescriptions: collectLineDescriptions(journalEntry.Line),
     attachmentFileNames,
-    isInReconciledPeriod: false,
+    isInReconciledPeriod: null,
     lastUpdatedTime: journalEntry.MetaData?.LastUpdatedTime ?? null,
     sourceTag: null,
   };
@@ -114,14 +143,14 @@ export function normalizeBillForAudit(
     postingAccounts: collectBillPostingAccounts(bill),
     lineDescriptions: collectLineDescriptions(bill.Line ?? []),
     attachmentFileNames,
-    isInReconciledPeriod: false,
+    isInReconciledPeriod: null,
     lastUpdatedTime: bill.MetaData?.LastUpdatedTime ?? null,
     sourceTag: null,
   };
 }
 
 export function normalizeTransferForAudit(
-  transfer: any,
+  transfer: QboTransfer,
   attachmentFileNames: string[],
 ): NormalizedAuditTransaction {
   return {
@@ -129,16 +158,16 @@ export function normalizeTransferForAudit(
     transactionId: transfer.Id,
     txnDate: transfer.TxnDate,
     amount: transfer.Amount,
-    currency: transfer.CurrencyRef?.value || null,
+    currency: transfer.CurrencyRef?.value ?? null,
     counterparty: null,
-    docNumber: transfer.DocNumber || null,
-    privateNote: transfer.PrivateNote || null,
+    docNumber: transfer.DocNumber ?? null,
+    privateNote: transfer.PrivateNote ?? null,
     dueDate: null,
-    postingAccounts: [transfer.FromAccountRef?.name || '', transfer.ToAccountRef?.name || ''].filter(Boolean),
+    postingAccounts: collectTransferPostingAccounts(transfer),
     lineDescriptions: [],
     attachmentFileNames,
-    isInReconciledPeriod: false,
-    lastUpdatedTime: transfer.MetaData?.LastUpdatedTime || null,
+    isInReconciledPeriod: null,
+    lastUpdatedTime: transfer.MetaData?.LastUpdatedTime ?? null,
     sourceTag: null,
   };
 }

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -43,7 +43,7 @@ export function normalizePurchaseForAudit(
     transactionId: purchase.Id,
     txnDate: purchase.TxnDate,
     amount: purchase.TotalAmt,
-    currency: null,
+    currency: purchase.CurrencyRef?.value ?? null,
     counterparty: purchase.EntityRef?.name ?? null,
     docNumber: purchase.DocNumber ?? null,
     privateNote: purchase.PrivateNote ?? null,

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -1,0 +1,62 @@
+import type { QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
+import type { NormalizedAuditTransaction } from './types';
+
+function collectPurchasePostingAccounts(purchase: QboPurchase): string[] {
+  return (purchase.Line ?? [])
+    .map((line) => line.AccountBasedExpenseLineDetail?.AccountRef.name ?? '')
+    .filter((account) => account.length > 0);
+}
+
+function collectJournalEntryPostingAccounts(journalEntry: QboJournalEntry): string[] {
+  return journalEntry.Line.map((line) => line.JournalEntryLineDetail.AccountRef.name ?? '');
+}
+
+function collectLineDescriptions(lines: Array<{ Description?: string }>): string[] {
+  return lines.map((line) => line.Description ?? '');
+}
+
+export function normalizePurchaseForAudit(
+  purchase: QboPurchase,
+  attachmentFileNames: string[],
+): NormalizedAuditTransaction {
+  return {
+    transactionType: 'Purchase',
+    transactionId: purchase.Id,
+    txnDate: purchase.TxnDate,
+    amount: purchase.TotalAmt,
+    currency: null,
+    counterparty: purchase.EntityRef?.name ?? null,
+    docNumber: purchase.DocNumber ?? null,
+    privateNote: purchase.PrivateNote ?? null,
+    dueDate: null,
+    postingAccounts: collectPurchasePostingAccounts(purchase),
+    lineDescriptions: collectLineDescriptions(purchase.Line ?? []),
+    attachmentFileNames,
+    isInReconciledPeriod: false,
+    lastUpdatedTime: purchase.MetaData?.LastUpdatedTime ?? null,
+    sourceTag: null,
+  };
+}
+
+export function normalizeJournalEntryForAudit(
+  journalEntry: QboJournalEntry,
+  attachmentFileNames: string[],
+): NormalizedAuditTransaction {
+  return {
+    transactionType: 'JournalEntry',
+    transactionId: journalEntry.Id,
+    txnDate: journalEntry.TxnDate,
+    amount: journalEntry.Line.reduce((sum, line) => sum + (line.Amount ?? 0), 0) / 2,
+    currency: journalEntry.CurrencyRef?.value ?? null,
+    counterparty: null,
+    docNumber: journalEntry.DocNumber ?? null,
+    privateNote: journalEntry.PrivateNote ?? null,
+    dueDate: null,
+    postingAccounts: collectJournalEntryPostingAccounts(journalEntry),
+    lineDescriptions: collectLineDescriptions(journalEntry.Line),
+    attachmentFileNames,
+    isInReconciledPeriod: false,
+    lastUpdatedTime: journalEntry.MetaData?.LastUpdatedTime ?? null,
+    sourceTag: null,
+  };
+}

--- a/apps/plutus/lib/qbo/full-history-audit/report.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/report.ts
@@ -1,5 +1,13 @@
 import type { AuditException } from './types';
 
+function escapeCsvField(value: string): string {
+  if (!/[",\n\r]/.test(value)) {
+    return value;
+  }
+
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
 export function buildAuditCsv(rows: readonly AuditException[]): string {
   const header = [
     'transaction_type',
@@ -35,7 +43,7 @@ export function buildAuditCsv(rows: readonly AuditException[]): string {
       row.supportStatus,
       row.reconciledPeriodRisk,
     ]
-      .map((value) => JSON.stringify(String(value)))
+      .map((value) => escapeCsvField(String(value)))
       .join(','),
   );
 

--- a/apps/plutus/lib/qbo/full-history-audit/report.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/report.ts
@@ -1,0 +1,69 @@
+import type { AuditException } from './types';
+
+export function buildAuditCsv(rows: readonly AuditException[]): string {
+  const header = [
+    'transaction_type',
+    'transaction_id',
+    'txn_date',
+    'amount',
+    'currency',
+    'counterparty',
+    'posting_account_summary',
+    'rule_id',
+    'rule_group',
+    'severity',
+    'exception_message',
+    'suggested_fix',
+    'support_status',
+    'reconciled_period_risk',
+  ];
+
+  const body = rows.map((row) =>
+    [
+      row.transactionType,
+      row.transactionId,
+      row.txnDate,
+      row.amount,
+      row.currency ?? '',
+      row.counterparty ?? '',
+      row.postingAccountSummary,
+      row.ruleId,
+      row.ruleGroup,
+      row.severity,
+      row.exceptionMessage,
+      row.suggestedFix,
+      row.supportStatus,
+      row.reconciledPeriodRisk,
+    ]
+      .map((value) => JSON.stringify(String(value)))
+      .join(','),
+  );
+
+  return [header.join(','), ...body].join('\n');
+}
+
+export function buildAuditMarkdownSummary(
+  rows: readonly AuditException[],
+  scannedCounts: Record<string, number>,
+): string {
+  const severityTotals = rows.reduce<Record<string, number>>((acc, row) => {
+    const current = acc[row.severity];
+    acc[row.severity] = current === undefined ? 1 : current + 1;
+    return acc;
+  }, {});
+
+  return [
+    '# QBO Full-History Exception Audit',
+    '',
+    '## Transactions Scanned',
+    ...Object.entries(scannedCounts).map(([type, count]) => `- ${type}: ${count}`),
+    '',
+    '## Exceptions By Severity',
+    ...Object.entries(severityTotals).map(([severity, count]) => `- ${severity}: ${count}`),
+    '',
+    '## Top Findings',
+    ...rows
+      .slice(0, 20)
+      .map((row) => `- ${row.severity} ${row.transactionType} ${row.transactionId}: ${row.exceptionMessage}`),
+  ].join('\n');
+}

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -34,20 +34,6 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
     if (tx.docNumber === null || tx.docNumber.trim() === '') {
       pushFinding(findings, tx, 'DOCNUMBER_MISSING', 'field_completeness', 'High', 'DocNumber is missing.', 'Populate DocNumber.');
     }
-    if (tx.transactionType === 'Bill' && (tx.dueDate === null || tx.dueDate.trim() === '')) {
-      pushFinding(findings, tx, 'BILL_DUE_DATE_MISSING', 'field_completeness', 'High', 'Bill due date is missing.', 'Populate DueDate.');
-    }
-    if (tx.lineDescriptions.some((description) => description.trim() === '')) {
-      pushFinding(
-        findings,
-        tx,
-        'LINE_DESCRIPTION_MISSING',
-        'field_completeness',
-        'High',
-        'One or more line descriptions are blank.',
-        'Add meaningful line descriptions.',
-      );
-    }
     if (tx.transactionType === 'Bill' && tx.attachmentFileNames.length === 0) {
       pushFinding(
         findings,

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -35,8 +35,7 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
     if (
       (tx.transactionType === 'Bill' ||
         tx.transactionType === 'Purchase' ||
-        tx.transactionType === 'Invoice' ||
-        tx.transactionType === 'BillPayment') &&
+        tx.transactionType === 'Invoice') &&
       (tx.docNumber === null || tx.docNumber.trim() === '')
     ) {
       pushFinding(
@@ -65,7 +64,7 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
     if (
       tx.privateNote?.toLowerCase().includes('transfer') &&
       tx.transactionType === 'Purchase' &&
-      tx.postingAccounts.some((account) => account.toLowerCase().includes('expenses'))
+      tx.postingAccounts.some((account) => account.toLowerCase().includes('expense'))
     ) {
       pushFinding(
         findings,

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -8,6 +8,7 @@ function pushFinding(
   severity: AuditException['severity'],
   exceptionMessage: string,
   suggestedFix: string,
+  supportStatus: AuditException['supportStatus'],
 ): void {
   out.push({
     transactionType: tx.transactionType,
@@ -22,7 +23,7 @@ function pushFinding(
     severity,
     exceptionMessage,
     suggestedFix,
-    supportStatus: tx.attachmentFileNames.length > 0 ? 'attached' : 'missing',
+    supportStatus,
     reconciledPeriodRisk: tx.isInReconciledPeriod ? 'yes' : 'no',
   });
 }
@@ -31,8 +32,23 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
   const findings: AuditException[] = [];
 
   for (const tx of transactions) {
-    if (tx.docNumber === null || tx.docNumber.trim() === '') {
-      pushFinding(findings, tx, 'DOCNUMBER_MISSING', 'field_completeness', 'High', 'DocNumber is missing.', 'Populate DocNumber.');
+    if (
+      (tx.transactionType === 'Bill' ||
+        tx.transactionType === 'Purchase' ||
+        tx.transactionType === 'Invoice' ||
+        tx.transactionType === 'BillPayment') &&
+      (tx.docNumber === null || tx.docNumber.trim() === '')
+    ) {
+      pushFinding(
+        findings,
+        tx,
+        'DOCNUMBER_MISSING',
+        'field_completeness',
+        'High',
+        'DocNumber is missing.',
+        'Populate DocNumber.',
+        'not_required',
+      );
     }
     if (tx.transactionType === 'Bill' && tx.attachmentFileNames.length === 0) {
       pushFinding(
@@ -43,12 +59,13 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
         'High',
         'Bill has no attachment.',
         'Attach the supporting invoice.',
+        'missing',
       );
     }
     if (
       tx.privateNote?.toLowerCase().includes('transfer') &&
       tx.transactionType === 'Purchase' &&
-      tx.postingAccounts.some((account) => account.includes('expenses'))
+      tx.postingAccounts.some((account) => account.toLowerCase().includes('expenses'))
     ) {
       pushFinding(
         findings,
@@ -58,6 +75,7 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
         'Critical',
         'Transfer-like activity is posted to a P&L account.',
         'Rebuild as transfer-style activity.',
+        'not_required',
       );
     }
   }

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -20,6 +20,17 @@ const BANK_CARD_CUES = [
   'stripe',
   'square',
 ];
+const ACCEPTED_FEE_ACCOUNT_CUES = [
+  'bank fees',
+  'service charges',
+  'merchant processing fees',
+  'merchant fees',
+  'payment processing fees',
+  'processor fees',
+  'merchant service charges',
+  'card processing fees',
+  'credit card processing fees',
+];
 
 function pushFinding(
   out: AuditException[],
@@ -71,7 +82,7 @@ function isOwnerEquityAccount(account: string): boolean {
 
 function isBankFeeAccount(account: string): boolean {
   const lower = account.toLowerCase();
-  return lower.includes('bank fees') || lower.includes('service charges');
+  return ACCEPTED_FEE_ACCOUNT_CUES.some((cue) => lower.includes(cue));
 }
 
 function isLikelyBankCardFee(tx: NormalizedAuditTransaction): boolean {
@@ -79,6 +90,30 @@ function isLikelyBankCardFee(tx: NormalizedAuditTransaction): boolean {
   const hasFeeCue = FEE_CUES.some((cue) => text.includes(cue));
   const hasBankCardCue = BANK_CARD_CUES.some((cue) => text.includes(cue));
   return hasFeeCue && hasBankCardCue;
+}
+
+function parseAuditDate(date: string): number {
+  return Date.parse(`${date}T00:00:00Z`);
+}
+
+function inferAuditAsOfDate(transactions: NormalizedAuditTransaction[]): string | null {
+  let latest = -Infinity;
+  let latestDate: string | null = null;
+
+  for (const tx of transactions) {
+    const time = parseAuditDate(tx.txnDate);
+    if (Number.isFinite(time) && time > latest) {
+      latest = time;
+      latestDate = tx.txnDate;
+    }
+  }
+
+  return latestDate;
+}
+
+function isOlderThanDays(txnDate: string, asOfDate: string, staleDays: number): boolean {
+  const ageMs = parseAuditDate(asOfDate) - parseAuditDate(txnDate);
+  return Number.isFinite(ageMs) && ageMs > staleDays * 24 * 60 * 60 * 1000;
 }
 
 function mentionsDifferentCurrency(tx: NormalizedAuditTransaction): boolean {
@@ -96,9 +131,19 @@ function mentionsDifferentCurrency(tx: NormalizedAuditTransaction): boolean {
   return false;
 }
 
-export function classifyAuditExceptions(transactions: NormalizedAuditTransaction[]): AuditException[] {
+export interface AuditClassificationOptions {
+  asOfDate?: string;
+  staleControlAccountDays?: number;
+}
+
+export function classifyAuditExceptions(
+  transactions: NormalizedAuditTransaction[],
+  options: AuditClassificationOptions = {},
+): AuditException[] {
   const findings: AuditException[] = [];
   const duplicateCounts = new Map<string, number>();
+  const asOfDate = options.asOfDate ?? inferAuditAsOfDate(transactions);
+  const staleControlAccountDays = options.staleControlAccountDays ?? 365;
 
   for (const tx of transactions) {
     const key = duplicateKey(tx);
@@ -166,7 +211,7 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
       );
     }
 
-    if (containsControlAccount(tx) && tx.txnDate < '2026-01-01') {
+    if (asOfDate !== null && containsControlAccount(tx) && isOlderThanDays(tx.txnDate, asOfDate, staleControlAccountDays)) {
       pushFinding(
         findings,
         tx,

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -1,0 +1,80 @@
+import type { AuditException, NormalizedAuditTransaction } from './types';
+
+function pushFinding(
+  out: AuditException[],
+  tx: NormalizedAuditTransaction,
+  ruleId: AuditException['ruleId'],
+  ruleGroup: AuditException['ruleGroup'],
+  severity: AuditException['severity'],
+  exceptionMessage: string,
+  suggestedFix: string,
+): void {
+  out.push({
+    transactionType: tx.transactionType,
+    transactionId: tx.transactionId,
+    txnDate: tx.txnDate,
+    amount: tx.amount,
+    currency: tx.currency,
+    counterparty: tx.counterparty,
+    postingAccountSummary: tx.postingAccounts.join(' | '),
+    ruleId,
+    ruleGroup,
+    severity,
+    exceptionMessage,
+    suggestedFix,
+    supportStatus: tx.attachmentFileNames.length > 0 ? 'attached' : 'missing',
+    reconciledPeriodRisk: tx.isInReconciledPeriod ? 'yes' : 'no',
+  });
+}
+
+export function classifyAuditExceptions(transactions: NormalizedAuditTransaction[]): AuditException[] {
+  const findings: AuditException[] = [];
+
+  for (const tx of transactions) {
+    if (tx.docNumber === null || tx.docNumber.trim() === '') {
+      pushFinding(findings, tx, 'DOCNUMBER_MISSING', 'field_completeness', 'High', 'DocNumber is missing.', 'Populate DocNumber.');
+    }
+    if (tx.transactionType === 'Bill' && (tx.dueDate === null || tx.dueDate.trim() === '')) {
+      pushFinding(findings, tx, 'BILL_DUE_DATE_MISSING', 'field_completeness', 'High', 'Bill due date is missing.', 'Populate DueDate.');
+    }
+    if (tx.lineDescriptions.some((description) => description.trim() === '')) {
+      pushFinding(
+        findings,
+        tx,
+        'LINE_DESCRIPTION_MISSING',
+        'field_completeness',
+        'High',
+        'One or more line descriptions are blank.',
+        'Add meaningful line descriptions.',
+      );
+    }
+    if (tx.transactionType === 'Bill' && tx.attachmentFileNames.length === 0) {
+      pushFinding(
+        findings,
+        tx,
+        'ATTACHMENT_REQUIRED_MISSING',
+        'attachment_controls',
+        'High',
+        'Bill has no attachment.',
+        'Attach the supporting invoice.',
+      );
+    }
+    if (
+      tx.privateNote?.toLowerCase().includes('transfer') &&
+      tx.transactionType === 'Purchase' &&
+      tx.postingAccounts.some((account) => account.includes('expenses'))
+    ) {
+      pushFinding(
+        findings,
+        tx,
+        'TRANSFER_LIKE_ACTIVITY_MISPOSTED',
+        'chart_of_accounts_sanity',
+        'Critical',
+        'Transfer-like activity is posted to a P&L account.',
+        'Rebuild as transfer-style activity.',
+      );
+    }
+  }
+
+  return findings;
+}

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -31,6 +31,7 @@ const ACCEPTED_FEE_ACCOUNT_CUES = [
   'card processing fees',
   'credit card processing fees',
 ];
+const DUPLICATE_FINDING_SEVERITY: AuditException['severity'] = 'High';
 
 function pushFinding(
   out: AuditException[],
@@ -56,7 +57,12 @@ function pushFinding(
     exceptionMessage,
     suggestedFix,
     supportStatus,
-    reconciledPeriodRisk: tx.isInReconciledPeriod ? 'yes' : 'no',
+    reconciledPeriodRisk:
+      tx.isInReconciledPeriod === true
+        ? 'yes'
+        : tx.isInReconciledPeriod === false
+          ? 'no'
+          : 'unknown',
   });
 }
 
@@ -71,8 +77,42 @@ function containsControlAccount(tx: NormalizedAuditTransaction): boolean {
   });
 }
 
-function duplicateKey(tx: NormalizedAuditTransaction): string {
-  return [tx.transactionType, tx.txnDate, tx.amount.toFixed(2), tx.counterparty || ''].join('::');
+function normalizeDuplicatePart(value: string | null): string {
+  if (value === null) {
+    return '';
+  }
+
+  return value.trim().toLowerCase();
+}
+
+function normalizeDuplicateList(values: string[]): string {
+  return values.map((value) => value.trim().toLowerCase()).filter(Boolean).join('|');
+}
+
+function duplicateKey(tx: NormalizedAuditTransaction): string | null {
+  const baseParts = [
+    tx.transactionType,
+    tx.txnDate,
+    tx.amount.toFixed(2),
+    normalizeDuplicatePart(tx.counterparty),
+  ];
+  const normalizedDocNumber = normalizeDuplicatePart(tx.docNumber);
+  if (normalizedDocNumber !== '') {
+    return [...baseParts, `doc:${normalizedDocNumber}`].join('::');
+  }
+
+  const evidenceParts = [
+    normalizeDuplicatePart(tx.dueDate),
+    normalizeDuplicateList(tx.postingAccounts),
+    normalizeDuplicateList(tx.lineDescriptions),
+    normalizeDuplicatePart(tx.privateNote),
+  ];
+
+  if (evidenceParts.every((value) => value === '')) {
+    return null;
+  }
+
+  return [...baseParts, ...evidenceParts].join('::');
 }
 
 function isOwnerEquityAccount(account: string): boolean {
@@ -147,7 +187,11 @@ export function classifyAuditExceptions(
 
   for (const tx of transactions) {
     const key = duplicateKey(tx);
-    duplicateCounts.set(key, (duplicateCounts.get(key) || 0) + 1);
+    if (key === null) {
+      continue;
+    }
+
+    duplicateCounts.set(key, (duplicateCounts.get(key) ?? 0) + 1);
   }
 
   for (const tx of transactions) {
@@ -198,15 +242,16 @@ export function classifyAuditExceptions(
       );
     }
 
-    if (duplicateCounts.get(duplicateKey(tx))! > 1) {
+    const candidateDuplicateKey = duplicateKey(tx);
+    if (candidateDuplicateKey !== null && (duplicateCounts.get(candidateDuplicateKey) ?? 0) > 1) {
       pushFinding(
         findings,
         tx,
         'LIKELY_DUPLICATE',
         'transaction_logic',
-        'Critical',
-        'Possible duplicate transaction.',
-        'Review and remove duplicate posting.',
+        DUPLICATE_FINDING_SEVERITY,
+        'Possible duplicate transaction with matching audit fingerprint.',
+        'Review for duplicate posting or document why repeated activity is legitimate.',
         'not_required',
       );
     }

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -1,5 +1,7 @@
 import type { AuditException, NormalizedAuditTransaction } from './types';
 
+const FOREIGN_CURRENCY_CODES = ['USD', 'GBP', 'EUR', 'CAD', 'AUD', 'JPY', 'CHF', 'NZD', 'MXN'];
+
 function pushFinding(
   out: AuditException[],
   tx: NormalizedAuditTransaction,
@@ -28,8 +30,54 @@ function pushFinding(
   });
 }
 
+function looksTransferLike(tx: NormalizedAuditTransaction): boolean {
+  const text = `${tx.privateNote || ''} ${tx.lineDescriptions.join(' ')}`.toLowerCase();
+  return text.includes('transfer') || text.includes('wise') || text.includes('funding');
+}
+
+function containsControlAccount(tx: NormalizedAuditTransaction): boolean {
+  return tx.postingAccounts.some((account) =>
+    account.includes('Settlement Control') || account.includes('Clearing') || account.includes('Suspense'),
+  );
+}
+
+function duplicateKey(tx: NormalizedAuditTransaction): string {
+  return [tx.transactionType, tx.txnDate, tx.amount.toFixed(2), tx.counterparty || ''].join('::');
+}
+
+function isOwnerEquityAccount(account: string): boolean {
+  const lower = account.toLowerCase();
+  return lower.includes('owner draws') || lower.includes('equity');
+}
+
+function isBankFeeAccount(account: string): boolean {
+  const lower = account.toLowerCase();
+  return lower.includes('bank fees') || lower.includes('service charges');
+}
+
+function mentionsDifferentCurrency(tx: NormalizedAuditTransaction): boolean {
+  if (tx.currency === null) {
+    return false;
+  }
+
+  const text = `${tx.counterparty || ''} ${tx.privateNote || ''} ${tx.lineDescriptions.join(' ')}`.toUpperCase();
+  for (const currencyCode of FOREIGN_CURRENCY_CODES) {
+    if (text.includes(currencyCode) && currencyCode !== tx.currency.toUpperCase()) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 export function classifyAuditExceptions(transactions: NormalizedAuditTransaction[]): AuditException[] {
   const findings: AuditException[] = [];
+  const duplicateCounts = new Map<string, number>();
+
+  for (const tx of transactions) {
+    const key = duplicateKey(tx);
+    duplicateCounts.set(key, (duplicateCounts.get(key) || 0) + 1);
+  }
 
   for (const tx of transactions) {
     if (
@@ -61,11 +109,80 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
         'missing',
       );
     }
+
+    if (duplicateCounts.get(duplicateKey(tx))! > 1) {
+      pushFinding(
+        findings,
+        tx,
+        'LIKELY_DUPLICATE',
+        'transaction_logic',
+        'Critical',
+        'Possible duplicate transaction.',
+        'Review and remove duplicate posting.',
+        'not_required',
+      );
+    }
+
+    if (containsControlAccount(tx) && tx.txnDate < '2026-01-01') {
+      pushFinding(
+        findings,
+        tx,
+        'UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY',
+        'control_exceptions',
+        'High',
+        'Old unresolved control-account activity remains posted.',
+        'Resolve or document the control-account balance.',
+        'not_required',
+      );
+    }
+
     if (
-      tx.privateNote?.toLowerCase().includes('transfer') &&
-      tx.transactionType === 'Purchase' &&
-      tx.postingAccounts.some((account) => account.toLowerCase().includes('expense'))
+      tx.counterparty?.toLowerCase().includes('owner') &&
+      !tx.postingAccounts.some((account) => isOwnerEquityAccount(account))
     ) {
+      pushFinding(
+        findings,
+        tx,
+        'OWNER_ACTIVITY_MISCLASSIFIED',
+        'chart_of_accounts_sanity',
+        'Critical',
+        'Owner activity is not posted to owner draw/equity.',
+        'Reclass owner activity to owner draw/equity.',
+        'not_required',
+      );
+    }
+
+    if (
+      tx.counterparty?.toLowerCase().includes('chase') &&
+      tx.lineDescriptions.join(' ').toLowerCase().includes('fee') &&
+      !tx.postingAccounts.some((account) => isBankFeeAccount(account))
+    ) {
+      pushFinding(
+        findings,
+        tx,
+        'BANK_FEE_MISCLASSIFIED',
+        'chart_of_accounts_sanity',
+        'High',
+        'Bank fee is not posted to a fee account.',
+        'Reclass to bank fees and service charges.',
+        'not_required',
+      );
+    }
+
+    if (mentionsDifferentCurrency(tx)) {
+      pushFinding(
+        findings,
+        tx,
+        'CURRENCY_COUNTERPARTY_MISMATCH',
+        'transaction_logic',
+        'High',
+        'Transaction currency does not match the counterparty context.',
+        'Verify the currency and reclassify if needed.',
+        'not_required',
+      );
+    }
+
+    if (looksTransferLike(tx) && tx.postingAccounts.some((account) => account.toLowerCase().includes('expenses'))) {
       pushFinding(
         findings,
         tx,

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -1,6 +1,25 @@
 import type { AuditException, NormalizedAuditTransaction } from './types';
 
 const FOREIGN_CURRENCY_CODES = ['USD', 'GBP', 'EUR', 'CAD', 'AUD', 'JPY', 'CHF', 'NZD', 'MXN'];
+const FEE_CUES = ['fee', 'fees', 'service charge', 'service charges', 'monthly fee', 'card fee', 'processing fee', 'maintenance fee'];
+const BANK_CARD_CUES = [
+  'bank',
+  'card',
+  'credit card',
+  'debit card',
+  'visa',
+  'mastercard',
+  'amex',
+  'american express',
+  'chase',
+  'capital one',
+  'wells fargo',
+  'bank of america',
+  'citibank',
+  'paypal',
+  'stripe',
+  'square',
+];
 
 function pushFinding(
   out: AuditException[],
@@ -30,15 +49,15 @@ function pushFinding(
   });
 }
 
-function looksTransferLike(tx: NormalizedAuditTransaction): boolean {
-  const text = `${tx.privateNote || ''} ${tx.lineDescriptions.join(' ')}`.toLowerCase();
-  return text.includes('transfer') || text.includes('wise') || text.includes('funding');
-}
-
 function containsControlAccount(tx: NormalizedAuditTransaction): boolean {
-  return tx.postingAccounts.some((account) =>
-    account.includes('Settlement Control') || account.includes('Clearing') || account.includes('Suspense'),
-  );
+  return tx.postingAccounts.some((account) => {
+    const lower = account.toLowerCase();
+    return (
+      lower.includes('settlement control') ||
+      lower.includes('clearing') ||
+      lower.includes('suspense')
+    );
+  });
 }
 
 function duplicateKey(tx: NormalizedAuditTransaction): string {
@@ -53,6 +72,13 @@ function isOwnerEquityAccount(account: string): boolean {
 function isBankFeeAccount(account: string): boolean {
   const lower = account.toLowerCase();
   return lower.includes('bank fees') || lower.includes('service charges');
+}
+
+function isLikelyBankCardFee(tx: NormalizedAuditTransaction): boolean {
+  const text = `${tx.counterparty || ''} ${tx.privateNote || ''} ${tx.lineDescriptions.join(' ')}`.toLowerCase();
+  const hasFeeCue = FEE_CUES.some((cue) => text.includes(cue));
+  const hasBankCardCue = BANK_CARD_CUES.some((cue) => text.includes(cue));
+  return hasFeeCue && hasBankCardCue;
 }
 
 function mentionsDifferentCurrency(tx: NormalizedAuditTransaction): boolean {
@@ -110,6 +136,23 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
       );
     }
 
+    if (
+      tx.privateNote?.toLowerCase().includes('transfer') &&
+      tx.transactionType === 'Purchase' &&
+      tx.postingAccounts.some((account) => account.toLowerCase().includes('expense'))
+    ) {
+      pushFinding(
+        findings,
+        tx,
+        'TRANSFER_LIKE_ACTIVITY_MISPOSTED',
+        'chart_of_accounts_sanity',
+        'Critical',
+        'Transfer-like activity is posted to a P&L account.',
+        'Rebuild as transfer-style activity.',
+        'not_required',
+      );
+    }
+
     if (duplicateCounts.get(duplicateKey(tx))! > 1) {
       pushFinding(
         findings,
@@ -152,11 +195,7 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
       );
     }
 
-    if (
-      tx.counterparty?.toLowerCase().includes('chase') &&
-      tx.lineDescriptions.join(' ').toLowerCase().includes('fee') &&
-      !tx.postingAccounts.some((account) => isBankFeeAccount(account))
-    ) {
+    if (isLikelyBankCardFee(tx) && !tx.postingAccounts.some((account) => isBankFeeAccount(account))) {
       pushFinding(
         findings,
         tx,
@@ -182,18 +221,6 @@ export function classifyAuditExceptions(transactions: NormalizedAuditTransaction
       );
     }
 
-    if (looksTransferLike(tx) && tx.postingAccounts.some((account) => account.toLowerCase().includes('expenses'))) {
-      pushFinding(
-        findings,
-        tx,
-        'TRANSFER_LIKE_ACTIVITY_MISPOSTED',
-        'chart_of_accounts_sanity',
-        'Critical',
-        'Transfer-like activity is posted to a P&L account.',
-        'Rebuild as transfer-style activity.',
-        'not_required',
-      );
-    }
   }
 
   return findings;

--- a/apps/plutus/lib/qbo/full-history-audit/types.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/types.ts
@@ -1,0 +1,53 @@
+export type AuditSeverity = 'Critical' | 'High' | 'Medium' | 'Low';
+
+export type AuditTransactionType = 'Purchase' | 'Bill' | 'Transfer' | 'JournalEntry' | 'BillPayment' | 'Invoice';
+
+export type AuditRuleId =
+  | 'DOCNUMBER_MISSING'
+  | 'PRIVATE_NOTE_MISSING'
+  | 'LINE_DESCRIPTION_MISSING'
+  | 'COUNTERPARTY_MISSING'
+  | 'BILL_DUE_DATE_MISSING'
+  | 'ATTACHMENT_REQUIRED_MISSING'
+  | 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'
+  | 'OWNER_ACTIVITY_MISCLASSIFIED'
+  | 'BANK_FEE_MISCLASSIFIED'
+  | 'CURRENCY_COUNTERPARTY_MISMATCH'
+  | 'LIKELY_DUPLICATE'
+  | 'UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY'
+  | 'POST_RECONCILE_MODIFICATION';
+
+export interface NormalizedAuditTransaction {
+  transactionType: AuditTransactionType;
+  transactionId: string;
+  txnDate: string;
+  amount: number;
+  currency: string | null;
+  counterparty: string | null;
+  docNumber: string | null;
+  privateNote: string | null;
+  dueDate: string | null;
+  postingAccounts: string[];
+  lineDescriptions: string[];
+  attachmentFileNames: string[];
+  isInReconciledPeriod: boolean;
+  lastUpdatedTime: string | null;
+  sourceTag: string | null;
+}
+
+export interface AuditException {
+  transactionType: AuditTransactionType;
+  transactionId: string;
+  txnDate: string;
+  amount: number;
+  currency: string | null;
+  counterparty: string | null;
+  postingAccountSummary: string;
+  ruleId: AuditRuleId;
+  ruleGroup: string;
+  severity: AuditSeverity;
+  exceptionMessage: string;
+  suggestedFix: string;
+  supportStatus: 'attached' | 'missing' | 'not_required' | 'unknown';
+  reconciledPeriodRisk: 'yes' | 'no';
+}

--- a/apps/plutus/lib/qbo/full-history-audit/types.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/types.ts
@@ -30,7 +30,7 @@ export interface NormalizedAuditTransaction {
   postingAccounts: string[];
   lineDescriptions: string[];
   attachmentFileNames: string[];
-  isInReconciledPeriod: boolean;
+  isInReconciledPeriod: boolean | null;
   lastUpdatedTime: string | null;
   sourceTag: string | null;
 }
@@ -49,5 +49,5 @@ export interface AuditException {
   exceptionMessage: string;
   suggestedFix: string;
   supportStatus: 'attached' | 'missing' | 'not_required' | 'unknown';
-  reconciledPeriodRisk: 'yes' | 'no';
+  reconciledPeriodRisk: 'yes' | 'no' | 'unknown';
 }

--- a/apps/plutus/scripts/qbo-full-history-exception-audit.ts
+++ b/apps/plutus/scripts/qbo-full-history-exception-audit.ts
@@ -1,16 +1,20 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-import type { QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
+import { getApiBaseUrl } from '@/lib/qbo/client';
 import {
   type CoverageRow,
-  type RawAttachable,
+  fetchAuditSourceData,
   getActiveQboConnection,
   mergeAttachmentRefs,
-  qboQueryAll,
   summarizeCoverage,
 } from '@/lib/qbo/full-history-audit/fetch';
-import { normalizeJournalEntryForAudit, normalizePurchaseForAudit } from '@/lib/qbo/full-history-audit/normalize';
+import {
+  normalizeBillForAudit,
+  normalizeJournalEntryForAudit,
+  normalizePurchaseForAudit,
+  normalizeTransferForAudit,
+} from '@/lib/qbo/full-history-audit/normalize';
 import { buildAuditCsv, buildAuditMarkdownSummary } from '@/lib/qbo/full-history-audit/report';
 import { classifyAuditExceptions } from '@/lib/qbo/full-history-audit/rules';
 
@@ -26,40 +30,49 @@ function parseArgs(argv: string[]) {
 async function main() {
   const { outDir } = parseArgs(process.argv.slice(2));
   const activeConnection = await getActiveQboConnection();
-
-  const purchasesResult = await qboQueryAll(activeConnection, 'SELECT * FROM Purchase ORDERBY TxnDate');
-  const journalEntriesResult = await qboQueryAll(activeConnection, 'SELECT * FROM JournalEntry ORDERBY TxnDate');
-  const attachablesResult = await qboQueryAll(activeConnection, 'SELECT * FROM Attachable');
-
-  const purchases = purchasesResult.rows as unknown as QboPurchase[];
-  const journalEntries = journalEntriesResult.rows as unknown as QboJournalEntry[];
-  const attachables = attachablesResult.rows as unknown as RawAttachable[];
-
-  const attachmentMap = mergeAttachmentRefs(attachables);
+  const baseUrl = getApiBaseUrl();
+  const sourceData = await fetchAuditSourceData(
+    activeConnection.accessToken,
+    activeConnection.connection.realmId,
+    baseUrl,
+  );
+  const attachmentMap = mergeAttachmentRefs(sourceData.attachables.rows);
   const normalized = [
-    ...purchases.map((purchase) => {
-      const attachmentRefs = attachmentMap.get(`Purchase:${purchase.Id}`);
-      const attachmentFileNames = attachmentRefs === undefined ? [] : attachmentRefs;
-      return normalizePurchaseForAudit(purchase, attachmentFileNames);
-    }),
-    ...journalEntries.map((journalEntry) => {
-      const attachmentRefs = attachmentMap.get(`JournalEntry:${journalEntry.Id}`);
-      const attachmentFileNames = attachmentRefs === undefined ? [] : attachmentRefs;
-      return normalizeJournalEntryForAudit(journalEntry, attachmentFileNames);
-    }),
+    ...sourceData.purchases.rows.map((purchase) =>
+      normalizePurchaseForAudit(purchase, attachmentMap.get(`Purchase:${purchase.Id}`) || []),
+    ),
+    ...sourceData.bills.rows.map((bill) =>
+      normalizeBillForAudit(bill, attachmentMap.get(`Bill:${bill.Id}`) || []),
+    ),
+    ...sourceData.journalEntries.rows.map((journalEntry) =>
+      normalizeJournalEntryForAudit(journalEntry, attachmentMap.get(`JournalEntry:${journalEntry.Id}`) || []),
+    ),
+    ...sourceData.transfers.rows.map((transfer) =>
+      normalizeTransferForAudit(transfer, attachmentMap.get(`Transfer:${transfer.Id}`) || []),
+    ),
   ];
 
   const findings = classifyAuditExceptions(normalized);
   const coverageRows: CoverageRow[] = [
     {
       transactionType: 'Purchase',
-      scannedCount: purchases.length,
-      complete: purchasesResult.complete,
+      scannedCount: sourceData.purchases.rows.length,
+      complete: sourceData.purchases.complete,
+    },
+    {
+      transactionType: 'Bill',
+      scannedCount: sourceData.bills.rows.length,
+      complete: sourceData.bills.complete,
     },
     {
       transactionType: 'JournalEntry',
-      scannedCount: journalEntries.length,
-      complete: journalEntriesResult.complete,
+      scannedCount: sourceData.journalEntries.rows.length,
+      complete: sourceData.journalEntries.complete,
+    },
+    {
+      transactionType: 'Transfer',
+      scannedCount: sourceData.transfers.rows.length,
+      complete: sourceData.transfers.complete,
     },
   ];
   const coverage = summarizeCoverage(coverageRows);
@@ -69,13 +82,15 @@ async function main() {
   await fs.writeFile(
     path.join(outDir, 'qbo-full-history-exception-audit.md'),
     buildAuditMarkdownSummary(findings, {
-      Purchase: purchases.length,
-      JournalEntry: journalEntries.length,
-      Attachable: attachables.length,
+      Purchase: sourceData.purchases.rows.length,
+      Bill: sourceData.bills.rows.length,
+      JournalEntry: sourceData.journalEntries.rows.length,
+      Transfer: sourceData.transfers.rows.length,
+      Attachable: sourceData.attachables.rows.length,
     }) +
       `\n\n## Coverage\n- completeCoverage: ${coverage.completeCoverage}\n- failedTypes: ${
         coverage.failedTypes.length === 0 ? 'none' : coverage.failedTypes.join(', ')
-      }\n- attachablesComplete: ${attachablesResult.complete}\n`,
+      }\n- attachablesComplete: ${sourceData.attachables.complete}\n`,
   );
 
   console.log(
@@ -85,8 +100,8 @@ async function main() {
         findings: findings.length,
         coverage: {
           ...coverage,
-          attachablesComplete: attachablesResult.complete,
-          attachablesScannedCount: attachables.length,
+          attachablesComplete: sourceData.attachables.complete,
+          attachablesScannedCount: sourceData.attachables.rows.length,
         },
       },
       null,

--- a/apps/plutus/scripts/qbo-full-history-exception-audit.ts
+++ b/apps/plutus/scripts/qbo-full-history-exception-audit.ts
@@ -27,6 +27,15 @@ function parseArgs(argv: string[]) {
   return { outDir };
 }
 
+function getAttachmentFileNames(attachmentMap: Map<string, string[]>, transactionType: string, transactionId: string): string[] {
+  const attachmentFileNames = attachmentMap.get(`${transactionType}:${transactionId}`);
+  if (attachmentFileNames === undefined) {
+    return [];
+  }
+
+  return attachmentFileNames;
+}
+
 async function main() {
   const { outDir } = parseArgs(process.argv.slice(2));
   const activeConnection = await getActiveQboConnection();
@@ -39,16 +48,19 @@ async function main() {
   const attachmentMap = mergeAttachmentRefs(sourceData.attachables.rows);
   const normalized = [
     ...sourceData.purchases.rows.map((purchase) =>
-      normalizePurchaseForAudit(purchase, attachmentMap.get(`Purchase:${purchase.Id}`) || []),
+      normalizePurchaseForAudit(purchase, getAttachmentFileNames(attachmentMap, 'Purchase', purchase.Id)),
     ),
     ...sourceData.bills.rows.map((bill) =>
-      normalizeBillForAudit(bill, attachmentMap.get(`Bill:${bill.Id}`) || []),
+      normalizeBillForAudit(bill, getAttachmentFileNames(attachmentMap, 'Bill', bill.Id)),
     ),
     ...sourceData.journalEntries.rows.map((journalEntry) =>
-      normalizeJournalEntryForAudit(journalEntry, attachmentMap.get(`JournalEntry:${journalEntry.Id}`) || []),
+      normalizeJournalEntryForAudit(
+        journalEntry,
+        getAttachmentFileNames(attachmentMap, 'JournalEntry', journalEntry.Id),
+      ),
     ),
     ...sourceData.transfers.rows.map((transfer) =>
-      normalizeTransferForAudit(transfer, attachmentMap.get(`Transfer:${transfer.Id}`) || []),
+      normalizeTransferForAudit(transfer, getAttachmentFileNames(attachmentMap, 'Transfer', transfer.Id)),
     ),
   ];
 

--- a/apps/plutus/scripts/qbo-full-history-exception-audit.ts
+++ b/apps/plutus/scripts/qbo-full-history-exception-audit.ts
@@ -1,0 +1,101 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { QboJournalEntry, QboPurchase } from '@/lib/qbo/api';
+import {
+  type CoverageRow,
+  type RawAttachable,
+  getActiveQboConnection,
+  mergeAttachmentRefs,
+  qboQueryAll,
+  summarizeCoverage,
+} from '@/lib/qbo/full-history-audit/fetch';
+import { normalizeJournalEntryForAudit, normalizePurchaseForAudit } from '@/lib/qbo/full-history-audit/normalize';
+import { buildAuditCsv, buildAuditMarkdownSummary } from '@/lib/qbo/full-history-audit/report';
+import { classifyAuditExceptions } from '@/lib/qbo/full-history-audit/rules';
+
+function parseArgs(argv: string[]) {
+  const outDir = argv[0];
+  if (outDir === undefined) {
+    throw new Error('Usage: pnpm -s exec tsx scripts/qbo-full-history-exception-audit.ts <out-dir>');
+  }
+
+  return { outDir };
+}
+
+async function main() {
+  const { outDir } = parseArgs(process.argv.slice(2));
+  const activeConnection = await getActiveQboConnection();
+
+  const purchasesResult = await qboQueryAll(activeConnection, 'SELECT * FROM Purchase ORDERBY TxnDate');
+  const journalEntriesResult = await qboQueryAll(activeConnection, 'SELECT * FROM JournalEntry ORDERBY TxnDate');
+  const attachablesResult = await qboQueryAll(activeConnection, 'SELECT * FROM Attachable');
+
+  const purchases = purchasesResult.rows as unknown as QboPurchase[];
+  const journalEntries = journalEntriesResult.rows as unknown as QboJournalEntry[];
+  const attachables = attachablesResult.rows as unknown as RawAttachable[];
+
+  const attachmentMap = mergeAttachmentRefs(attachables);
+  const normalized = [
+    ...purchases.map((purchase) => {
+      const attachmentRefs = attachmentMap.get(`Purchase:${purchase.Id}`);
+      const attachmentFileNames = attachmentRefs === undefined ? [] : attachmentRefs;
+      return normalizePurchaseForAudit(purchase, attachmentFileNames);
+    }),
+    ...journalEntries.map((journalEntry) => {
+      const attachmentRefs = attachmentMap.get(`JournalEntry:${journalEntry.Id}`);
+      const attachmentFileNames = attachmentRefs === undefined ? [] : attachmentRefs;
+      return normalizeJournalEntryForAudit(journalEntry, attachmentFileNames);
+    }),
+  ];
+
+  const findings = classifyAuditExceptions(normalized);
+  const coverageRows: CoverageRow[] = [
+    {
+      transactionType: 'Purchase',
+      scannedCount: purchases.length,
+      complete: purchasesResult.complete,
+    },
+    {
+      transactionType: 'JournalEntry',
+      scannedCount: journalEntries.length,
+      complete: journalEntriesResult.complete,
+    },
+  ];
+  const coverage = summarizeCoverage(coverageRows);
+
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(path.join(outDir, 'qbo-full-history-exception-audit.csv'), buildAuditCsv(findings));
+  await fs.writeFile(
+    path.join(outDir, 'qbo-full-history-exception-audit.md'),
+    buildAuditMarkdownSummary(findings, {
+      Purchase: purchases.length,
+      JournalEntry: journalEntries.length,
+      Attachable: attachables.length,
+    }) +
+      `\n\n## Coverage\n- completeCoverage: ${coverage.completeCoverage}\n- failedTypes: ${
+        coverage.failedTypes.length === 0 ? 'none' : coverage.failedTypes.join(', ')
+      }\n- attachablesComplete: ${attachablesResult.complete}\n`,
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        outDir,
+        findings: findings.length,
+        coverage: {
+          ...coverage,
+          attachablesComplete: attachablesResult.complete,
+          attachablesScannedCount: attachables.length,
+        },
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/plutus/scripts/qbo-full-history-exception-audit.ts
+++ b/apps/plutus/scripts/qbo-full-history-exception-audit.ts
@@ -86,6 +86,11 @@ async function main() {
       scannedCount: sourceData.transfers.rows.length,
       complete: sourceData.transfers.complete,
     },
+    {
+      transactionType: 'Attachable',
+      scannedCount: sourceData.attachables.rows.length,
+      complete: sourceData.attachables.complete,
+    },
   ];
   const coverage = summarizeCoverage(coverageRows);
 
@@ -102,7 +107,7 @@ async function main() {
     }) +
       `\n\n## Coverage\n- completeCoverage: ${coverage.completeCoverage}\n- failedTypes: ${
         coverage.failedTypes.length === 0 ? 'none' : coverage.failedTypes.join(', ')
-      }\n- attachablesComplete: ${sourceData.attachables.complete}\n`,
+      }\n`,
   );
 
   console.log(
@@ -110,11 +115,7 @@ async function main() {
       {
         outDir,
         findings: findings.length,
-        coverage: {
-          ...coverage,
-          attachablesComplete: sourceData.attachables.complete,
-          attachablesScannedCount: sourceData.attachables.rows.length,
-        },
+        coverage,
       },
       null,
       2,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2664,6 +2664,32 @@ test('normalizePurchaseForAudit preserves descriptions, accounts, payee, and att
   assert.deepEqual(normalized.attachmentFileNames, ['bitwarden-1093.txt']);
 });
 
+test('normalizePurchaseForAudit preserves item-based accounts and omits missing descriptions', () => {
+  const normalized = normalizePurchaseForAudit(
+    {
+      Id: '1094',
+      TxnDate: '2026-04-07',
+      TotalAmt: 42,
+      PaymentType: 'CreditCard',
+      DocNumber: 'BITWARDEN-20260407',
+      PrivateNote: 'Bitwarden follow-up purchase.',
+      EntityRef: { value: '76', name: 'Bitwarden' },
+      Line: [
+        {
+          Id: '1',
+          Amount: 42,
+          ItemBasedExpenseLineDetail: { AccountRef: { value: '500', name: 'Office expenses:Software & apps' } },
+        },
+      ],
+      SyncToken: '1',
+    },
+    ['bitwarden-1094.txt'],
+  );
+
+  assert.deepEqual(normalized.postingAccounts, ['Office expenses:Software & apps']);
+  assert.deepEqual(normalized.lineDescriptions, []);
+});
+
 test('normalizeJournalEntryForAudit captures line descriptions and control-account usage', () => {
   const normalized = normalizeJournalEntryForAudit(
     {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -94,6 +94,10 @@ import {
   classifyAuditExceptions,
 } from '../lib/qbo/full-history-audit/rules';
 import {
+  normalizeJournalEntryForAudit,
+  normalizePurchaseForAudit,
+} from '../lib/qbo/full-history-audit/normalize';
+import {
   getActiveQboConnection,
   mergeAttachmentRefs,
   qboFullHistoryAuditDeps,
@@ -2630,6 +2634,65 @@ test('audit does not require doc number for transfer transactions', () => {
 
   const findings = classifyAuditExceptions([tx]);
   assert.equal(findings.some((finding) => finding.ruleId === 'DOCNUMBER_MISSING'), false);
+});
+
+test('normalizePurchaseForAudit preserves descriptions, accounts, payee, and attachments', () => {
+  const normalized = normalizePurchaseForAudit(
+    {
+      Id: '1093',
+      TxnDate: '2026-04-06',
+      TotalAmt: 19.8,
+      PaymentType: 'CreditCard',
+      DocNumber: 'BITWARDEN-20260406',
+      PrivateNote: 'Bitwarden software subscription matched from Chase Ink card feed.',
+      EntityRef: { value: '76', name: 'Bitwarden' },
+      Line: [
+        {
+          Id: '1',
+          Amount: 19.8,
+          Description: 'BITWARDEN',
+          AccountBasedExpenseLineDetail: { AccountRef: { value: '500', name: 'Office expenses:Software & apps' } },
+        },
+      ],
+      SyncToken: '1',
+    },
+    ['bitwarden-1093.txt'],
+  );
+
+  assert.equal(normalized.counterparty, 'Bitwarden');
+  assert.deepEqual(normalized.postingAccounts, ['Office expenses:Software & apps']);
+  assert.deepEqual(normalized.attachmentFileNames, ['bitwarden-1093.txt']);
+});
+
+test('normalizeJournalEntryForAudit captures line descriptions and control-account usage', () => {
+  const normalized = normalizeJournalEntryForAudit(
+    {
+      Id: '1098',
+      SyncToken: '1',
+      TxnDate: '2026-04-03',
+      DocNumber: 'AMZN-260403-1164',
+      PrivateNote: 'Temporary Amazon bank-receipt suspense entry.',
+      Line: [
+        {
+          Amount: 11.64,
+          Description: 'Temporary suspense for Amazon-originated Chase USD receipt pending settlement sync',
+          DetailType: 'JournalEntryLineDetail',
+          JournalEntryLineDetail: { PostingType: 'Debit', AccountRef: { value: '136', name: 'Targon US Chase USD (9899)' } },
+        },
+        {
+          Amount: 11.64,
+          Description: 'Offset to Plutus Settlement Control until final Amazon settlement journal is regenerated',
+          DetailType: 'JournalEntryLineDetail',
+          JournalEntryLineDetail: { PostingType: 'Credit', AccountRef: { value: '178', name: 'Plutus Settlement Control' } },
+        },
+      ],
+    },
+    ['support.txt'],
+  );
+
+  assert.equal(normalized.transactionType, 'JournalEntry');
+  assert.equal(normalized.postingAccounts.includes('Plutus Settlement Control'), true);
+  assert.equal(normalized.lineDescriptions.length, 2);
 });
 
 test('mergeAttachmentRefs maps attachables back to transaction ids', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2606,4 +2606,27 @@ test('audit flags transfer-like expenses posted to p-and-l accounts', () => {
   ]);
 });
 
+test('audit does not require doc number for transfer transactions', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Transfer',
+    transactionId: 'T1',
+    txnDate: '2026-04-01',
+    amount: 250,
+    currency: 'USD',
+    counterparty: 'Operating account',
+    docNumber: null,
+    privateNote: 'Owner funding move',
+    dueDate: null,
+    postingAccounts: ['Assets:Bank'],
+    lineDescriptions: ['Transfer between cash accounts'],
+    attachmentFileNames: [],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.equal(findings.some((finding) => finding.ruleId === 'DOCNUMBER_MISSING'), false);
+});
+
 process.stdout.write('All tests passed.\n');

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -99,6 +99,7 @@ import {
   normalizePurchaseForAudit,
 } from '../lib/qbo/full-history-audit/normalize';
 import {
+  fetchAuditSourceData,
   getActiveQboConnection,
   mergeAttachmentRefs,
   qboFullHistoryAuditDeps,
@@ -107,6 +108,10 @@ import {
 } from '../lib/qbo/full-history-audit/fetch';
 import { buildAuditCsv, buildAuditMarkdownSummary } from '../lib/qbo/full-history-audit/report';
 import type { NormalizedAuditTransaction } from '../lib/qbo/full-history-audit/types';
+import {
+  normalizeBillForAudit,
+  normalizeTransferForAudit,
+} from '../lib/qbo/full-history-audit/normalize';
 import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
 import type { QboAccount, QboBill, QboRecurringTransaction } from '../lib/qbo/api';
@@ -2944,6 +2949,68 @@ test('normalizeJournalEntryForAudit captures line descriptions and control-accou
   ]);
 });
 
+test('normalizeBillForAudit preserves vendor due date accounts and attachments', () => {
+  const normalized = normalizeBillForAudit(
+    {
+      Id: '10',
+      SyncToken: '0',
+      TxnDate: '2026-04-01',
+      TotalAmt: 1250,
+      DocNumber: 'B-10',
+      DueDate: '2026-04-30',
+      PrivateNote: 'Inventory replenishment',
+      CurrencyRef: { value: 'USD' },
+      VendorRef: { value: '20', name: 'Vendor A' },
+      Line: [
+        {
+          Id: '1',
+          Amount: 1000,
+          Description: 'Widgets',
+          AccountBasedExpenseLineDetail: {
+            AccountRef: { value: '300', name: 'Inventory Asset' },
+          },
+        },
+      ],
+      MetaData: {
+        CreateTime: '2026-04-01T00:00:00Z',
+        LastUpdatedTime: '2026-04-02T00:00:00Z',
+      },
+    },
+    ['invoice.pdf'],
+  );
+
+  assert.equal(normalized.transactionType, 'Bill');
+  assert.equal(normalized.counterparty, 'Vendor A');
+  assert.equal(normalized.dueDate, '2026-04-30');
+  assert.deepEqual(normalized.postingAccounts, ['Inventory Asset']);
+  assert.deepEqual(normalized.lineDescriptions, ['Widgets']);
+  assert.deepEqual(normalized.attachmentFileNames, ['invoice.pdf']);
+});
+
+test('normalizeTransferForAudit preserves both transfer accounts', () => {
+  const normalized = normalizeTransferForAudit(
+    {
+      Id: '55',
+      TxnDate: '2026-04-03',
+      Amount: 500,
+      DocNumber: 'TR-55',
+      PrivateNote: 'Sweep',
+      CurrencyRef: { value: 'USD' },
+      FromAccountRef: { value: '10', name: 'Chase Checking' },
+      ToAccountRef: { value: '20', name: 'Reserve Account' },
+      MetaData: {
+        LastUpdatedTime: '2026-04-03T10:00:00Z',
+      },
+    },
+    ['support.pdf'],
+  );
+
+  assert.equal(normalized.transactionType, 'Transfer');
+  assert.deepEqual(normalized.postingAccounts, ['Chase Checking', 'Reserve Account']);
+  assert.equal(normalized.counterparty, null);
+  assert.deepEqual(normalized.attachmentFileNames, ['support.pdf']);
+});
+
 test('mergeAttachmentRefs maps attachables back to transaction ids', () => {
   const result = mergeAttachmentRefs(
     [
@@ -2962,6 +3029,16 @@ test('summarizeCoverage preserves partial coverage failures', () => {
   ]);
   assert.equal(summary.completeCoverage, false);
   assert.equal(summary.failedTypes[0], 'Transfer');
+});
+
+test('audit coverage summary reports failed transaction-type coverage', () => {
+  const coverage = summarizeCoverage([
+    { transactionType: 'Purchase', scannedCount: 10, complete: true },
+    { transactionType: 'Bill', scannedCount: 5, complete: true },
+    { transactionType: 'Transfer', scannedCount: 3, complete: false },
+  ]);
+  assert.equal(coverage.completeCoverage, false);
+  assert.deepEqual(coverage.failedTypes, ['Transfer']);
 });
 
 test('audit report builders render severity totals and csv rows', () => {
@@ -3182,6 +3259,50 @@ test('qboQueryAll throws after bounded network retries', async () => {
       /socket hang up/,
     );
     assert.equal(attempts, 4);
+  } finally {
+    qboFullHistoryAuditDeps.fetch = originalFetch;
+    qboFullHistoryAuditDeps.sleep = originalSleep;
+  }
+});
+
+test('fetchAuditSourceData queries purchases bills journal entries transfers and attachables', async () => {
+  const originalFetch = qboFullHistoryAuditDeps.fetch;
+  const originalSleep = qboFullHistoryAuditDeps.sleep;
+  const requestedQueries: string[] = [];
+
+  qboFullHistoryAuditDeps.sleep = async () => {};
+  qboFullHistoryAuditDeps.fetch = async (url) => {
+    const requestUrl = new URL(url);
+    const query = requestUrl.searchParams.get('query') ?? '';
+    requestedQueries.push(query);
+
+    if (query.includes('FROM Purchase')) {
+      return makeQboResponse({ QueryResponse: { Purchase: [{ Id: 'P1' }] } });
+    }
+    if (query.includes('FROM Bill')) {
+      return makeQboResponse({ QueryResponse: { Bill: [{ Id: 'B1' }] } });
+    }
+    if (query.includes('FROM JournalEntry')) {
+      return makeQboResponse({ QueryResponse: { JournalEntry: [{ Id: 'J1' }] } });
+    }
+    if (query.includes('FROM Transfer')) {
+      return makeQboResponse({ QueryResponse: { Transfer: [{ Id: 'T1' }] } });
+    }
+    if (query.includes('FROM Attachable')) {
+      return makeQboResponse({ QueryResponse: { Attachable: [{ Id: 'A1' }] } });
+    }
+
+    throw new Error(`unexpected query: ${query}`);
+  };
+
+  try {
+    const result = await fetchAuditSourceData('fresh-token', '123', 'https://example.com');
+    assert.equal(result.purchases.rows.length, 1);
+    assert.equal(result.bills.rows.length, 1);
+    assert.equal(result.journalEntries.rows.length, 1);
+    assert.equal(result.transfers.rows.length, 1);
+    assert.equal(result.attachables.rows.length, 1);
+    assert.equal(requestedQueries.length, 5);
   } finally {
     qboFullHistoryAuditDeps.fetch = originalFetch;
     qboFullHistoryAuditDeps.sleep = originalSleep;

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2576,12 +2576,16 @@ test('audit flags missing doc number and missing attachment on bills', () => {
     postingAccounts: ['Inventory'],
     lineDescriptions: [''],
     attachmentFileNames: [],
-    isInReconciledPeriod: false,
+    isInReconciledPeriod: null,
     lastUpdatedTime: '2026-04-10T10:00:00Z',
     sourceTag: null,
   };
 
   const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(
+    findings.map((finding) => finding.reconciledPeriodRisk),
+    ['unknown', 'unknown'],
+  );
   assert.deepEqual(
     findings.map((finding) => ({
       ruleId: finding.ruleId,
@@ -2721,7 +2725,7 @@ test('audit flags likely duplicates by date amount and counterparty', () => {
       amount: 1015.85,
       currency: 'USD',
       counterparty: 'Internal funding move',
-      docNumber: 'X2',
+      docNumber: 'X1',
       privateNote: 'Transfer to Wise',
       dueDate: null,
       postingAccounts: ['Owner draws'],
@@ -2735,6 +2739,48 @@ test('audit flags likely duplicates by date amount and counterparty', () => {
 
   const findings = classifyAuditExceptions(input);
   assert.deepEqual(ruleIds(findings), ['LIKELY_DUPLICATE', 'LIKELY_DUPLICATE']);
+});
+
+test('audit does not flag duplicates when the doc numbers differ', () => {
+  const input: NormalizedAuditTransaction[] = [
+    {
+      transactionType: 'Purchase',
+      transactionId: 'P200',
+      txnDate: '2026-03-03',
+      amount: 1015.85,
+      currency: 'USD',
+      counterparty: 'Internal funding move',
+      docNumber: 'X1',
+      privateNote: 'Transfer to Wise',
+      dueDate: null,
+      postingAccounts: ['Owner draws'],
+      lineDescriptions: ['Transfer to Wise USD'],
+      attachmentFileNames: ['x.txt'],
+      isInReconciledPeriod: true,
+      lastUpdatedTime: '2026-04-13T12:00:00Z',
+      sourceTag: null,
+    },
+    {
+      transactionType: 'Purchase',
+      transactionId: 'P201',
+      txnDate: '2026-03-03',
+      amount: 1015.85,
+      currency: 'USD',
+      counterparty: 'Internal funding move',
+      docNumber: 'X2',
+      privateNote: 'Transfer to Wise',
+      dueDate: null,
+      postingAccounts: ['Owner draws'],
+      lineDescriptions: ['Transfer to Wise USD'],
+      attachmentFileNames: ['y.txt'],
+      isInReconciledPeriod: true,
+      lastUpdatedTime: '2026-04-13T12:00:00Z',
+      sourceTag: null,
+    },
+  ];
+
+  const findings = classifyAuditExceptions(input);
+  assert.deepEqual(ruleIds(findings), []);
 });
 
 test('audit flags unresolved settlement-control usage', () => {
@@ -3043,9 +3089,10 @@ test('audit coverage summary reports failed transaction-type coverage', () => {
     { transactionType: 'Purchase', scannedCount: 10, complete: true },
     { transactionType: 'Bill', scannedCount: 5, complete: true },
     { transactionType: 'Transfer', scannedCount: 3, complete: false },
+    { transactionType: 'Attachable', scannedCount: 2, complete: false },
   ]);
   assert.equal(coverage.completeCoverage, false);
-  assert.deepEqual(coverage.failedTypes, ['Transfer']);
+  assert.deepEqual(coverage.failedTypes, ['Transfer', 'Attachable']);
 });
 
 test('audit report builders render severity totals and csv rows', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2970,6 +2970,13 @@ test('normalizeBillForAudit preserves vendor due date accounts and attachments',
             AccountRef: { value: '300', name: 'Inventory Asset' },
           },
         },
+        {
+          Id: '2',
+          Amount: 250,
+          ItemBasedExpenseLineDetail: {
+            AccountRef: { value: '301', name: 'Freight Clearing' },
+          },
+        },
       ],
       MetaData: {
         CreateTime: '2026-04-01T00:00:00Z',
@@ -2982,7 +2989,7 @@ test('normalizeBillForAudit preserves vendor due date accounts and attachments',
   assert.equal(normalized.transactionType, 'Bill');
   assert.equal(normalized.counterparty, 'Vendor A');
   assert.equal(normalized.dueDate, '2026-04-30');
-  assert.deepEqual(normalized.postingAccounts, ['Inventory Asset']);
+  assert.deepEqual(normalized.postingAccounts, ['Inventory Asset', 'Freight Clearing']);
   assert.deepEqual(normalized.lineDescriptions, ['Widgets']);
   assert.deepEqual(normalized.attachmentFileNames, ['invoice.pdf']);
 });

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2636,6 +2636,71 @@ test('audit does not require doc number for transfer transactions', () => {
   assert.equal(findings.some((finding) => finding.ruleId === 'DOCNUMBER_MISSING'), false);
 });
 
+test('audit flags likely duplicates by date amount and counterparty', () => {
+  const input: NormalizedAuditTransaction[] = [
+    {
+      transactionType: 'Purchase',
+      transactionId: 'P100',
+      txnDate: '2026-03-03',
+      amount: 1015.85,
+      currency: 'USD',
+      counterparty: 'Internal funding move',
+      docNumber: 'X1',
+      privateNote: 'Transfer to Wise',
+      dueDate: null,
+      postingAccounts: ['Owner draws'],
+      lineDescriptions: ['Transfer to Wise USD'],
+      attachmentFileNames: ['x.txt'],
+      isInReconciledPeriod: true,
+      lastUpdatedTime: '2026-04-13T12:00:00Z',
+      sourceTag: null,
+    },
+    {
+      transactionType: 'Purchase',
+      transactionId: 'P101',
+      txnDate: '2026-03-03',
+      amount: 1015.85,
+      currency: 'USD',
+      counterparty: 'Internal funding move',
+      docNumber: 'X2',
+      privateNote: 'Transfer to Wise',
+      dueDate: null,
+      postingAccounts: ['Owner draws'],
+      lineDescriptions: ['Transfer to Wise USD'],
+      attachmentFileNames: ['y.txt'],
+      isInReconciledPeriod: true,
+      lastUpdatedTime: '2026-04-13T12:00:00Z',
+      sourceTag: null,
+    },
+  ];
+
+  const findings = classifyAuditExceptions(input);
+  assert.equal(findings.some((f) => f.ruleId === 'LIKELY_DUPLICATE'), true);
+});
+
+test('audit flags unresolved settlement-control usage', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'JournalEntry',
+    transactionId: 'J1',
+    txnDate: '2025-01-10',
+    amount: 11.64,
+    currency: 'USD',
+    counterparty: null,
+    docNumber: 'AMZN-1',
+    privateNote: 'Temporary suspense entry',
+    dueDate: null,
+    postingAccounts: ['Plutus Settlement Control'],
+    lineDescriptions: ['Temporary suspense entry'],
+    attachmentFileNames: ['support.txt'],
+    isInReconciledPeriod: true,
+    lastUpdatedTime: '2025-01-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.equal(findings.some((f) => f.ruleId === 'UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY'), true);
+});
+
 test('normalizePurchaseForAudit preserves descriptions, accounts, payee, and attachments', () => {
   const normalized = normalizePurchaseForAudit(
     {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -93,6 +93,10 @@ import {
 import {
   classifyAuditExceptions,
 } from '../lib/qbo/full-history-audit/rules';
+import {
+  mergeAttachmentRefs,
+  summarizeCoverage,
+} from '../lib/qbo/full-history-audit/fetch';
 import type { NormalizedAuditTransaction } from '../lib/qbo/full-history-audit/types';
 import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
@@ -2627,6 +2631,26 @@ test('audit does not require doc number for transfer transactions', () => {
 
   const findings = classifyAuditExceptions([tx]);
   assert.equal(findings.some((finding) => finding.ruleId === 'DOCNUMBER_MISSING'), false);
+});
+
+test('mergeAttachmentRefs maps attachables back to transaction ids', () => {
+  const result = mergeAttachmentRefs(
+    [
+      { Id: 'A1', FileName: 'bill.pdf', AttachableRef: [{ EntityRef: { type: 'Bill', value: '10' } }] },
+      { Id: 'A2', FileName: 'support.txt', AttachableRef: [{ EntityRef: { type: 'JournalEntry', value: '20' } }] },
+    ],
+  );
+  assert.deepEqual(result.get('Bill:10'), ['bill.pdf']);
+  assert.deepEqual(result.get('JournalEntry:20'), ['support.txt']);
+});
+
+test('summarizeCoverage preserves partial coverage failures', () => {
+  const summary = summarizeCoverage([
+    { transactionType: 'Purchase', scannedCount: 100, complete: true },
+    { transactionType: 'Transfer', scannedCount: 80, complete: false },
+  ]);
+  assert.equal(summary.completeCoverage, false);
+  assert.equal(summary.failedTypes[0], 'Transfer');
 });
 
 process.stdout.write('All tests passed.\n');

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2977,8 +2977,8 @@ test('audit report builders render severity totals and csv rows', () => {
       ruleId: 'ATTACHMENT_REQUIRED_MISSING',
       ruleGroup: 'attachment_controls',
       severity: 'High',
-      exceptionMessage: 'Bill has no attachment.',
-      suggestedFix: 'Attach the supporting invoice.',
+      exceptionMessage: 'Bill has no attachment, review "support" docs.',
+      suggestedFix: 'Attach the supporting invoice,\nthen mark "received".',
       supportStatus: 'missing',
       reconciledPeriodRisk: 'no',
     },
@@ -2987,6 +2987,15 @@ test('audit report builders render severity totals and csv rows', () => {
   const csv = buildAuditCsv(rows);
   const summary = buildAuditMarkdownSummary(rows, { Purchase: 10, Bill: 1 });
   assert.equal(csv.includes('ATTACHMENT_REQUIRED_MISSING'), true);
+  assert.equal(
+    csv.includes('"Bill has no attachment, review ""support"" docs."'),
+    true,
+  );
+  assert.equal(
+    csv.includes('"Attach the supporting invoice,\nthen mark ""received""."'),
+    true,
+  );
+  assert.equal(csv.includes('\\"support\\"'), false);
   assert.equal(summary.includes('High'), true);
   assert.equal(summary.includes('Bill: 1'), true);
 });

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2636,6 +2636,43 @@ test('audit does not require doc number for transfer transactions', () => {
   assert.equal(findings.some((finding) => finding.ruleId === 'DOCNUMBER_MISSING'), false);
 });
 
+test('audit keeps the original transfer mispost guard purchase-only and expense-based', () => {
+  const purchaseTx: NormalizedAuditTransaction = {
+    transactionType: 'Purchase',
+    transactionId: 'P-transfer',
+    txnDate: '2026-04-01',
+    amount: 250,
+    currency: 'USD',
+    counterparty: 'Operating account',
+    docNumber: 'T-1',
+    privateNote: 'Transfer to Wise',
+    dueDate: null,
+    postingAccounts: ['Office expense:Software'],
+    lineDescriptions: ['Transfer between cash accounts'],
+    attachmentFileNames: ['support.txt'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const transferTx: NormalizedAuditTransaction = {
+    ...purchaseTx,
+    transactionType: 'Transfer',
+    transactionId: 'T-transfer',
+  };
+
+  const purchaseFindings = classifyAuditExceptions([purchaseTx]);
+  const transferFindings = classifyAuditExceptions([transferTx]);
+  assert.equal(
+    purchaseFindings.some((finding) => finding.ruleId === 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'),
+    true,
+  );
+  assert.equal(
+    transferFindings.some((finding) => finding.ruleId === 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'),
+    false,
+  );
+});
+
 test('audit flags likely duplicates by date amount and counterparty', () => {
   const input: NormalizedAuditTransaction[] = [
     {
@@ -2689,7 +2726,7 @@ test('audit flags unresolved settlement-control usage', () => {
     docNumber: 'AMZN-1',
     privateNote: 'Temporary suspense entry',
     dueDate: null,
-    postingAccounts: ['Plutus Settlement Control'],
+    postingAccounts: ['plutus settlement control'],
     lineDescriptions: ['Temporary suspense entry'],
     attachmentFileNames: ['support.txt'],
     isInReconciledPeriod: true,
@@ -2699,6 +2736,29 @@ test('audit flags unresolved settlement-control usage', () => {
 
   const findings = classifyAuditExceptions([tx]);
   assert.equal(findings.some((f) => f.ruleId === 'UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY'), true);
+});
+
+test('audit flags bank fee activity from note and line description cues', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Purchase',
+    transactionId: 'F1',
+    txnDate: '2026-04-02',
+    amount: 17.5,
+    currency: 'USD',
+    counterparty: 'Capital One',
+    docNumber: 'FEE-1',
+    privateNote: 'Monthly card fee for account maintenance',
+    dueDate: null,
+    postingAccounts: ['Other expenses:Misc'],
+    lineDescriptions: ['Card service fee'],
+    attachmentFileNames: ['support.txt'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.equal(findings.some((f) => f.ruleId === 'BANK_FEE_MISCLASSIFIED'), true);
 });
 
 test('normalizePurchaseForAudit preserves descriptions, accounts, payee, and attachments', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -9,6 +9,7 @@ import {
   formatAuditInvoiceResolutionMessage,
   resolveAuditInvoiceForSettlementChild,
 } from '../lib/plutus/audit-invoice-resolution';
+import { buildSettlementListRowViewModel } from '../lib/plutus/settlement-review';
 import {
   computeSaleCostFromAverage,
   createEmptyLedgerSnapshot,
@@ -104,6 +105,7 @@ import {
   qboQueryAll,
   summarizeCoverage,
 } from '../lib/qbo/full-history-audit/fetch';
+import { buildAuditCsv, buildAuditMarkdownSummary } from '../lib/qbo/full-history-audit/report';
 import type { NormalizedAuditTransaction } from '../lib/qbo/full-history-audit/types';
 import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
@@ -330,6 +332,23 @@ test('getSettlementDisplayId hides EG-prefixed source settlement ids behind the 
     }),
     'UK-260130-260131-S1',
   );
+});
+
+test('buildSettlementListRowViewModel keeps non-split settlements to one secondary label', () => {
+  const row = {
+    sourceSettlementId: 'UK-260213-260227-S1',
+    marketplace: { label: 'Amazon.co.uk', currency: 'GBP', region: 'UK' },
+    periodStart: '2026-02-13',
+    periodEnd: '2026-02-27',
+    settlementTotal: 4508.25,
+    plutusStatus: 'Processed',
+    splitCount: 1,
+    isSplit: false,
+    children: [{ docNumber: 'UK-260213-260227-S1' }],
+  } as const;
+
+  const view = buildSettlementListRowViewModel(row);
+  assert.equal(view.subtitle, 'Amazon.co.uk');
 });
 
 test('normalizeSettlementMarketplaceQuery maps settlement route params to marketplace filters', () => {
@@ -2943,6 +2962,33 @@ test('summarizeCoverage preserves partial coverage failures', () => {
   ]);
   assert.equal(summary.completeCoverage, false);
   assert.equal(summary.failedTypes[0], 'Transfer');
+});
+
+test('audit report builders render severity totals and csv rows', () => {
+  const rows = [
+    {
+      transactionType: 'Bill',
+      transactionId: '10',
+      txnDate: '2026-04-01',
+      amount: 1250,
+      currency: 'USD',
+      counterparty: 'Vendor A',
+      postingAccountSummary: 'Inventory',
+      ruleId: 'ATTACHMENT_REQUIRED_MISSING',
+      ruleGroup: 'attachment_controls',
+      severity: 'High',
+      exceptionMessage: 'Bill has no attachment.',
+      suggestedFix: 'Attach the supporting invoice.',
+      supportStatus: 'missing',
+      reconciledPeriodRisk: 'no',
+    },
+  ] as const;
+
+  const csv = buildAuditCsv(rows);
+  const summary = buildAuditMarkdownSummary(rows, { Purchase: 10, Bill: 1 });
+  assert.equal(csv.includes('ATTACHMENT_REQUIRED_MISSING'), true);
+  assert.equal(summary.includes('High'), true);
+  assert.equal(summary.includes('Bill: 1'), true);
 });
 
 function makeQboResponse(body: Record<string, unknown>, status = 200): Response {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -92,8 +92,8 @@ import {
 } from '../lib/qbo/connection-feedback';
 import {
   classifyAuditExceptions,
-  type NormalizedAuditTransaction,
 } from '../lib/qbo/full-history-audit/rules';
+import type { NormalizedAuditTransaction } from '../lib/qbo/full-history-audit/types';
 import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
 import type { QboAccount, QboBill, QboRecurringTransaction } from '../lib/qbo/api';
@@ -2549,7 +2549,7 @@ test('audit flags missing doc number and missing attachment on bills', () => {
   const findings = classifyAuditExceptions([tx]);
   assert.deepEqual(
     findings.map((f) => f.ruleId).sort(),
-    ['ATTACHMENT_REQUIRED_MISSING', 'BILL_DUE_DATE_MISSING', 'DOCNUMBER_MISSING', 'LINE_DESCRIPTION_MISSING'].sort(),
+    ['ATTACHMENT_REQUIRED_MISSING', 'DOCNUMBER_MISSING'].sort(),
   );
 });
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -115,6 +115,10 @@ function test(name: string, fn: () => void | Promise<void>) {
   tests.push({ name, fn });
 }
 
+function ruleIds(findings: Array<{ ruleId: string }>): string[] {
+  return findings.map((finding) => finding.ruleId).sort();
+}
+
 test('normalizeAuditMarketToMarketplaceId maps common values', () => {
   assert.equal(normalizeAuditMarketToMarketplaceId('Amazon.com'), 'amazon.com');
   assert.equal(normalizeAuditMarketToMarketplaceId('amazon.co.uk'), 'amazon.co.uk');
@@ -2663,14 +2667,8 @@ test('audit keeps the original transfer mispost guard purchase-only and expense-
 
   const purchaseFindings = classifyAuditExceptions([purchaseTx]);
   const transferFindings = classifyAuditExceptions([transferTx]);
-  assert.equal(
-    purchaseFindings.some((finding) => finding.ruleId === 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'),
-    true,
-  );
-  assert.equal(
-    transferFindings.some((finding) => finding.ruleId === 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'),
-    false,
-  );
+  assert.deepEqual(ruleIds(purchaseFindings), ['TRANSFER_LIKE_ACTIVITY_MISPOSTED']);
+  assert.deepEqual(ruleIds(transferFindings), []);
 });
 
 test('audit flags likely duplicates by date amount and counterparty', () => {
@@ -2712,7 +2710,7 @@ test('audit flags likely duplicates by date amount and counterparty', () => {
   ];
 
   const findings = classifyAuditExceptions(input);
-  assert.equal(findings.some((f) => f.ruleId === 'LIKELY_DUPLICATE'), true);
+  assert.deepEqual(ruleIds(findings), ['LIKELY_DUPLICATE', 'LIKELY_DUPLICATE']);
 });
 
 test('audit flags unresolved settlement-control usage', () => {
@@ -2734,8 +2732,8 @@ test('audit flags unresolved settlement-control usage', () => {
     sourceTag: null,
   };
 
-  const findings = classifyAuditExceptions([tx]);
-  assert.equal(findings.some((f) => f.ruleId === 'UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY'), true);
+  const findings = classifyAuditExceptions([tx], { asOfDate: '2026-04-10', staleControlAccountDays: 365 });
+  assert.deepEqual(ruleIds(findings), ['UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY']);
 });
 
 test('audit flags bank fee activity from note and line description cues', () => {
@@ -2758,7 +2756,84 @@ test('audit flags bank fee activity from note and line description cues', () => 
   };
 
   const findings = classifyAuditExceptions([tx]);
-  assert.equal(findings.some((f) => f.ruleId === 'BANK_FEE_MISCLASSIFIED'), true);
+  assert.deepEqual(ruleIds(findings), ['BANK_FEE_MISCLASSIFIED']);
+});
+
+test('audit accepts merchant processing fee accounts', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Purchase',
+    transactionId: 'F2',
+    txnDate: '2026-04-03',
+    amount: 21.75,
+    currency: 'USD',
+    counterparty: 'Stripe',
+    docNumber: 'FEE-2',
+    privateNote: 'Monthly card fee for account maintenance',
+    dueDate: null,
+    postingAccounts: ['Merchant processing fees'],
+    lineDescriptions: ['Card service fee'],
+    attachmentFileNames: ['support.txt'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(ruleIds(findings), []);
+});
+
+test('audit flags owner activity misclassified away from owner equity', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Purchase',
+    transactionId: 'O1',
+    txnDate: '2026-04-04',
+    amount: 300,
+    currency: 'USD',
+    counterparty: 'Owner distribution',
+    docNumber: 'OWN-1',
+    privateNote: 'Owner reimbursement',
+    dueDate: null,
+    postingAccounts: ['Other expenses:Misc'],
+    lineDescriptions: ['Owner reimbursement'],
+    attachmentFileNames: ['support.txt'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(ruleIds(findings), ['OWNER_ACTIVITY_MISCLASSIFIED']);
+});
+
+test('audit flags currency counterparty mismatch on purchases when currency is preserved', () => {
+  const purchase = normalizePurchaseForAudit(
+    {
+      Id: 'C1',
+      SyncToken: '1',
+      TxnDate: '2026-04-05',
+      TotalAmt: 42.5,
+      PaymentType: 'CreditCard',
+      DocNumber: 'CUR-1',
+      PrivateNote: 'GBP charge from overseas vendor',
+      CurrencyRef: { value: 'USD' },
+      EntityRef: { value: '91', name: 'Overseas Vendor' },
+      Line: [
+        {
+          Id: '1',
+          Amount: 42.5,
+          Description: 'GBP card charge',
+          AccountBasedExpenseLineDetail: { AccountRef: { value: '500', name: 'Office expenses:Travel' } },
+        },
+      ],
+      MetaData: { CreateTime: '2026-04-05T10:00:00Z', LastUpdatedTime: '2026-04-10T10:00:00Z' },
+    },
+    ['support.txt'],
+  );
+
+  assert.equal(purchase.currency, 'USD');
+
+  const findings = classifyAuditExceptions([purchase]);
+  assert.deepEqual(ruleIds(findings), ['CURRENCY_COUNTERPARTY_MISMATCH']);
 });
 
 test('normalizePurchaseForAudit preserves descriptions, accounts, payee, and attachments', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -90,6 +90,10 @@ import {
   classifyQboRefreshFailure,
   classifyQboVerificationFailure,
 } from '../lib/qbo/connection-feedback';
+import {
+  classifyAuditExceptions,
+  type NormalizedAuditTransaction,
+} from '../lib/qbo/full-history-audit/rules';
 import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
 import type { QboAccount, QboBill, QboRecurringTransaction } from '../lib/qbo/api';
@@ -2521,6 +2525,55 @@ test('historical refund routing keeps multiple dated refunds for the same order 
 
   assert.equal(historicalRefundGroups.size, 2);
   assert.equal(currentSettlementRefundGroups.size, 0);
+});
+
+test('audit flags missing doc number and missing attachment on bills', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Bill',
+    transactionId: 'B1',
+    txnDate: '2026-04-01',
+    amount: 1250,
+    currency: 'USD',
+    counterparty: 'Vendor A',
+    docNumber: null,
+    privateNote: 'April inventory invoice',
+    dueDate: null,
+    postingAccounts: ['Inventory'],
+    lineDescriptions: [''],
+    attachmentFileNames: [],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(
+    findings.map((f) => f.ruleId).sort(),
+    ['ATTACHMENT_REQUIRED_MISSING', 'BILL_DUE_DATE_MISSING', 'DOCNUMBER_MISSING', 'LINE_DESCRIPTION_MISSING'].sort(),
+  );
+});
+
+test('audit flags transfer-like expenses posted to p-and-l accounts', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Purchase',
+    transactionId: 'P1',
+    txnDate: '2026-04-01',
+    amount: 1000,
+    currency: 'USD',
+    counterparty: 'Internal funding move',
+    docNumber: 'INT-001',
+    privateNote: 'Transfer to Wise',
+    dueDate: null,
+    postingAccounts: ['General business expenses:Software & apps'],
+    lineDescriptions: ['Transfer to Wise USD'],
+    attachmentFileNames: ['support.txt'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-04-10T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.equal(findings.some((f) => f.ruleId === 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'), true);
 });
 
 process.stdout.write('All tests passed.\n');

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2548,8 +2548,26 @@ test('audit flags missing doc number and missing attachment on bills', () => {
 
   const findings = classifyAuditExceptions([tx]);
   assert.deepEqual(
-    findings.map((f) => f.ruleId).sort(),
-    ['ATTACHMENT_REQUIRED_MISSING', 'DOCNUMBER_MISSING'].sort(),
+    findings.map((finding) => ({
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+      ruleGroup: finding.ruleGroup,
+      supportStatus: finding.supportStatus,
+    })).sort((left, right) => left.ruleId.localeCompare(right.ruleId)),
+    [
+      {
+        ruleId: 'ATTACHMENT_REQUIRED_MISSING',
+        severity: 'High',
+        ruleGroup: 'attachment_controls',
+        supportStatus: 'missing',
+      },
+      {
+        ruleId: 'DOCNUMBER_MISSING',
+        severity: 'High',
+        ruleGroup: 'field_completeness',
+        supportStatus: 'not_required',
+      },
+    ].sort((left, right) => left.ruleId.localeCompare(right.ruleId)),
   );
 });
 
@@ -2564,7 +2582,7 @@ test('audit flags transfer-like expenses posted to p-and-l accounts', () => {
     docNumber: 'INT-001',
     privateNote: 'Transfer to Wise',
     dueDate: null,
-    postingAccounts: ['General business expenses:Software & apps'],
+    postingAccounts: ['General Business Expenses:Software & Apps'],
     lineDescriptions: ['Transfer to Wise USD'],
     attachmentFileNames: ['support.txt'],
     isInReconciledPeriod: false,
@@ -2573,7 +2591,19 @@ test('audit flags transfer-like expenses posted to p-and-l accounts', () => {
   };
 
   const findings = classifyAuditExceptions([tx]);
-  assert.equal(findings.some((f) => f.ruleId === 'TRANSFER_LIKE_ACTIVITY_MISPOSTED'), true);
+  assert.deepEqual(findings.map((finding) => ({
+    ruleId: finding.ruleId,
+    severity: finding.severity,
+    ruleGroup: finding.ruleGroup,
+    supportStatus: finding.supportStatus,
+  })), [
+    {
+      ruleId: 'TRANSFER_LIKE_ACTIVITY_MISPOSTED',
+      severity: 'Critical',
+      ruleGroup: 'chart_of_accounts_sanity',
+      supportStatus: 'not_required',
+    },
+  ]);
 });
 
 process.stdout.write('All tests passed.\n');

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2661,6 +2661,7 @@ test('normalizePurchaseForAudit preserves descriptions, accounts, payee, and att
 
   assert.equal(normalized.counterparty, 'Bitwarden');
   assert.deepEqual(normalized.postingAccounts, ['Office expenses:Software & apps']);
+  assert.deepEqual(normalized.lineDescriptions, ['BITWARDEN']);
   assert.deepEqual(normalized.attachmentFileNames, ['bitwarden-1093.txt']);
 });
 
@@ -2718,7 +2719,10 @@ test('normalizeJournalEntryForAudit captures line descriptions and control-accou
 
   assert.equal(normalized.transactionType, 'JournalEntry');
   assert.equal(normalized.postingAccounts.includes('Plutus Settlement Control'), true);
-  assert.equal(normalized.lineDescriptions.length, 2);
+  assert.deepEqual(normalized.lineDescriptions, [
+    'Temporary suspense for Amazon-originated Chase USD receipt pending settlement sync',
+    'Offset to Plutus Settlement Control until final Amazon settlement journal is regenerated',
+  ]);
 });
 
 test('mergeAttachmentRefs maps attachables back to transaction ids', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -94,7 +94,10 @@ import {
   classifyAuditExceptions,
 } from '../lib/qbo/full-history-audit/rules';
 import {
+  getActiveQboConnection,
   mergeAttachmentRefs,
+  qboFullHistoryAuditDeps,
+  qboQueryAll,
   summarizeCoverage,
 } from '../lib/qbo/full-history-audit/fetch';
 import type { NormalizedAuditTransaction } from '../lib/qbo/full-history-audit/types';
@@ -102,14 +105,10 @@ import { resolveMuiThemeMode } from '../lib/theme-mode';
 import type { ProcessingBlock } from '../lib/plutus/settlement-types';
 import type { QboAccount, QboBill, QboRecurringTransaction } from '../lib/qbo/api';
 
-function test(name: string, fn: () => void) {
-  try {
-    fn();
-    process.stdout.write(`ok - ${name}\n`);
-  } catch (error) {
-    process.stderr.write(`not ok - ${name}\n`);
-    throw error;
-  }
+const tests: Array<{ name: string; fn: () => void | Promise<void> }> = [];
+
+function test(name: string, fn: () => void | Promise<void>) {
+  tests.push({ name, fn });
 }
 
 test('normalizeAuditMarketToMarketplaceId maps common values', () => {
@@ -2653,4 +2652,206 @@ test('summarizeCoverage preserves partial coverage failures', () => {
   assert.equal(summary.failedTypes[0], 'Transfer');
 });
 
-process.stdout.write('All tests passed.\n');
+function makeQboResponse(body: Record<string, unknown>, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as Response;
+}
+
+test('getActiveQboConnection refreshes and persists updated connection state', async () => {
+  const originalDeps = {
+    getQboConnection: qboFullHistoryAuditDeps.getQboConnection,
+    getValidToken: qboFullHistoryAuditDeps.getValidToken,
+    saveServerQboConnection: qboFullHistoryAuditDeps.saveServerQboConnection,
+    fetch: qboFullHistoryAuditDeps.fetch,
+    sleep: qboFullHistoryAuditDeps.sleep,
+  };
+
+  const storedConnection: QboConnection = {
+    realmId: '123',
+    accessToken: 'stale-token',
+    refreshToken: 'refresh-token',
+    expiresAt: '2026-04-14T00:00:00.000Z',
+  };
+  const refreshedConnection: QboConnection = {
+    ...storedConnection,
+    accessToken: 'fresh-token',
+    expiresAt: '2026-04-14T02:00:00.000Z',
+  };
+
+  let savedConnection: QboConnection | null = null;
+
+  qboFullHistoryAuditDeps.getQboConnection = async () => storedConnection;
+  qboFullHistoryAuditDeps.getValidToken = async () => ({
+    accessToken: refreshedConnection.accessToken,
+    updatedConnection: refreshedConnection,
+  });
+  qboFullHistoryAuditDeps.saveServerQboConnection = async (connection) => {
+    savedConnection = connection;
+  };
+
+  try {
+    const active = await getActiveQboConnection();
+    assert.equal(active.accessToken, 'fresh-token');
+    assert.equal(active.connection.accessToken, 'fresh-token');
+    assert.deepEqual(savedConnection, refreshedConnection);
+
+    let observedAuthorization = '';
+    qboFullHistoryAuditDeps.fetch = async (_url, init) => {
+      observedAuthorization = new Headers(init?.headers).get('Authorization') ?? '';
+      return makeQboResponse({ QueryResponse: { Bill: [] } });
+    };
+    qboFullHistoryAuditDeps.sleep = async () => {};
+
+    const queryResult = await qboQueryAll(active, 'SELECT * FROM Bill');
+    assert.equal(queryResult.complete, true);
+    assert.equal(observedAuthorization, 'Bearer fresh-token');
+  } finally {
+    qboFullHistoryAuditDeps.getQboConnection = originalDeps.getQboConnection;
+    qboFullHistoryAuditDeps.getValidToken = originalDeps.getValidToken;
+    qboFullHistoryAuditDeps.saveServerQboConnection = originalDeps.saveServerQboConnection;
+    qboFullHistoryAuditDeps.fetch = originalDeps.fetch;
+    qboFullHistoryAuditDeps.sleep = originalDeps.sleep;
+  }
+});
+
+test('qboQueryAll paginates until the final short page', async () => {
+  const originalFetch = qboFullHistoryAuditDeps.fetch;
+  const originalSleep = qboFullHistoryAuditDeps.sleep;
+  const requests: string[] = [];
+
+  qboFullHistoryAuditDeps.sleep = async () => {};
+  qboFullHistoryAuditDeps.fetch = async (url) => {
+    requests.push(url);
+    if (requests.length === 1) {
+      return makeQboResponse({
+        QueryResponse: {
+          Bill: Array.from({ length: 1000 }, (_, index) => ({ Id: `B${index + 1}` })),
+        },
+      });
+    }
+
+    if (requests.length === 2) {
+      return makeQboResponse({
+        QueryResponse: {
+          Bill: [{ Id: 'B1001' }],
+        },
+      });
+    }
+
+    throw new Error('unexpected fetch');
+  };
+
+  try {
+    const result = await qboQueryAll(
+      {
+        connection: {
+          realmId: '123',
+          accessToken: 'fresh-token',
+        },
+        accessToken: 'fresh-token',
+      },
+      'SELECT * FROM Bill',
+    );
+
+    assert.equal(result.complete, true);
+    assert.equal(result.rows.length, 1001);
+    assert.equal(requests.length, 2);
+    assert.match(requests[0] ?? '', /STARTPOSITION%201%20MAXRESULTS%201000/);
+    assert.match(requests[1] ?? '', /STARTPOSITION%201001%20MAXRESULTS%201000/);
+  } finally {
+    qboFullHistoryAuditDeps.fetch = originalFetch;
+    qboFullHistoryAuditDeps.sleep = originalSleep;
+  }
+});
+
+test('qboQueryAll retries retryable qbo responses before succeeding', async () => {
+  const originalFetch = qboFullHistoryAuditDeps.fetch;
+  const originalSleep = qboFullHistoryAuditDeps.sleep;
+  const requests: number[] = [];
+
+  qboFullHistoryAuditDeps.sleep = async () => {};
+  qboFullHistoryAuditDeps.fetch = async () => {
+    requests.push(requests.length + 1);
+    if (requests.length < 3) {
+      return makeQboResponse({ QueryResponse: { Bill: [] } }, 503);
+    }
+
+    return makeQboResponse({
+      QueryResponse: {
+        Bill: [{ Id: 'B1' }],
+      },
+    });
+  };
+
+  try {
+    const result = await qboQueryAll(
+      {
+        connection: {
+          realmId: '123',
+          accessToken: 'fresh-token',
+        },
+        accessToken: 'fresh-token',
+      },
+      'SELECT * FROM Bill',
+    );
+
+    assert.equal(result.complete, true);
+    assert.equal(result.rows.length, 1);
+    assert.equal(requests.length, 3);
+  } finally {
+    qboFullHistoryAuditDeps.fetch = originalFetch;
+    qboFullHistoryAuditDeps.sleep = originalSleep;
+  }
+});
+
+test('qboQueryAll throws after bounded network retries', async () => {
+  const originalFetch = qboFullHistoryAuditDeps.fetch;
+  const originalSleep = qboFullHistoryAuditDeps.sleep;
+  let attempts = 0;
+
+  qboFullHistoryAuditDeps.sleep = async () => {};
+  qboFullHistoryAuditDeps.fetch = async () => {
+    attempts++;
+    throw new Error('socket hang up');
+  };
+
+  try {
+    await assert.rejects(
+      qboQueryAll(
+        {
+          connection: {
+            realmId: '123',
+            accessToken: 'fresh-token',
+          },
+          accessToken: 'fresh-token',
+        },
+        'SELECT * FROM Bill',
+      ),
+      /socket hang up/,
+    );
+    assert.equal(attempts, 4);
+  } finally {
+    qboFullHistoryAuditDeps.fetch = originalFetch;
+    qboFullHistoryAuditDeps.sleep = originalSleep;
+  }
+});
+
+void (async () => {
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      process.stdout.write(`ok - ${name}\n`);
+    } catch (error) {
+      process.stderr.write(`not ok - ${name}\n`);
+      throw error;
+    }
+  }
+
+  process.stdout.write('All tests passed.\n');
+})().catch(() => {
+  process.exitCode = 1;
+});

--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,6 +8,9 @@
     "build": "next build",
     "start": "next start -p 3200",
     "type-check": "tsc --noEmit",
+    "test:auth-smoke": "playwright test --grep \"portal login|stale encrypted session|authenticated launcher\"",
+    "test:e2e": "playwright test",
+    "test:hosted-smoke": "PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",
     "postinstall": "node ../../scripts/link-prisma-client-auth.js"
   },
   "dependencies": {

--- a/apps/sso/playwright.config.ts
+++ b/apps/sso/playwright.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from '@playwright/test'
 
-const localPortalBaseUrl = 'http://127.0.0.1:3200'
+const localPortalBaseUrl = 'http://127.0.0.1:3320'
 const localPortalAuthSecret = 'playwright-portal-auth-secret-000000000000'
+const runHostedSmokeOnly = process.env.PLAYWRIGHT_HOSTED_ONLY === '1'
 
 export default defineConfig({
   testDir: './tests',
@@ -14,31 +15,33 @@ export default defineConfig({
     viewport: { width: 1440, height: 900 },
     trace: 'retain-on-failure',
   },
-  webServer: [
-    {
-      command: 'pnpm exec next dev -p 3200 --hostname 127.0.0.1',
-      cwd: __dirname,
-      url: `${localPortalBaseUrl}/login`,
-      reuseExistingServer: !process.env.CI,
-      env: {
-        ...process.env,
-        NEXTAUTH_URL: localPortalBaseUrl,
-        PORTAL_AUTH_URL: localPortalBaseUrl,
-        NEXT_PUBLIC_PORTAL_AUTH_URL: localPortalBaseUrl,
-        NEXT_PUBLIC_APP_URL: localPortalBaseUrl,
-        COOKIE_DOMAIN: '127.0.0.1',
-        NEXTAUTH_SECRET: localPortalAuthSecret,
-        PORTAL_AUTH_SECRET: localPortalAuthSecret,
-        PORTAL_DB_URL: '',
-        GOOGLE_CLIENT_ID: 'playwright-google-client-id',
-        GOOGLE_CLIENT_SECRET: 'playwright-google-client-secret',
+  webServer: runHostedSmokeOnly
+    ? undefined
+    : [
+      {
+        command: 'pnpm exec next dev -p 3320 --hostname 127.0.0.1',
+        cwd: __dirname,
+        url: `${localPortalBaseUrl}/login`,
+        reuseExistingServer: false,
+        env: {
+          ...process.env,
+          NEXTAUTH_URL: localPortalBaseUrl,
+          PORTAL_AUTH_URL: localPortalBaseUrl,
+          NEXT_PUBLIC_PORTAL_AUTH_URL: localPortalBaseUrl,
+          NEXT_PUBLIC_APP_URL: localPortalBaseUrl,
+          COOKIE_DOMAIN: '127.0.0.1',
+          NEXTAUTH_SECRET: localPortalAuthSecret,
+          PORTAL_AUTH_SECRET: localPortalAuthSecret,
+          PORTAL_DB_URL: '',
+          GOOGLE_CLIENT_ID: 'playwright-google-client-id',
+          GOOGLE_CLIENT_SECRET: 'playwright-google-client-secret',
+        },
       },
-    },
-    {
-      command: 'node tests/fixtures/callback-target-server.mjs',
-      cwd: __dirname,
-      url: 'http://127.0.0.1:3201/operations/purchase-orders',
-      reuseExistingServer: !process.env.CI,
-    },
-  ],
+      {
+        command: 'node tests/fixtures/callback-target-server.mjs',
+        cwd: __dirname,
+        url: 'http://127.0.0.1:3321/operations/purchase-orders',
+        reuseExistingServer: false,
+      },
+    ],
 })

--- a/apps/sso/scripts/ensure-hosted-smoke-user.ts
+++ b/apps/sso/scripts/ensure-hosted-smoke-user.ts
@@ -1,0 +1,59 @@
+import { upsertManualUserAppGrant } from '@targon/auth/server'
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (typeof value !== 'string') {
+    throw new Error(`${name} must be defined.`)
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    throw new Error(`${name} must be defined.`)
+  }
+
+  return trimmed
+}
+
+async function main() {
+  process.env.PORTAL_DB_URL = requireEnv('PORTAL_DB_URL')
+
+  const userId = requireEnv('E2E_PORTAL_USER_ID')
+  const email = requireEnv('E2E_PORTAL_EMAIL').toLowerCase()
+
+  const updatedUser = await upsertManualUserAppGrant({
+    userId,
+    appSlug: 'talos',
+    appName: 'Talos',
+    departments: ['Ops'],
+    tenantMemberships: ['US', 'UK'],
+    locked: false,
+  })
+
+  if (updatedUser.id !== userId) {
+    throw new Error(`Hosted smoke user id mismatch: expected ${userId}, received ${updatedUser.id}.`)
+  }
+
+  if (updatedUser.email.toLowerCase() !== email) {
+    throw new Error(`Hosted smoke user email mismatch: expected ${email}, received ${updatedUser.email}.`)
+  }
+
+  const talosGrant = updatedUser.entitlements.talos
+  if (!talosGrant) {
+    throw new Error('Hosted smoke user is missing Talos entitlements after grant update.')
+  }
+
+  if (!talosGrant.tenantMemberships.includes('US')) {
+    throw new Error('Hosted smoke user is missing Talos US tenant membership after grant update.')
+  }
+
+  if (!talosGrant.tenantMemberships.includes('UK')) {
+    throw new Error('Hosted smoke user is missing Talos UK tenant membership after grant update.')
+  }
+
+  console.log(`Ensured hosted smoke Talos grant for ${updatedUser.email}.`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/apps/sso/tests/fixtures/callback-target-server.mjs
+++ b/apps/sso/tests/fixtures/callback-target-server.mjs
@@ -1,7 +1,7 @@
 import http from 'node:http'
 
 const host = '127.0.0.1'
-const port = 3201
+const port = 3321
 
 const routes = new Map([
   [

--- a/apps/sso/tests/fixtures/dev-login.ts
+++ b/apps/sso/tests/fixtures/dev-login.ts
@@ -1,8 +1,8 @@
 import type { Page } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
 
-export const portalBaseUrl = 'http://127.0.0.1:3200'
-export const talosBaseUrl = 'http://localhost:3201/operations/purchase-orders'
+export const portalBaseUrl = 'http://127.0.0.1:3320'
+export const talosBaseUrl = 'http://localhost:3321/operations/purchase-orders'
 export const demoEmail = 'e2e@targonglobal.com'
 export const sessionCookieName = 'targon.next-auth.session-token'
 const portalAuthSecret = 'playwright-portal-auth-secret-000000000000'
@@ -51,8 +51,7 @@ export async function seedPortalSession(page: Page) {
     {
       name: sessionCookieName,
       value: token,
-      domain: '127.0.0.1',
-      path: '/',
+      url: portalBaseUrl,
       httpOnly: true,
       secure: false,
       sameSite: 'Lax',

--- a/apps/sso/tests/fixtures/hosted-auth.ts
+++ b/apps/sso/tests/fixtures/hosted-auth.ts
@@ -1,8 +1,23 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import type { Page } from '@playwright/test'
+import { expect, type Page, type Response } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
+
+type CriticalResponseRecord = {
+  method: string
+  resourceType: string
+  status: number
+  url: string
+}
+
+const criticalStatusCodes = new Set([401, 403, 500, 502])
+const trackedResourceTypes = new Set(['document', 'fetch', 'xhr'])
+const hostedErrorMarkers = [
+  'Bad gateway',
+  'Error code 502',
+  "Unexpected token '<'",
+] as const
 
 function requireEnv(name: string): string {
   const value = process.env[name]
@@ -18,18 +33,12 @@ function requireEnv(name: string): string {
   return trimmed
 }
 
-function requireSharedSecret(): string {
-  const nextAuthSecret = process.env.NEXTAUTH_SECRET
-  if (typeof nextAuthSecret === 'string' && nextAuthSecret.trim() !== '') {
-    return nextAuthSecret.trim()
-  }
+function getHostedPortalBaseUrl() {
+  return requireEnv('PORTAL_BASE_URL')
+}
 
-  const portalAuthSecret = process.env.PORTAL_AUTH_SECRET
-  if (typeof portalAuthSecret === 'string' && portalAuthSecret.trim() !== '') {
-    return portalAuthSecret.trim()
-  }
-
-  throw new Error('NEXTAUTH_SECRET or PORTAL_AUTH_SECRET must be defined for hosted portal smoke tests.')
+function getHostedPortalOrigin() {
+  return new URL(getHostedPortalBaseUrl()).origin
 }
 
 function buildPortalAuthz() {
@@ -50,8 +59,7 @@ function buildPortalAuthz() {
 }
 
 function buildScreenshotDirectory(): string {
-  const portalBaseUrl = requireEnv('PORTAL_BASE_URL')
-  const portalHost = new URL(portalBaseUrl).hostname
+  const portalHost = new URL(getHostedPortalBaseUrl()).hostname
   const outputDir = path.join(process.cwd(), '.codex-artifacts', 'hosted-smoke', portalHost)
   fs.mkdirSync(outputDir, { recursive: true })
   return outputDir
@@ -60,7 +68,7 @@ function buildScreenshotDirectory(): string {
 async function buildSessionCookie(portalBaseUrl: string) {
   const authz = buildPortalAuthz()
   const sessionCookieName = '__Secure-next-auth.session-token'
-  const secret = requireSharedSecret()
+  const secret = requireEnv('NEXTAUTH_SECRET')
   const activeTenant = requireEnv('E2E_ACTIVE_TENANT')
   const domain = new URL(portalBaseUrl).hostname
   const token = await encode({
@@ -93,7 +101,7 @@ async function buildSessionCookie(portalBaseUrl: string) {
 async function buildActiveTenantCookie(portalBaseUrl: string) {
   const appId = 'talos'
   const cookieName = `__Secure-targon.active-tenant.${appId}`
-  const secret = requireSharedSecret()
+  const secret = requireEnv('NEXTAUTH_SECRET')
   const domain = new URL(portalBaseUrl).hostname
   const value = await encode({
     token: { activeTenant: requireEnv('E2E_ACTIVE_TENANT') },
@@ -125,17 +133,91 @@ function buildTalosTenantCookie(portalBaseUrl: string) {
 }
 
 export async function loginToHostedPortal(page: Page) {
-  const portalBaseUrl = requireEnv('PORTAL_BASE_URL')
   const context = page.context()
   await context.clearCookies()
   await context.addCookies([
-    await buildSessionCookie(portalBaseUrl),
-    await buildActiveTenantCookie(portalBaseUrl),
-    buildTalosTenantCookie(portalBaseUrl),
+    await buildSessionCookie(getHostedPortalBaseUrl()),
+    await buildActiveTenantCookie(getHostedPortalBaseUrl()),
+    buildTalosTenantCookie(getHostedPortalBaseUrl()),
   ])
-  await page.goto(`${portalBaseUrl}/`, { waitUntil: 'domcontentloaded' })
+  await page.goto(`${getHostedPortalBaseUrl()}/`, { waitUntil: 'domcontentloaded' })
 }
 
 export function hostedScreenshotPath(routeName: string): string {
   return path.join(buildScreenshotDirectory(), `${routeName}.png`)
+}
+
+export function hostedRoute(pathname: string): string {
+  return new URL(pathname, getHostedPortalBaseUrl()).toString()
+}
+
+export function hostedPortalBaseUrl() {
+  return getHostedPortalBaseUrl()
+}
+
+export function hostedVersionBadge(page: Page) {
+  return page.getByRole('link', { name: /v\d+\.\d+\.\d+/i }).first()
+}
+
+export async function assertHostedVersionBadge(page: Page) {
+  await expect(hostedVersionBadge(page)).toBeVisible({ timeout: 20_000 })
+}
+
+export async function assertNoHostedErrorMarkers(page: Page) {
+  const bodyText = await page.locator('body').innerText()
+  for (const marker of hostedErrorMarkers) {
+    expect(bodyText).not.toContain(marker)
+  }
+}
+
+export async function assertNoHostedAuthRedirect(page: Page) {
+  const currentUrl = page.url()
+  expect(currentUrl).not.toContain('/login')
+  expect(currentUrl).not.toContain('/no-access')
+}
+
+export function installHostedResponseTracker(page: Page) {
+  const criticalResponses: CriticalResponseRecord[] = []
+
+  const handleResponse = (response: Response) => {
+    const request = response.request()
+    const resourceType = request.resourceType()
+    if (!trackedResourceTypes.has(resourceType)) {
+      return
+    }
+
+    const responseUrl = new URL(response.url())
+    if (responseUrl.origin !== getHostedPortalOrigin()) {
+      return
+    }
+
+    const status = response.status()
+    if (!criticalStatusCodes.has(status)) {
+      return
+    }
+
+    criticalResponses.push({
+      method: request.method(),
+      resourceType,
+      status,
+      url: response.url(),
+    })
+  }
+
+  page.on('response', handleResponse)
+
+  return {
+    assertNone() {
+      expect(
+        criticalResponses,
+        `Hosted app returned critical responses: ${JSON.stringify(criticalResponses, null, 2)}`,
+      ).toEqual([])
+    },
+    reset() {
+      criticalResponses.length = 0
+    },
+    dispose() {
+      page.off('response', handleResponse)
+    },
+  }
 }

--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -1,33 +1,126 @@
-import { test, expect, type Page } from '@playwright/test'
+import { expect, test, type BrowserContext, type Page, type TestInfo } from '@playwright/test'
 
-import { hostedScreenshotPath, loginToHostedPortal } from './fixtures/hosted-auth'
+import {
+  assertHostedVersionBadge,
+  assertNoHostedAuthRedirect,
+  assertNoHostedErrorMarkers,
+  hostedPortalBaseUrl,
+  hostedRoute,
+  hostedScreenshotPath,
+  installHostedResponseTracker,
+  loginToHostedPortal,
+} from './fixtures/hosted-auth'
 
-const portalBaseUrl = process.env.PORTAL_BASE_URL
-if (typeof portalBaseUrl !== 'string' || portalBaseUrl.trim() === '') {
-  throw new Error('PORTAL_BASE_URL must be defined for hosted portal smoke tests.')
+type HostedRouteCheck = {
+  name: string
+  path: string
+  visibleText: string
 }
 
-const routes = [
-  { name: 'portal', url: `${portalBaseUrl}/`, visible: 'TargonOS Portal' },
-  { name: 'talos', url: `${portalBaseUrl}/talos/operations/purchase-orders`, visible: 'Purchase Orders' },
-  { name: 'atlas', url: `${portalBaseUrl}/atlas/employees`, visible: 'Employees' },
-  { name: 'kairos', url: `${portalBaseUrl}/kairos/forecasts`, visible: 'Forecasts' },
-  { name: 'xplan', url: `${portalBaseUrl}/xplan/1-setup`, visible: 'Setup' },
-  { name: 'plutus', url: `${portalBaseUrl}/plutus/settlements`, visible: 'Settlements' },
-  { name: 'hermes', url: `${portalBaseUrl}/hermes/insights`, visible: 'Insights' },
-  { name: 'argus', url: `${portalBaseUrl}/argus/wpr`, visible: 'Weekly performance reporting' },
-] as const
+const hostedRouteChecks: HostedRouteCheck[] = [
+  { name: 'portal', path: '/', visibleText: 'TargonOS Portal' },
+  { name: 'atlas', path: '/atlas/employees', visibleText: 'Employees' },
+  { name: 'kairos', path: '/kairos/forecasts', visibleText: 'Forecasts' },
+  { name: 'xplan', path: '/xplan/1-setup', visibleText: 'Setup' },
+  { name: 'plutus', path: '/plutus/settlements', visibleText: 'Settlements' },
+  { name: 'hermes', path: '/hermes/insights', visibleText: 'Insights' },
+  { name: 'argus', path: '/argus/wpr', visibleText: 'Weekly performance reporting' },
+]
 
-function versionBadge(page: Page) {
-  return page.getByRole('link', { name: /v\d+\.\d+\.\d+/i }).first()
-}
+test.describe('hosted cross-app auth smoke', () => {
+  test.describe.configure({ mode: 'serial' })
 
-for (const route of routes) {
-  test(`${route.name} deep link renders visible screen`, async ({ page }) => {
+  let context: BrowserContext
+  let page: Page
+  let responseTracker: ReturnType<typeof installHostedResponseTracker>
+
+  async function captureFailure(routeName: string, testInfo: TestInfo, run: () => Promise<void>) {
+    try {
+      await run()
+    } catch (error) {
+      await page.screenshot({
+        path: hostedScreenshotPath(`${routeName}-${testInfo.retry}`),
+        fullPage: true,
+      })
+      throw error
+    }
+  }
+
+  async function assertHostedRoute(check: HostedRouteCheck) {
+    const targetUrl = hostedRoute(check.path)
+    await page.goto(targetUrl, { waitUntil: 'domcontentloaded' })
+
+    const currentPath = new URL(page.url()).pathname
+    if (check.path === '/') {
+      expect(currentPath).toBe('/')
+    } else {
+      expect(
+        currentPath === check.path || currentPath.startsWith(`${check.path}/`),
+        `Expected hosted path ${check.path}, got ${currentPath}`,
+      ).toBe(true)
+    }
+
+    await expect(page.getByText(check.visibleText, { exact: false }).first()).toBeVisible({ timeout: 20_000 })
+    await assertNoHostedAuthRedirect(page)
+    await assertNoHostedErrorMarkers(page)
+    await assertHostedVersionBadge(page)
+    responseTracker.assertNone()
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext()
+    page = await context.newPage()
+    responseTracker = installHostedResponseTracker(page)
     await loginToHostedPortal(page)
-    await page.goto(route.url, { waitUntil: 'domcontentloaded' })
-    await expect(page.getByText(route.visible, { exact: false }).first()).toBeVisible({ timeout: 20_000 })
-    await page.screenshot({ path: hostedScreenshotPath(route.name), fullPage: true })
-    await expect(versionBadge(page)).toBeVisible({ timeout: 20_000 })
   })
-}
+
+  test.beforeEach(async () => {
+    responseTracker.reset()
+  })
+
+  test.afterAll(async () => {
+    responseTracker.dispose()
+    await context.close()
+  })
+
+  for (const check of hostedRouteChecks) {
+    test(`${check.name} deep link renders a real screen`, async ({}, testInfo) => {
+      await captureFailure(check.name, testInfo, async () => {
+        await assertHostedRoute(check)
+      })
+    })
+  }
+
+  test('talos region selection reaches dashboard', async ({}, testInfo) => {
+    await captureFailure('talos-region-selection', testInfo, async () => {
+      await page.goto(hostedRoute('/talos'), { waitUntil: 'domcontentloaded' })
+      await expect(page.getByText('Select your region to continue', { exact: false })).toBeVisible({
+        timeout: 20_000,
+      })
+
+      const tenantSelectResponsePromise = page.waitForResponse((response) => {
+        if (response.request().method() !== 'POST') {
+          return false
+        }
+
+        const responseUrl = new URL(response.url())
+        return responseUrl.origin === new URL(hostedPortalBaseUrl()).origin &&
+          responseUrl.pathname === '/talos/api/tenant/select'
+      })
+
+      await page.getByRole('button', { name: /\bUS\b/i }).first().click()
+
+      const tenantSelectResponse = await tenantSelectResponsePromise
+      expect(tenantSelectResponse.ok()).toBe(true)
+
+      await page.waitForURL(new RegExp(`^${hostedRoute('/talos/dashboard').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`), {
+        timeout: 20_000,
+      })
+      await expect(page.getByText('Dashboard', { exact: false }).first()).toBeVisible({ timeout: 20_000 })
+      await assertNoHostedAuthRedirect(page)
+      await assertNoHostedErrorMarkers(page)
+      await assertHostedVersionBadge(page)
+      responseTracker.assertNone()
+    })
+  })
+})

--- a/apps/sso/tests/login.spec.ts
+++ b/apps/sso/tests/login.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '@playwright/test'
+import { encode } from 'next-auth/jwt'
 
-import { portalBaseUrl } from './fixtures/dev-login'
+import { portalBaseUrl, sessionCookieName } from './fixtures/dev-login'
+
+const staleSessionSecret = 'playwright-stale-session-secret-111111111111'
 
 test('portal login only offers Google sign-in', async ({ page }) => {
   await page.goto(`${portalBaseUrl}/login`, { waitUntil: 'domcontentloaded' })
@@ -18,4 +21,57 @@ test('portal login preserves the requested callback target for Google sign-in', 
   )
 
   await expect(page.locator('input[name="callbackUrl"]')).toHaveValue(callbackUrl)
+})
+
+test('portal recovers from a stale encrypted session cookie and still redirects to Google auth', async ({ page }) => {
+  const staleToken = await encode({
+    token: {
+      sub: 'stale-e2e-user',
+      email: 'stale-e2e@targonglobal.com',
+      name: 'Stale E2E User',
+    },
+    secret: staleSessionSecret,
+    salt: sessionCookieName,
+  })
+
+  await page.context().clearCookies()
+  await page.context().addCookies([
+    {
+      name: sessionCookieName,
+      value: staleToken,
+      url: portalBaseUrl,
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ])
+
+  const response = await page.request.get(
+    `${portalBaseUrl}/login/google?callbackUrl=${encodeURIComponent('/talos/operations/purchase-orders')}`,
+    {
+      maxRedirects: 0,
+    },
+  )
+
+  expect(response.status()).toBe(307)
+  expect(response.headers().location).toContain('https://accounts.google.com/o/oauth2/v2/auth')
+
+  const setCookieHeader = response.headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value)
+    .join('\n')
+
+  expect(setCookieHeader).toContain('authjs.pkce.code_verifier=')
+
+  const sessionResponse = await page.request.get(`${portalBaseUrl}/api/auth/session`)
+
+  expect(sessionResponse.status()).toBe(200)
+  expect(await sessionResponse.json()).toBe(null)
+
+  const sessionSetCookieHeader = sessionResponse.headersArray()
+    .filter((header) => header.name.toLowerCase() === 'set-cookie')
+    .map((header) => header.value)
+    .join('\n')
+
+  expect(sessionSetCookieHeader).toContain(`${sessionCookieName}=;`)
 })

--- a/docs/superpowers/specs/2026-04-14-argus-cases-approval-queue-design.md
+++ b/docs/superpowers/specs/2026-04-14-argus-cases-approval-queue-design.md
@@ -1,0 +1,259 @@
+# Argus Cases Approval Queue Design
+
+## Purpose
+
+Redesign the Argus `/cases` surface from a narrative case brief into a lean approval queue for daily agent recommendations.
+
+The operator workflow is:
+
+1. agents survey forum posts and Seller Central cases
+2. Argus presents the recommended next action for each active issue
+3. the human scans the queue, reviews the rationale only when needed, and approves or rejects the proposed action
+
+This design is intentionally about the Argus frontend surface. It is not a rebuild of Amazon case-history browsing inside Argus.
+
+## Evidence From The Current Codebase
+
+The current cases flow is a markdown reader with a narrative layout, not an approval queue:
+
+- `/cases/[market]/[reportDate]` loads a `CaseReportBundle` and renders one page component in [apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx](/Users/jarraramjad/dev/targonos-main/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx:18).
+- The parsed report shape is section-based: `sections[]` with `entity` and `rows[]`, and each row has only `category`, `issue`, `caseId`, `daysAgo`, `status`, `evidence`, `assessment`, and `nextStep` in [apps/argus/lib/cases/reader-core.ts](/Users/jarraramjad/dev/targonos-main/apps/argus/lib/cases/reader-core.ts:25).
+- The current page leads with a hero, market pills, summary metrics, report-date pills, sticky section headers, and wide three-column row blocks in [apps/argus/components/cases/report-page.tsx](/Users/jarraramjad/dev/targonos-main/apps/argus/components/cases/report-page.tsx:314).
+- The current reader tests only cover markdown parsing and latest-report resolution in [apps/argus/lib/cases/reader.test.ts](/Users/jarraramjad/dev/targonos-main/apps/argus/lib/cases/reader.test.ts:11). There is no decision or approval state anywhere in the cases module today.
+
+## Decisions
+
+The design is based on the following approved choices:
+
+- The page becomes a daily approval queue for agent-recommended actions.
+- One row equals one proposed action.
+- The primary surface is a dense table, not cards, tiles, or entity blocks.
+- The default view hides resolved items and focuses on pending approval work.
+- Entity grouping is removed from the main layout. `entity` remains row context, not a section header.
+- Inline `Approve` and `Reject` controls live in the rightmost table column.
+- Full context moves into a plain detail band below the table instead of staying expanded in every row.
+- The redesign uses the existing markdown data fields. It does not invent a second report source.
+- Because no cases decision API exists today, the redesign defines a frontend decision interface and state model. Persistence is explicitly out of scope for this design pass.
+
+## Goals
+
+- Make the next operator decision obvious within one screen.
+- Reduce page chrome and narrative copy to the minimum needed to work the queue.
+- Keep operators in a fast scan-select-decide loop.
+- Preserve access to the evidence and assessment without forcing that detail into every row.
+- Keep the current route structure and markdown ingestion path intact.
+
+## Non-Goals
+
+- Rebuilding Amazon Seller Central case history inside Argus
+- Designing or implementing a backend approval workflow store
+- Changing how markdown reports are generated in shared drive storage
+- Adding dashboard metrics, decorative report framing, or explanatory marketing copy
+
+## Approaches Considered
+
+### 1. Keep The Current Brief And Compress It
+
+Remove some spacing and visual styling but keep the hero, entity sections, and wide narrative row blocks.
+
+Why not:
+
+- It still optimizes for reading a brief instead of approving the next action.
+- It keeps the operator scanning through prose and grouped sections before they can decide anything.
+
+### 2. Flat Approval Queue With Detail Band
+
+Flatten all section rows into one queue, keep the page chrome minimal, and move full rationale into a selected-row detail band.
+
+Why this is the selected approach:
+
+- It matches the operator job: scan pending recommendations, inspect one, decide, move on.
+- It removes the current section-framing noise without losing the underlying case context.
+- It can be built directly from the current markdown bundle without requiring a new backend source.
+
+### 3. Split Columns By Entity Or Case State
+
+Show separate buckets per entity or separate panes for action-due, watching, and forum-watch items.
+
+Why not:
+
+- It reintroduces layout grouping that slows down scanning.
+- It makes the page feel like a report organizer again instead of a decision queue.
+
+## Target Design
+
+### 1. Route And Data Loading Stay The Same
+
+The route chain remains:
+
+- `/cases` redirects to a default market in [apps/argus/app/(app)/cases/page.tsx](/Users/jarraramjad/dev/targonos-main/apps/argus/app/(app)/cases/page.tsx:5)
+- `/cases/[market]` resolves the latest report date in [apps/argus/app/(app)/cases/[market]/page.tsx](/Users/jarraramjad/dev/targonos-main/apps/argus/app/(app)/cases/[market]/page.tsx:15)
+- `/cases/[market]/[reportDate]` reads the bundle and renders the page in [apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx](/Users/jarraramjad/dev/targonos-main/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx:18)
+
+This redesign changes the rendering model, not the route contract.
+
+### 2. Flatten The Report Into Queue Rows
+
+The page will derive a client-facing queue model from `bundle.sections`.
+
+Each queue row will contain:
+
+- `rowKey` — deterministic key from `entity`, `caseId`, `issue`, and row index
+- `entity`
+- `category`
+- `issue`
+- `assessment`
+- `nextStep`
+- `status`
+- `daysAgo`
+- `caseId`
+- `evidence`
+- `decision` — frontend-only state: `pending`, `approved`, or `rejected`
+
+Column mapping:
+
+- `Type` -> `category`
+- `Issue` -> `issue`
+- `Assessment` -> `assessment`
+- `Next step` -> `nextStep`
+- `Entity` -> `entity`
+- `Age` -> `daysAgo`
+- `Decision` -> inline actions or resolved label
+
+`status`, `caseId`, and `evidence` do not get dedicated default columns. They live in the selected-row detail band.
+
+### 3. Page Layout
+
+The page becomes a two-part working surface:
+
+- A compact top rail with market selector, report-date selector, search, and decision filter
+- A single dense table with a sticky header
+- A plain detail band below the table for the currently selected row
+
+Removed from the page:
+
+- hero copy
+- summary metrics
+- market pill stack
+- report-date pill cloud
+- section headers by entity
+- expanded multi-column row narratives
+- footer copy about the shared drive backend
+
+### 4. Table Behavior
+
+Default table behavior:
+
+- Show only `pending` rows on first load
+- Sort rows by fixed category order: `Action due`, `New case`, `Forum watch`, `Watching`
+- Within the same category, sort older items first
+- Keep each table row to one line per cell in the default view
+- Truncate long `assessment` and `nextStep` values with ellipsis in-row
+- Click anywhere on a row to select it and populate the detail band
+
+The table is a work queue, not a document viewer. The row should answer: what is wrong, what do the agents think, and what do they want to do next.
+
+### 5. Detail Band
+
+Selecting a row reveals a plain detail band directly below the table.
+
+The detail band contains:
+
+- issue title
+- proposed next step as the primary line
+- assessment in full
+- evidence in full
+- metadata strip: entity, case ID, support status, age, category
+
+This band is intentionally flat and quiet. No cards, no decorative framing, no nested panels.
+
+### 6. Decision Model
+
+The UI exposes two explicit actions per pending row:
+
+- `Approve`
+- `Reject`
+
+Decision behavior in this design:
+
+- Clicking either action updates frontend state for that row
+- Decided rows leave the default `pending` queue immediately
+- A status filter can reveal `approved` and `rejected` rows again
+- Resolved rows render a compact decision label instead of action buttons
+
+Because there is no cases decision API today, this state is session-local in the initial redesign. The component contract must still be shaped as `onDecision(rowKey, decision)` so persistence can be attached later without redesigning the page again.
+
+### 7. Filtering
+
+The top rail contains only the controls that directly help work the queue:
+
+- market
+- report date
+- free-text search across `issue`, `assessment`, `nextStep`, `caseId`, and `entity`
+- decision filter: `pending`, `approved`, `rejected`, `all`
+
+There is no separate entity sidebar and no category tab strip. Category remains visible as a column and as part of the default sort order.
+
+### 8. Visual Direction
+
+The surface should feel operational and restrained:
+
+- use Inter for interface copy and JetBrains Mono for case IDs and age values
+- use the existing navy and teal theme language from Argus
+- use teal as the affirmative action color
+- use red only for rejection and urgent rows
+- keep borders light, spacing tight, and typography hierarchy strong
+- no gradients, no ornamental typography, no serif display type, no report-style mood setting
+
+The table should feel closer to a review ledger than a dashboard.
+
+### 9. Component Decomposition
+
+The current `report-page.tsx` should be broken into smaller units instead of replaced by another monolith.
+
+Target split:
+
+- `apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx` — unchanged server entrypoint
+- `apps/argus/components/cases/approval-queue-page.tsx` — client shell, filter state, selected row state, decision state
+- `apps/argus/components/cases/approval-queue-table.tsx` — sticky-header table and row rendering
+- `apps/argus/components/cases/approval-detail-band.tsx` — selected-row detail surface
+- `apps/argus/lib/cases/view-model.ts` — flattening, sorting, filtering helpers derived from `CaseReportBundle`
+
+`apps/argus/components/cases/report-page.tsx` should be replaced by `approval-queue-page.tsx` and removed. The new approval queue should not be implemented by continuing to grow the current narrative component.
+
+### 10. Testing
+
+Existing parser coverage in `apps/argus/lib/cases/reader.test.ts` stays.
+
+Add coverage for the redesign at the view-model layer:
+
+- flattening sectioned rows into queue rows
+- stable default sorting
+- decision filtering
+- search matching across the intended fields
+
+Do not introduce a new React component test harness as part of this redesign. Extend the existing `node:test` coverage around the queue view-model and verify the row-selection and decision-flow behavior during implementation with app-level manual checks plus the normal Argus lint and type-check commands.
+
+## Files Expected To Change
+
+- delete: `apps/argus/components/cases/report-page.tsx`
+- `apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx`
+- `apps/argus/lib/cases/theme.ts`
+- `apps/argus/lib/cases/theme.test.ts`
+- `apps/argus/lib/cases/reader.test.ts`
+- new: `apps/argus/components/cases/approval-queue-page.tsx`
+- new: `apps/argus/components/cases/approval-queue-table.tsx`
+- new: `apps/argus/components/cases/approval-detail-band.tsx`
+- new: `apps/argus/lib/cases/view-model.ts`
+- new test file for the queue view-model
+
+## Scope Check
+
+This is still one frontend redesign project:
+
+- same route structure
+- same bundle source
+- same markdown contract
+- no backend persistence work
+
+That keeps the next step focused enough for a single implementation plan.

--- a/docs/superpowers/specs/2026-04-14-hosted-cross-app-auth-smoke-design.md
+++ b/docs/superpowers/specs/2026-04-14-hosted-cross-app-auth-smoke-design.md
@@ -1,0 +1,242 @@
+# Hosted Cross-App Auth Smoke Design
+
+## Purpose
+
+Define a permanent every-PR smoke gate that proves central auth can open the hosted TargonOS portal and the main hosted app entry screens without relying on real Google OAuth during CI.
+
+This design is intended to stop regressions where:
+
+- portal login looks healthy but child apps cannot actually be entered
+- Talos breaks after login during tenant selection or active-tenant persistence
+- an app deep link silently redirects back to `/login` or `/no-access`
+- hosted routes return HTML error pages while the UI expects JSON
+- local-only auth smoke passes while the hosted suite is broken
+
+## Evidence From The Current Codebase
+
+- Current required CI auth checks are local-only:
+  - local SSO smoke in [.github/workflows/ci.yml](/Users/jarraramjad/dev/targonos-main/.github/workflows/ci.yml:93)
+  - topology assertions in [scripts/assert-auth-topology.mjs](/Users/jarraramjad/dev/targonos-main/scripts/assert-auth-topology.mjs:1)
+- The current Playwright SSO harness runs a disposable local portal on `127.0.0.1:3320` in [apps/sso/playwright.config.ts](/Users/jarraramjad/dev/targonos-main/apps/sso/playwright.config.ts:17).
+- The local login smoke verifies:
+  - Google-only login page
+  - callback preservation
+  - stale encrypted session recovery
+  - authenticated launcher rendering
+  in [apps/sso/tests/login.spec.ts](/Users/jarraramjad/dev/targonos-main/apps/sso/tests/login.spec.ts:8) and [apps/sso/tests/e2e.spec.ts](/Users/jarraramjad/dev/targonos-main/apps/sso/tests/e2e.spec.ts:10).
+- A hosted deep-link smoke already exists in [apps/sso/tests/hosted-deep-links.spec.ts](/Users/jarraramjad/dev/targonos-main/apps/sso/tests/hosted-deep-links.spec.ts:1), but it is not wired into CI.
+- The hosted auth fixture already supports seeded portal sessions through [apps/sso/tests/fixtures/hosted-auth.ts](/Users/jarraramjad/dev/targonos-main/apps/sso/tests/fixtures/hosted-auth.ts:127).
+- Talos region selection is a real post-auth failure point:
+  - UI POSTs to `/api/tenant/select` in [apps/talos/src/components/tenant/WorldMap.tsx](/Users/jarraramjad/dev/targonos-main/apps/talos/src/components/tenant/WorldMap.tsx:165)
+  - API forwards tenant persistence to portal `/api/v1/session/active-tenant` in [apps/talos/src/app/api/tenant/select/route.ts](/Users/jarraramjad/dev/targonos-main/apps/talos/src/app/api/tenant/select/route.ts:64)
+  - non-OK responses are parsed as JSON in [apps/talos/src/components/tenant/WorldMap.tsx](/Users/jarraramjad/dev/targonos-main/apps/talos/src/components/tenant/WorldMap.tsx:180), which turns upstream HTML `502` pages into confusing UI errors.
+- App coverage is inconsistent today:
+  - SSO has Playwright smoke via [apps/sso/package.json](/Users/jarraramjad/dev/targonos-main/apps/sso/package.json:11)
+  - Atlas has Playwright tests via [apps/atlas/package.json](/Users/jarraramjad/dev/targonos-main/apps/atlas/package.json:9)
+  - Talos has no browser smoke script in [apps/talos/package.json](/Users/jarraramjad/dev/targonos-main/apps/talos/package.json:1)
+- Recent `CI` runs are fast, not hour-scale. Recent self-hosted runs sampled from GitHub completed in about `1m25s`, `2m16s`, and `4m29s`, so the existing `ci.yml` workflow is not the main latency problem.
+
+## Goals
+
+- Add one required every-PR hosted smoke lane for central auth entry into the suite
+- Prove the hosted portal session can open each major app through a real hosted deep link
+- Catch Talos tenant-selection regressions before merge
+- Fail hard on hosted auth regressions instead of letting local-only smoke mask them
+- Keep runtime fast enough for every PR
+
+## Non-Goals
+
+- Real Google OAuth login in PR CI
+- Production smoke tests in the PR path
+- Full workflow coverage inside each app
+- Replacing the existing local SSO smoke gate
+- Solving broader PR-to-deploy latency in this change
+
+## Approaches Considered
+
+### 1. Promote The Existing Hosted Deep-Link Smoke
+
+Use the existing SSO-owned hosted Playwright harness, tighten assertions, and wire it into required CI.
+
+Why this is the selected approach:
+
+- fastest path to meaningful hosted coverage
+- reuses the existing hosted session fixture and route inventory
+- centralizes auth smoke ownership in one place
+- proves the real hosted cookie and deep-link contract across apps
+
+### 2. Add Per-App Browser Smokes
+
+Each app owns its own hosted login smoke.
+
+Why not:
+
+- duplicates the same portal-session setup many times
+- makes auth coverage drift by app
+- slower to ship and maintain
+
+### 3. Require Real Google OAuth In Every PR
+
+Drive a full hosted Google login and then enter each app.
+
+Why not:
+
+- slower and more brittle
+- depends on interactive third-party OAuth in CI
+- not needed to prove the central hosted session contract
+
+## Selected Design
+
+### 1. Keep Two Layers Of Auth Verification
+
+The suite should retain:
+
+- local SSO smoke for fast contract checks on portal auth behavior
+- hosted cross-app smoke for real hosted deep-link entry into apps
+
+The local layer protects auth mechanics.
+The hosted layer protects the actual deployed suite topology and app-entry flow.
+
+### 2. Hosted Smoke Target
+
+The hosted smoke runs against the dev hosted stack, not production.
+
+Required target:
+
+- `https://dev-os.targonglobal.com`
+
+The smoke suite seeds a valid portal session cookie using the shared hosted secret and then verifies hosted deep links from that real hosted origin.
+
+There is no fallback to local routes or to production. Missing hosted env must fail the job.
+
+### 3. Required Route Coverage
+
+The hosted smoke must cover one stable entry route per app:
+
+- portal: `/`
+- talos: `/talos`
+- atlas: `/atlas/employees`
+- kairos: `/kairos/forecasts`
+- xplan: `/xplan/1-setup`
+- plutus: `/plutus/settlements`
+- hermes: `/hermes/insights`
+- argus: `/argus/wpr`
+
+These routes are chosen because they are stable, user-facing, and representative of whether the app can actually be entered through central auth.
+
+### 4. Assertion Contract
+
+The suite must do more than “page loaded”.
+
+Per route it must assert:
+
+- final URL is inside the intended app
+- page does not land on `/login` or `/no-access`
+- stable app-specific visible text exists
+- version badge exists so the app shell is actually booted
+- page body does not contain known host failure markers such as:
+  - `Bad gateway`
+  - `Error code 502`
+  - `Unexpected token '<'`
+
+If the test depends on a critical app request, that request must not return:
+
+- `401`
+- `403`
+- `500`
+- `502`
+
+### 5. Talos Special Flow
+
+Talos is not allowed to pass by merely showing the region selector.
+
+The Talos smoke must:
+
+1. open `/talos`
+2. if the region selector is present, click `US`
+3. verify `/talos/api/tenant/select` succeeds
+4. verify navigation reaches `/talos/dashboard`
+5. verify a stable dashboard or operations marker such as `Dashboard` or `Purchase Orders`
+
+This is mandatory because the live regression occurred after auth, during active-tenant persistence.
+
+### 6. Runtime Constraints
+
+To keep this viable on every PR:
+
+- one shared authenticated browser context for the suite
+- one worker
+- no retries by default
+- screenshots only on failure
+- one core screen per app
+
+Target runtime budget:
+
+- about `2-4` minutes added to PR CI
+
+## CI Wiring
+
+### 1. Workflow Placement
+
+The hosted smoke belongs in the main required `CI` workflow in [.github/workflows/ci.yml](/Users/jarraramjad/dev/targonos-main/.github/workflows/ci.yml:1).
+
+It should run after:
+
+- local auth topology tests
+- local SSO smoke
+
+This ordering keeps fast local failures cheap and then validates the hosted suite contract.
+
+### 2. Required Environment
+
+The job must require explicit hosted env such as:
+
+- `PORTAL_BASE_URL=https://dev-os.targonglobal.com`
+- `NEXTAUTH_SECRET` or `PORTAL_AUTH_SECRET`
+- hosted seeded-user identifiers already expected by the hosted auth fixture
+
+If any required variable is missing, the job fails immediately.
+
+### 3. Failure Policy
+
+This is a blocking PR gate.
+
+It must not be optional, manual-only, or best-effort if central auth is treated as a release contract.
+
+## Test Ownership
+
+Ownership stays with the SSO/auth layer because:
+
+- the fixture is portal-auth based
+- the suite validates the shared auth contract across apps
+- failures indicate auth/topology regressions as often as app regressions
+
+App teams still own their own deeper workflow tests. This suite only owns “can central auth get me into the app and onto a real first screen”.
+
+## Implementation Outline
+
+1. Tighten [apps/sso/tests/hosted-deep-links.spec.ts](/Users/jarraramjad/dev/targonos-main/apps/sso/tests/hosted-deep-links.spec.ts:1) to enforce the stronger assertion contract.
+2. Add Talos-specific region-selection handling and request verification.
+3. Optimize the hosted suite for CI runtime:
+   - shared login context
+   - one worker
+   - screenshot-on-failure only
+4. Add a dedicated SSO script for hosted smoke execution.
+5. Wire the hosted smoke into `CI` as a required step after the local auth checks.
+6. Verify the lane against the dev hosted stack before opening a PR.
+
+## Risks
+
+- Hosted dev stack instability can create noisy failures. That is acceptable because the point of the gate is to reveal hosted auth breakage before merge.
+- Some app landing screens may be too brittle for marker-text assertions and may need more stable selectors.
+- Talos may require special handling if tenant-selection behavior changes by user or environment.
+
+## Success Criteria
+
+This design is successful when:
+
+- every PR runs a required hosted cross-app auth smoke
+- Talos tenant-selection regressions fail before merge
+- app-entry regressions redirecting to `/login` or `/no-access` fail before merge
+- hosted `502`/HTML error-page regressions fail before merge
+- the lane remains fast enough to stay required on every PR


### PR DESCRIPTION
## Summary
- Add a QBO full-history exception audit module for Purchases, Bills, Journal Entries, Transfers, and Attachables.
- Normalize QBO transactions into a shared audit shape, classify accounting/evidence exceptions, and export CSV + Markdown reports.
- Harden audit output semantics: explicit `unknown` reconciled-period risk, stronger duplicate fingerprinting, proper CSV escaping, attachables in coverage, and bounded QBO fetch timeouts.

## Generated Artifacts
- `/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Finance/Reports/qbo-audit-support/2026-04-14/full-history-exception-audit/qbo-full-history-exception-audit.csv`
- `/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Finance/Reports/qbo-audit-support/2026-04-14/full-history-exception-audit/qbo-full-history-exception-audit.md`

Latest live run summary:
- `findings: 79`
- `completeCoverage: true`
- `failedTypes: []`
- `scannedCount: 991`

## Test Plan
- [x] `cd apps/plutus && pnpm test`
- [x] `cd apps/plutus && pnpm type-check`
- [x] `cd apps/plutus && pnpm exec dotenv -f /Users/jarraramjad/dev/targonos-main/apps/plutus/.env.production run -- sh -lc 'export PLUTUS_QBO_CONNECTION_PATH="/Users/jarraramjad/.targonos/plutus/qbo_connection.main.production.json"; pnpm -s exec tsx scripts/qbo-full-history-exception-audit.ts "/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Finance/Reports/qbo-audit-support/2026-04-14/full-history-exception-audit"'`
