### PR TITLE
fix(plutus): handle low value goods settlement tax

### DIFF
--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -133,13 +133,23 @@ function feeTypeMemoForShipment(feeType: string): string | null {
   return null;
 }
 
+const MARKETPLACE_PRINCIPAL_WITHHELD_CHARGE_TYPES = new Set([
+  'MarketplaceFacilitatorTax-Principal',
+  'LowValueGoodsTax-Principal',
+]);
+
+const MARKETPLACE_SHIPPING_WITHHELD_CHARGE_TYPES = new Set([
+  'MarketplaceFacilitatorTax-Shipping',
+  'LowValueGoodsTax-Shipping',
+]);
+
 function withheldChargeMemo(chargeType: string, context: 'shipment' | 'refund'): string | null {
-  if (chargeType === 'MarketplaceFacilitatorTax-Principal') {
+  if (MARKETPLACE_PRINCIPAL_WITHHELD_CHARGE_TYPES.has(chargeType)) {
     return context === 'shipment'
       ? 'Amazon Sales Tax - Marketplace Facilitator Tax - (Principal)'
       : 'Amazon Sales Tax - Refunded Marketplace Facilitator Tax - (Principal)';
   }
-  if (chargeType === 'MarketplaceFacilitatorTax-Shipping') {
+  if (MARKETPLACE_SHIPPING_WITHHELD_CHARGE_TYPES.has(chargeType)) {
     return context === 'shipment'
       ? 'Amazon Sales Tax - Marketplace Facilitator Tax - (Shipping)'
       : 'Amazon Sales Tax - Refunded Marketplace Facilitator Tax - (Shipping)';

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1063,6 +1063,53 @@ test('US settlement SP-API paths do not gate month splitting on runtime env', ()
   }
 });
 
+test('buildUsSettlementDraftFromSpApiFinances maps low value goods withheld tax', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-LVG-1',
+    eventGroupId: 'GROUP-LVG-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: 9 },
+    },
+    events: {
+      ShipmentEventList: [
+        {
+          PostedDate: '2026-04-03T08:00:00.000Z',
+          AmazonOrderId: 'ORDER-LVG-1',
+          ShipmentItemList: [
+            {
+              SellerSKU: 'SKU-LVG-1',
+              QuantityShipped: 1,
+              ItemChargeList: [
+                { ChargeType: 'Principal', ChargeAmount: { CurrencyCode: 'USD', CurrencyAmount: 10 } },
+              ],
+              ItemTaxWithheldList: [
+                {
+                  TaxesWithheld: [
+                    {
+                      ChargeType: 'LowValueGoodsTax-Principal',
+                      ChargeAmount: { CurrencyCode: 'USD', CurrencyAmount: -1 },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    skuToBrandName: new Map([['SKU-LVG-1', 'Brand A']]),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(
+    draft.segments[0]?.memoTotalsCents.get('Amazon Sales Tax - Marketplace Facilitator Tax - (Principal)'),
+    -100,
+  );
+});
+
 test('buildUkSettlementDraftFromSpApiFinances always splits multi-month settlements into monthly segments with rollovers', () => {
   const draft = buildUkSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-SPLIT-UK-1',


### PR DESCRIPTION
## Summary
- Treat US SP-API `LowValueGoodsTax-Principal` and `LowValueGoodsTax-Shipping` as marketplace facilitator withheld tax.
- Add a regression test for the low-value-goods principal tax case that blocked reposting settlement `26003231841`.

## Root Cause
The US settlement builder only recognized `MarketplaceFacilitatorTax-*` withheld tax charge types. Amazon returned `LowValueGoodsTax-Principal` for the target settlement, causing the sync builder to throw before it could post the split entries.

## Verification
- `pnpm --filter @targon/plutus test`
- `pnpm --filter @targon/plutus type-check`
- `pnpm --filter @targon/plutus lint`