### PR TITLE
fix(talos): finish po legacy cleanup

### DIFF
--- a/apps/talos/prisma/migrations/20260417103000_remove_po_legacy_terminal_statuses/migration.sql
+++ b/apps/talos/prisma/migrations/20260417103000_remove_po_legacy_terminal_statuses/migration.sql
@@ -1,0 +1,65 @@
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "purchase_orders"
+    WHERE "status"::text IN ('SHIPPED', 'CLOSED', 'REJECTED')
+  ) THEN
+    RAISE EXCEPTION 'Legacy purchase-order terminal statuses still exist. Resolve SHIPPED/CLOSED/REJECTED rows before running this migration.';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "purchase_order_documents"
+    WHERE "stage"::text = 'SHIPPED'
+  ) THEN
+    RAISE EXCEPTION 'Legacy shipped-stage purchase-order documents still exist. Resolve SHIPPED document rows before running this migration.';
+  END IF;
+END
+$$;
+
+ALTER TYPE "PurchaseOrderStatus" RENAME TO "PurchaseOrderStatus_old";
+
+CREATE TYPE "PurchaseOrderStatus" AS ENUM (
+  'ISSUED',
+  'MANUFACTURING',
+  'OCEAN',
+  'WAREHOUSE',
+  'CANCELLED',
+  'ARCHIVED',
+  'RFQ',
+  'AWAITING_PROOF',
+  'REVIEW',
+  'POSTED'
+);
+
+ALTER TABLE "purchase_orders" ALTER COLUMN "status" DROP DEFAULT;
+
+ALTER TABLE "purchase_orders"
+ALTER COLUMN "status" TYPE "PurchaseOrderStatus"
+USING ("status"::text::"PurchaseOrderStatus");
+
+ALTER TABLE "purchase_orders" ALTER COLUMN "status" SET DEFAULT 'ISSUED';
+
+DROP TYPE "PurchaseOrderStatus_old";
+
+ALTER TYPE "PurchaseOrderDocumentStage" RENAME TO "PurchaseOrderDocumentStage_old";
+
+CREATE TYPE "PurchaseOrderDocumentStage" AS ENUM (
+  'DRAFT',
+  'RFQ',
+  'ISSUED',
+  'MANUFACTURING',
+  'OCEAN',
+  'WAREHOUSE'
+);
+
+ALTER TABLE "purchase_order_documents"
+ALTER COLUMN "stage" TYPE "PurchaseOrderDocumentStage"
+USING ("stage"::text::"PurchaseOrderDocumentStage");
+
+DROP TYPE "PurchaseOrderDocumentStage_old";

--- a/apps/talos/prisma/schema.prisma
+++ b/apps/talos/prisma/schema.prisma
@@ -995,15 +995,11 @@ enum PurchaseOrderStatus {
   CANCELLED
   ARCHIVED
 
-  // Legacy status compatibility values retained for current Talos compile/read support.
-  // These cannot be removed until reviewed legacy resolution and broader read cleanup land.
+  // Non-terminal compatibility values retained for read normalization and older flows.
   RFQ
-  SHIPPED
-  REJECTED
   AWAITING_PROOF
   REVIEW
   POSTED
-  CLOSED
 
   @@map("PurchaseOrderStatus")
 }
@@ -1066,12 +1062,12 @@ enum OutboundShipMode {
 }
 
 enum PurchaseOrderDocumentStage {
+  DRAFT // Dormant compatibility only. Active Talos uploads start at ISSUED.
   RFQ
   ISSUED
   MANUFACTURING
   OCEAN
   WAREHOUSE
-  SHIPPED // Legacy outbound document-stage compatibility only
 
   @@map("PurchaseOrderDocumentStage")
 }

--- a/apps/talos/scripts/maintenance/cleanup-legacy-purchase-orders.ts
+++ b/apps/talos/scripts/maintenance/cleanup-legacy-purchase-orders.ts
@@ -25,7 +25,6 @@ const LEGACY_STATUSES: PurchaseOrderStatus[] = [
   PurchaseOrderStatus.AWAITING_PROOF,
   PurchaseOrderStatus.REVIEW,
   PurchaseOrderStatus.POSTED,
-  PurchaseOrderStatus.CLOSED,
   PurchaseOrderStatus.ARCHIVED,
 ]
 
@@ -116,7 +115,7 @@ Usage:
 
 Options:
   --tenant=US|UK|ALL        Which tenant(s) to process (default: ALL)
-  --mode=void               Set legacy orders to CANCELLED/CLOSED (default)
+  --mode=void               Set legacy orders to CANCELLED (default)
   --mode=hard-delete        Delete legacy purchase orders after cleanup
   --limit=N                 Process at most N orders per tenant (default: unlimited)
   --apply                   Apply changes (default: dry-run)
