### PR TITLE
fix(hermes): load production env for workers

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -281,6 +281,14 @@ function createNextAppEnvWithPortal(rootDir, appName, environment, runtimeEnv) {
   };
 }
 
+function createHermesWorkerEnv(rootDir, environment, runtimeEnv) {
+  const hostedLoadOptions = getHostedEnvLoadOptions(environment);
+  return {
+    ...loadAppEnv(path.join(rootDir, 'apps/hermes'), environment, hostedLoadOptions),
+    ...runtimeEnv,
+  };
+}
+
 if (!DEV_DIR) {
   throw new Error('Missing TARGONOS_DEV_DIR (or legacy TARGON_DEV_DIR).');
 }
@@ -488,7 +496,10 @@ module.exports = {
       args: 'src/server/jobs/orders-sync-hourly.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: { ...loadEnvFile(path.join(DEV_DIR, 'apps/hermes/.env.local')), NODE_ENV: 'production', HERMES_ORDERS_SYNC_INTERVAL_MINUTES: 60 },
+      env: createHermesWorkerEnv(DEV_DIR, 'dev', {
+        NODE_ENV: 'production',
+        HERMES_ORDERS_SYNC_INTERVAL_MINUTES: 60,
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -500,7 +511,9 @@ module.exports = {
       args: 'src/server/jobs/request-review-dispatcher.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: { ...loadEnvFile(path.join(DEV_DIR, 'apps/hermes/.env.local')), NODE_ENV: 'production' },
+      env: createHermesWorkerEnv(DEV_DIR, 'dev', {
+        NODE_ENV: 'production',
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -711,7 +724,10 @@ module.exports = {
       args: 'src/server/jobs/orders-sync-hourly.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: { ...loadEnvFile(path.join(MAIN_DIR, 'apps/hermes/.env.local')), NODE_ENV: 'production', HERMES_ORDERS_SYNC_INTERVAL_MINUTES: 60 },
+      env: createHermesWorkerEnv(MAIN_DIR, 'production', {
+        NODE_ENV: 'production',
+        HERMES_ORDERS_SYNC_INTERVAL_MINUTES: 60,
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -723,7 +739,9 @@ module.exports = {
       args: 'src/server/jobs/request-review-dispatcher.ts',
       interpreter: 'none',
       exec_mode: 'fork',
-      env: { ...loadEnvFile(path.join(MAIN_DIR, 'apps/hermes/.env.local')), NODE_ENV: 'production' },
+      env: createHermesWorkerEnv(MAIN_DIR, 'production', {
+        NODE_ENV: 'production',
+      }),
       autorestart: true,
       watch: false,
       max_memory_restart: '300M'
@@ -748,5 +766,6 @@ module.exports = {
 };
 module.exports.createPortalRuntimeEnv = createPortalRuntimeEnv;
 module.exports.createNextAppEnvWithPortal = createNextAppEnvWithPortal;
+module.exports.createHermesWorkerEnv = createHermesWorkerEnv;
 module.exports.buildHostedAppUrl = buildHostedAppUrl;
 module.exports.getHostedCookieDomain = getHostedCookieDomain;

--- a/ecosystem.topology.test.cjs
+++ b/ecosystem.topology.test.cjs
@@ -79,6 +79,36 @@ test('talos hosted runtimes skip server dotenv loading', () => {
   assert.equal(mainTalos.env.SKIP_DOTENV, '1')
 })
 
+test('hosted Hermes workers load production env files', () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'targonos-hermes-worker-env-'))
+  const hermesDir = path.join(fixtureRoot, 'apps', 'hermes')
+  fs.mkdirSync(hermesDir, { recursive: true })
+
+  fs.writeFileSync(
+    path.join(hermesDir, '.env.production'),
+    [
+      'DATABASE_URL=postgresql://portal_hermes:secret@localhost:5432/portal_db?schema=main_hermes',
+      'HERMES_DB_SCHEMA=main_hermes',
+      '',
+    ].join('\n'),
+  )
+
+  try {
+    const env = ecosystem.createHermesWorkerEnv(fixtureRoot, 'production', {
+      NODE_ENV: 'production',
+    })
+
+    assert.equal(
+      env.DATABASE_URL,
+      'postgresql://portal_hermes:secret@localhost:5432/portal_db?schema=main_hermes',
+    )
+    assert.equal(env.HERMES_DB_SCHEMA, 'main_hermes')
+    assert.equal(env.NODE_ENV, 'production')
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true })
+  }
+})
+
 test('hosted child app env strips local hosted overrides and uses portal-managed values', () => {
   const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'targonos-hosted-env-'))
   const ssoDir = path.join(fixtureRoot, 'apps', 'sso')


### PR DESCRIPTION
## Summary
- Load Hermes worker PM2 env through the same hosted env resolution used by hosted apps
- Ensure production workers read `.env.production` when the runtime clone does not have `.env.local`
- Add a topology regression for production Hermes worker env loading

## Root cause
The Hermes web app used hosted env loading, but `main-hermes-orders-sync` and `main-hermes-request-review` hard-coded `apps/hermes/.env.local`. The main runtime clone had `.env.production`, so workers started without `DATABASE_URL` and the main CD rerun failed when `main-hermes-request-review` hard-failed in `pool.ts`.

## Validation
- `node --test ecosystem.topology.test.cjs scripts/deploy-app.test.cjs`
- `node --check ecosystem.config.js`
- `git diff --check`