### PR TITLE
fix(plutus): split US settlements by month

### DIFF
--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -231,11 +231,8 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
   skuToBrandName: Map<string, string>;
   brandLabelByBrandName?: Map<string, string>;
   timeZone?: string;
-  /// When true, split the settlement into month-bounded segments with zero-total rollovers (LMB-style).
-  splitByMonth?: boolean;
 }): UsSettlementDraft {
   const timeZone = input.timeZone === undefined ? US_TIME_ZONE : input.timeZone;
-  const splitByMonth = input.splitByMonth === true;
 
   const groupStartTs = requireEventGroupField(input.eventGroup.FinancialEventGroupStart, 'FinancialEventGroupStart', input.settlementId);
   const groupEndTs = requireEventGroupField(input.eventGroup.FinancialEventGroupEnd, 'FinancialEventGroupEnd', input.settlementId);
@@ -253,24 +250,11 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
     input.settlementId,
   );
 
-  const segments: UsSettlementSegmentDraft[] = splitByMonth
-    ? buildMonthlySettlementSegments<UsSettlementAuditRowDraft>({
-        startIsoDay,
-        endIsoDay,
-        buildDocNumber: buildUsSettlementDocNumber,
-      })
-    : [
-        {
-          seq: 1,
-          yearMonth: isoDayToYearMonth(startIsoDay, 'group start day'),
-          startIsoDay,
-          endIsoDay,
-          txnDate: endIsoDay,
-          docNumber: buildUsSettlementDocNumber({ startIsoDay, endIsoDay, seq: 1 }),
-          memoTotalsCents: new Map(),
-          auditRows: [],
-        },
-      ];
+  const segments: UsSettlementSegmentDraft[] = buildMonthlySettlementSegments<UsSettlementAuditRowDraft>({
+    startIsoDay,
+    endIsoDay,
+    buildDocNumber: buildUsSettlementDocNumber,
+  });
 
   const lastSegment = segments[segments.length - 1];
   if (!lastSegment) throw new Error('No settlement segment built');