@@ -184,12 +183,10 @@ async function runTenant(tenant: TenantCode, options: ScriptOptions) {
         if (!current) return
 
         const previousStatus = current.status as PurchaseOrderStatus
-        const isPosted = previousStatus === PurchaseOrderStatus.POSTED
-
         if (options.mode === 'void') {
-          const targetStatus = isPosted ? PurchaseOrderStatus.CLOSED : PurchaseOrderStatus.CANCELLED
+          const targetStatus = PurchaseOrderStatus.CANCELLED
 
-          if (!isPosted) {
+          if (previousStatus !== PurchaseOrderStatus.POSTED) {
             await tx.inventoryTransaction.deleteMany({
               where: { purchaseOrderId: order.id },
             })
@@ -206,14 +203,14 @@ async function runTenant(tenant: TenantCode, options: ScriptOptions) {
             where: { id: order.id },
             data: {
               status: targetStatus,
-              postedAt: targetStatus === PurchaseOrderStatus.CLOSED ? current.postedAt : null,
+              postedAt: current.postedAt,
             },
           })
           return
         }
 
         if (options.mode === 'hard-delete') {
-          if (!isPosted) {
+          if (previousStatus !== PurchaseOrderStatus.POSTED) {
             await tx.inventoryTransaction.deleteMany({
               where: { purchaseOrderId: order.id },
             })

--- a/apps/talos/scripts/migrations/add-purchase-order-document-table.ts
+++ b/apps/talos/scripts/migrations/add-purchase-order-document-table.ts
@@ -94,7 +94,7 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
           WHERE n.nspname = current_schema()
             AND t.typname = 'PurchaseOrderDocumentStage'
         ) THEN
-          EXECUTE 'CREATE TYPE "PurchaseOrderDocumentStage" AS ENUM (''DRAFT'', ''ISSUED'', ''MANUFACTURING'', ''OCEAN'', ''WAREHOUSE'', ''SHIPPED'')';
+          EXECUTE 'CREATE TYPE "PurchaseOrderDocumentStage" AS ENUM (''DRAFT'', ''ISSUED'', ''MANUFACTURING'', ''OCEAN'', ''WAREHOUSE'')';
         END IF;
       END $$;
     `,

--- a/apps/talos/scripts/migrations/backfill-uk-batch-documents.ts
+++ b/apps/talos/scripts/migrations/backfill-uk-batch-documents.ts
@@ -48,6 +48,14 @@ const MIGRATION_USER_NAME = 'Talos Migration'
 const SHARED_DRIVES_ROOT =
   '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives'
 
+type S3PurchaseOrderDocumentStage =
+  | 'RFQ'
+  | 'ISSUED'
+  | 'MANUFACTURING'
+  | 'OCEAN'
+  | 'WAREHOUSE'
+  | 'SHIPPED'
+
 const IGNORE_DIR_NAMES = new Set([
   'inspection',
   'photos',
@@ -368,6 +376,27 @@ function buildOrderNumber(tenant: TenantCode, batchIdRaw: string, variant: strin
   return `INV-${normalizedBatch}-${normalizedVariant}-${tenant}`
 }
 
+function toS3PurchaseOrderDocumentStage(
+  stage: string
+): S3PurchaseOrderDocumentStage {
+  switch (stage) {
+    case 'DRAFT':
+      return 'ISSUED'
+    case 'RFQ':
+      return 'RFQ'
+    case 'ISSUED':
+      return 'ISSUED'
+    case 'MANUFACTURING':
+      return 'MANUFACTURING'
+    case 'OCEAN':
+      return 'OCEAN'
+    case 'WAREHOUSE':
+      return 'WAREHOUSE'
+  }
+
+  throw new Error(`Unsupported purchase-order document stage for S3 upload: ${stage}`)
+}
+
 async function uploadPurchaseOrderDocument(params: {
   prisma: Prisma.TransactionClient
   tenant: TenantCode
@@ -400,13 +429,14 @@ async function uploadPurchaseOrderDocument(params: {
 
   const fileName = path.basename(params.filePath)
   const fileBuffer = fs.readFileSync(params.filePath)
+  const s3Stage = toS3PurchaseOrderDocumentStage(params.stage)
   const s3Key = params.s3.generateKey(
     {
       type: 'purchase-order',
       purchaseOrderId: params.purchaseOrderId,
       tenantCode: params.tenant,
       purchaseOrderNumber: params.purchaseOrderNumber,
-      stage: params.stage,
+      stage: s3Stage,
       documentType: params.documentType,
     },
     fileName

--- a/apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts
+++ b/apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts
@@ -354,7 +354,10 @@ const baselineChecks: SchemaCheck[] = [
   ]),
   buildRequiredEnumValuesCheck('PurchaseOrderStatus enum values', 'PurchaseOrderStatus', [
     'ISSUED',
-    'REJECTED',
+    'MANUFACTURING',
+    'OCEAN',
+    'WAREHOUSE',
+    'CANCELLED',
   ]),
   buildRequiredColumnsCheck('purchase_orders stage fields', 'purchase_orders', [
     'incoterms',
@@ -701,7 +704,10 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
 
     // Purchase order essentials (stage 1 / issued)
     `ALTER TYPE "PurchaseOrderStatus" ADD VALUE IF NOT EXISTS 'ISSUED'`,
-    `ALTER TYPE "PurchaseOrderStatus" ADD VALUE IF NOT EXISTS 'REJECTED'`,
+    `ALTER TYPE "PurchaseOrderStatus" ADD VALUE IF NOT EXISTS 'MANUFACTURING'`,
+    `ALTER TYPE "PurchaseOrderStatus" ADD VALUE IF NOT EXISTS 'OCEAN'`,
+    `ALTER TYPE "PurchaseOrderStatus" ADD VALUE IF NOT EXISTS 'WAREHOUSE'`,
+    `ALTER TYPE "PurchaseOrderStatus" ADD VALUE IF NOT EXISTS 'CANCELLED'`,
     `ALTER TABLE "purchase_orders" ADD COLUMN IF NOT EXISTS "incoterms" text`,
     `ALTER TABLE "purchase_orders" ADD COLUMN IF NOT EXISTS "payment_terms" text`,
     `ALTER TABLE "purchase_orders" ADD COLUMN IF NOT EXISTS "counterparty_address" text`,

--- a/apps/talos/src/app/api/purchase-orders/[id]/documents/presigned-url/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/documents/presigned-url/route.ts
@@ -5,58 +5,28 @@ import { getCurrentTenantCode, getTenantPrisma } from '@/lib/tenant/server'
 import { getS3Service } from '@/services/s3.service'
 import { validateFile } from '@/lib/security/file-upload'
 import { enforceCrossTenantManufacturingOnlyForPurchaseOrder } from '@/lib/services/purchase-order-cross-tenant-access'
-import { PurchaseOrderDocumentStage, PurchaseOrderStatus } from '@targon/prisma-talos'
+import { PurchaseOrderStatus } from '@targon/prisma-talos'
 import { toPublicOrderNumber } from '@/lib/services/purchase-order-utils'
 import { ApiResponses } from '@/lib/api'
 import { assertPurchaseOrderMutable } from '@/lib/purchase-orders/workflow'
+import {
+  getPurchaseOrderDocumentStageForStatus,
+  parseActivePurchaseOrderDocumentStage,
+  PURCHASE_ORDER_DOCUMENT_STAGE_ORDER,
+  type ActivePurchaseOrderDocumentStage,
+} from '@/lib/purchase-orders/document-stages'
 
 export const dynamic = 'force-dynamic'
 
 const MAX_DOCUMENT_SIZE_MB = 1024
 const DISABLE_PO_DOCUMENT_STAGE_LOCK = process.env.TALOS_DISABLE_PO_DOCUMENT_STAGE_LOCK === 'true'
 
-const STAGES: readonly PurchaseOrderDocumentStage[] = [
-  'ISSUED',
-  'MANUFACTURING',
-  'OCEAN',
-  'WAREHOUSE',
-  'SHIPPED',
-]
-
-const DOCUMENT_STAGE_ORDER: Record<PurchaseOrderDocumentStage, number> = {
-  RFQ: 0, // Legacy; treat as ISSUED
-  ISSUED: 0,
-  MANUFACTURING: 1,
-  OCEAN: 2,
-  WAREHOUSE: 3,
-  SHIPPED: 4,
+function statusToDocumentStage(status: PurchaseOrderStatus): ActivePurchaseOrderDocumentStage | null {
+  return getPurchaseOrderDocumentStageForStatus(status)
 }
 
-function statusToDocumentStage(status: PurchaseOrderStatus): PurchaseOrderDocumentStage | null {
-  switch (status) {
-    case PurchaseOrderStatus.RFQ:
-      return PurchaseOrderDocumentStage.ISSUED
-    case PurchaseOrderStatus.ISSUED:
-      return PurchaseOrderDocumentStage.ISSUED
-    case PurchaseOrderStatus.MANUFACTURING:
-      return PurchaseOrderDocumentStage.MANUFACTURING
-    case PurchaseOrderStatus.OCEAN:
-      return PurchaseOrderDocumentStage.OCEAN
-    case PurchaseOrderStatus.WAREHOUSE:
-      return PurchaseOrderDocumentStage.WAREHOUSE
-    case PurchaseOrderStatus.SHIPPED:
-      return PurchaseOrderDocumentStage.SHIPPED
-    default:
-      return null
-  }
-}
-
-function parseStage(value: unknown): PurchaseOrderDocumentStage | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return (STAGES as readonly string[]).includes(trimmed)
-    ? (trimmed as PurchaseOrderDocumentStage)
-    : null
+function parseStage(value: unknown): ActivePurchaseOrderDocumentStage | null {
+  return parseActivePurchaseOrderDocumentStage(value)
 }
 
 function parseDocumentType(value: unknown): string | null {
@@ -144,7 +114,11 @@ export const POST = withAuthAndParams(async (request, params, session) => {
 
     if (!DISABLE_PO_DOCUMENT_STAGE_LOCK) {
       const currentStage = statusToDocumentStage(order.status as PurchaseOrderStatus)
-      if (currentStage && DOCUMENT_STAGE_ORDER[stage] < DOCUMENT_STAGE_ORDER[currentStage]) {
+      if (
+        currentStage &&
+        PURCHASE_ORDER_DOCUMENT_STAGE_ORDER[stage] <
+          PURCHASE_ORDER_DOCUMENT_STAGE_ORDER[currentStage]
+      ) {
         return NextResponse.json(
           { error: `Documents for completed stages are locked (current stage: ${order.status})` },
           { status: 409 }

--- a/apps/talos/src/app/api/purchase-orders/[id]/documents/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/documents/route.ts
@@ -6,10 +6,17 @@ import { getS3Service } from '@/services/s3.service'
 import { validateFile, scanFileContent } from '@/lib/security/file-upload'
 import { auditLog } from '@/lib/security/audit-logger'
 import { enforceCrossTenantManufacturingOnlyForPurchaseOrder } from '@/lib/services/purchase-order-cross-tenant-access'
-import { PurchaseOrderDocumentStage, Prisma, PurchaseOrderStatus } from '@targon/prisma-talos'
+import { Prisma, PurchaseOrderStatus } from '@targon/prisma-talos'
 import { toPublicOrderNumber } from '@/lib/services/purchase-order-utils'
 import { ApiResponses } from '@/lib/api'
 import { assertPurchaseOrderMutable } from '@/lib/purchase-orders/workflow'
+import {
+  getActivePurchaseOrderDocumentStageFromStoredStage,
+  getPurchaseOrderDocumentStageForStatus,
+  parseActivePurchaseOrderDocumentStage,
+  PURCHASE_ORDER_DOCUMENT_STAGE_ORDER,
+  type ActivePurchaseOrderDocumentStage,
+} from '@/lib/purchase-orders/document-stages'
 
 export const dynamic = 'force-dynamic'
 export const maxDuration = 300 // 5 minutes for large file uploads (up to 1GB)
@@ -17,48 +24,12 @@ export const maxDuration = 300 // 5 minutes for large file uploads (up to 1GB)
 const MAX_DOCUMENT_SIZE_MB = 1024
 const DISABLE_PO_DOCUMENT_STAGE_LOCK = process.env.TALOS_DISABLE_PO_DOCUMENT_STAGE_LOCK === 'true'
 
-const STAGES: readonly PurchaseOrderDocumentStage[] = [
-  'ISSUED',
-  'MANUFACTURING',
-  'OCEAN',
-  'WAREHOUSE',
-  'SHIPPED',
-]
-
-const DOCUMENT_STAGE_ORDER: Record<PurchaseOrderDocumentStage, number> = {
-  RFQ: 0, // Legacy; treat as ISSUED
-  ISSUED: 0,
-  MANUFACTURING: 1,
-  OCEAN: 2,
-  WAREHOUSE: 3,
-  SHIPPED: 4,
+function statusToDocumentStage(status: PurchaseOrderStatus): ActivePurchaseOrderDocumentStage | null {
+  return getPurchaseOrderDocumentStageForStatus(status)
 }
 
-function statusToDocumentStage(status: PurchaseOrderStatus): PurchaseOrderDocumentStage | null {
-  switch (status) {
-    case PurchaseOrderStatus.RFQ:
-      return PurchaseOrderDocumentStage.ISSUED
-    case PurchaseOrderStatus.ISSUED:
-      return PurchaseOrderDocumentStage.ISSUED
-    case PurchaseOrderStatus.MANUFACTURING:
-      return PurchaseOrderDocumentStage.MANUFACTURING
-    case PurchaseOrderStatus.OCEAN:
-      return PurchaseOrderDocumentStage.OCEAN
-    case PurchaseOrderStatus.WAREHOUSE:
-      return PurchaseOrderDocumentStage.WAREHOUSE
-    case PurchaseOrderStatus.SHIPPED:
-      return PurchaseOrderDocumentStage.SHIPPED
-    default:
-      return null
-  }
-}
-
-function parseStage(value: unknown): PurchaseOrderDocumentStage | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return (STAGES as readonly string[]).includes(trimmed)
-    ? (trimmed as PurchaseOrderDocumentStage)
-    : null
+function parseStage(value: unknown): ActivePurchaseOrderDocumentStage | null {
+  return parseActivePurchaseOrderDocumentStage(value)
 }
 
 function parseDocumentType(value: unknown): string | null {
@@ -74,7 +45,7 @@ function parseDocumentType(value: unknown): string | null {
 
 export const POST = withAuthAndParams(async (request, params, session) => {
   let purchaseOrderId: string | null = null
-  let stage: PurchaseOrderDocumentStage | null = null
+  let stage: ActivePurchaseOrderDocumentStage | null = null
   let documentType: string | null = null
   let fileName: string | null = null
   let fileType: string | null = null
@@ -192,7 +163,12 @@ export const POST = withAuthAndParams(async (request, params, session) => {
 
     if (!DISABLE_PO_DOCUMENT_STAGE_LOCK) {
       const currentStage = statusToDocumentStage(order.status as PurchaseOrderStatus)
-      if (currentStage && stage && DOCUMENT_STAGE_ORDER[stage] < DOCUMENT_STAGE_ORDER[currentStage]) {
+      if (
+        currentStage &&
+        stage &&
+        PURCHASE_ORDER_DOCUMENT_STAGE_ORDER[stage] <
+          PURCHASE_ORDER_DOCUMENT_STAGE_ORDER[currentStage]
+      ) {
         return NextResponse.json(
           { error: `Documents for completed stages are locked (current stage: ${order.status})` },
           { status: 409 }
@@ -257,7 +233,7 @@ export const POST = withAuthAndParams(async (request, params, session) => {
           purchaseOrderId: id,
           tenantCode,
           purchaseOrderNumber,
-          stage: stage as PurchaseOrderDocumentStage,
+          stage,
           documentType: documentType as string,
         },
         (file as File).name
@@ -269,7 +245,7 @@ export const POST = withAuthAndParams(async (request, params, session) => {
           purchaseOrderId: id,
           tenantCode,
           purchaseOrderNumber,
-          stage: stage as PurchaseOrderDocumentStage,
+          stage,
           documentType: documentType as string,
           uploadedBy: session.user.id,
         },
@@ -284,7 +260,7 @@ export const POST = withAuthAndParams(async (request, params, session) => {
     const compositeKey = {
       purchaseOrderId_stage_documentType: {
         purchaseOrderId: id,
-        stage: stage as PurchaseOrderDocumentStage,
+        stage,
         documentType: documentType as string,
       },
     }
@@ -316,7 +292,7 @@ export const POST = withAuthAndParams(async (request, params, session) => {
       where: compositeKey,
       create: {
         purchaseOrderId: id,
-        stage: stage as PurchaseOrderDocumentStage,
+        stage,
         documentType: documentType as string,
         fileName: fileName as string,
         contentType: fileType as string,
@@ -445,7 +421,7 @@ export const GET = withAuthAndParams(async (request, params, _session) => {
 
         return {
           id: doc.id,
-          stage: doc.stage === PurchaseOrderDocumentStage.RFQ ? PurchaseOrderDocumentStage.ISSUED : doc.stage,
+          stage: getActivePurchaseOrderDocumentStageFromStoredStage(doc.stage),
           documentType: doc.documentType,
           fileName: doc.fileName,
           contentType: doc.contentType,

--- a/apps/talos/src/app/api/purchase-orders/[id]/documents/upload-proxy/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/documents/upload-proxy/route.ts
@@ -5,11 +5,17 @@ import { getCurrentTenantCode, getTenantPrisma } from '@/lib/tenant/server'
 import { getS3Service } from '@/services/s3.service'
 import { scanFileContent, validateFile } from '@/lib/security/file-upload'
 import { enforceCrossTenantManufacturingOnlyForPurchaseOrder } from '@/lib/services/purchase-order-cross-tenant-access'
-import { PurchaseOrderDocumentStage, PurchaseOrderStatus } from '@targon/prisma-talos'
+import { PurchaseOrderStatus } from '@targon/prisma-talos'
 import { toPublicOrderNumber } from '@/lib/services/purchase-order-utils'
 import { Readable, Transform } from 'node:stream'
 import { ApiResponses } from '@/lib/api'
 import { assertPurchaseOrderMutable } from '@/lib/purchase-orders/workflow'
+import {
+  getPurchaseOrderDocumentStageForStatus,
+  parseActivePurchaseOrderDocumentStage,
+  PURCHASE_ORDER_DOCUMENT_STAGE_ORDER,
+  type ActivePurchaseOrderDocumentStage,
+} from '@/lib/purchase-orders/document-stages'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -19,48 +25,12 @@ const MAX_DOCUMENT_SIZE_MB = 1024
 const MAX_SNIFF_BYTES = 16 * 1024
 const DISABLE_PO_DOCUMENT_STAGE_LOCK = process.env.TALOS_DISABLE_PO_DOCUMENT_STAGE_LOCK === 'true'
 
-const STAGES: readonly PurchaseOrderDocumentStage[] = [
-  'ISSUED',
-  'MANUFACTURING',
-  'OCEAN',
-  'WAREHOUSE',
-  'SHIPPED',
-]
-
-const DOCUMENT_STAGE_ORDER: Record<PurchaseOrderDocumentStage, number> = {
-  RFQ: 0, // Legacy; treat as ISSUED
-  ISSUED: 0,
-  MANUFACTURING: 1,
-  OCEAN: 2,
-  WAREHOUSE: 3,
-  SHIPPED: 4,
+function statusToDocumentStage(status: PurchaseOrderStatus): ActivePurchaseOrderDocumentStage | null {
+  return getPurchaseOrderDocumentStageForStatus(status)
 }
 
-function statusToDocumentStage(status: PurchaseOrderStatus): PurchaseOrderDocumentStage | null {
-  switch (status) {
-    case PurchaseOrderStatus.RFQ:
-      return PurchaseOrderDocumentStage.ISSUED
-    case PurchaseOrderStatus.ISSUED:
-      return PurchaseOrderDocumentStage.ISSUED
-    case PurchaseOrderStatus.MANUFACTURING:
-      return PurchaseOrderDocumentStage.MANUFACTURING
-    case PurchaseOrderStatus.OCEAN:
-      return PurchaseOrderDocumentStage.OCEAN
-    case PurchaseOrderStatus.WAREHOUSE:
-      return PurchaseOrderDocumentStage.WAREHOUSE
-    case PurchaseOrderStatus.SHIPPED:
-      return PurchaseOrderDocumentStage.SHIPPED
-    default:
-      return null
-  }
-}
-
-function parseStage(value: unknown): PurchaseOrderDocumentStage | null {
-  if (typeof value !== 'string') return null
-  const trimmed = value.trim()
-  return (STAGES as readonly string[]).includes(trimmed)
-    ? (trimmed as PurchaseOrderDocumentStage)
-    : null
+function parseStage(value: unknown): ActivePurchaseOrderDocumentStage | null {
+  return parseActivePurchaseOrderDocumentStage(value)
 }
 
 function parseDocumentType(value: unknown): string | null {
@@ -80,7 +50,7 @@ class UploadValidationError extends Error {
 
 export const PUT = withAuthAndParams(async (request, params, session) => {
   let purchaseOrderId: string | null = null
-  let stage: PurchaseOrderDocumentStage | null = null
+  let stage: ActivePurchaseOrderDocumentStage | null = null
   let documentType: string | null = null
   let fileName: string | null = null
   let fileType: string | null = null
@@ -210,7 +180,11 @@ export const PUT = withAuthAndParams(async (request, params, session) => {
 
     if (!DISABLE_PO_DOCUMENT_STAGE_LOCK) {
       const currentStage = statusToDocumentStage(order.status as PurchaseOrderStatus)
-      if (currentStage && DOCUMENT_STAGE_ORDER[parsedStage] < DOCUMENT_STAGE_ORDER[currentStage]) {
+      if (
+        currentStage &&
+        PURCHASE_ORDER_DOCUMENT_STAGE_ORDER[parsedStage] <
+          PURCHASE_ORDER_DOCUMENT_STAGE_ORDER[currentStage]
+      ) {
         return NextResponse.json(
           { error: `Documents for completed stages are locked (current stage: ${order.status})` },
           { status: 409 }

--- a/apps/talos/src/app/api/purchase-orders/[id]/pdf/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/pdf/route.ts
@@ -5,6 +5,7 @@ import { getPurchaseOrderById } from '@/lib/services/purchase-order-service'
 import { toPublicOrderNumber } from '@/lib/services/purchase-order-utils'
 import { getCurrentTenant, getTenantPrisma } from '@/lib/tenant/server'
 import { BUYER_LEGAL_ENTITY, getBuyerVatNumber } from '@/lib/config/legal-entity'
+import { resolvePurchaseOrderDestination } from '@/lib/purchase-orders/destination'
 
 export const runtime = 'nodejs'
 export const dynamic = 'force-dynamic'
@@ -846,6 +847,14 @@ export const GET = withAuthAndParams(async (_request, params, _session) => {
         select: { name: true, address: true },
       })
     : null
+  const destination = resolvePurchaseOrderDestination(
+    {
+      warehouseName: order.warehouseName,
+      shipToName: order.shipToName,
+      shipToAddress: order.shipToAddress,
+    },
+    destinationWarehouse
+  )
 
   const documentNumber = toPublicOrderNumber(order.poNumber ?? order.orderNumber)
 
@@ -920,8 +929,8 @@ export const GET = withAuthAndParams(async (_request, params, _session) => {
     expectedDate: order.expectedDate,
     incoterms: order.incoterms,
     paymentTerms: order.paymentTerms,
-    destinationName: destinationWarehouse?.name ?? order.warehouseName ?? null,
-    destinationAddress: destinationWarehouse?.address ?? null,
+    destinationName: destination.name,
+    destinationAddress: destination.address,
     notes: order.notes,
     lines,
   })

--- a/apps/talos/src/app/api/purchase-orders/[id]/pdf/route.ts
+++ b/apps/talos/src/app/api/purchase-orders/[id]/pdf/route.ts
@@ -114,8 +114,8 @@ function renderOrderDocumentHtml(params: {
   inspectionDate?: Date | null
   incoterms?: string | null
   paymentTerms?: string | null
-  shipToName?: string | null
-  shipToAddress?: string | null
+  destinationName?: string | null
+  destinationAddress?: string | null
   notes?: string | null
   lines: Array<{
     skuCode: string
@@ -189,15 +189,15 @@ function renderOrderDocumentHtml(params: {
     return normalizedLines
   }
 
-  const shipToName = params.shipToName && params.shipToName.trim().length > 0
-    ? params.shipToName
+  const destinationName = params.destinationName && params.destinationName.trim().length > 0
+    ? params.destinationName
     : params.buyerName
 
-  const shipToAddressHtml = (() => {
+  const destinationAddressHtml = (() => {
     const lines: string[] = []
 
-    if (params.shipToAddress && params.shipToAddress.trim().length > 0) {
-      lines.push(...normalizeAddressLines(params.shipToAddress, shipToName))
+    if (params.destinationAddress && params.destinationAddress.trim().length > 0) {
+      lines.push(...normalizeAddressLines(params.destinationAddress, destinationName))
     } else {
       const line1 = buyerAddressLines.slice(0, 2).join(', ')
       if (line1) lines.push(line1)
@@ -699,8 +699,8 @@ function renderOrderDocumentHtml(params: {
         </div>
         <div class="party">
           <div class="party-label">Ship To</div>
-          <div class="party-name">${escapeHtml(shipToName)}</div>
-          <div class="party-address">${shipToAddressHtml}</div>
+          <div class="party-name">${escapeHtml(destinationName)}</div>
+          <div class="party-address">${destinationAddressHtml}</div>
         </div>
       </div>
 
@@ -840,6 +840,12 @@ export const GET = withAuthAndParams(async (_request, params, _session) => {
 
   const tenant = await getCurrentTenant()
   const buyerVatNumber = getBuyerVatNumber(tenant.code)
+  const destinationWarehouse = order.warehouseCode
+    ? await prisma.warehouse.findUnique({
+        where: { code: order.warehouseCode },
+        select: { name: true, address: true },
+      })
+    : null
 
   const documentNumber = toPublicOrderNumber(order.poNumber ?? order.orderNumber)
 
@@ -914,8 +920,8 @@ export const GET = withAuthAndParams(async (_request, params, _session) => {
     expectedDate: order.expectedDate,
     incoterms: order.incoterms,
     paymentTerms: order.paymentTerms,
-    shipToName: order.shipToName,
-    shipToAddress: order.shipToAddress ?? null,
+    destinationName: destinationWarehouse?.name ?? order.warehouseName ?? null,
+    destinationAddress: destinationWarehouse?.address ?? null,
     notes: order.notes,
     lines,
   })

--- a/apps/talos/src/app/api/suppliers/route.ts
+++ b/apps/talos/src/app/api/suppliers/route.ts
@@ -229,11 +229,7 @@ export const DELETE = withAuth(async (request, session) => {
           mode: 'insensitive',
         },
         status: {
-          notIn: [
-            PurchaseOrderStatus.CLOSED,
-            PurchaseOrderStatus.CANCELLED,
-            PurchaseOrderStatus.REJECTED,
-          ],
+          notIn: [PurchaseOrderStatus.CANCELLED],
         },
       },
     }),

--- a/apps/talos/src/app/api/tenant/current/route.test.ts
+++ b/apps/talos/src/app/api/tenant/current/route.test.ts
@@ -1,20 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
-
-async function loadRouteModule() {
-  process.env.NEXT_PUBLIC_APP_URL = 'https://os.targonglobal.com/talos'
-  process.env.PORTAL_AUTH_URL = 'https://os.targonglobal.com'
-  process.env.NEXT_PUBLIC_PORTAL_AUTH_URL = 'https://os.targonglobal.com'
-  process.env.NEXTAUTH_URL = 'https://os.targonglobal.com/talos'
-  process.env.NEXTAUTH_SECRET = 'test-nextauth-secret'
-  process.env.PORTAL_AUTH_SECRET = 'test-portal-auth-secret'
-  process.env.COOKIE_DOMAIN = 'localhost'
-
-  return import('./route')
-}
+import { resolveCurrentTenantSelection } from './selection'
 
 test('tenant current uses portal claim memberships instead of tenant DB scans', async () => {
-  const { resolveCurrentTenantSelection } = await loadRouteModule()
   const session = {
     user: { email: 'ops@targonglobal.com' },
     authz: {
@@ -33,7 +21,6 @@ test('tenant current uses portal claim memberships instead of tenant DB scans', 
 })
 
 test('tenant current falls back to an allowed cookie tenant when no active tenant is set', async () => {
-  const { resolveCurrentTenantSelection } = await loadRouteModule()
   const session = {
     user: { email: 'ops@targonglobal.com' },
     authz: {
@@ -51,7 +38,6 @@ test('tenant current falls back to an allowed cookie tenant when no active tenan
 })
 
 test('tenant current falls back to the default tenant when the portal claim is empty', async () => {
-  const { resolveCurrentTenantSelection } = await loadRouteModule()
   const session = {
     user: { email: 'ops@targonglobal.com' },
     authz: {

--- a/apps/talos/src/app/api/tenant/current/route.ts
+++ b/apps/talos/src/app/api/tenant/current/route.ts
@@ -1,56 +1,16 @@
 import { NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
-import type { Session } from 'next-auth'
 import { auth } from '@/lib/auth'
 import {
   TENANT_COOKIE_NAME,
   TENANT_COOKIE_MAX_AGE,
-  DEFAULT_TENANT,
   isValidTenantCode,
   getTenantConfig,
   getAllTenants,
-  TenantCode,
 } from '@/lib/tenant/constants'
-import {
-  getAuthorizedTenantCodesForSession,
-  getSessionActiveTenant,
-} from '@/lib/tenant/session'
+import { resolveCurrentTenantSelection } from './selection'
 
 export const dynamic = 'force-dynamic'
-
-export function resolveCurrentTenantSelection(
-  session: Session,
-  cookieTenantCode: TenantCode | null,
-): { available: TenantCode[]; current: TenantCode } {
-  const memberships = getAuthorizedTenantCodesForSession(session)
-  const activeTenant = getSessionActiveTenant(session)
-
-  if (memberships.length === 0) {
-    return {
-      available: memberships,
-      current: DEFAULT_TENANT,
-    }
-  }
-
-  if (activeTenant && memberships.includes(activeTenant)) {
-    return {
-      available: memberships,
-      current: activeTenant,
-    }
-  }
-
-  if (cookieTenantCode && memberships.includes(cookieTenantCode)) {
-    return {
-      available: memberships,
-      current: cookieTenantCode,
-    }
-  }
-
-  return {
-    available: memberships,
-    current: memberships[0],
-  }
-}
 
 /**
  * GET /api/tenant/current

--- a/apps/talos/src/app/api/tenant/current/selection.ts
+++ b/apps/talos/src/app/api/tenant/current/selection.ts
@@ -1,0 +1,43 @@
+import type { Session } from 'next-auth'
+import {
+  DEFAULT_TENANT,
+  type TenantCode,
+} from '@/lib/tenant/constants'
+import {
+  getAuthorizedTenantCodesForSession,
+  getSessionActiveTenant,
+} from '@/lib/tenant/session'
+
+export function resolveCurrentTenantSelection(
+  session: Session,
+  cookieTenantCode: TenantCode | null,
+): { available: TenantCode[]; current: TenantCode } {
+  const memberships = getAuthorizedTenantCodesForSession(session)
+  const activeTenant = getSessionActiveTenant(session)
+
+  if (memberships.length === 0) {
+    return {
+      available: memberships,
+      current: DEFAULT_TENANT,
+    }
+  }
+
+  if (activeTenant && memberships.includes(activeTenant)) {
+    return {
+      available: memberships,
+      current: activeTenant,
+    }
+  }
+
+  if (cookieTenantCode && memberships.includes(cookieTenantCode)) {
+    return {
+      available: memberships,
+      current: cookieTenantCode,
+    }
+  }
+
+  return {
+    available: memberships,
+    current: memberships[0],
+  }
+}

--- a/apps/talos/src/app/api/tenant/select/portal-request.ts
+++ b/apps/talos/src/app/api/tenant/select/portal-request.ts
@@ -1,0 +1,22 @@
+import type { TenantCode } from '@/lib/tenant/constants'
+import { portalUrl } from '@/lib/portal'
+
+export function buildPortalActiveTenantRequest(
+  request: Request,
+  tenantCode: TenantCode,
+): {
+  url: URL
+  init: RequestInit
+} {
+  return {
+    url: portalUrl('/api/v1/session/active-tenant', request),
+    init: {
+      method: 'PUT',
+      headers: {
+        'content-type': 'application/json',
+        cookie: request.headers.get('cookie') ?? '',
+      },
+      body: JSON.stringify({ appId: 'talos', tenantCode }),
+    },
+  }
+}

--- a/apps/talos/src/app/api/tenant/select/route.test.ts
+++ b/apps/talos/src/app/api/tenant/select/route.test.ts
@@ -2,18 +2,15 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import { isTenantAllowedForSession } from '@/lib/tenant/session'
+import { buildPortalActiveTenantRequest } from './portal-request'
 
-async function loadRouteModule() {
-  process.env.NEXT_PUBLIC_APP_URL = 'https://os.targonglobal.com/talos'
-  process.env.PORTAL_AUTH_URL = 'https://os.targonglobal.com'
-  process.env.NEXT_PUBLIC_PORTAL_AUTH_URL = 'https://os.targonglobal.com'
-  process.env.NEXTAUTH_URL = 'https://os.targonglobal.com/talos'
-  process.env.NEXTAUTH_SECRET = 'test-nextauth-secret'
-  process.env.PORTAL_AUTH_SECRET = 'test-portal-auth-secret'
-  process.env.COOKIE_DOMAIN = 'localhost'
-
-  return import('./route')
-}
+process.env.NEXT_PUBLIC_APP_URL = 'https://os.targonglobal.com/talos'
+process.env.PORTAL_AUTH_URL = 'https://os.targonglobal.com'
+process.env.NEXT_PUBLIC_PORTAL_AUTH_URL = 'https://os.targonglobal.com'
+process.env.NEXTAUTH_URL = 'https://os.targonglobal.com/talos'
+process.env.NEXTAUTH_SECRET = 'test-nextauth-secret'
+process.env.PORTAL_AUTH_SECRET = 'test-portal-auth-secret'
+process.env.COOKIE_DOMAIN = 'localhost'
 
 test('tenant select rejects a tenant outside the portal claim', () => {
   const session = {
@@ -31,7 +28,6 @@ test('tenant select rejects a tenant outside the portal claim', () => {
 })
 
 test('tenant select forwards portal active-tenant persistence through the portal auth endpoint', async () => {
-  const { buildPortalActiveTenantRequest } = await loadRouteModule()
   const request = new Request('https://os.targonglobal.com/talos/api/tenant/select', {
     method: 'POST',
     headers: {

--- a/apps/talos/src/app/api/tenant/select/route.ts
+++ b/apps/talos/src/app/api/tenant/select/route.ts
@@ -2,32 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { auth } from '@/lib/auth'
 import {
-  TenantCode,
+  type TenantCode,
   isValidTenantCode,
   TENANT_COOKIE_NAME,
   TENANT_COOKIE_MAX_AGE,
   getTenantConfig,
 } from '@/lib/tenant/constants'
 import { isTenantAllowedForSession } from '@/lib/tenant/session'
+import { buildPortalActiveTenantRequest } from './portal-request'
 
 export const dynamic = 'force-dynamic'
-
-export function buildPortalActiveTenantRequest(request: Request, tenantCode: TenantCode): {
-  url: URL
-  init: RequestInit
-} {
-  return {
-    url: new URL('/api/v1/session/active-tenant', process.env.PORTAL_AUTH_URL),
-    init: {
-      method: 'PUT',
-      headers: {
-        'content-type': 'application/json',
-        cookie: request.headers.get('cookie') ?? '',
-      },
-      body: JSON.stringify({ appId: 'talos', tenantCode }),
-    },
-  }
-}
 
 /**
  * POST /api/tenant/select

--- a/apps/talos/src/app/auth/login/page.tsx
+++ b/apps/talos/src/app/auth/login/page.tsx
@@ -4,12 +4,9 @@ import { auth } from '@/lib/auth'
 import { portalOrigin } from '@/lib/portal'
 import { withoutBasePath } from '@/lib/utils/base-path'
 
-type SearchParamsInput =
- | { callbackUrl?: string }
- | Promise<{ callbackUrl?: string } | undefined>
- | undefined
+type SearchParamsInput = Promise<{ callbackUrl?: string } | undefined>
 
-export default async function LoginPage({ searchParams }: { searchParams?: SearchParamsInput }) {
+export default async function LoginPage({ searchParams }: { searchParams: SearchParamsInput }) {
  const resolved = await Promise.resolve(searchParams)
  const desiredRawInput = typeof resolved?.callbackUrl === 'string' ? resolved.callbackUrl.trim() : ''
  const desiredDefault = '/dashboard'

--- a/apps/talos/src/app/finance/cost-ledger/page.tsx
+++ b/apps/talos/src/app/finance/cost-ledger/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 type SearchParams = Record<string, string | string[] | undefined>
+type SearchParamsInput = Promise<SearchParams | undefined>
 
 function getRedirectUrl(pathname: string, searchParams: SearchParams) {
   const urlSearchParams = new URLSearchParams()
@@ -19,11 +20,11 @@ function getRedirectUrl(pathname: string, searchParams: SearchParams) {
   return query ? `${pathname}?${query}` : pathname
 }
 
-export default function CostLedgerRedirectPage({
+export default async function CostLedgerRedirectPage({
   searchParams,
 }: {
-  searchParams: SearchParams
+  searchParams: SearchParamsInput
 }) {
-  redirect(getRedirectUrl('/operations/cost-ledger', searchParams))
+  const resolvedSearchParams = (await Promise.resolve(searchParams)) ?? {}
+  redirect(getRedirectUrl('/operations/cost-ledger', resolvedSearchParams))
 }
-

--- a/apps/talos/src/app/finance/storage-ledger/page.tsx
+++ b/apps/talos/src/app/finance/storage-ledger/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation'
 
 type SearchParams = Record<string, string | string[] | undefined>
+type SearchParamsInput = Promise<SearchParams | undefined>
 
 function getRedirectUrl(pathname: string, searchParams: SearchParams) {
   const urlSearchParams = new URLSearchParams()
@@ -19,11 +20,11 @@ function getRedirectUrl(pathname: string, searchParams: SearchParams) {
   return query ? `${pathname}?${query}` : pathname
 }
 
-export default function StorageLedgerRedirectPage({
+export default async function StorageLedgerRedirectPage({
   searchParams,
 }: {
-  searchParams: SearchParams
+  searchParams: SearchParamsInput
 }) {
-  redirect(getRedirectUrl('/operations/storage-ledger', searchParams))
+  const resolvedSearchParams = (await Promise.resolve(searchParams)) ?? {}
+  redirect(getRedirectUrl('/operations/storage-ledger', resolvedSearchParams))
 }
-

--- a/apps/talos/src/app/operations/inventory/purchase-orders-panel.tsx
+++ b/apps/talos/src/app/operations/inventory/purchase-orders-panel.tsx
@@ -91,13 +91,6 @@ type PurchaseOrderStageData = {
     dutyAmount: number | null
     dutyCurrency: string | null
   }
-  shipped: {
-    shipToName: string | null
-    shippingCarrier: string | null
-    trackingNumber: string | null
-    shippedDate: string | null
-    deliveredDate: string | null
-  }
 }
 
 export interface PurchaseOrderSummary {
@@ -976,7 +969,7 @@ export function PurchaseOrdersPanel({
         break
       }
       default: {
-        // No stage-specific columns for unknown statuses (ex: legacy / shipped)
+        // No stage-specific columns for unknown statuses.
       }
     }
 

--- a/apps/talos/src/app/operations/orders/[id]/page.tsx
+++ b/apps/talos/src/app/operations/orders/[id]/page.tsx
@@ -1,5 +1,8 @@
 import { redirect } from 'next/navigation'
 
-export default function OrderRedirectPage({ params }: { params: { id: string } }) {
-  redirect(`/operations/purchase-orders/${params.id}`)
+type ParamsInput = Promise<{ id: string }>
+
+export default async function OrderRedirectPage({ params }: { params: ParamsInput }) {
+  const resolvedParams = await Promise.resolve(params)
+  redirect(`/operations/purchase-orders/${resolvedParams.id}`)
 }

--- a/apps/talos/src/app/operations/orders/page.tsx
+++ b/apps/talos/src/app/operations/orders/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 
 type SearchParamValue = string | string[] | undefined
 type SearchParams = Record<string, SearchParamValue>
+type SearchParamsInput = Promise<SearchParams | undefined>
 
 function serializeSearchParams(searchParams: SearchParams) {
   const params = new URLSearchParams()
@@ -17,12 +18,13 @@ function serializeSearchParams(searchParams: SearchParams) {
   return params.toString()
 }
 
-export default function OrdersRedirectPage({
-  searchParams = {},
+export default async function OrdersRedirectPage({
+  searchParams,
 }: {
-  searchParams?: SearchParams
+  searchParams: SearchParamsInput
 }) {
-  const queryString = serializeSearchParams(searchParams)
+  const resolvedSearchParams = (await Promise.resolve(searchParams)) ?? {}
+  const queryString = serializeSearchParams(resolvedSearchParams)
   const target = queryString
     ? `/operations/purchase-orders?${queryString}`
     : '/operations/purchase-orders'

--- a/apps/talos/src/components/purchase-orders/purchase-order-flow.tsx
+++ b/apps/talos/src/components/purchase-orders/purchase-order-flow.tsx
@@ -79,9 +79,10 @@ import {
   isPurchaseOrderReadOnlyForUi,
   normalizePurchaseOrderWorkflowStatus,
 } from '@/lib/purchase-orders/workflow'
+import { type ActivePurchaseOrderDocumentStage } from '@/lib/purchase-orders/document-stages'
 
 // 5-Stage State Machine Types
-type POStageStatus = 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED' | 'CANCELLED'
+type POStageStatus = 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'CANCELLED'
 
 interface PurchaseOrderLineSummary {
   id: string
@@ -266,23 +267,6 @@ interface StageData {
     transactionCertificate: string | null
     customsDeclaration: string | null
   }
-  shipped: {
-    shipToName: string | null
-    shipToAddress: string | null
-    shipToCity: string | null
-    shipToCountry: string | null
-    shipToPostalCode: string | null
-    shippingCarrier: string | null
-    shippingMethod: string | null
-    trackingNumber: string | null
-    shippedDate: string | null
-    proofOfDeliveryRef: string | null
-    deliveredDate: string | null
-    // Legacy
-    proofOfDelivery: string | null
-    shippedAt: string | null
-    shippedBy: string | null
-  }
 }
 
 interface ProformaInvoiceSummary {
@@ -349,11 +333,9 @@ type SplitGroupOrderSummary = {
   createdAt: string
 }
 
-type PurchaseOrderDocumentStage = 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED'
-
 interface PurchaseOrderDocumentSummary {
   id: string
-  stage: PurchaseOrderDocumentStage
+  stage: ActivePurchaseOrderDocumentStage
   documentType: string
   fileName: string
   contentType: string
@@ -439,7 +421,7 @@ function formatCurrencySummary(amounts: Partial<Record<PoCostCurrency, number>>)
 }
 
 const STAGE_DOCUMENTS: Record<
-  Exclude<PurchaseOrderDocumentStage, 'SHIPPED'>,
+  ActivePurchaseOrderDocumentStage,
   Array<{ id: string; label: string }>
 > = {
   ISSUED: [],
@@ -458,7 +440,7 @@ const STAGE_DOCUMENTS: Record<
 }
 
 function getStageDocuments(
-  stage: Exclude<PurchaseOrderDocumentStage, 'SHIPPED'>,
+  stage: ActivePurchaseOrderDocumentStage,
   lines: PurchaseOrderLineSummary[]
 ): Array<{ id: string; label: string }> {
   if (stage === 'ISSUED') {
@@ -473,14 +455,13 @@ function getStageDocuments(
 }
 
 const DOCUMENT_STAGE_META: Record<
-  PurchaseOrderDocumentStage,
+  ActivePurchaseOrderDocumentStage,
   { label: string; icon: ComponentType<{ className?: string }> }
 > = {
   ISSUED: { label: 'Issued', icon: Send },
   MANUFACTURING: { label: 'Manufacturing', icon: Factory },
   OCEAN: { label: 'Transit', icon: Ship },
   WAREHOUSE: { label: 'Warehouse', icon: Warehouse },
-  SHIPPED: { label: 'Shipped', icon: Package2 },
 }
 
 function formatDocumentTypeFallback(documentType: string) {
@@ -499,17 +480,57 @@ function buildPiDocumentType(piNumber: string): string {
 }
 
 function getDocumentLabel(
-  stage: PurchaseOrderDocumentStage,
+  stage: ActivePurchaseOrderDocumentStage,
   documentType: string,
   lines?: PurchaseOrderLineSummary[]
 ) {
-  if (stage !== 'SHIPPED') {
-    const required = lines ? getStageDocuments(stage, lines) : (STAGE_DOCUMENTS[stage] ?? [])
-    const match = required.find(candidate => candidate.id === documentType)
-    if (match) return match.label
-  }
+  const required = lines ? getStageDocuments(stage, lines) : STAGE_DOCUMENTS[stage]
+  const match = required.find(candidate => candidate.id === documentType)
+  if (match) return match.label
 
   return formatDocumentTypeFallback(documentType)
+}
+
+function getActiveDocumentStage(
+  order: Pick<PurchaseOrderSummary, 'stageData'>,
+  activeViewStage: POStageStatus
+): ActivePurchaseOrderDocumentStage {
+  if (activeViewStage !== 'CANCELLED') {
+    return activeViewStage
+  }
+
+  const warehouse = order.stageData.warehouse
+  if (
+    warehouse.warehouseCode ||
+    warehouse.receivedDate ||
+    warehouse.customsEntryNumber ||
+    warehouse.customsClearedDate
+  ) {
+    return 'WAREHOUSE'
+  }
+
+  const ocean = order.stageData.ocean
+  if (
+    ocean.houseBillOfLading ||
+    ocean.commercialInvoiceNumber ||
+    ocean.packingListRef ||
+    ocean.vesselName ||
+    ocean.portOfLoading ||
+    ocean.portOfDischarge
+  ) {
+    return 'OCEAN'
+  }
+
+  const manufacturing = order.stageData.manufacturing
+  if (
+    manufacturing.proformaInvoiceNumber ||
+    manufacturing.factoryName ||
+    manufacturing.manufacturingStartDate
+  ) {
+    return 'MANUFACTURING'
+  }
+
+  return 'ISSUED'
 }
 
 // Stage configuration
@@ -534,7 +555,7 @@ const INCOTERMS_OPTIONS = [
 ] as const
 
 function formatStatusLabel(status: POStageStatus) {
-  return PO_STATUS_LABELS[status] ?? status
+  return PO_STATUS_LABELS[status]
 }
 
 function formatDate(value: string | null) {
@@ -1000,7 +1021,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
   }>({ open: false, type: null, title: '', message: '', lineId: null })
 
   // Stage-based navigation - which stage view is currently selected
-  const [selectedStageView, setSelectedStageView] = useState<string | null>(null)
+  const [selectedStageView, setSelectedStageView] = useState<POStageStatus | null>(null)
   const [inlinePreviewDocument, setInlinePreviewDocument] =
     useState<PurchaseOrderDocumentSummary | null>(null)
   const [previewDocument, setPreviewDocument] = useState<PurchaseOrderDocumentSummary | null>(null)
@@ -1770,7 +1791,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
   const handleDocumentUpload = useCallback(
     async (
       event: ChangeEvent<HTMLInputElement>,
-      stage: PurchaseOrderDocumentStage,
+      stage: ActivePurchaseOrderDocumentStage,
       documentType: string
     ) => {
       const orderId = order?.id
@@ -2670,9 +2691,8 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
     GBP: forwardingSubtotalByCurrency.GBP,
   }
   const isTerminalStatus = order
-    ? normalizePurchaseOrderWorkflowStatus(order.status) === 'CANCELLED' || order.status === 'SHIPPED'
+    ? normalizePurchaseOrderWorkflowStatus(order.status) === 'CANCELLED'
     : false
-  const isLegacyShipmentOrder = order ? order.status === 'SHIPPED' : false
   const isReadOnly = order
     ? isPurchaseOrderReadOnlyForUi({
         status: order.status,
@@ -3172,7 +3192,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                                 </Link>
                               )}
                               <Badge variant="outline" className="text-[10px]">
-                                {formatStatusLabel(member.status)}
+                                {formatStatusLabel(getPurchaseOrderDisplayStatus(member.status))}
                               </Badge>
                             </div>
                           )
@@ -3300,9 +3320,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
               <p className="text-sm text-slate-700 dark:text-slate-300">
                 {order.postedAt
                   ? 'This order has been posted and is read-only.'
-                  : isLegacyShipmentOrder
-                    ? 'This legacy shipment order is read-only.'
-                    : 'This order is cancelled and cannot be modified.'}
+                  : 'This order is cancelled and cannot be modified.'}
               </p>
             </div>
           )}
@@ -4969,15 +4987,9 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                   ) : (
                     (() => {
                       if (!order) return null
-                      const stage = activeViewStage as PurchaseOrderDocumentStage
-                      const stageKey = stage as keyof typeof STAGE_DOCUMENTS
+                      const stage = getActiveDocumentStage(order, activeViewStage)
                       const canUpload = !isReadOnly
-                      const stageDocs = documents.filter(doc => {
-                        if (doc.stage === stage) return true
-                        if (stage !== 'WAREHOUSE') return false
-                        if (!isLegacyShipmentOrder) return false
-                        return doc.stage === 'SHIPPED'
-                      })
+                      const stageDocs = documents.filter(doc => doc.stage === stage)
                       const docsByType = new Map(stageDocs.map(doc => [doc.documentType, doc]))
                       const issuedPiNumbers =
                         stage === 'ISSUED'
@@ -5033,7 +5045,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                           ]
                         }
 
-                        const requiredDocs = getStageDocuments(stageKey, order.lines)
+                        const requiredDocs = getStageDocuments(stage, order.lines)
                         const requiredIds = new Set(requiredDocs.map(doc => doc.id))
                         const otherDocs = stageDocs.filter(
                           doc => !requiredIds.has(doc.documentType)
@@ -5049,7 +5061,7 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                           })),
                           ...otherDocs.map(doc => ({
                             id: doc.documentType,
-                            label: getDocumentLabel(doc.stage as PurchaseOrderDocumentStage, doc.documentType),
+                            label: getDocumentLabel(doc.stage, doc.documentType),
                             required: false,
                             doc,
                             gateKey: `documents.${doc.documentType}`,
@@ -7681,86 +7693,6 @@ export function PurchaseOrderFlow(props: PurchaseOrderFlowProps) {
                               )}
                             </>
                           )}
-                        </div>
-                      )
-                    })()}
-
-                    {/* Shipped Section */}
-                    {(() => {
-                      if (!isLegacyShipmentOrder || activeViewStage !== 'WAREHOUSE') return null
-                      const shipped = order.stageData.shipped
-                      const hasData =
-                        shipped?.shipToName ||
-                        shipped?.shippingCarrier ||
-                        shipped?.trackingNumber ||
-                        shipped?.shippedDate
-                      if (!hasData) return null
-                      return (
-                        <div className="pt-6 border-t border-slate-200 dark:border-slate-700">
-                          <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-4">
-                            Legacy Shipment
-                          </h4>
-                          <div className="grid grid-cols-2 gap-x-6 gap-y-3 md:grid-cols-3 lg:grid-cols-4">
-                            <div className="space-y-1 col-span-2">
-                              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                Ship To
-                              </p>
-                              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                                {formatTextOrDash(
-                                  [
-                                    shipped?.shipToName,
-                                    shipped?.shipToAddress,
-                                    shipped?.shipToCity,
-                                    shipped?.shipToCountry,
-                                  ]
-                                    .filter(Boolean)
-                                    .join(', ')
-                                )}
-                              </p>
-                            </div>
-                            <div className="space-y-1">
-                              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                Carrier
-                              </p>
-                              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                                {formatTextOrDash(shipped?.shippingCarrier)}
-                              </p>
-                            </div>
-                            <div className="space-y-1">
-                              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                Method
-                              </p>
-                              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                                {formatTextOrDash(shipped?.shippingMethod)}
-                              </p>
-                            </div>
-                            <div className="space-y-1">
-                              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                Tracking
-                              </p>
-                              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                                {formatTextOrDash(shipped?.trackingNumber)}
-                              </p>
-                            </div>
-                            <div className="space-y-1">
-                              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                Shipped Date
-                              </p>
-                              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                                {formatTextOrDash(
-                                  formatDateOnly(shipped?.shippedDate ?? shipped?.shippedAt ?? null)
-                                )}
-                              </p>
-                            </div>
-                            <div className="space-y-1">
-                              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                                Delivered Date
-                              </p>
-                              <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
-                                {formatTextOrDash(formatDateOnly(shipped?.deliveredDate ?? null))}
-                              </p>
-                            </div>
-                          </div>
                         </div>
                       )
                     })()}

--- a/apps/talos/src/lib/constants/status-mappings.ts
+++ b/apps/talos/src/lib/constants/status-mappings.ts
@@ -9,14 +9,11 @@ export type POStatus =
   | 'MANUFACTURING'
   | 'OCEAN'
   | 'WAREHOUSE'
-  | 'SHIPPED'
-  | 'REJECTED'
   | 'CANCELLED'
   | 'ARCHIVED'
   | 'AWAITING_PROOF'
   | 'REVIEW'
   | 'POSTED'
-  | 'CLOSED'
 
 export type POType = 'PURCHASE' | 'ADJUSTMENT'
 
@@ -37,14 +34,11 @@ export const PO_STATUS_BADGE_CLASSES: Record<POStatus, string> = {
   MANUFACTURING: 'bg-amber-50 text-amber-700 border border-amber-200',
   OCEAN: 'bg-blue-50 text-blue-700 border border-blue-200',
   WAREHOUSE: 'bg-purple-50 text-purple-700 border border-purple-200',
-  SHIPPED: 'bg-purple-50 text-purple-700 border border-purple-200',
-  REJECTED: 'bg-red-50 text-red-700 border border-red-200',
   CANCELLED: 'bg-red-50 text-red-700 border border-red-200',
   ARCHIVED: 'bg-slate-50 text-slate-600 border border-slate-200',
   AWAITING_PROOF: 'bg-amber-50 text-amber-700 border border-amber-200',
   REVIEW: 'bg-blue-50 text-blue-700 border border-blue-200',
   POSTED: 'bg-emerald-50 text-emerald-700 border border-emerald-200',
-  CLOSED: 'bg-red-50 text-red-700 border border-red-200',
 }
 
 /**
@@ -55,14 +49,11 @@ export const PO_STATUS_LABELS: Record<POStatus, string> = {
   MANUFACTURING: 'Manufacturing',
   OCEAN: 'Transit',
   WAREHOUSE: 'Warehouse',
-  SHIPPED: 'Warehouse',
-  REJECTED: 'Cancelled',
   CANCELLED: 'Cancelled',
   ARCHIVED: 'Archived',
   AWAITING_PROOF: 'Awaiting Proof',
   REVIEW: 'Review',
   POSTED: 'Posted',
-  CLOSED: 'Cancelled',
 }
 
 /**
@@ -145,19 +136,15 @@ export const PO_LINE_STATUS_LABELS: Record<POLineStatus, string> = {
  * Helper function to get status badge class with fallback
  */
 export function getStatusBadgeClass(status: string, type: 'po' | 'tx' | 'mn' | 'poLine'): string {
-  const fallback = 'bg-muted text-muted-foreground border border-muted'
-
   switch (type) {
     case 'po':
-      return PO_STATUS_BADGE_CLASSES[status as POStatus] ?? fallback
+      return PO_STATUS_BADGE_CLASSES[status as POStatus]
     case 'tx':
-      return TX_TYPE_BADGE_CLASSES[status as TxType] ?? fallback
+      return TX_TYPE_BADGE_CLASSES[status as TxType]
     case 'mn':
-      return GRN_STATUS_BADGE_CLASSES[status as GRNStatus] ?? fallback
+      return GRN_STATUS_BADGE_CLASSES[status as GRNStatus]
     case 'poLine':
-      return PO_LINE_STATUS_BADGE_CLASSES[status as POLineStatus] ?? fallback
-    default:
-      return fallback
+      return PO_LINE_STATUS_BADGE_CLASSES[status as POLineStatus]
   }
 }
 
@@ -167,14 +154,12 @@ export function getStatusBadgeClass(status: string, type: 'po' | 'tx' | 'mn' | '
 export function getStatusLabel(status: string, type: 'po' | 'tx' | 'mn' | 'poLine'): string {
   switch (type) {
     case 'po':
-      return PO_STATUS_LABELS[status as POStatus] ?? status
+      return PO_STATUS_LABELS[status as POStatus]
     case 'tx':
-      return TX_TYPE_LABELS[status as TxType] ?? status
+      return TX_TYPE_LABELS[status as TxType]
     case 'mn':
-      return GRN_STATUS_LABELS[status as GRNStatus] ?? status
+      return GRN_STATUS_LABELS[status as GRNStatus]
     case 'poLine':
-      return PO_LINE_STATUS_LABELS[status as POLineStatus] ?? status
-    default:
-      return status
+      return PO_LINE_STATUS_LABELS[status as POLineStatus]
   }
 }

--- a/apps/talos/src/lib/permissions/catalog.ts
+++ b/apps/talos/src/lib/permissions/catalog.ts
@@ -49,12 +49,6 @@ export const TALOS_PERMISSION_CATALOG: readonly TalosPermissionCatalogEntry[] = 
     category: 'purchase_order',
   },
   {
-    code: 'po.approve.warehouse_to_shipped',
-    name: 'Approve Warehouse To Shipped',
-    description: 'Permission to approve purchase orders from warehouse to shipped.',
-    category: 'purchase_order',
-  },
-  {
     code: 'po.cancel',
     name: 'Cancel Purchase Orders',
     description: 'Permission to cancel purchase orders.',

--- a/apps/talos/src/lib/purchase-orders/destination.ts
+++ b/apps/talos/src/lib/purchase-orders/destination.ts
@@ -1,0 +1,54 @@
+type PurchaseOrderDestinationInput = {
+  warehouseName: string | null
+  shipToName: string | null
+  shipToAddress: string | null
+}
+
+type WarehouseDestinationRecord = {
+  name: string | null
+  address: string | null
+}
+
+export type PurchaseOrderDestination = {
+  name: string | null
+  address: string | null
+}
+
+function normalizeOptionalString(value: string | null): string | null {
+  if (value === null) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return null
+  }
+
+  return trimmed
+}
+
+export function resolvePurchaseOrderDestination(
+  input: PurchaseOrderDestinationInput,
+  warehouse: WarehouseDestinationRecord | null
+): PurchaseOrderDestination {
+  const liveWarehouseName = warehouse ? normalizeOptionalString(warehouse.name) : null
+  const snapshotWarehouseName = normalizeOptionalString(input.warehouseName)
+  const legacyShipToName = normalizeOptionalString(input.shipToName)
+  const liveWarehouseAddress = warehouse ? normalizeOptionalString(warehouse.address) : null
+  const legacyShipToAddress = normalizeOptionalString(input.shipToAddress)
+
+  let name = liveWarehouseName
+  if (name === null) {
+    name = snapshotWarehouseName
+  }
+  if (name === null) {
+    name = legacyShipToName
+  }
+
+  let address = liveWarehouseAddress
+  if (address === null) {
+    address = legacyShipToAddress
+  }
+
+  return { name, address }
+}

--- a/apps/talos/src/lib/purchase-orders/document-stages.ts
+++ b/apps/talos/src/lib/purchase-orders/document-stages.ts
@@ -1,0 +1,70 @@
+export const ACTIVE_PURCHASE_ORDER_DOCUMENT_STAGES = [
+  'ISSUED',
+  'MANUFACTURING',
+  'OCEAN',
+  'WAREHOUSE',
+] as const
+
+export type ActivePurchaseOrderDocumentStage =
+  (typeof ACTIVE_PURCHASE_ORDER_DOCUMENT_STAGES)[number]
+
+export const PURCHASE_ORDER_DOCUMENT_STAGE_ORDER: Record<
+  ActivePurchaseOrderDocumentStage,
+  number
+> = {
+  ISSUED: 0,
+  MANUFACTURING: 1,
+  OCEAN: 2,
+  WAREHOUSE: 3,
+}
+
+export function isActivePurchaseOrderDocumentStage(
+  value: string
+): value is ActivePurchaseOrderDocumentStage {
+  return ACTIVE_PURCHASE_ORDER_DOCUMENT_STAGES.includes(
+    value as ActivePurchaseOrderDocumentStage
+  )
+}
+
+export function parseActivePurchaseOrderDocumentStage(
+  value: unknown
+): ActivePurchaseOrderDocumentStage | null {
+  if (typeof value !== 'string') return null
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  return isActivePurchaseOrderDocumentStage(trimmed) ? trimmed : null
+}
+
+export function getPurchaseOrderDocumentStageForStatus(
+  status: string
+): ActivePurchaseOrderDocumentStage | null {
+  if (status === 'RFQ' || status === 'ISSUED') {
+    return 'ISSUED'
+  }
+
+  if (status === 'MANUFACTURING') {
+    return 'MANUFACTURING'
+  }
+
+  if (status === 'OCEAN') {
+    return 'OCEAN'
+  }
+
+  if (status === 'WAREHOUSE') {
+    return 'WAREHOUSE'
+  }
+
+  return null
+}
+
+export function getActivePurchaseOrderDocumentStageFromStoredStage(
+  stage: string
+): ActivePurchaseOrderDocumentStage | null {
+  if (stage === 'DRAFT' || stage === 'RFQ') {
+    return 'ISSUED'
+  }
+
+  return parseActivePurchaseOrderDocumentStage(stage)
+}

--- a/apps/talos/src/lib/purchase-orders/workflow.ts
+++ b/apps/talos/src/lib/purchase-orders/workflow.ts
@@ -8,6 +8,8 @@ export const ACTIVE_PURCHASE_ORDER_STATUSES = [
   'CANCELLED',
 ] as const
 
+const LEGACY_VISIBLE_PURCHASE_ORDER_STATUSES = ['SHIPPED', 'CLOSED', 'REJECTED'] as const
+
 export const CANCELABLE_PURCHASE_ORDER_STATUSES = [
   'ISSUED',
   'MANUFACTURING',
@@ -38,6 +40,14 @@ export function getValidNextPurchaseOrderStatuses(
 
 export function getRenderablePurchaseOrderStatuses(): ActivePurchaseOrderStatus[] {
   return [...ACTIVE_PURCHASE_ORDER_STATUSES]
+}
+
+export function getVisiblePurchaseOrderStatuses(): string[] {
+  return [
+    'RFQ',
+    ...ACTIVE_PURCHASE_ORDER_STATUSES,
+    ...LEGACY_VISIBLE_PURCHASE_ORDER_STATUSES,
+  ]
 }
 
 export function isCancelablePurchaseOrderStatus(status: string): status is TransitionablePurchaseOrderStatus {

--- a/apps/talos/src/lib/services/permission-service.ts
+++ b/apps/talos/src/lib/services/permission-service.ts
@@ -365,20 +365,13 @@ export async function getAllUsersWithPermissions(): Promise<
 // Stage transition permission codes
 export const STAGE_TRANSITION_PERMISSIONS = {
   RFQ_TO_ISSUED: 'po.approve.draft_to_manufacturing',
-  RFQ_TO_REJECTED: 'po.approve.draft_to_manufacturing',
   RFQ_TO_MANUFACTURING: 'po.approve.draft_to_manufacturing',
   ISSUED_TO_MANUFACTURING: 'po.approve.draft_to_manufacturing',
-  ISSUED_TO_REJECTED: 'po.approve.draft_to_manufacturing',
-  REJECTED_TO_RFQ: 'po.approve.draft_to_manufacturing',
-  REJECTED_TO_ISSUED: 'po.approve.draft_to_manufacturing',
   // Legacy keys using DRAFT (pre-RFQ rename)
   DRAFT_TO_ISSUED: 'po.approve.draft_to_manufacturing',
-  DRAFT_TO_REJECTED: 'po.approve.draft_to_manufacturing',
   DRAFT_TO_MANUFACTURING: 'po.approve.draft_to_manufacturing',
-  REJECTED_TO_DRAFT: 'po.approve.draft_to_manufacturing',
   MANUFACTURING_TO_OCEAN: 'po.approve.manufacturing_to_ocean',
   OCEAN_TO_WAREHOUSE: 'po.approve.ocean_to_warehouse',
-  WAREHOUSE_TO_SHIPPED: 'po.approve.warehouse_to_shipped',
 } as const
 
 /**

--- a/apps/talos/src/lib/services/po-stage-service.ts
+++ b/apps/talos/src/lib/services/po-stage-service.ts
@@ -52,6 +52,7 @@ import {
   toPurchaseOrderTotalCostNumberOrNull,
 } from '@/lib/purchase-order-line-costs'
 import { calculatePalletValues } from '@/lib/utils/pallet-calculations'
+import { resolvePurchaseOrderDestination } from '@/lib/purchase-orders/destination'
 import { formatDimensionTripletCm, resolveDimensionTripletCm } from '@/lib/sku-dimensions'
 import {
   formatDimensionTripletDisplayFromCm,
@@ -3593,12 +3594,23 @@ export async function generatePurchaseOrderShippingMarks(params: {
   })
 
   const poNumber = order.poNumber ? escapeHtml(order.poNumber) : ''
-  const consigneeSource = warehouse?.name ?? order.warehouseName ?? null
+  const destinationDetails = resolvePurchaseOrderDestination(
+    {
+      warehouseName: order.warehouseName,
+      shipToName: order.shipToName,
+      shipToAddress: order.shipToAddress,
+    },
+    warehouse
+  )
+  const consigneeSource = destinationDetails.name
   const consignee =
     typeof consigneeSource === 'string' && consigneeSource.trim().length > 0
       ? escapeHtml(consigneeSource.trim())
       : ''
-  const destination = warehouse?.address ? warehouse.address.replace(/\r?\n/g, ', ') : ''
+  const destination =
+    typeof destinationDetails.address === 'string'
+      ? destinationDetails.address.replace(/\r?\n/g, ', ')
+      : ''
   const portOfDischarge = order.portOfDischarge ? escapeHtml(order.portOfDischarge) : ''
 
   const labels = activeLines.map(line => {

--- a/apps/talos/src/lib/services/po-stage-service.ts
+++ b/apps/talos/src/lib/services/po-stage-service.ts
@@ -124,28 +124,10 @@ type WarehouseStageData = {
   customsDeclaration: PurchaseOrder['customsDeclaration']
 }
 
-type ShippedStageData = {
-  shipToName: PurchaseOrder['shipToName']
-  shipToAddress: PurchaseOrder['shipToAddress']
-  shipToCity: PurchaseOrder['shipToCity']
-  shipToCountry: PurchaseOrder['shipToCountry']
-  shipToPostalCode: PurchaseOrder['shipToPostalCode']
-  shippingCarrier: PurchaseOrder['shippingCarrier']
-  shippingMethod: PurchaseOrder['shippingMethod']
-  trackingNumber: PurchaseOrder['trackingNumber']
-  shippedDate: PurchaseOrder['shippedDate']
-  proofOfDeliveryRef: PurchaseOrder['proofOfDeliveryRef']
-  deliveredDate: PurchaseOrder['deliveredDate']
-  proofOfDelivery: PurchaseOrder['proofOfDelivery']
-  shippedAt: PurchaseOrder['shippedAt']
-  shippedBy: PurchaseOrder['shippedByName']
-}
-
 type StageData = {
   manufacturing: ManufacturingStageData
   ocean: OceanStageData
   warehouse: WarehouseStageData
-  shipped: ShippedStageData
 }
 
 type SerializedStageSection<T> = {
@@ -172,9 +154,7 @@ export const VALID_TRANSITIONS: Partial<Record<PurchaseOrderStatus, PurchaseOrde
   MANUFACTURING: [PurchaseOrderStatus.OCEAN, PurchaseOrderStatus.CANCELLED],
   OCEAN: [PurchaseOrderStatus.WAREHOUSE, PurchaseOrderStatus.CANCELLED],
   WAREHOUSE: [PurchaseOrderStatus.CANCELLED],
-  SHIPPED: [], // Terminal state
   CANCELLED: [], // Terminal state
-  CLOSED: [], // Terminal state
 }
 
 function normalizeWorkflowStatus(status: PurchaseOrderStatus): PurchaseOrderStatus {
@@ -1869,12 +1849,6 @@ export async function transitionPurchaseOrderStage(
   const currentStatus = normalizeWorkflowStatus(rawStatus)
   const isInPlaceUpdate = targetStatus === currentStatus
 
-  if (!isInPlaceUpdate && targetStatus === PurchaseOrderStatus.SHIPPED) {
-    throw new ValidationError(
-      'Purchase orders no longer ship inventory. Create a fulfillment order to ship stock.'
-    )
-  }
-
   if (!isInPlaceUpdate && !isValidTransition(currentStatus, targetStatus)) {
     const validTargets = getValidNextStages(currentStatus)
     throw new ValidationError(
@@ -3518,6 +3492,13 @@ export async function generatePurchaseOrderShippingMarks(params: {
     supplierCountry = deriveSupplierCountry(supplier ? supplier.address : null)
   }
 
+  const warehouse = order.warehouseCode
+    ? await prisma.warehouse.findUnique({
+        where: { code: order.warehouseCode },
+        select: { name: true, address: true },
+      })
+    : null
+
   if (activeLines.length === 0) {
     recordGateIssue(issues, 'cargo.lines', 'At least one cargo line is required')
   }
@@ -3612,8 +3593,12 @@ export async function generatePurchaseOrderShippingMarks(params: {
   })
 
   const poNumber = order.poNumber ? escapeHtml(order.poNumber) : ''
-  const consignee = order.shipToName ? escapeHtml(order.shipToName) : ''
-  const destination = [order.shipToCity, order.shipToCountry].filter(Boolean).join(', ')
+  const consigneeSource = warehouse?.name ?? order.warehouseName ?? null
+  const consignee =
+    typeof consigneeSource === 'string' && consigneeSource.trim().length > 0
+      ? escapeHtml(consigneeSource.trim())
+      : ''
+  const destination = warehouse?.address ? warehouse.address.replace(/\r?\n/g, ', ') : ''
   const portOfDischarge = order.portOfDischarge ? escapeHtml(order.portOfDischarge) : ''
 
   const labels = activeLines.map(line => {
@@ -3857,23 +3842,6 @@ export function getStageData(order: PurchaseOrder): StageData {
       transactionCertificate: order.transactionCertificate,
       customsDeclaration: order.customsDeclaration,
     },
-    shipped: {
-      shipToName: order.shipToName,
-      shipToAddress: order.shipToAddress,
-      shipToCity: order.shipToCity,
-      shipToCountry: order.shipToCountry,
-      shipToPostalCode: order.shipToPostalCode,
-      shippingCarrier: order.shippingCarrier,
-      shippingMethod: order.shippingMethod,
-      trackingNumber: order.trackingNumber,
-      shippedDate: order.shippedDate,
-      proofOfDeliveryRef: order.proofOfDeliveryRef,
-      deliveredDate: order.deliveredDate,
-      // Legacy
-      proofOfDelivery: order.proofOfDelivery,
-      shippedAt: order.shippedAt,
-      shippedBy: order.shippedByName,
-    },
   }
 }
 
@@ -3913,13 +3881,6 @@ function serializeStageData(data: StageData): SerializedStageData {
       customsClearedDate: serializeDate(data.warehouse.customsClearedDate),
       surrenderBlDate: serializeDate(data.warehouse.surrenderBlDate),
       receivedDate: serializeDate(data.warehouse.receivedDate),
-    },
-    shipped: {
-      ...data.shipped,
-      shippedDate: serializeDate(data.shipped.shippedDate),
-      deliveredDate: serializeDate(data.shipped.deliveredDate),
-      // Legacy
-      shippedAt: serializeDate(data.shipped.shippedAt),
     },
   }
 }

--- a/apps/talos/src/lib/services/purchase-order-service.ts
+++ b/apps/talos/src/lib/services/purchase-order-service.ts
@@ -50,9 +50,6 @@ const VISIBLE_STATUSES: PurchaseOrderStatus[] = [
   PurchaseOrderStatus.MANUFACTURING,
   PurchaseOrderStatus.OCEAN,
   PurchaseOrderStatus.WAREHOUSE,
-  PurchaseOrderStatus.SHIPPED,
-  PurchaseOrderStatus.CLOSED,
-  PurchaseOrderStatus.REJECTED,
   PurchaseOrderStatus.CANCELLED,
 ]
 

--- a/apps/talos/src/lib/services/purchase-order-service.ts
+++ b/apps/talos/src/lib/services/purchase-order-service.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/purchase-order-line-costs'
 import {
   assertPurchaseOrderMutable,
+  getVisiblePurchaseOrderStatuses,
   normalizePurchaseOrderWorkflowStatus,
 } from '@/lib/purchase-orders/workflow'
 import { toPublicOrderNumber } from './purchase-order-utils'
@@ -44,14 +45,7 @@ export type PurchaseOrderWithLinesAndProformaInvoices = Prisma.PurchaseOrderGetP
   }
 }>
 
-const VISIBLE_STATUSES: PurchaseOrderStatus[] = [
-  PurchaseOrderStatus.RFQ,
-  PurchaseOrderStatus.ISSUED,
-  PurchaseOrderStatus.MANUFACTURING,
-  PurchaseOrderStatus.OCEAN,
-  PurchaseOrderStatus.WAREHOUSE,
-  PurchaseOrderStatus.CANCELLED,
-]
+const VISIBLE_STATUSES = getVisiblePurchaseOrderStatuses() as PurchaseOrderStatus[]
 
 export function serializePurchaseOrder(
   order: PurchaseOrderWithLines,

--- a/apps/talos/tests/unit/permission-catalog.test.ts
+++ b/apps/talos/tests/unit/permission-catalog.test.ts
@@ -17,7 +17,6 @@ test('permission catalog covers every live Talos authorization code', () => {
       'po.approve.draft_to_manufacturing',
       'po.approve.manufacturing_to_ocean',
       'po.approve.ocean_to_warehouse',
-      'po.approve.warehouse_to_shipped',
       'po.cancel',
       'po.create',
       'po.edit',

--- a/apps/talos/tests/unit/purchase-order-destination.test.ts
+++ b/apps/talos/tests/unit/purchase-order-destination.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { resolvePurchaseOrderDestination } from '../../src/lib/purchase-orders/destination'
+
+test('purchase-order destination prefers the live warehouse record when it is complete', () => {
+  const destination = resolvePurchaseOrderDestination(
+    {
+      warehouseName: 'Amazon Snapshot',
+      shipToName: 'Legacy Name',
+      shipToAddress: 'Legacy Address',
+    },
+    {
+      name: 'Amazon LBA1',
+      address: '1 Warehouse Way\nLeeds',
+    }
+  )
+
+  assert.deepEqual(destination, {
+    name: 'Amazon LBA1',
+    address: '1 Warehouse Way\nLeeds',
+  })
+})
+
+test('purchase-order destination falls back to stored ship-to fields when warehouse address is missing', () => {
+  const destination = resolvePurchaseOrderDestination(
+    {
+      warehouseName: 'Amazon Snapshot',
+      shipToName: 'Legacy Name',
+      shipToAddress: 'Legacy Address',
+    },
+    {
+      name: 'Amazon Snapshot',
+      address: null,
+    }
+  )
+
+  assert.deepEqual(destination, {
+    name: 'Amazon Snapshot',
+    address: 'Legacy Address',
+  })
+})
+
+test('purchase-order destination uses stored legacy values when no warehouse record is available', () => {
+  const destination = resolvePurchaseOrderDestination(
+    {
+      warehouseName: null,
+      shipToName: 'Amazon BHX4',
+      shipToAddress: 'Legacy Dock 4',
+    },
+    null
+  )
+
+  assert.deepEqual(destination, {
+    name: 'Amazon BHX4',
+    address: 'Legacy Dock 4',
+  })
+})

--- a/apps/talos/tests/unit/purchase-order-document-stages.test.ts
+++ b/apps/talos/tests/unit/purchase-order-document-stages.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  ACTIVE_PURCHASE_ORDER_DOCUMENT_STAGES,
+  getActivePurchaseOrderDocumentStageFromStoredStage,
+  getPurchaseOrderDocumentStageForStatus,
+} from '../../src/lib/purchase-orders/document-stages'
+
+test('active purchase-order document stages stop at warehouse', () => {
+  assert.deepEqual(ACTIVE_PURCHASE_ORDER_DOCUMENT_STAGES, [
+    'ISSUED',
+    'MANUFACTURING',
+    'OCEAN',
+    'WAREHOUSE',
+  ])
+})
+
+test('purchase-order statuses map only to active document stages', () => {
+  assert.equal(getPurchaseOrderDocumentStageForStatus('RFQ'), 'ISSUED')
+  assert.equal(getPurchaseOrderDocumentStageForStatus('ISSUED'), 'ISSUED')
+  assert.equal(getPurchaseOrderDocumentStageForStatus('MANUFACTURING'), 'MANUFACTURING')
+  assert.equal(getPurchaseOrderDocumentStageForStatus('OCEAN'), 'OCEAN')
+  assert.equal(getPurchaseOrderDocumentStageForStatus('WAREHOUSE'), 'WAREHOUSE')
+  assert.equal(getPurchaseOrderDocumentStageForStatus('SHIPPED'), null)
+  assert.equal(getPurchaseOrderDocumentStageForStatus('CLOSED'), null)
+  assert.equal(getPurchaseOrderDocumentStageForStatus('REJECTED'), null)
+  assert.equal(getPurchaseOrderDocumentStageForStatus('CANCELLED'), null)
+})
+
+test('stored purchase-order document stages normalize to active document stages only', () => {
+  assert.equal(getActivePurchaseOrderDocumentStageFromStoredStage('DRAFT'), 'ISSUED')
+  assert.equal(getActivePurchaseOrderDocumentStageFromStoredStage('RFQ'), 'ISSUED')
+  assert.equal(getActivePurchaseOrderDocumentStageFromStoredStage('ISSUED'), 'ISSUED')
+  assert.equal(
+    getActivePurchaseOrderDocumentStageFromStoredStage('MANUFACTURING'),
+    'MANUFACTURING'
+  )
+  assert.equal(getActivePurchaseOrderDocumentStageFromStoredStage('OCEAN'), 'OCEAN')
+  assert.equal(getActivePurchaseOrderDocumentStageFromStoredStage('WAREHOUSE'), 'WAREHOUSE')
+  assert.equal(getActivePurchaseOrderDocumentStageFromStoredStage('SHIPPED'), null)
+})

--- a/apps/talos/tests/unit/purchase-order-service.test.ts
+++ b/apps/talos/tests/unit/purchase-order-service.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getVisiblePurchaseOrderStatuses } from '../../src/lib/purchase-orders/workflow'
+
+test('purchase-order reads keep legacy terminal statuses visible until the enum migration is applied', () => {
+  assert.deepEqual(getVisiblePurchaseOrderStatuses(), [
+    'RFQ',
+    'ISSUED',
+    'MANUFACTURING',
+    'OCEAN',
+    'WAREHOUSE',
+    'CANCELLED',
+    'SHIPPED',
+    'CLOSED',
+    'REJECTED',
+  ])
+})

--- a/packages/aws-s3/dist/index.d.ts
+++ b/packages/aws-s3/dist/index.d.ts
@@ -46,7 +46,7 @@ export type FileContext = {
     tenantCode?: string;
     /** Optional public order number (e.g., PO-0001) to keep PO uploads human-navigable in S3. */
     purchaseOrderNumber?: string;
-    stage: 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
+    stage: 'DRAFT' | 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
     documentType: string;
 } | {
     type: 'fulfillment-order';

--- a/packages/aws-s3/dist/index.d.ts
+++ b/packages/aws-s3/dist/index.d.ts
@@ -46,7 +46,7 @@ export type FileContext = {
     tenantCode?: string;
     /** Optional public order number (e.g., PO-0001) to keep PO uploads human-navigable in S3. */
     purchaseOrderNumber?: string;
-    stage: 'DRAFT' | 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
+    stage: 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
     documentType: string;
 } | {
     type: 'fulfillment-order';

--- a/packages/aws-s3/dist/index.js
+++ b/packages/aws-s3/dist/index.js
@@ -397,7 +397,7 @@ export function isValidFileContext(context) {
             return typeof c.transactionId === 'string' && typeof c.documentType === 'string';
         case 'purchase-order':
             return (typeof c.purchaseOrderId === 'string' &&
-                ['RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
+                ['DRAFT', 'RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
                 typeof c.documentType === 'string');
         case 'fulfillment-order':
             return (typeof c.fulfillmentOrderId === 'string' &&

--- a/packages/aws-s3/dist/index.js
+++ b/packages/aws-s3/dist/index.js
@@ -397,7 +397,7 @@ export function isValidFileContext(context) {
             return typeof c.transactionId === 'string' && typeof c.documentType === 'string';
         case 'purchase-order':
             return (typeof c.purchaseOrderId === 'string' &&
-                ['DRAFT', 'RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
+                ['RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
                 typeof c.documentType === 'string');
         case 'fulfillment-order':
             return (typeof c.fulfillmentOrderId === 'string' &&

--- a/packages/aws-s3/src/index.ts
+++ b/packages/aws-s3/src/index.ts
@@ -64,7 +64,7 @@ export type FileContext =
       tenantCode?: string;
       /** Optional public order number (e.g., PO-0001) to keep PO uploads human-navigable in S3. */
       purchaseOrderNumber?: string;
-      stage: 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
+      stage: 'DRAFT' | 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
       documentType: string;
     }
   | {
@@ -510,7 +510,7 @@ export function isValidFileContext(context: unknown): context is FileContext {
     case 'purchase-order':
       return (
         typeof c.purchaseOrderId === 'string' &&
-        ['RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
+        ['DRAFT', 'RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
         typeof c.documentType === 'string'
       );
     case 'fulfillment-order':

--- a/packages/aws-s3/src/index.ts
+++ b/packages/aws-s3/src/index.ts
@@ -64,7 +64,7 @@ export type FileContext =
       tenantCode?: string;
       /** Optional public order number (e.g., PO-0001) to keep PO uploads human-navigable in S3. */
       purchaseOrderNumber?: string;
-      stage: 'DRAFT' | 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
+      stage: 'RFQ' | 'ISSUED' | 'MANUFACTURING' | 'OCEAN' | 'WAREHOUSE' | 'SHIPPED';
       documentType: string;
     }
   | {
@@ -510,7 +510,7 @@ export function isValidFileContext(context: unknown): context is FileContext {
     case 'purchase-order':
       return (
         typeof c.purchaseOrderId === 'string' &&
-        ['DRAFT', 'RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
+        ['RFQ', 'ISSUED', 'MANUFACTURING', 'OCEAN', 'WAREHOUSE', 'SHIPPED'].includes(c.stage) &&
         typeof c.documentType === 'string'
       );
     case 'fulfillment-order':


### PR DESCRIPTION
## Summary
- remove SHIPPED/CLOSED/REJECTED from the active Talos PO workflow and tighten document-stage handling around active inbound stages
- add a guarded Prisma migration that removes the legacy PO terminal enum values and keeps the remaining compatibility stages explicit
- fix Talos Next 16 compatibility issues in tenant routes and redirect pages so the app builds cleanly

## Verification
- `pnpm --filter @targon/talos lint`
- `pnpm --filter @targon/talos test`
- `pnpm --filter @targon/talos type-check`
- `set -a; source apps/talos/.env.dev.ci; set +a; pnpm --filter @targon/talos exec next build --webpack`

## Notes
- `lint` still reports the same pre-existing 8 warnings outside this change scope.
- The standard `pnpm --filter @targon/talos build` path uses Next 16 Turbopack and fails in an isolated worktree because Turbopack rejects out-of-root `node_modules` symlinks; the webpack build above is the clean code verification path for this branch.