### PR TITLE
fix(plutus): promote liquidation settlement event handling

### DIFF
--- a/apps/plutus/lib/amazon-finances/types.ts
+++ b/apps/plutus/lib/amazon-finances/types.ts
@@ -128,6 +128,25 @@ export type SpApiServiceFeeEvent = {
   FeeList?: SpApiFeeComponent[];
 };
 
+export type SpApiRemovalShipmentItem = {
+  Quantity?: number;
+  FulfillmentNetworkSKU?: string;
+  RemovalShipmentItemId?: string;
+  FeeAmount?: SpApiMoney;
+  Revenue?: SpApiMoney;
+  TaxAmount?: SpApiMoney;
+  TaxWithheld?: SpApiMoney;
+  TaxCollectionModel?: string;
+};
+
+export type SpApiRemovalShipmentEvent = {
+  OrderId?: string;
+  MerchantOrderId?: string;
+  PostedDate?: string;
+  TransactionType?: string;
+  RemovalShipmentItemList?: SpApiRemovalShipmentItem[];
+};
+
 export type SpApiProductAdsPaymentEvent = {
   postedDate?: string;
   transactionType?: string;
@@ -142,6 +161,7 @@ export type SpApiFinancialEvents = {
   RefundEventList?: SpApiRefundEvent[];
   AdjustmentEventList?: SpApiAdjustmentEvent[];
   ServiceFeeEventList?: SpApiServiceFeeEvent[];
+  RemovalShipmentEventList?: SpApiRemovalShipmentEvent[];
   ProductAdsPaymentEventList?: SpApiProductAdsPaymentEvent[];
   AdhocDisbursementEventList?: Array<{
     TransactionType?: string;

--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -190,6 +190,7 @@ function serviceFeeMemo(feeType: string): string | null {
   if (feeType === 'AmazonUpstreamProcessingFee') return 'Amazon FBA Fees - AWD Processing Fee';
   if (feeType === 'AmazonUpstreamStorageTransportationFee') return 'Amazon FBA Fees - AWD Transportation Fee';
   if (feeType === 'FBAPerUnitFulfillmentFee') return 'Amazon FBA Fees - FBA Pick & Pack Fee Adjustment';
+  if (feeType === 'FBADisposalFee') return 'Amazon FBA Fees - FBA Pick & Pack Fee Adjustment';
   if (feeType === 'FBAStorageFee') return 'Amazon Storage Fees - Storage Fee';
   if (feeType === 'STARStorageFee') return 'Amazon Storage Fees - AWD Storage Fee';
   if (feeType === 'FBAWeightBasedFee') return null;
@@ -206,6 +207,8 @@ function adjustmentMemo(event: SpApiAdjustmentEvent): string | null {
     return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement';
   if (type === 'FREE_REPLACEMENT_REFUND_ITEMS')
     return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Free Replacement Refund Items';
+  if (type === 'COMPENSATED_CLAWBACK')
+    return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Compensated Clawback';
   return null;
 }
 
@@ -542,6 +545,75 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
       description: memo,
       netCents: cents,
     });
+  }
+
+  // Removal shipment liquidations
+  for (const removal of input.events.RemovalShipmentEventList ?? []) {
+    const postedDate = requirePostedDate(removal.PostedDate, 'RemovalShipmentEvent');
+    const localIsoDay = isoTimestampToZonedIsoDay(postedDate, timeZone, 'RemovalShipmentEvent.PostedDate');
+    const segment = requireSegmentForIsoDay(localIsoDay);
+
+    const transactionType = typeof removal.TransactionType === 'string' ? removal.TransactionType : '';
+    if (transactionType !== 'CUSTOMER_RETURN_BASED_WHOLESALE_LIQUIDATION') {
+      throw new Error(`Unhandled removal shipment transaction type: ${transactionType}`);
+    }
+
+    const orderId = typeof removal.OrderId === 'string' ? removal.OrderId : '';
+    const items = removal.RemovalShipmentItemList ?? [];
+    for (const item of items) {
+      const skuRaw = typeof item.FulfillmentNetworkSKU === 'string' ? item.FulfillmentNetworkSKU : '';
+      const qty = typeof item.Quantity === 'number' && Number.isInteger(item.Quantity) ? item.Quantity : 0;
+
+      const taxAmount = item.TaxAmount;
+      if (taxAmount) {
+        const taxCents = moneyToCents(taxAmount, 'Removal shipment tax amount');
+        if (taxCents !== 0) throw new Error(`Unhandled nonzero removal shipment tax amount: ${taxCents}`);
+      }
+
+      const taxWithheld = item.TaxWithheld;
+      if (taxWithheld) {
+        const withheldCents = moneyToCents(taxWithheld, 'Removal shipment tax withheld');
+        if (withheldCents !== 0) throw new Error(`Unhandled nonzero removal shipment tax withheld: ${withheldCents}`);
+      }
+
+      const revenue = item.Revenue;
+      if (revenue) {
+        const cents = moneyToCents(revenue, 'Removal shipment revenue');
+        if (cents !== 0) {
+          const memo = 'Amazon Sales - Removal Shipment Revenue';
+          addCents(segment.memoTotalsCents, memo, cents);
+          segment.auditRows.push({
+            invoiceId: segment.docNumber,
+            market: 'us',
+            date: localIsoDay,
+            orderId,
+            sku: skuRaw,
+            quantity: qty,
+            description: memo,
+            netCents: cents,
+          });
+        }
+      }
+
+      const feeAmount = item.FeeAmount;
+      if (feeAmount) {
+        const cents = moneyToCents(feeAmount, 'Removal shipment fee amount');
+        if (cents !== 0) {
+          const memo = 'Amazon FBA Fees - Removal Shipment Fee';
+          addCents(segment.memoTotalsCents, memo, cents);
+          segment.auditRows.push({
+            invoiceId: segment.docNumber,
+            market: 'us',
+            date: localIsoDay,
+            orderId,
+            sku: skuRaw,
+            quantity: 0,
+            description: memo,
+            netCents: cents,
+          });
+        }
+      }
+    }
   }
 
   // Service fees (no PostedDate; assign to last segment)

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1210,6 +1210,103 @@ test('buildUsSettlementDraftFromSpApiFinances maps free replacement refund item 
   );
 });
 
