### PR TITLE
fix(argus): sync standalone deploy assets

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -716,6 +716,29 @@ start_and_verify_pm2_process() {
   log "Runtime verified for $process_name (cwd=$actual_cwd sha=$actual_sha)"
 }
 
+sync_next_standalone_assets() {
+  local standalone_app_dir="$app_dir/.next/standalone/apps/$app_key"
+
+  if [[ ! -d "$standalone_app_dir" ]]; then
+    return 0
+  fi
+
+  if [[ ! -d "$app_dir/.next/static" ]]; then
+    error "Standalone output exists but generated static assets are missing: $app_dir/.next/static"
+    exit 1
+  fi
+
+  mkdir -p "$standalone_app_dir/.next/static"
+  rsync -a --delete "$app_dir/.next/static/" "$standalone_app_dir/.next/static/"
+
+  if [[ -d "$app_dir/public" ]]; then
+    mkdir -p "$standalone_app_dir/public"
+    rsync -a --delete "$app_dir/public/" "$standalone_app_dir/public/"
+  fi
+
+  log "Standalone assets synced for $app_key"
+}
+
 load_env_file() {
   local file="$1"
   if [[ ! -f "$file" ]]; then
@@ -1495,6 +1518,7 @@ if [[ "$build_status" -ne 0 ]]; then
 fi
 
 log "Build complete"
+sync_next_standalone_assets
 
 # Step 7: Restart PM2 app
 if [[ "$app_key" == "kairos" ]]; then

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -137,3 +137,18 @@ test('pm2 starts scrub workflow-inherited database and hosted runtime env', () =
     assert.match(block, new RegExp(`${key}=\\s*\\\\`))
   }
 })
+
+test('standalone Next deploys copy generated static and public assets before PM2 starts', () => {
+  assert.match(
+    deployScript,
+    /sync_next_standalone_assets\(\)[\s\S]*?rsync -a --delete "\$app_dir\/.next\/static\/" "\$standalone_app_dir\/.next\/static\/"/,
+  )
+  assert.match(
+    deployScript,
+    /sync_next_standalone_assets\(\)[\s\S]*?rsync -a --delete "\$app_dir\/public\/" "\$standalone_app_dir\/public\/"/,
+  )
+  assert.match(
+    deployScript,
+    /log "Build complete"[\s\S]*?sync_next_standalone_assets[\s\S]*?log "Step 7: Starting \$pm2_name"/,
+  )
+})


### PR DESCRIPTION
## Summary

Fixes the Argus standalone deploy path so generated Next static chunks and public assets are copied into the standalone server tree before PM2 starts.

Root cause: the production Argus process was running the standalone server, but the deploy script left `.next/standalone/apps/argus/.next/static` empty. The new server HTML referenced fresh chunks while the standalone server could not serve them.

## Validation

- `node --test scripts/deploy-app.test.cjs`
- `node --test scripts/deploy-app.test.cjs scripts/detect-cd-affected-apps.test.cjs`
- `bash -n scripts/deploy-app.sh`

## Production check

Manually synced the runtime standalone static assets after the hot deploy. Fresh live load of `/argus/cases/us/2026-04-15` now shows `Argus v1.362.0`, all chunk requests return 200, and browser console has no errors.