### PR TITLE
fix(talos): repair export and warehouse list flows

### DIFF
--- a/apps/talos/src/app/api/finance/export/cost-ledger/route.test.ts
+++ b/apps/talos/src/app/api/finance/export/cost-ledger/route.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+async function loadRouteModule() {
+  process.env.NEXT_PUBLIC_APP_URL = 'https://os.targonglobal.com/talos'
+  process.env.PORTAL_AUTH_URL = 'https://os.targonglobal.com'
+  process.env.NEXT_PUBLIC_PORTAL_AUTH_URL = 'https://os.targonglobal.com'
+  process.env.NEXTAUTH_URL = 'https://os.targonglobal.com/talos'
+  process.env.NEXTAUTH_SECRET = 'test-nextauth-secret'
+  process.env.PORTAL_AUTH_SECRET = 'test-portal-auth-secret'
+  process.env.COOKIE_DOMAIN = 'localhost'
+
+  return import('./route')
+}
+
+test('cost-ledger export builds a self-fetch URL inside the Talos base path', async () => {
+  const { buildCostLedgerRequestUrl } = await loadRouteModule()
+
+  const requestUrl =
+    'https://os.targonglobal.com/talos/api/finance/export/cost-ledger?startDate=2026-04-01&endDate=2026-04-30&groupBy=week&warehouseCode=LAX'
+
+  const result = buildCostLedgerRequestUrl(requestUrl)
+
+  assert.equal(
+    result,
+    'https://os.targonglobal.com/talos/api/finance/cost-ledger?startDate=2026-04-01&endDate=2026-04-30&groupBy=week&warehouseCode=LAX'
+  )
+})

--- a/apps/talos/src/app/api/finance/export/cost-ledger/route.ts
+++ b/apps/talos/src/app/api/finance/export/cost-ledger/route.ts
@@ -7,25 +7,33 @@ import type { CostLedgerGroupResult, CostLedgerBucketTotals } from '@targon/ledg
 export const dynamic = 'force-dynamic'
 export const maxDuration = 60 // Allow up to 60 seconds for large exports
 
