### PR TITLE
fix(argus): promote cases day-over-day table

### DIFF
--- a/apps/argus/components/cases/approval-queue-page.tsx
+++ b/apps/argus/components/cases/approval-queue-page.tsx
@@ -21,6 +21,7 @@ import {
 import { getCaseQueueBorderColor } from '@/lib/cases/theme'
 import { CaseApprovalQueueTable } from './approval-queue-table'
 import { CaseApprovalDetailBand } from './approval-detail-band'
+import { CaseDaySummaryTable } from './day-summary-table'
 
 const MARKET_OPTIONS = [
   { slug: 'us', label: 'USA - Dust Sheets' },
@@ -106,8 +107,8 @@ export function CaseApprovalQueuePage({ bundle }: { bundle: CaseReportBundle }) 
     router.push(`/cases/${event.target.value}`)
   }
 
-  function handleReportDateChange(event: SelectChangeEvent<string>) {
-    router.push(`/cases/${bundle.marketSlug}/${event.target.value}`)
+  function handleReportDateChange(reportDate: string) {
+    router.push(`/cases/${bundle.marketSlug}/${reportDate}`)
   }
 
   function handleDecisionFilterChange(event: SelectChangeEvent<string>) {
@@ -146,16 +147,6 @@ export function CaseApprovalQueuePage({ bundle }: { bundle: CaseReportBundle }) 
             </Select>
           </FormControl>
 
-          <FormControl size="small" sx={{ minWidth: 150 }}>
-            <Select value={bundle.reportDate} onChange={handleReportDateChange}>
-              {bundle.availableReportDates.map((reportDate) => (
-                <MenuItem key={reportDate} value={reportDate}>
-                  {reportDate}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
           <TextField
             size="small"
             placeholder="Search"
@@ -182,6 +173,12 @@ export function CaseApprovalQueuePage({ bundle }: { bundle: CaseReportBundle }) 
         selectedRowKey={selectedRowKey}
         onSelectRow={setSelectedRowKey}
         onDecision={handleDecision}
+      />
+
+      <CaseDaySummaryTable
+        daySummaries={bundle.daySummaries}
+        selectedReportDate={bundle.reportDate}
+        onSelectReportDate={handleReportDateChange}
       />
 
       <CaseApprovalDetailBand row={selectedRow} />

--- a/apps/argus/components/cases/approval-queue-table.tsx
+++ b/apps/argus/components/cases/approval-queue-table.tsx
@@ -63,9 +63,12 @@ function DecisionCell({
         }}
         sx={(theme) => ({
           minWidth: 0,
-          px: 0.75,
+          px: 0.45,
+          py: 0,
           color: getCaseQueueActionColor('approve', theme.palette.mode),
+          fontSize: '0.72rem',
           fontWeight: 700,
+          lineHeight: 1.15,
           textTransform: 'none',
         })}
       >
@@ -79,9 +82,12 @@ function DecisionCell({
         }}
         sx={(theme) => ({
           minWidth: 0,
-          px: 0.75,
+          px: 0.45,
+          py: 0,
           color: getCaseQueueActionColor('reject', theme.palette.mode),
+          fontSize: '0.72rem',
           fontWeight: 700,
+          lineHeight: 1.15,
           textTransform: 'none',
         })}
       >
@@ -99,14 +105,14 @@ function CategoryCell({ category }: { category: string }) {
         return {
           display: 'inline-flex',
           alignItems: 'center',
-          px: 0.9,
-          py: 0.35,
+          px: 0.65,
+          py: 0.22,
           border: '1px solid',
           borderColor: tone.border,
           bgcolor: tone.background,
           color: tone.color,
           borderRadius: 1,
-          fontSize: '0.74rem',
+          fontSize: '0.66rem',
           fontWeight: 700,
           lineHeight: 1.1,
           whiteSpace: 'nowrap',
@@ -123,12 +129,14 @@ function HeaderCell({ label, align = 'left' }: { label: string; align?: 'left' |
     <TableCell
       align={align}
       sx={(theme) => ({
+        px: 1,
+        py: 0.55,
         borderBottom: '1px solid',
         borderColor: getCaseQueueBorderColor(theme.palette.mode),
         bgcolor: 'background.paper',
         color: getCaseQueueMutedTextColor(theme.palette.mode),
-        fontSize: '0.7rem',
-        fontWeight: 700,
+        fontSize: '0.62rem',
+        fontWeight: 800,
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
         whiteSpace: 'nowrap',
@@ -152,12 +160,15 @@ function BodyCell({
     <TableCell
       align={align}
       sx={{
+        px: 1,
+        py: 0.45,
         borderBottom: 'none',
         whiteSpace: 'nowrap',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         fontFamily: mono ? 'var(--font-mono), "JetBrains Mono", monospace' : 'inherit',
-        fontSize: '0.92rem',
+        fontSize: '0.78rem',
+        lineHeight: 1.25,
       }}
     >
       {children}
@@ -177,7 +188,8 @@ export function CaseApprovalQueueTable({
         border: '1px solid',
         borderColor: getCaseQueueBorderColor(theme.palette.mode),
         borderRadius: 1,
-        maxHeight: 560,
+        height: 260,
+        overflow: 'auto',
       })}
     >
       <Table stickyHeader size="small" sx={{ tableLayout: 'fixed' }}>
@@ -221,17 +233,15 @@ export function CaseApprovalQueueTable({
                 '& td': {
                   borderTop: '1px solid',
                   borderColor: getCaseQueueBorderColor(theme.palette.mode),
+                  ...(row.rowKey === selectedRowKey
+                    ? {
+                        bgcolor: getCaseQueueSelectedRowBackground(theme.palette.mode),
+                      }
+                    : null),
                 },
                 '&:first-of-type td': {
                   borderTop: 'none',
                 },
-                ...(row.rowKey === selectedRowKey
-                  ? {
-                      '& td': {
-                        bgcolor: getCaseQueueSelectedRowBackground(theme.palette.mode),
-                      },
-                    }
-                  : null),
               })}
             >
               <BodyCell>

--- a/apps/argus/components/cases/day-summary-table.tsx
+++ b/apps/argus/components/cases/day-summary-table.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import type { KeyboardEvent, ReactNode } from 'react'
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material'
+import type { CaseReportDaySummary } from '@/lib/cases/reader'
+import {
+  getCaseQueueBorderColor,
+  getCaseQueueMutedTextColor,
+  getCaseQueueSelectedRowBackground,
+} from '@/lib/cases/theme'
+
+type CaseDaySummaryTableProps = {
+  daySummaries: CaseReportDaySummary[]
+  selectedReportDate: string
+  onSelectReportDate: (reportDate: string) => void
+}
+
+function HeaderCell({ label, align = 'left' }: { label: string; align?: 'left' | 'right' }) {
+  return (
+    <TableCell
+      align={align}
+      sx={(theme) => ({
+        px: 1,
+        py: 0.55,
+        borderBottom: '1px solid',
+        borderColor: getCaseQueueBorderColor(theme.palette.mode),
+        bgcolor: 'background.paper',
+        color: getCaseQueueMutedTextColor(theme.palette.mode),
+        fontSize: '0.62rem',
+        fontWeight: 800,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+      })}
+    >
+      {label}
+    </TableCell>
+  )
+}
+
+function BodyCell({
+  children,
+  align = 'left',
+  mono,
+}: {
+  children: ReactNode
+  align?: 'left' | 'right'
+  mono?: boolean
+}) {
+  return (
+    <TableCell
+      align={align}
+      sx={{
+        px: 1,
+        py: 0.45,
+        borderBottom: 'none',
+        fontFamily: mono ? 'var(--font-mono), "JetBrains Mono", monospace' : 'inherit',
+        fontSize: '0.78rem',
+        lineHeight: 1.25,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </TableCell>
+  )
+}
+
+export function CaseDaySummaryTable({
+  daySummaries,
+  selectedReportDate,
+  onSelectReportDate,
+}: CaseDaySummaryTableProps) {
+  function handleKeyDown(event: KeyboardEvent<HTMLTableRowElement>, reportDate: string) {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      onSelectReportDate(reportDate)
+      return
+    }
+
+    if (event.key === ' ') {
+      event.preventDefault()
+      onSelectReportDate(reportDate)
+    }
+  }
+
+  return (
+    <Box sx={{ mt: 1.2 }}>
+      <Typography
+        sx={(theme) => ({
+          mb: 0.55,
+          color: getCaseQueueMutedTextColor(theme.palette.mode),
+          fontSize: '0.68rem',
+          fontWeight: 800,
+          letterSpacing: '0.08em',
+          textTransform: 'uppercase',
+        })}
+      >
+        Day over day
+      </Typography>
+      <TableContainer
+        sx={(theme) => ({
+          border: '1px solid',
+          borderColor: getCaseQueueBorderColor(theme.palette.mode),
+          borderRadius: 1,
+          height: 150,
+          overflow: 'auto',
+        })}
+      >
+        <Table stickyHeader size="small" sx={{ tableLayout: 'fixed' }}>
+          <TableHead>
+            <TableRow>
+              <HeaderCell label="Day" />
+              <HeaderCell label="Total" align="right" />
+              <HeaderCell label="Action due" align="right" />
+              <HeaderCell label="New" align="right" />
+              <HeaderCell label="Forum" align="right" />
+              <HeaderCell label="Watching" align="right" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {daySummaries.map((summary) => (
+              <TableRow
+                key={summary.reportDate}
+                hover
+                selected={summary.reportDate === selectedReportDate}
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  onSelectReportDate(summary.reportDate)
+                }}
+                onKeyDown={(event) => {
+                  handleKeyDown(event, summary.reportDate)
+                }}
+                sx={(theme) => ({
+                  cursor: 'pointer',
+                  '& td': {
+                    borderTop: '1px solid',
+                    borderColor: getCaseQueueBorderColor(theme.palette.mode),
+                    ...(summary.reportDate === selectedReportDate
+                      ? {
+                          bgcolor: getCaseQueueSelectedRowBackground(theme.palette.mode),
+                        }
+                      : null),
+                  },
+                  '&:first-of-type td': {
+                    borderTop: 'none',
+                  },
+                })}
+              >
+                <BodyCell mono>
+                  <Typography sx={{ fontFamily: 'inherit', fontSize: 'inherit', fontWeight: 800 }}>
+                    {summary.reportDate}
+                  </Typography>
+                </BodyCell>
+                <BodyCell align="right" mono>
+                  {summary.totalRows}
+                </BodyCell>
+                <BodyCell align="right" mono>
+                  {summary.actionDueRows}
+                </BodyCell>
+                <BodyCell align="right" mono>
+                  {summary.newCaseRows}
+                </BodyCell>
+                <BodyCell align="right" mono>
+                  {summary.forumWatchRows}
+                </BodyCell>
+                <BodyCell align="right" mono>
+                  {summary.watchingRows}
+                </BodyCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  )
+}

--- a/apps/argus/lib/cases/reader-core.ts
+++ b/apps/argus/lib/cases/reader-core.ts
@@ -44,6 +44,15 @@ export type ParsedCaseReport = {
   sections: CaseReportSection[];
 };
 
+export type CaseReportDaySummary = {
+  reportDate: string;
+  totalRows: number;
+  actionDueRows: number;
+  newCaseRows: number;
+  forumWatchRows: number;
+  watchingRows: number;
+};
+
 export type CaseReportBundle = ParsedCaseReport & {
   marketSlug: CaseReportMarketSlug;
   marketLabel: string;
@@ -51,6 +60,7 @@ export type CaseReportBundle = ParsedCaseReport & {
   reportPath: string;
   caseJsonPath: string;
   availableReportDates: string[];
+  daySummaries: CaseReportDaySummary[];
   trackedCaseIds: string[];
   generatedAt: string | null;
 };
@@ -167,6 +177,71 @@ async function listAvailableReportDates(caseRoot: string): Promise<string[]> {
     .sort((left, right) => right.localeCompare(left));
 }
 
+function countCaseReportRows(parsedReport: ParsedCaseReport): CaseReportDaySummary {
+  const summary: CaseReportDaySummary = {
+    reportDate: parsedReport.reportDate,
+    totalRows: 0,
+    actionDueRows: 0,
+    newCaseRows: 0,
+    forumWatchRows: 0,
+    watchingRows: 0,
+  };
+
+  for (const section of parsedReport.sections) {
+    for (const row of section.rows) {
+      summary.totalRows += 1;
+
+      if (row.category === 'Action due') {
+        summary.actionDueRows += 1;
+        continue;
+      }
+
+      if (row.category === 'New case') {
+        summary.newCaseRows += 1;
+        continue;
+      }
+
+      if (row.category === 'Forum watch') {
+        summary.forumWatchRows += 1;
+        continue;
+      }
+
+      if (row.category === 'Watching') {
+        summary.watchingRows += 1;
+        continue;
+      }
+
+      throw new Error(`Unsupported case report summary category: ${row.category}`);
+    }
+  }
+
+  return summary;
+}
+
+async function readCaseReportDaySummaries(
+  caseRoot: string,
+  availableReportDates: string[],
+  marketCode: string,
+): Promise<CaseReportDaySummary[]> {
+  return Promise.all(
+    availableReportDates.map(async (reportDate) => {
+      const reportPath = path.join(caseRoot, 'reports', `${reportDate}.md`);
+      const markdown = await fs.readFile(reportPath, 'utf8');
+      const parsedReport = parseCaseReportMarkdown(markdown);
+
+      if (parsedReport.reportDate !== reportDate) {
+        throw new Error(`Case report date mismatch: expected ${reportDate}, got ${parsedReport.reportDate}`);
+      }
+
+      if (parsedReport.marketCode !== marketCode) {
+        throw new Error(`Case report market mismatch: expected ${marketCode}, got ${parsedReport.marketCode}`);
+      }
+
+      return countCaseReportRows(parsedReport);
+    }),
+  );
+}
+
 export async function readCaseReportBundleFromCaseRoot(
   caseRoot: string,
   marketSlug: CaseReportMarketSlug,
@@ -207,6 +282,8 @@ export async function readCaseReportBundleFromCaseRoot(
     throw new Error(`case.json market mismatch: expected ${market.marketCode}, got ${caseState.market}`);
   }
 
+  const daySummaries = await readCaseReportDaySummaries(caseRoot, availableReportDates, market.marketCode);
+
   return {
     ...parsedReport,
     marketSlug,
@@ -215,6 +292,7 @@ export async function readCaseReportBundleFromCaseRoot(
     reportPath,
     caseJsonPath,
     availableReportDates,
+    daySummaries,
     trackedCaseIds: Array.isArray(caseState.tracked_case_ids) ? caseState.tracked_case_ids : [],
     generatedAt: typeof caseState.generated_at === 'string' ? caseState.generated_at : null,
   };

--- a/apps/argus/lib/cases/reader.test.ts
+++ b/apps/argus/lib/cases/reader.test.ts
@@ -75,7 +75,7 @@ test('readCaseReportBundleFromCaseRoot resolves the latest dated report and trac
       '',
       '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
       '|---|---|---|---|---|---|---|---|',
-      '| Watching | Old issue | 19550165441 | 1 day ago | Work in progress | Old evidence. | Old assessment. | Old next step. |',
+      '| Action due | Old issue | 19550165441 | 1 day ago | Answered | Old evidence. | Old assessment. | Old next step. |',
       '',
     ].join('\n'),
   )
@@ -98,6 +98,24 @@ test('readCaseReportBundleFromCaseRoot resolves the latest dated report and trac
 
   assert.equal(bundle.reportDate, '2026-04-08')
   assert.deepEqual(bundle.availableReportDates, ['2026-04-08', '2026-04-07'])
+  assert.deepEqual(bundle.daySummaries, [
+    {
+      reportDate: '2026-04-08',
+      totalRows: 1,
+      actionDueRows: 0,
+      newCaseRows: 0,
+      forumWatchRows: 0,
+      watchingRows: 1,
+    },
+    {
+      reportDate: '2026-04-07',
+      totalRows: 1,
+      actionDueRows: 1,
+      newCaseRows: 0,
+      forumWatchRows: 0,
+      watchingRows: 0,
+    },
+  ])
   assert.deepEqual(bundle.trackedCaseIds, ['19550165441'])
   assert.equal(bundle.sections[0]?.rows[0]?.caseId, '19550165441')
 })

--- a/apps/argus/lib/cases/view-model.test.ts
+++ b/apps/argus/lib/cases/view-model.test.ts
@@ -18,6 +18,16 @@ function buildBundle(): CaseReportBundle {
     reportPath: '/tmp/cases/reports/2026-04-14.md',
     caseJsonPath: '/tmp/cases/case.json',
     availableReportDates: ['2026-04-14'],
+    daySummaries: [
+      {
+        reportDate: '2026-04-14',
+        totalRows: 4,
+        actionDueRows: 1,
+        newCaseRows: 1,
+        forumWatchRows: 1,
+        watchingRows: 1,
+      },
+    ],
     trackedCaseIds: ['A-100', 'A-200', 'A-300', 'A-400'],
     generatedAt: '2026-04-14T08:00:00-05:00',
     sections: [


### PR DESCRIPTION
## Summary
- promote the Argus cases day-over-day table from `dev` to `main`
- includes fixed-height internal scroll regions for the cases queue and day table

## Validation
- PR #5006 to `dev` passed GitHub CI and was merged
- `dev` is ahead of `main` by only `fix(argus): add day-over-day case table (#5006)`