### PR TITLE
fix(talos): block CI on unresolved review threads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on:
   pull_request:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
   workflow_dispatch:
 
 concurrency:
@@ -9,8 +15,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  review-thread-policy:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Assert PR review threads are resolved
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/assert-resolved-review-threads.mjs
   build-test-self-hosted:
-    if: vars.USE_SELF_HOSTED == 'true'
+    if: vars.USE_SELF_HOSTED == 'true' && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     runs-on: [self-hosted, macOS, ARM64]
     steps: &build-test-steps
       - uses: actions/checkout@v4
@@ -132,21 +152,33 @@ jobs:
   build-test-github-hosted:
     needs:
       - build-test-self-hosted
-    if: always() && (vars.USE_SELF_HOSTED != 'true' || needs.build-test-self-hosted.result != 'success')
+    if: always() && (github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && (vars.USE_SELF_HOSTED != 'true' || needs.build-test-self-hosted.result != 'success')
     runs-on: ubuntu-latest
     steps: *build-test-steps
   build-test:
     needs:
+      - review-thread-policy
       - build-test-self-hosted
       - build-test-github-hosted
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Validate at least one CI path succeeded
+      - name: Validate CI gates
         run: |
-          if [[ "${{ needs.build-test-self-hosted.result }}" == "success" || "${{ needs.build-test-github-hosted.result }}" == "success" ]]; then
-            echo "A CI execution path completed successfully."
-          else
-            echo "No CI execution path succeeded."
-            exit 1
+          if [[ "${{ github.event_name }}" == "pull_request" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ needs.build-test-self-hosted.result }}" == "success" || "${{ needs.build-test-github-hosted.result }}" == "success" ]]; then
+              echo "A CI execution path completed successfully."
+            else
+              echo "No CI execution path succeeded."
+              exit 1
+            fi
+          fi
+
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            if [[ "${{ needs.review-thread-policy.result }}" == "success" ]]; then
+              echo "Review thread policy passed."
+            else
+              echo "Unresolved review threads are blocking this PR."
+              exit 1
+            fi
           fi

--- a/scripts/assert-resolved-review-threads.mjs
+++ b/scripts/assert-resolved-review-threads.mjs
@@ -1,0 +1,174 @@
+function requireEnv(name) {
+  const value = process.env[name]
+  if (typeof value !== 'string') {
+    throw new Error(`${name} must be defined for review thread assertions.`)
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    throw new Error(`${name} must be defined for review thread assertions.`)
+  }
+
+  return trimmed
+}
+
+function truncate(value, maxLength = 140) {
+  const normalized = value.replace(/\s+/g, ' ').trim()
+  if (normalized.length <= maxLength) {
+    return normalized
+  }
+
+  return `${normalized.slice(0, maxLength - 1)}…`
+}
+
+function requireNonEmptyString(value, description) {
+  if (typeof value !== 'string') {
+    throw new Error(`${description} must be a non-empty string.`)
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    throw new Error(`${description} must be a non-empty string.`)
+  }
+
+  return trimmed
+}
+
+function summarizeBlockingThread(thread) {
+  const path = requireNonEmptyString(thread.path, 'Blocking review thread path')
+
+  if (!Array.isArray(thread.comments) || thread.comments.length === 0) {
+    throw new Error(`Blocking review thread ${path} must include a first comment.`)
+  }
+
+  const firstComment = thread.comments[0]
+  const authorLogin = requireNonEmptyString(firstComment.author?.login, `Blocking review thread ${path} first comment author login`)
+  const body = truncate(requireNonEmptyString(firstComment.body, `Blocking review thread ${path} first comment body`))
+  const location = typeof thread.line === 'number'
+    ? `${path}:${thread.line}`
+    : path
+
+  return `- ${location} (${authorLogin}): ${body}`
+}
+
+export function evaluateReviewThreads(reviewThreads) {
+  const blockingThreads = reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated)
+
+  if (blockingThreads.length === 0) {
+    return { ok: true, message: 'ok' }
+  }
+
+  const summary = blockingThreads.map(summarizeBlockingThread).join('\n')
+
+  return {
+    ok: false,
+    message: `Unresolved review threads must be resolved before merge:\n${summary}`,
+  }
+}
+
+async function fetchReviewThreads() {
+  const token = requireEnv('GITHUB_TOKEN')
+  const repository = requireEnv('GITHUB_REPOSITORY')
+  const pullRequestNumber = Number.parseInt(requireEnv('GITHUB_PR_NUMBER'), 10)
+
+  if (!Number.isInteger(pullRequestNumber) || pullRequestNumber <= 0) {
+    throw new Error('GITHUB_PR_NUMBER must be a positive integer.')
+  }
+
+  const [owner, name] = repository.split('/')
+  if (!owner || !name) {
+    throw new Error('GITHUB_REPOSITORY must be in owner/name format.')
+  }
+
+  const query = `
+    query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: String) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              isResolved
+              isOutdated
+              path
+              line
+              comments(first: 1) {
+                nodes {
+                  body
+                  author {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `
+
+  const threads = []
+  let after = null
+
+  while (true) {
+    const response = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        query,
+        variables: {
+          owner,
+          name,
+          number: pullRequestNumber,
+          after,
+        },
+      }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`GitHub GraphQL request failed: ${response.status} ${response.statusText}`)
+    }
+
+    const payload = await response.json()
+    if (Array.isArray(payload.errors) && payload.errors.length > 0) {
+      throw new Error(`GitHub GraphQL request failed: ${payload.errors.map((error) => error.message).join('; ')}`)
+    }
+
+    const reviewThreads = payload.data?.repository?.pullRequest?.reviewThreads
+    if (!reviewThreads) {
+      throw new Error(`Pull request #${pullRequestNumber} was not found in ${repository}.`)
+    }
+
+    threads.push(...reviewThreads.nodes.map((thread) => ({
+      ...thread,
+      comments: thread.comments.nodes,
+    })))
+
+    if (!reviewThreads.pageInfo.hasNextPage) {
+      return threads
+    }
+
+    after = reviewThreads.pageInfo.endCursor
+  }
+}
+
+export async function assertReviewThreadsFromEnv() {
+  const reviewThreads = await fetchReviewThreads()
+  const result = evaluateReviewThreads(reviewThreads)
+
+  if (!result.ok) {
+    throw new Error(result.message)
+  }
+
+  return result
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = await assertReviewThreadsFromEnv()
+  process.stdout.write(`${result.message}\n`)
+}

