### PR TITLE
fix(plutus): handle free replacement refund items

### DIFF
--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -204,6 +204,8 @@ function adjustmentMemo(event: SpApiAdjustmentEvent): string | null {
   if (type === 'MISSING_FROM_INBOUND') return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Missing From Inbound';
   if (type === 'REVERSAL_REIMBURSEMENT')
     return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement';
+  if (type === 'FREE_REPLACEMENT_REFUND_ITEMS')
+    return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Free Replacement Refund Items';
   return null;
 }
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1179,6 +1179,37 @@ test('buildUsSettlementDraftFromSpApiFinances maps reversal reimbursement adjust
   );
 });
 
+test('buildUsSettlementDraftFromSpApiFinances maps free replacement refund item adjustments', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-FREE-REPLACEMENT-REFUND-1',
+    eventGroupId: 'GROUP-FREE-REPLACEMENT-REFUND-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -4 },
+    },
+    events: {
+      AdjustmentEventList: [
+        {
+          PostedDate: '2026-04-04T08:00:00.000Z',
+          AdjustmentType: 'FREE_REPLACEMENT_REFUND_ITEMS',
+          AdjustmentAmount: { CurrencyCode: 'USD', CurrencyAmount: -4 },
+        },
+      ],
+    },
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(
+    draft.segments[0]?.memoTotalsCents.get(
+      'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Free Replacement Refund Items',
+    ),
+    -400,
+  );
+});
+
 test('buildUkSettlementDraftFromSpApiFinances always splits multi-month settlements into monthly segments with rollovers', () => {
   const draft = buildUkSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-SPLIT-UK-1',


### PR DESCRIPTION
## Summary
- map US SP-API FREE_REPLACEMENT_REFUND_ITEMS adjustments to the existing free replacement refund item memo
- add regression coverage for the settlement builder path that blocked settlement 26003231841

## Validation
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint

## Live remediation context
The guarded live repair failed before QBO posting/deletion on FREE_REPLACEMENT_REFUND_ITEMS. The old combined JE 1101 remains intact until the split replacement entries are posted and verified.
