### PR TITLE
fix(sso): clear legacy auth cookies

### DIFF
--- a/apps/sso/app/api/auth/reset/route.ts
+++ b/apps/sso/app/api/auth/reset/route.ts
@@ -1,15 +1,15 @@
+import { appendExpiredAuthCookieHeaders } from '@/lib/auth-cookie-clear'
 import { requireAuthEnv } from '@/lib/required-auth-env'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
-const AUTH_COOKIE_PATTERNS = ['authjs', 'next-auth', '__Secure-', '__Host-', 'csrf', 'pkce', 'callback', 'targon', 'session']
 const cookieDomain = requireAuthEnv('COOKIE_DOMAIN')
 const baseUrl = requireAuthEnv('NEXTAUTH_URL')
 
 export async function GET(request: NextRequest) {
   // Get provider and callbackUrl for direct signin flow
   const provider = request.nextUrl.searchParams.get('provider')
-  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl') || '/'
+  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl') ?? '/'
 
   // Clear cookies first, then start the OAuth flow in a clean request.
   const redirectUrl = new URL(provider === 'google' ? '/login/google' : '/login', baseUrl)
@@ -17,74 +17,10 @@ export async function GET(request: NextRequest) {
 
   const response = NextResponse.redirect(redirectUrl)
 
-  // Clear ALL auth-related cookies
-  const cookies = request.cookies.getAll()
-
-  // Known cookie names that NextAuth uses
-  const knownCookies = [
-    '__Secure-next-auth.session-token',
-    '__Secure-next-auth.callback-url',
-    '__Secure-next-auth.csrf-token',
-    '__Host-next-auth.csrf-token',
-    'next-auth.session-token',
-    'next-auth.callback-url',
-    'next-auth.csrf-token',
-    'targon.next-auth.session-token',
-    'targon.next-auth.callback-url',
-    'targon.next-auth.csrf-token',
-    '__Secure-authjs.session-token',
-    '__Secure-authjs.callback-url',
-    '__Secure-authjs.csrf-token',
-    'authjs.session-token',
-    'authjs.callback-url',
-    'authjs.csrf-token',
-  ]
-
-  // Clear all known cookies explicitly
-  for (const name of knownCookies) {
-    // With domain and secure
-    response.cookies.set({
-      name,
-      value: '',
-      domain: cookieDomain,
-      path: '/',
-      maxAge: 0,
-      expires: new Date(0),
-      secure: true,
-    })
-    // Without domain (for host-only cookies)
-    response.cookies.set({
-      name,
-      value: '',
-      path: '/',
-      maxAge: 0,
-      expires: new Date(0),
-      secure: true,
-    })
-  }
-
-  // Also clear any cookies from the request that match patterns
-  for (const cookie of cookies) {
-    const nameLower = cookie.name.toLowerCase()
-    if (AUTH_COOKIE_PATTERNS.some(p => nameLower.includes(p.toLowerCase()))) {
-      response.cookies.set({
-        name: cookie.name,
-        value: '',
-        domain: cookieDomain,
-        path: '/',
-        maxAge: 0,
-        expires: new Date(0),
-        secure: true,
-      })
-      response.cookies.set({
-        name: cookie.name,
-        value: '',
-        path: '/',
-        maxAge: 0,
-        expires: new Date(0),
-      })
-    }
-  }
+  appendExpiredAuthCookieHeaders(response, {
+    cookieDomain,
+    requestCookieNames: request.cookies.getAll().map((cookie) => cookie.name),
+  })
 
   return response
 }

--- a/apps/sso/app/login/google/route.ts
+++ b/apps/sso/app/login/google/route.ts
@@ -1,30 +1,10 @@
 import { signIn } from '@/lib/auth'
+import { appendExpiredAuthCookieHeaders } from '@/lib/auth-cookie-clear'
 import { requireAuthEnv } from '@/lib/required-auth-env'
-import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 const COOKIE_DOMAIN = requireAuthEnv('COOKIE_DOMAIN')
-
-const AUTH_COOKIE_PATTERNS = ['authjs', 'next-auth', '__Secure-', '__Host-', 'csrf', 'pkce', 'callback', 'targon', 'session']
-const KNOWN_COOKIES = [
-  '__Secure-next-auth.session-token',
-  '__Secure-next-auth.callback-url',
-  '__Secure-next-auth.csrf-token',
-  '__Host-next-auth.csrf-token',
-  'next-auth.session-token',
-  'next-auth.callback-url',
-  'next-auth.csrf-token',
-  'targon.next-auth.session-token',
-  'targon.next-auth.callback-url',
-  'targon.next-auth.csrf-token',
-  '__Secure-authjs.session-token',
-  '__Secure-authjs.callback-url',
-  '__Secure-authjs.csrf-token',
-  'authjs.session-token',
-  'authjs.callback-url',
-  'authjs.csrf-token',
-]
 
 function isRecoverableAuthError(error: unknown): boolean {
   if (!(error instanceof Error)) return false
@@ -40,54 +20,8 @@ function isRecoverableAuthError(error: unknown): boolean {
   )
 }
 
-async function clearAuthCookies() {
-  const cookieStore = await cookies()
-  const allCookies = cookieStore.getAll()
-
-  const expire = {
-    value: '',
-    path: '/',
-    maxAge: 0,
-    expires: new Date(0),
-  } as const
-
-  const clearCookie = (name: string) => {
-    cookieStore.set({
-      name,
-      ...expire,
-      domain: COOKIE_DOMAIN,
-      secure: true,
-    })
-    cookieStore.set({
-      name,
-      ...expire,
-      secure: true,
-    })
-    cookieStore.set({
-      name,
-      ...expire,
-      domain: COOKIE_DOMAIN,
-    })
-    cookieStore.set({
-      name,
-      ...expire,
-    })
-  }
-
-  for (const name of KNOWN_COOKIES) {
-    clearCookie(name)
-  }
-
-  for (const cookie of allCookies) {
-    const nameLower = cookie.name.toLowerCase()
-    if (AUTH_COOKIE_PATTERNS.some(pattern => nameLower.includes(pattern.toLowerCase()))) {
-      clearCookie(cookie.name)
-    }
-  }
-}
-
 export async function GET(request: NextRequest) {
-  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl') || '/'
+  const callbackUrl = request.nextUrl.searchParams.get('callbackUrl') ?? '/'
   const hasRetried = request.nextUrl.searchParams.get('retry') === '1'
 
   try {
@@ -96,10 +30,14 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     if (!hasRetried && isRecoverableAuthError(error)) {
       console.warn('[login/google] Recovering from auth error by clearing cookies:', error)
-      await clearAuthCookies()
       const retryUrl = new URL(request.nextUrl)
       retryUrl.searchParams.set('retry', '1')
-      return NextResponse.redirect(retryUrl)
+      const response = NextResponse.redirect(retryUrl)
+      appendExpiredAuthCookieHeaders(response, {
+        cookieDomain: COOKIE_DOMAIN,
+        requestCookieNames: request.cookies.getAll().map((cookie) => cookie.name),
+      })
+      return response
     }
 
     console.error('[login/google] Sign-in failed:', error)

--- a/apps/sso/lib/auth-cookie-clear.ts
+++ b/apps/sso/lib/auth-cookie-clear.ts
@@ -1,0 +1,106 @@
+const AUTH_COOKIE_PATTERNS = ['authjs', 'next-auth', '__Secure-', '__Host-', 'csrf', 'pkce', 'callback', 'targon', 'session']
+
+const KNOWN_AUTH_COOKIE_NAMES = [
+  '__Secure-next-auth.session-token',
+  '__Secure-next-auth.callback-url',
+  '__Secure-next-auth.csrf-token',
+  '__Host-next-auth.csrf-token',
+  'next-auth.session-token',
+  'next-auth.callback-url',
+  'next-auth.csrf-token',
+  'targon.next-auth.session-token',
+  'targon.next-auth.callback-url',
+  'targon.next-auth.csrf-token',
+  '__Secure-authjs.session-token',
+  '__Secure-authjs.callback-url',
+  '__Secure-authjs.csrf-token',
+  'authjs.session-token',
+  'authjs.callback-url',
+  'authjs.csrf-token',
+]
+
+type ExpiredAuthCookieOptions = {
+  cookieDomain: string
+  requestCookieNames?: Iterable<string>
+}
+
+type AuthCookieClearSpec = {
+  name: string
+  domain?: string
+}
+
+function isAuthCookieName(name: string): boolean {
+  const normalizedName = name.toLowerCase()
+  return AUTH_COOKIE_PATTERNS.some((pattern) => normalizedName.includes(pattern.toLowerCase()))
+}
+
+function normalizeCookieDomain(cookieDomain: string): string {
+  const normalized = cookieDomain.trim().toLowerCase()
+  if (normalized.startsWith('.')) {
+    return normalized.slice(1)
+  }
+  return normalized
+}
+
+function getCookieDomainsForName(name: string, cookieDomain: string): Array<string | undefined> {
+  const domains: Array<string | undefined> = [undefined]
+
+  if (name.startsWith('__Host-')) {
+    return domains
+  }
+
+  const normalizedDomain = normalizeCookieDomain(cookieDomain)
+  if (normalizedDomain.length === 0) {
+    return domains
+  }
+
+  domains.push(`.${normalizedDomain}`)
+
+  if (normalizedDomain.endsWith('targonglobal.com') && normalizedDomain !== 'targonglobal.com') {
+    domains.push('.targonglobal.com')
+  }
+
+  return Array.from(new Set(domains))
+}
+
+function collectAuthCookieNames(requestCookieNames: Iterable<string> = []): string[] {
+  const names = new Set(KNOWN_AUTH_COOKIE_NAMES)
+
+  for (const name of requestCookieNames) {
+    if (isAuthCookieName(name)) {
+      names.add(name)
+    }
+  }
+
+  return Array.from(names)
+}
+
+export function buildExpiredAuthCookieSpecs(options: ExpiredAuthCookieOptions): AuthCookieClearSpec[] {
+  const specs: AuthCookieClearSpec[] = []
+
+  for (const name of collectAuthCookieNames(options.requestCookieNames)) {
+    for (const domain of getCookieDomainsForName(name, options.cookieDomain)) {
+      specs.push(domain === undefined ? { name } : { name, domain })
+    }
+  }
+
+  return specs
+}
+
+export function serializeExpiredAuthCookie(spec: AuthCookieClearSpec): string {
+  const domainSegment = spec.domain === undefined ? '' : ` Domain=${spec.domain};`
+  return `${spec.name}=;${domainSegment} Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax`
+}
+
+export function buildExpiredAuthCookieHeaders(options: ExpiredAuthCookieOptions): string[] {
+  return buildExpiredAuthCookieSpecs(options).map(serializeExpiredAuthCookie)
+}
+
+export function appendExpiredAuthCookieHeaders(
+  response: { headers: Headers },
+  options: ExpiredAuthCookieOptions,
+): void {
+  for (const header of buildExpiredAuthCookieHeaders(options)) {
+    response.headers.append('Set-Cookie', header)
+  }
+}

--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start -p 3200",
     "type-check": "tsc --noEmit",
-    "test:auth-smoke": "playwright test --grep \"portal login|stale encrypted session|authenticated launcher\"",
+    "test:auth-smoke": "playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",
     "test:e2e": "playwright test",
     "test:hosted-smoke": "PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",
     "postinstall": "node ../../scripts/link-prisma-client-auth.js"

--- a/apps/sso/tests/login.spec.ts
+++ b/apps/sso/tests/login.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
 
+import { buildExpiredAuthCookieHeaders } from '../lib/auth-cookie-clear'
 import { portalBaseUrl, sessionCookieName } from './fixtures/dev-login'
 
 const staleSessionSecret = 'playwright-stale-session-secret-111111111111'
@@ -74,4 +75,23 @@ test('portal recovers from a stale encrypted session cookie and still redirects 
     .join('\n')
 
   expect(sessionSetCookieHeader).toContain(`${sessionCookieName}=;`)
+})
+
+test('auth cleanup clears legacy parent-domain session cookies', () => {
+  const headers = buildExpiredAuthCookieHeaders({
+    cookieDomain: '.os.targonglobal.com',
+    requestCookieNames: ['__Secure-next-auth.session-token'],
+  })
+
+  const matchingHeaders = headers.filter((header) => header.startsWith('__Secure-next-auth.session-token=;'))
+
+  expect(matchingHeaders).toContain(
+    '__Secure-next-auth.session-token=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax',
+  )
+  expect(matchingHeaders).toContain(
+    '__Secure-next-auth.session-token=; Domain=.os.targonglobal.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax',
+  )
+  expect(matchingHeaders).toContain(
+    '__Secure-next-auth.session-token=; Domain=.targonglobal.com; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; HttpOnly; Secure; SameSite=Lax',
+  )
 })


### PR DESCRIPTION
## Summary
- clear auth cookies via explicit Set-Cookie headers so same-name cookies with different domains are all expired
- remove legacy parent-domain .targonglobal.com SSO cookies that can shadow .os.targonglobal.com sessions
- add the regression to the SSO auth smoke grep so CI runs it

## Verification
- pnpm --filter @targon/sso type-check
- pnpm --filter @targon/sso test:auth-smoke
- APP_CHANGED_SINCE=origin/dev pnpm lint
- APP_CHANGED_SINCE=origin/dev pnpm build