--- a/scripts/assert-resolved-review-threads.test.mjs
+++ b/scripts/assert-resolved-review-threads.test.mjs
@@ -1,0 +1,92 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { evaluateReviewThreads } from './assert-resolved-review-threads.mjs'
+
+test('evaluateReviewThreads passes when every thread is resolved', () => {
+  const result = evaluateReviewThreads([
+    {
+      isResolved: true,
+      isOutdated: false,
+      path: 'apps/talos/src/middleware.ts',
+      line: 16,
+      comments: [
+        {
+          author: { login: 'chatgpt-codex-connector' },
+          body: 'Looks good.',
+        },
+      ],
+    },
+  ])
+
+  assert.deepEqual(result, { ok: true, message: 'ok' })
+})
+
+test('evaluateReviewThreads ignores outdated unresolved threads', () => {
+  const result = evaluateReviewThreads([
+    {
+      isResolved: false,
+      isOutdated: true,
+      path: 'apps/talos/src/lib/utils/base-path.ts',
+      line: 32,
+      comments: [
+        {
+          author: { login: 'chatgpt-codex-connector' },
+          body: 'Outdated warning.',
+        },
+      ],
+    },
+  ])
+
+  assert.deepEqual(result, { ok: true, message: 'ok' })
+})
+
+test('evaluateReviewThreads fails when a non-outdated thread is unresolved', () => {
+  const result = evaluateReviewThreads([
+    {
+      isResolved: false,
+      isOutdated: false,
+      path: 'apps/talos/src/lib/utils/base-path.ts',
+      line: 32,
+      comments: [
+        {
+          author: { login: 'chatgpt-codex-connector' },
+          body: 'Preserve fallback when BASE_PATH is an empty string.',
+        },
+      ],
+    },
+  ])
+
+  assert.equal(result.ok, false)
+  assert.match(result.message, /apps\/talos\/src\/lib\/utils\/base-path\.ts:32/)
+  assert.match(result.message, /chatgpt-codex-connector/)
+  assert.match(result.message, /Preserve fallback/)
+})
+
+test('evaluateReviewThreads throws when a blocking thread has no first comment', () => {
+  assert.throws(() => evaluateReviewThreads([
+    {
+      isResolved: false,
+      isOutdated: false,
+      path: 'apps/talos/src/lib/utils/base-path.ts',
+      line: 32,
+      comments: [],
+    },
+  ]), /must include a first comment/)
+})
+
+test('evaluateReviewThreads throws when a blocking thread comment is missing author metadata', () => {
+  assert.throws(() => evaluateReviewThreads([
+    {
+      isResolved: false,
+      isOutdated: false,
+      path: 'apps/talos/src/lib/utils/base-path.ts',
+      line: 32,
+      comments: [
+        {
+          body: 'Missing author should fail loudly.',
+        },
+      ],
+    },
+  ]), /author login must be a non-empty string/)
+})


### PR DESCRIPTION
## Summary
- add a GitHub GraphQL assertion that fails when a PR still has unresolved, non-outdated review threads
- wire that assertion into the required CI workflow and rerun the aggregate build-test check on review events
- keep malformed review payloads as hard failures instead of formatting them with fallbacks

## Testing
- node --test scripts/assert-resolved-review-threads.test.mjs
- python - <<'PY'
import yaml
from pathlib import Path
yaml.safe_load(Path('.github/workflows/ci.yml').read_text())
print('ok')
PY
- GITHUB_TOKEN="<redacted>" GITHUB_REPOSITORY="progami/targonos" GITHUB_PR_NUMBER="3775" node scripts/assert-resolved-review-threads.mjs
- GITHUB_TOKEN="<redacted>" GITHUB_REPOSITORY="progami/targonos" GITHUB_PR_NUMBER="5035" node scripts/assert-resolved-review-threads.mjs