@@ -281,7 +265,6 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
   }
 
   const requireSegmentForIsoDay = (localIsoDay: string): UsSettlementSegmentDraft => {
-    if (!splitByMonth) return lastSegment;
     const yearMonth = isoDayToYearMonth(localIsoDay, 'event day');
     const segment = segmentsByYearMonth.get(yearMonth);
     if (!segment) {

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -505,7 +505,6 @@ export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlemen
   const requiredMemos = new Set<string>();
   let needBankAccount = false;
   let needPaymentAccount = false;
-  const splitByMonth = globalThis.process.env.PLUTUS_SPLIT_SETTLEMENTS_BY_MONTH === 'true';
 
   for (const [settlementId, eventGroupId] of Array.from(settlementToGroupId.entries()).sort((a, b) => a[0].localeCompare(b[0]))) {
     const eventGroup = groupById.get(eventGroupId);
@@ -521,7 +520,6 @@ export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlemen
       eventGroup,
       events,
       skuToBrandName,
-      splitByMonth,
     });
 
     if (draft.originalTotalCents > 0 && draft.fundTransferStatus === 'Succeeded') needBankAccount = true;

--- a/apps/plutus/scripts/us-settlement-ingest-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-ingest-spapi.ts
@@ -393,7 +393,6 @@ async function main(): Promise<void> {
   }
 
   const runSummary: Array<Record<string, unknown>> = [];
-  const splitByMonth = process.env.PLUTUS_SPLIT_SETTLEMENTS_BY_MONTH === 'true';
 
   for (const settlementId of options.settlementIds) {
     const eventGroupId = await findFinancialEventGroupIdForSettlementId({
@@ -416,7 +415,6 @@ async function main(): Promise<void> {
       eventGroup,
       events,
       skuToBrandName,
-      splitByMonth,
     });
 
     const jeDrafts = buildQboJournalEntriesFromUsSettlementDraft({

--- a/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
@@ -420,7 +420,6 @@ async function main(): Promise<void> {
   }
 
   const results: SegmentResult[] = [];
-  const splitByMonth = process.env.PLUTUS_SPLIT_SETTLEMENTS_BY_MONTH === 'true';
 
   for (const settlementId of targetSettlementIds) {
     const settlementJournals = journalsBySettlement.get(settlementId);
@@ -451,7 +450,6 @@ async function main(): Promise<void> {
       events,
       skuToBrandName,
       brandLabelByBrandName,
-      splitByMonth,
     });
 
     const journalsByDocNumber = new Map<string, QboJournalEntry>();

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -958,7 +958,7 @@ test('buildSettlementMtdDailySummaryCsvBytes builds daily totals by memo', () =>
   assert.equal(csv, expected);
 });
 
-test('buildUsSettlementDraftFromSpApiFinances preserves cross-month settlement periods', () => {
+test('buildUsSettlementDraftFromSpApiFinances splits cross-month settlement periods by default', () => {
   const draft = buildUsSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-1',
     eventGroupId: 'GROUP-1',
@@ -980,17 +980,20 @@ test('buildUsSettlementDraftFromSpApiFinances preserves cross-month settlement p
     skuToBrandName: new Map(),
   });
 
-  assert.equal(draft.segments.length, 1);
-  assert.equal(draft.segments[0]?.docNumber, 'US-251219-260102-S1');
+  assert.equal(draft.segments.length, 2);
+  assert.equal(draft.segments[0]?.docNumber, 'US-251219-251231-S1');
+  assert.equal(draft.segments[1]?.docNumber, 'US-260101-260102-S2');
 
-  const cents = draft.segments[0]?.memoTotalsCents.get('Amazon Reserved Balances - Current Reserve Amount');
+  const cents = draft.segments[1]?.memoTotalsCents.get('Amazon Reserved Balances - Current Reserve Amount');
   assert.equal(cents, -100);
 
   assert.equal(draft.segments[0]?.memoTotalsCents.has('Split month settlement - balance of this invoice rolled forward'), false);
   assert.equal(draft.segments[0]?.memoTotalsCents.has('Split month settlement - balance of previous invoice(s) rolled forward'), false);
+  assert.equal(draft.segments[1]?.memoTotalsCents.has('Split month settlement - balance of this invoice rolled forward'), false);
+  assert.equal(draft.segments[1]?.memoTotalsCents.has('Split month settlement - balance of previous invoice(s) rolled forward'), false);
 });
 
-test('buildUsSettlementDraftFromSpApiFinances can split multi-month settlements into monthly segments with rollovers', () => {
+test('buildUsSettlementDraftFromSpApiFinances splits multi-month settlements into monthly segments with rollovers', () => {
   const draft = buildUsSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-SPLIT-1',
     eventGroupId: 'GROUP-SPLIT-1',
@@ -1015,7 +1018,6 @@ test('buildUsSettlementDraftFromSpApiFinances can split multi-month settlements 
       ],
     },
     skuToBrandName: new Map(),
-    splitByMonth: true,
   });
 
   assert.equal(draft.segments.length, 3);
@@ -1046,6 +1048,19 @@ test('buildUsSettlementDraftFromSpApiFinances can split multi-month settlements 
   assert.equal(seg3.memoTotalsCents.get('Split month settlement - balance of previous invoice(s) rolled forward'), -100);
   assert.equal(seg3.memoTotalsCents.has('Split month settlement - balance of this invoice rolled forward'), false);
   assert.equal(sum(seg3.memoTotalsCents), -300);
+});
+
+test('US settlement SP-API paths do not gate month splitting on runtime env', () => {
+  const sourcePaths = [
+    '../lib/amazon-finances/us-settlement-sync.ts',
+    '../scripts/us-settlement-ingest-spapi.ts',
+    '../scripts/us-settlement-reconcile-spapi.ts',
+  ];
+
+  for (const sourcePath of sourcePaths) {
+    const source = readFileSync(new URL(sourcePath, import.meta.url), 'utf8');
+    assert.equal(source.includes('PLUTUS_SPLIT_SETTLEMENTS_BY_MONTH'), false);
+  }
 });
 
 test('buildUkSettlementDraftFromSpApiFinances always splits multi-month settlements into monthly segments with rollovers', () => {


### PR DESCRIPTION
## Summary
- Make US SP-API settlement drafting always split cross-month settlements into month-bounded segments.
- Remove the `PLUTUS_SPLIT_SETTLEMENTS_BY_MONTH` runtime gate from the worker and manual SP-API scripts.
- Update Plutus tests so default US behavior matches the split settlement detail view expectation.

## Root Cause
US settlement splitting was still controlled by a runtime env flag. Production PM2 did not have that flag set, so a March 27-April 10 settlement posted as one journal entry instead of two month-bounded entries.

## Verification
- `pnpm --filter @targon/plutus test`
- `pnpm --filter @targon/plutus type-check`
- `pnpm --filter @targon/plutus lint`