### PR TITLE
fix(plutus): promote reversal reimbursement handling

### DIFF
--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -202,6 +202,8 @@ function adjustmentMemo(event: SpApiAdjustmentEvent): string | null {
   if (type === 'ReserveDebit') return 'Amazon Reserved Balances - Current Reserve Amount';
   if (type === 'WAREHOUSE_DAMAGE') return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Warehouse Damage';
   if (type === 'MISSING_FROM_INBOUND') return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Missing From Inbound';
+  if (type === 'REVERSAL_REIMBURSEMENT')
+    return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement';
   return null;
 }
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1148,6 +1148,37 @@ test('buildUsSettlementDraftFromSpApiFinances maps refunded shipping tax', () =>
   );
 });
 
+test('buildUsSettlementDraftFromSpApiFinances maps reversal reimbursement adjustments', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-REVERSAL-REIMBURSEMENT-1',
+    eventGroupId: 'GROUP-REVERSAL-REIMBURSEMENT-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -3 },
+    },
+    events: {
+      AdjustmentEventList: [
+        {
+          PostedDate: '2026-04-04T08:00:00.000Z',
+          AdjustmentType: 'REVERSAL_REIMBURSEMENT',
+          AdjustmentAmount: { CurrencyCode: 'USD', CurrencyAmount: -3 },
+        },
+      ],
+    },
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(
+    draft.segments[0]?.memoTotalsCents.get(
+      'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement',
+    ),
+    -300,
+  );
+});
+
 test('buildUkSettlementDraftFromSpApiFinances always splits multi-month settlements into monthly segments with rollovers', () => {
   const draft = buildUkSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-SPLIT-UK-1',


### PR DESCRIPTION
## Summary
- promote the Plutus US reversal reimbursement parser fix from dev to main
- unblocks settlement 26003231841 live repair after the SP-API adjustment type blocked sync before QBO posting

## Validation
- dev PR #5016 passed CI
- local Plutus checks passed on the feature branch: test, type-check, lint
