### PR TITLE
fix(plutus): allow cashflow worker snapshot imports

### DIFF
--- a/apps/plutus/app/api/plutus/cashflow/config/route.ts
+++ b/apps/plutus/app/api/plutus/cashflow/config/route.ts
@@ -8,7 +8,7 @@ import {
   buildCashAccountCandidates,
   ensureCashflowConfigWithAccounts,
   updateCashflowConfig,
-} from '@/lib/plutus/cashflow/snapshot';
+} from '@/lib/plutus/cashflow/snapshot.server';
 
 const logger = createLogger({ name: 'plutus-cashflow-config-route' });
 

--- a/apps/plutus/app/api/plutus/cashflow/export/route.ts
+++ b/apps/plutus/app/api/plutus/cashflow/export/route.ts
@@ -4,7 +4,7 @@ import { createLogger } from '@targon/logger';
 import {
   getCashflowSnapshotPayloadById,
   getLatestCashflowSnapshotPayload,
-} from '@/lib/plutus/cashflow/snapshot';
+} from '@/lib/plutus/cashflow/snapshot.server';
 
 const logger = createLogger({ name: 'plutus-cashflow-export-route' });
 

--- a/apps/plutus/app/api/plutus/cashflow/snapshot/route.ts
+++ b/apps/plutus/app/api/plutus/cashflow/snapshot/route.ts
@@ -5,7 +5,7 @@ import {
   CashflowSnapshotError,
   generateAndPersistCashflowSnapshot,
   getLatestCashflowSnapshotPayload,
-} from '@/lib/plutus/cashflow/snapshot';
+} from '@/lib/plutus/cashflow/snapshot.server';
 
 const logger = createLogger({ name: 'plutus-cashflow-snapshot-route' });
 

--- a/apps/plutus/lib/plutus/cashflow/snapshot.server.ts
+++ b/apps/plutus/lib/plutus/cashflow/snapshot.server.ts
@@ -1,0 +1,3 @@
+import 'server-only';
+
+export * from './snapshot';

--- a/apps/plutus/lib/plutus/cashflow/snapshot.ts
+++ b/apps/plutus/lib/plutus/cashflow/snapshot.ts
@@ -1,5 +1,3 @@
-import 'server-only';
-
 import { createLogger } from '@targon/logger';
 import type { Prisma } from '@targon/prisma-plutus';
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
 
 import {
   normalizeAuditMarketToMarketplaceId,
@@ -129,6 +131,10 @@ function withDatabaseUrl(databaseUrl: string | undefined, fn: () => void) {
   }
 }
 
+function readAppFile(...segments: string[]) {
+  return readFileSync(path.join(process.cwd(), ...segments), 'utf8');
+}
+
 test('normalizeAuditMarketToMarketplaceId maps common values', () => {
   assert.equal(normalizeAuditMarketToMarketplaceId('Amazon.com'), 'amazon.com');
   assert.equal(normalizeAuditMarketToMarketplaceId('amazon.co.uk'), 'amazon.co.uk');
@@ -164,6 +170,22 @@ test('dbTableIdentifier rejects missing schema and unsafe identifiers', () => {
   withDatabaseUrl('postgresql://user:pass@localhost:5432/portal_db?schema=plutus_dev', () => {
     assert.throws(() => dbTableIdentifier('AuditDataRow;DROP'), /Invalid database table identifier/);
   });
+});
+
+test('cashflow snapshot server-only guard stays out of standalone worker path', () => {
+  const snapshotModule = readAppFile('lib/plutus/cashflow/snapshot.ts');
+  const snapshotServerModule = readAppFile('lib/plutus/cashflow/snapshot.server.ts');
+  const workerModule = readAppFile('scripts/cashflow-refresh-worker.ts');
+  const snapshotRoute = readAppFile('app/api/plutus/cashflow/snapshot/route.ts');
+  const exportRoute = readAppFile('app/api/plutus/cashflow/export/route.ts');
+  const configRoute = readAppFile('app/api/plutus/cashflow/config/route.ts');
+
+  assert.equal(snapshotModule.includes("import 'server-only';"), false);
+  assert.equal(snapshotServerModule.includes("import 'server-only';"), true);
+  assert.equal(workerModule.includes("@/lib/plutus/cashflow/snapshot';"), true);
+  assert.equal(snapshotRoute.includes("@/lib/plutus/cashflow/snapshot.server';"), true);
+  assert.equal(exportRoute.includes("@/lib/plutus/cashflow/snapshot.server';"), true);
+  assert.equal(configRoute.includes("@/lib/plutus/cashflow/snapshot.server';"), true);
 });
 
 test('classifyQboRefreshFailure maps invalid_client to oauth client mismatch', () => {


### PR DESCRIPTION
## Summary

Fixes the `dev-plutus-cashflow-refresh` deploy crash by moving the `server-only` import out of the shared cashflow snapshot implementation and into a Next-only `snapshot.server` wrapper.

- Keeps Next cashflow API routes guarded through `snapshot.server`.
- Lets the standalone `tsx` worker import `snapshot.ts` without tripping `server-only` at startup.
- Adds a regression test for the worker/server import boundary.

## Validation

- `pnpm -C apps/plutus test`
- `pnpm -C apps/plutus type-check`
- `pnpm -C apps/plutus lint`
- `git diff --check`
- Worker smoke check: `PLUTUS_CASHFLOW_REFRESH_WORKER_ENABLED=0 pnpm -C apps/plutus exec tsx scripts/cashflow-refresh-worker.ts` logged disabled/idling instead of crashing.