### PR TITLE
fix(plutus): handle reversal reimbursement adjustments

### DIFF
--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -202,6 +202,8 @@ function adjustmentMemo(event: SpApiAdjustmentEvent): string | null {
   if (type === 'ReserveDebit') return 'Amazon Reserved Balances - Current Reserve Amount';
   if (type === 'WAREHOUSE_DAMAGE') return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Warehouse Damage';
   if (type === 'MISSING_FROM_INBOUND') return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Missing From Inbound';
+  if (type === 'REVERSAL_REIMBURSEMENT')
+    return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement';
   return null;
 }
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1148,6 +1148,37 @@ test('buildUsSettlementDraftFromSpApiFinances maps refunded shipping tax', () =>
   );
 });
 
+test('buildUsSettlementDraftFromSpApiFinances maps reversal reimbursement adjustments', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-REVERSAL-REIMBURSEMENT-1',
+    eventGroupId: 'GROUP-REVERSAL-REIMBURSEMENT-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -3 },
+    },
+    events: {
+      AdjustmentEventList: [
+        {
+          PostedDate: '2026-04-04T08:00:00.000Z',
+          AdjustmentType: 'REVERSAL_REIMBURSEMENT',
+          AdjustmentAmount: { CurrencyCode: 'USD', CurrencyAmount: -3 },
+        },
+      ],
+    },
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(
+    draft.segments[0]?.memoTotalsCents.get(
+      'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement',
+    ),
+    -300,
+  );
+});
+
 test('buildUkSettlementDraftFromSpApiFinances always splits multi-month settlements into monthly segments with rollovers', () => {
   const draft = buildUkSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-SPLIT-UK-1',


### PR DESCRIPTION
## Summary
- map US SP-API REVERSAL_REIMBURSEMENT adjustments to the existing reversal reimbursement memo
- add regression coverage for the settlement builder path that blocked settlement 26003231841

## Validation
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint

## Live remediation context
The guarded live repair failed before posting or deleting any QBO journal entries because the US builder did not recognize REVERSAL_REIMBURSEMENT. The old combined JE 1101 remains intact until the repair script can post and verify the split replacement JEs.