+export function buildCostLedgerRequestUrl(requestUrl: string): string {
+ const url = new URL(requestUrl)
+ url.pathname = url.pathname.replace('/api/finance/export/cost-ledger', '/api/finance/cost-ledger')
+ return url.toString()
+}
+
 export const GET = withAuth(async (request, session) => {
  try {
  // Fetch the cost ledger data using the same logic as the main route
  const searchParams = request.nextUrl.searchParams
- const costLedgerUrl = new URL('/api/finance/cost-ledger', request.url)
- 
- // Pass through all search params
- searchParams.forEach((value, key) => {
- costLedgerUrl.searchParams.set(key, value)
- })
-
- const costLedgerResponse = await fetch(costLedgerUrl.toString(), {
- headers: {
- cookie: request.headers.get('cookie') || ''
+ const headers = new Headers()
+ const cookieHeader = request.headers.get('cookie')
+ if (cookieHeader !== null) {
+ headers.set('cookie', cookieHeader)
  }
+
+ const costLedgerResponse = await fetch(buildCostLedgerRequestUrl(request.url), {
+ headers,
  })
 
  if (!costLedgerResponse.ok) {
  throw new Error('Failed to fetch cost ledger data')
+ }
+
+ const contentType = costLedgerResponse.headers.get('content-type')
+ if (contentType === null || !contentType.includes('application/json')) {
+ throw new Error(`Expected JSON from cost ledger route, received ${contentType}`)
  }
 
  const data = await costLedgerResponse.json()

--- a/apps/talos/src/app/api/transactions/[id]/route.ts
+++ b/apps/talos/src/app/api/transactions/[id]/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server'
 import { withAuthAndParams } from '@/lib/api/auth-wrapper'
 import { getTenantPrisma } from '@/lib/tenant/server'
-import { withBasePath } from '@/lib/utils/base-path'
 import { Prisma } from '@targon/prisma-talos'
 import { getS3Service } from '@/services/s3.service'
 
@@ -112,6 +111,12 @@ function normalizeAttachmentRecord(value: unknown): Record<string, ApiAttachment
  }
 
  return result
+}
+
+export function buildTransactionValidationUrl(requestUrl: string): string {
+ const url = new URL(requestUrl)
+ url.pathname = `${url.pathname}/validate-edit`
+ return url.toString()
 }
 
 async function addPresignedUrls(
@@ -314,11 +319,14 @@ export const DELETE = withAuthAndParams(async (request, params, session) => {
 
  const prisma = await getTenantPrisma()
  // First validate if this transaction can be deleted
-  const validationResponse = await fetch(withBasePath(`/api/transactions/${id}/validate-edit`), {
+ const headers = new Headers()
+ const cookieHeader = request.headers.get('cookie')
+ if (cookieHeader !== null) {
+ headers.set('Cookie', cookieHeader)
+ }
+  const validationResponse = await fetch(buildTransactionValidationUrl(request.url), {
   method: 'GET',
-  headers: {
-  'Cookie': request.headers.get('cookie') || ''
-  }
+  headers
   })
 
 

--- a/apps/talos/src/app/api/transactions/validation-url.test.ts
+++ b/apps/talos/src/app/api/transactions/validation-url.test.ts
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+async function loadRouteModule() {
+  process.env.NEXT_PUBLIC_APP_URL = 'https://os.targonglobal.com/talos'
+  process.env.PORTAL_AUTH_URL = 'https://os.targonglobal.com'
+  process.env.NEXT_PUBLIC_PORTAL_AUTH_URL = 'https://os.targonglobal.com'
+  process.env.NEXTAUTH_URL = 'https://os.targonglobal.com/talos'
+  process.env.NEXTAUTH_SECRET = 'test-nextauth-secret'
+  process.env.PORTAL_AUTH_SECRET = 'test-portal-auth-secret'
+  process.env.COOKIE_DOMAIN = 'localhost'
+
+  return import('./[id]/route')
+}
+
+test('transaction delete builds a validation URL inside the Talos base path', async () => {
+  const { buildTransactionValidationUrl } = await loadRouteModule()
+
+  const result = buildTransactionValidationUrl(
+    'https://os.targonglobal.com/talos/api/transactions/tx_123'
+  )
+
+  assert.equal(result, 'https://os.targonglobal.com/talos/api/transactions/tx_123/validate-edit')
+})

--- a/apps/talos/src/app/api/warehouses/list-query.test.ts
+++ b/apps/talos/src/app/api/warehouses/list-query.test.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { warehouseListSelect } from './list-query'
+
+test('warehouse list query excludes billingConfig from the selected columns', () => {
+  assert.equal('billingConfig' in warehouseListSelect, false)
+})

--- a/apps/talos/src/app/api/warehouses/list-query.ts
+++ b/apps/talos/src/app/api/warehouses/list-query.ts
@@ -1,0 +1,23 @@
+import type { Prisma } from '@targon/prisma-talos'
+
+export const warehouseListSelect = {
+  id: true,
+  code: true,
+  name: true,
+  address: true,
+  latitude: true,
+  longitude: true,
+  contactEmail: true,
+  contactPhone: true,
+  kind: true,
+  isActive: true,
+  rateListAttachment: true,
+  createdAt: true,
+  updatedAt: true,
+  _count: {
+    select: {
+      users: true,
+      costRates: true,
+    },
+  },
+} satisfies Prisma.WarehouseSelect

--- a/apps/talos/src/app/api/warehouses/route.ts
+++ b/apps/talos/src/app/api/warehouses/route.ts
@@ -2,6 +2,7 @@ import { withAuth, withRole, ApiResponses, z } from '@/lib/api'
 import { getTenantPrisma } from '@/lib/tenant/server'
 import { Prisma, WarehouseKind } from '@targon/prisma-talos'
 import { sanitizeForDisplay, validateAlphanumeric } from '@/lib/security/input-sanitization'
+import { warehouseListSelect } from './list-query'
 export const dynamic = 'force-dynamic'
 
 const optionalEmailSchema = z.preprocess(val => {
@@ -127,14 +128,7 @@ export const GET = withAuth(async (req, _session) => {
   const warehouses = await prisma.warehouse.findMany({
     where,
     orderBy: { name: 'asc' },
-    include: {
-      _count: {
-        select: {
-          users: true,
-          costRates: true,
-        },
-      },
-    },
+    select: warehouseListSelect,
   })
 
   // Get transaction counts for all warehouses in a single query

--- a/apps/talos/src/app/operations/cost-ledger/export.test.ts
+++ b/apps/talos/src/app/operations/cost-ledger/export.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { parseCostLedgerExportResponse } from './export'
+
+test('cost-ledger export parses the presigned download response payload', async () => {
+  const response = {
+    ok: true,
+    json: async () => ({
+      downloadUrl: 'https://downloads.targonglobal.com/cost-ledger.xlsx',
+      filename: 'cost-ledger-2026-04-16.xlsx',
+    }),
+  }
+
+  const result = await parseCostLedgerExportResponse(response as never)
+
+  assert.deepEqual(result, {
+    downloadUrl: 'https://downloads.targonglobal.com/cost-ledger.xlsx',
+    filename: 'cost-ledger-2026-04-16.xlsx',
+  })
+})
+
+test('cost-ledger export rejects a payload without a download url', async () => {
+  const response = {
+    ok: true,
+    json: async () => ({
+      filename: 'cost-ledger-2026-04-16.xlsx',
+    }),
+  }
+
+  await assert.rejects(() => parseCostLedgerExportResponse(response as never), /download url/i)
+})

--- a/apps/talos/src/app/operations/cost-ledger/export.ts
+++ b/apps/talos/src/app/operations/cost-ledger/export.ts
@@ -1,0 +1,33 @@
+type CostLedgerExportPayload = {
+  downloadUrl: string
+  filename: string
+}
+
+type JsonResponseLike = Pick<Response, 'ok' | 'json'>
+
+export async function parseCostLedgerExportResponse(
+  response: JsonResponseLike
+): Promise<CostLedgerExportPayload> {
+  if (!response.ok) {
+    throw new Error('Failed to export cost ledger')
+  }
+
+  const payload = await response.json()
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('Cost ledger export response is not a JSON object')
+  }
+
+  const record = payload as Record<string, unknown>
+  if (typeof record.downloadUrl !== 'string') {
+    throw new Error('Cost ledger export response is missing a download URL')
+  }
+
+  if (typeof record.filename !== 'string') {
+    throw new Error('Cost ledger export response is missing a filename')
+  }
+
+  return {
+    downloadUrl: record.downloadUrl,
+    filename: record.filename,
+  }
+}

--- a/apps/talos/src/app/operations/cost-ledger/page.tsx
+++ b/apps/talos/src/app/operations/cost-ledger/page.tsx
@@ -24,6 +24,7 @@ import { toast } from 'react-hot-toast'
 import type { CostLedgerBucketTotals, CostLedgerGroupResult } from '@targon/ledger'
 import { redirectToPortal } from '@/lib/portal'
 import { withBasePath } from '@/lib/utils/base-path'
+import { parseCostLedgerExportResponse } from './export'
 import { usePageState } from '@/lib/store'
 
 const baseFilterInputClass =
@@ -280,15 +281,13 @@ export default function CostLedgerPage() {
         return
       }
 
-      const blob = await response.blob()
-      const url = window.URL.createObjectURL(blob)
+      const { downloadUrl, filename } = await parseCostLedgerExportResponse(response)
       const link = document.createElement('a')
-      link.href = url
-      link.download = `cost-ledger-${filters.startDate}-to-${filters.endDate}.csv`
+      link.href = downloadUrl
+      link.download = filename
       document.body.appendChild(link)
       link.click()
       link.remove()
-      window.URL.revokeObjectURL(url)
     } catch (_error) {
       toast.error('Failed to export cost ledger')
     } finally {


### PR DESCRIPTION
## Summary
- preserve Talos base-path-aware self-fetch URLs in the cost-ledger export and transaction validation flows
- align the cost-ledger client export flow with the JSON presigned-download response contract
- narrow the warehouse list query to fields that exist in the live database schema and add regression tests

## Verification
- pnpm --filter @targon/talos exec tsx --test src/app/api/finance/export/cost-ledger/route.test.ts src/app/operations/cost-ledger/export.test.ts src/app/api/warehouses/list-query.test.ts src/app/api/transactions/validation-url.test.ts
- pnpm --filter @targon/talos type-check
- pnpm --filter @targon/talos lint