+test('buildUsSettlementDraftFromSpApiFinances maps compensated clawback adjustments', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-COMPENSATED-CLAWBACK-1',
+    eventGroupId: 'GROUP-COMPENSATED-CLAWBACK-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -4.26 },
+    },
+    events: {
+      AdjustmentEventList: [
+        {
+          PostedDate: '2026-04-04T08:00:00.000Z',
+          AdjustmentType: 'COMPENSATED_CLAWBACK',
+          AdjustmentAmount: { CurrencyCode: 'USD', CurrencyAmount: -4.26 },
+        },
+      ],
+    },
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(
+    draft.segments[0]?.memoTotalsCents.get(
+      'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Compensated Clawback',
+    ),
+    -426,
+  );
+});
+
+test('buildUsSettlementDraftFromSpApiFinances maps FBA disposal service fees', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-FBA-DISPOSAL-1',
+    eventGroupId: 'GROUP-FBA-DISPOSAL-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: -2.27 },
+    },
+    events: {
+      ServiceFeeEventList: [
+        {
+          FeeList: [
+            {
+              FeeType: 'FBADisposalFee',
+              FeeAmount: { CurrencyCode: 'USD', CurrencyAmount: -2.27 },
+            },
+          ],
+        },
+      ],
+    },
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(draft.segments[0]?.memoTotalsCents.get('Amazon FBA Fees - FBA Pick & Pack Fee Adjustment'), -227);
+});
+
+test('buildUsSettlementDraftFromSpApiFinances maps removal shipment liquidation revenue and fees', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-REMOVAL-LIQUIDATION-1',
+    eventGroupId: 'GROUP-REMOVAL-LIQUIDATION-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: 0.24 },
+    },
+    events: {
+      RemovalShipmentEventList: [
+        {
+          OrderId: 'ORDER-REMOVAL-LIQUIDATION-1',
+          PostedDate: '2026-04-04T08:00:00.000Z',
+          TransactionType: 'CUSTOMER_RETURN_BASED_WHOLESALE_LIQUIDATION',
+          RemovalShipmentItemList: [
+            {
+              FulfillmentNetworkSKU: 'FNSKU-REMOVAL-1',
+              Quantity: 1,
+              FeeAmount: { CurrencyCode: 'USD', CurrencyAmount: -0.46 },
+              Revenue: { CurrencyCode: 'USD', CurrencyAmount: 0.7 },
+              TaxAmount: { CurrencyCode: 'USD', CurrencyAmount: 0 },
+              TaxWithheld: { CurrencyCode: 'USD', CurrencyAmount: 0 },
+            },
+          ],
+        },
+      ],
+    } as any,
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(draft.segments[0]?.memoTotalsCents.get('Amazon Sales - Removal Shipment Revenue'), 70);
+  assert.equal(draft.segments[0]?.memoTotalsCents.get('Amazon FBA Fees - Removal Shipment Fee'), -46);
+});
+
 test('buildUkSettlementDraftFromSpApiFinances always splits multi-month settlements into monthly segments with rollovers', () => {
   const draft = buildUkSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-SPLIT-UK-1',


### PR DESCRIPTION
## Summary
- promote Plutus US settlement liquidation/adjustment event handling from dev to main
- includes compensated clawbacks, FBA disposal service fees, and removal shipment liquidation revenue/fees

## Validation
- dev PR #5022 passed CI
- local Plutus checks passed on the feature branch: test, type-check, lint
- read-only live sync for settlement 26003231841 with postToQbo=false returned 1 settlement, 2 segments, 0 errors
