### PR TITLE
fix(sso): make hosted smoke auth contract explicit

### DIFF
--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start -p 3200",
     "type-check": "tsc --noEmit",
-    "test:auth-contracts": "tsx --test tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts",
+    "test:auth-contracts": "tsx --test tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts scripts/ensure-hosted-smoke-user-lib.test.ts",
     "test:auth-smoke": "pnpm run test:auth-contracts && playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",
     "test:e2e": "playwright test",
     "test:hosted-smoke": "pnpm run test:auth-contracts && PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",
@@ -27,6 +27,7 @@
     "@types/node": "22.15.29",
     "@types/react": "19.1.10",
     "@types/react-dom": "19.1.6",
-    "@playwright/test": "^1.57.0"
+    "@playwright/test": "^1.57.0",
+    "tsx": "^4.21.0"
   }
 }

--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,9 +8,10 @@
     "build": "next build",
     "start": "next start -p 3200",
     "type-check": "tsc --noEmit",
-    "test:auth-smoke": "playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",
+    "test:auth-contracts": "tsx --test tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts",
+    "test:auth-smoke": "pnpm run test:auth-contracts && playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",
     "test:e2e": "playwright test",
-    "test:hosted-smoke": "PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",
+    "test:hosted-smoke": "pnpm run test:auth-contracts && PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",
     "postinstall": "node ../../scripts/link-prisma-client-auth.js"
   },
   "dependencies": {

--- a/apps/sso/scripts/ensure-hosted-smoke-user-lib.test.ts
+++ b/apps/sso/scripts/ensure-hosted-smoke-user-lib.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  assertHostedSmokeGrantMatches,
+  haveSameStringMembers,
+} from './ensure-hosted-smoke-user-lib'
+
+test('haveSameStringMembers accepts the same members in a different order', () => {
+  assert.equal(haveSameStringMembers(['US', 'UK'], ['UK', 'US']), true)
+})
+
+test('assertHostedSmokeGrantMatches accepts reordered tenant memberships', () => {
+  assert.doesNotThrow(() =>
+    assertHostedSmokeGrantMatches({
+      grant: {
+        appSlug: 'talos',
+        departments: ['Ops'],
+        tenantMemberships: ['US', 'UK'],
+      },
+      appGrant: {
+        departments: ['Ops'],
+        tenantMemberships: ['UK', 'US'],
+      },
+    }),
+  )
+})
+
+test('assertHostedSmokeGrantMatches rejects a missing tenant membership', () => {
+  assert.throws(
+    () =>
+      assertHostedSmokeGrantMatches({
+        grant: {
+          appSlug: 'talos',
+          departments: ['Ops'],
+          tenantMemberships: ['US', 'UK'],
+        },
+        appGrant: {
+          departments: ['Ops'],
+          tenantMemberships: ['US'],
+        },
+      }),
+    /tenant memberships mismatch/,
+  )
+})

--- a/apps/sso/scripts/ensure-hosted-smoke-user-lib.ts
+++ b/apps/sso/scripts/ensure-hosted-smoke-user-lib.ts
@@ -1,0 +1,54 @@
+type HostedSmokeGrantExpectation = {
+  appSlug: string
+  departments: string[]
+  tenantMemberships: string[]
+}
+
+type HostedSmokeGrantState = {
+  departments: string[]
+  tenantMemberships: string[]
+}
+
+function sortMembers(values: string[]): string[] {
+  return [...values].sort((left, right) => left.localeCompare(right))
+}
+
+function formatMembers(values: string[]): string {
+  return JSON.stringify(sortMembers(values))
+}
+
+export function haveSameStringMembers(expected: string[], actual: string[]): boolean {
+  if (expected.length !== actual.length) {
+    return false
+  }
+
+  const sortedExpected = sortMembers(expected)
+  const sortedActual = sortMembers(actual)
+
+  for (let index = 0; index < sortedExpected.length; index += 1) {
+    if (sortedExpected[index] !== sortedActual[index]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function assertHostedSmokeGrantMatches(input: {
+  grant: HostedSmokeGrantExpectation
+  appGrant: HostedSmokeGrantState
+}) {
+  const { appGrant, grant } = input
+
+  if (!haveSameStringMembers(grant.departments, appGrant.departments)) {
+    throw new Error(
+      `Hosted smoke user departments mismatch for ${grant.appSlug}: expected ${formatMembers(grant.departments)}, received ${formatMembers(appGrant.departments)}.`,
+    )
+  }
+
+  if (!haveSameStringMembers(grant.tenantMemberships, appGrant.tenantMemberships)) {
+    throw new Error(
+      `Hosted smoke user tenant memberships mismatch for ${grant.appSlug}: expected ${formatMembers(grant.tenantMemberships)}, received ${formatMembers(appGrant.tenantMemberships)}.`,
+    )
+  }
+}

--- a/apps/sso/scripts/ensure-hosted-smoke-user.ts
+++ b/apps/sso/scripts/ensure-hosted-smoke-user.ts
@@ -1,5 +1,6 @@
 import { upsertManualUserAppGrant } from '@targon/auth/server'
 
+import { assertHostedSmokeGrantMatches } from './ensure-hosted-smoke-user-lib'
 import { hostedSmokeAppGrants } from '../tests/fixtures/hosted-smoke-config'
 
 function requireEnv(name: string): string {
@@ -52,17 +53,7 @@ async function main() {
       throw new Error(`Hosted smoke user is missing ${grant.appSlug} entitlements after grant update.`)
     }
 
-    if (JSON.stringify(appGrant.departments) !== JSON.stringify(grant.departments)) {
-      throw new Error(
-        `Hosted smoke user departments mismatch for ${grant.appSlug}: expected ${JSON.stringify(grant.departments)}, received ${JSON.stringify(appGrant.departments)}.`,
-      )
-    }
-
-    if (JSON.stringify(appGrant.tenantMemberships) !== JSON.stringify(grant.tenantMemberships)) {
-      throw new Error(
-        `Hosted smoke user tenant memberships mismatch for ${grant.appSlug}: expected ${JSON.stringify(grant.tenantMemberships)}, received ${JSON.stringify(appGrant.tenantMemberships)}.`,
-      )
-    }
+    assertHostedSmokeGrantMatches({ grant, appGrant })
   }
 
   console.log(`Ensured hosted smoke grants for ${updatedUser.email}.`)

--- a/apps/sso/scripts/ensure-hosted-smoke-user.ts
+++ b/apps/sso/scripts/ensure-hosted-smoke-user.ts
@@ -1,5 +1,7 @@
 import { upsertManualUserAppGrant } from '@targon/auth/server'
 
+import { hostedSmokeAppGrants } from '../tests/fixtures/hosted-smoke-config'
+
 function requireEnv(name: string): string {
   const value = process.env[name]
   if (typeof value !== 'string') {
@@ -19,15 +21,22 @@ async function main() {
 
   const userId = requireEnv('E2E_PORTAL_USER_ID')
   const email = requireEnv('E2E_PORTAL_EMAIL').toLowerCase()
+  let updatedUser = null
 
-  const updatedUser = await upsertManualUserAppGrant({
-    userId,
-    appSlug: 'talos',
-    appName: 'Talos',
-    departments: ['Ops'],
-    tenantMemberships: ['US', 'UK'],
-    locked: false,
-  })
+  for (const grant of hostedSmokeAppGrants) {
+    updatedUser = await upsertManualUserAppGrant({
+      userId,
+      appSlug: grant.appSlug,
+      appName: grant.appName,
+      departments: grant.departments,
+      tenantMemberships: grant.tenantMemberships,
+      locked: grant.locked,
+    })
+  }
+
+  if (updatedUser === null) {
+    throw new Error('Hosted smoke user grants were not applied.')
+  }
 
   if (updatedUser.id !== userId) {
     throw new Error(`Hosted smoke user id mismatch: expected ${userId}, received ${updatedUser.id}.`)
@@ -37,20 +46,26 @@ async function main() {
     throw new Error(`Hosted smoke user email mismatch: expected ${email}, received ${updatedUser.email}.`)
   }
 
-  const talosGrant = updatedUser.entitlements.talos
-  if (!talosGrant) {
-    throw new Error('Hosted smoke user is missing Talos entitlements after grant update.')
+  for (const grant of hostedSmokeAppGrants) {
+    const appGrant = updatedUser.entitlements[grant.appSlug]
+    if (!appGrant) {
+      throw new Error(`Hosted smoke user is missing ${grant.appSlug} entitlements after grant update.`)
+    }
+
+    if (JSON.stringify(appGrant.departments) !== JSON.stringify(grant.departments)) {
+      throw new Error(
+        `Hosted smoke user departments mismatch for ${grant.appSlug}: expected ${JSON.stringify(grant.departments)}, received ${JSON.stringify(appGrant.departments)}.`,
+      )
+    }
+
+    if (JSON.stringify(appGrant.tenantMemberships) !== JSON.stringify(grant.tenantMemberships)) {
+      throw new Error(
+        `Hosted smoke user tenant memberships mismatch for ${grant.appSlug}: expected ${JSON.stringify(grant.tenantMemberships)}, received ${JSON.stringify(appGrant.tenantMemberships)}.`,
+      )
+    }
   }
 
-  if (!talosGrant.tenantMemberships.includes('US')) {
-    throw new Error('Hosted smoke user is missing Talos US tenant membership after grant update.')
-  }
-
-  if (!talosGrant.tenantMemberships.includes('UK')) {
-    throw new Error('Hosted smoke user is missing Talos UK tenant membership after grant update.')
-  }
-
-  console.log(`Ensured hosted smoke Talos grant for ${updatedUser.email}.`)
+  console.log(`Ensured hosted smoke grants for ${updatedUser.email}.`)
 }
 
 main().catch((error) => {

--- a/apps/sso/tests/fixtures/hosted-auth.ts
+++ b/apps/sso/tests/fixtures/hosted-auth.ts
@@ -4,6 +4,11 @@ import path from 'node:path'
 import { expect, type Page, type Response } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
 
+import {
+  buildHostedSmokeSessionTokenPayload,
+  getHostedAuthSecret,
+} from './hosted-smoke-config'
+
 type CriticalResponseRecord = {
   method: string
   resourceType: string
@@ -41,23 +46,6 @@ function getHostedPortalOrigin() {
   return new URL(getHostedPortalBaseUrl()).origin
 }
 
-function buildPortalAuthz() {
-  return {
-    version: 1,
-    globalRoles: ['platform_admin'],
-    apps: {
-      talos: { departments: ['Ops'], tenantMemberships: ['US', 'UK'] },
-      atlas: { departments: ['People Ops'], tenantMemberships: ['US', 'UK'] },
-      website: { departments: [], tenantMemberships: [] },
-      kairos: { departments: ['Product'], tenantMemberships: [] },
-      xplan: { departments: ['Product'], tenantMemberships: [] },
-      plutus: { departments: ['Finance'], tenantMemberships: [] },
-      hermes: { departments: ['Account / Listing'], tenantMemberships: [] },
-      argus: { departments: ['Account / Listing'], tenantMemberships: [] },
-    },
-  }
-}
-
 function buildScreenshotDirectory(): string {
   const portalHost = new URL(getHostedPortalBaseUrl()).hostname
   const outputDir = path.join(process.cwd(), '.codex-artifacts', 'hosted-smoke', portalHost)
@@ -66,23 +54,11 @@ function buildScreenshotDirectory(): string {
 }
 
 async function buildSessionCookie(portalBaseUrl: string) {
-  const authz = buildPortalAuthz()
   const sessionCookieName = '__Secure-next-auth.session-token'
-  const secret = requireEnv('NEXTAUTH_SECRET')
-  const activeTenant = requireEnv('E2E_ACTIVE_TENANT')
+  const secret = getHostedAuthSecret()
   const domain = new URL(portalBaseUrl).hostname
   const token = await encode({
-    token: {
-      sub: requireEnv('E2E_PORTAL_USER_ID'),
-      email: requireEnv('E2E_PORTAL_EMAIL'),
-      name: requireEnv('E2E_PORTAL_NAME'),
-      authz,
-      roles: authz.apps,
-      globalRoles: authz.globalRoles,
-      authzVersion: authz.version,
-      apps: Object.keys(authz.apps),
-      activeTenant,
-    },
+    token: buildHostedSmokeSessionTokenPayload(),
     secret,
     salt: sessionCookieName,
   })
@@ -101,7 +77,7 @@ async function buildSessionCookie(portalBaseUrl: string) {
 async function buildActiveTenantCookie(portalBaseUrl: string) {
   const appId = 'talos'
   const cookieName = `__Secure-targon.active-tenant.${appId}`
-  const secret = requireEnv('NEXTAUTH_SECRET')
+  const secret = getHostedAuthSecret()
   const domain = new URL(portalBaseUrl).hostname
   const value = await encode({
     token: { activeTenant: requireEnv('E2E_ACTIVE_TENANT') },

--- a/apps/sso/tests/fixtures/hosted-smoke-config.test.ts
+++ b/apps/sso/tests/fixtures/hosted-smoke-config.test.ts
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  buildHostedSmokeAuthz,
+  buildHostedSmokeSessionTokenPayload,
+  getHostedAuthSecret,
+  hostedSmokeAppGrants,
+} from './hosted-smoke-config'
+
+test('hosted smoke grants cover every hosted app route under test', () => {
+  assert.deepEqual(
+    hostedSmokeAppGrants.map((grant) => grant.appSlug),
+    ['talos', 'atlas', 'kairos', 'xplan', 'plutus', 'hermes', 'argus'],
+  )
+})
+
+test('buildHostedSmokeAuthz mirrors the hosted smoke grant plan', () => {
+  const authz = buildHostedSmokeAuthz()
+
+  assert.deepEqual(Object.keys(authz.apps), hostedSmokeAppGrants.map((grant) => grant.appSlug))
+  assert.deepEqual(authz.apps.talos?.tenantMemberships, ['US', 'UK'])
+  assert.deepEqual(authz.apps.plutus?.departments, ['Finance'])
+})
+
+test('getHostedAuthSecret accepts NEXTAUTH_SECRET', () => {
+  assert.equal(
+    getHostedAuthSecret({
+      NEXTAUTH_SECRET: 'nextauth-secret',
+      PORTAL_AUTH_SECRET: 'portal-secret',
+    }),
+    'nextauth-secret',
+  )
+})
+
+test('getHostedAuthSecret falls back to PORTAL_AUTH_SECRET when NEXTAUTH_SECRET is absent', () => {
+  assert.equal(
+    getHostedAuthSecret({
+      PORTAL_AUTH_SECRET: 'portal-secret',
+    }),
+    'portal-secret',
+  )
+})
+
+test('buildHostedSmokeSessionTokenPayload seeds entitlements_ver to avoid immediate auth refresh', () => {
+  const before = Date.now()
+  const payload = buildHostedSmokeSessionTokenPayload({
+    E2E_PORTAL_USER_ID: 'user-jarrar',
+    E2E_PORTAL_EMAIL: 'jarrar@targonglobal.com',
+    E2E_PORTAL_NAME: 'Jarrar Amjad',
+    E2E_ACTIVE_TENANT: 'US',
+  })
+  const after = Date.now()
+
+  assert.equal(payload.sub, 'user-jarrar')
+  assert.equal(payload.email, 'jarrar@targonglobal.com')
+  assert.equal(payload.activeTenant, 'US')
+  assert.equal(typeof payload.entitlements_ver, 'number')
+  assert.equal(payload.entitlements_ver >= before && payload.entitlements_ver <= after, true)
+  assert.deepEqual(Object.keys(payload.authz.apps), hostedSmokeAppGrants.map((grant) => grant.appSlug))
+})

--- a/apps/sso/tests/fixtures/hosted-smoke-config.ts
+++ b/apps/sso/tests/fixtures/hosted-smoke-config.ts
@@ -1,0 +1,130 @@
+type HostedSmokeGrant = {
+  appSlug: string
+  appName: string
+  departments: string[]
+  tenantMemberships: string[]
+  locked: boolean
+}
+
+type HostedSmokeEnv = Partial<Record<string, string>>
+
+export const hostedSmokeAppGrants: HostedSmokeGrant[] = [
+  {
+    appSlug: 'talos',
+    appName: 'Talos',
+    departments: ['Ops'],
+    tenantMemberships: ['US', 'UK'],
+    locked: false,
+  },
+  {
+    appSlug: 'atlas',
+    appName: 'Atlas',
+    departments: ['People Ops'],
+    tenantMemberships: ['US', 'UK'],
+    locked: false,
+  },
+  {
+    appSlug: 'kairos',
+    appName: 'Kairos',
+    departments: ['Product'],
+    tenantMemberships: [],
+    locked: false,
+  },
+  {
+    appSlug: 'xplan',
+    appName: 'xPlan',
+    departments: ['Product'],
+    tenantMemberships: [],
+    locked: false,
+  },
+  {
+    appSlug: 'plutus',
+    appName: 'Plutus',
+    departments: ['Finance'],
+    tenantMemberships: [],
+    locked: false,
+  },
+  {
+    appSlug: 'hermes',
+    appName: 'Hermes',
+    departments: ['Account / Listing'],
+    tenantMemberships: [],
+    locked: false,
+  },
+  {
+    appSlug: 'argus',
+    appName: 'Argus',
+    departments: ['Account / Listing'],
+    tenantMemberships: [],
+    locked: false,
+  },
+]
+
+function requireHostedSmokeEnv(name: string, env: HostedSmokeEnv): string {
+  const value = env[name]
+  if (typeof value !== 'string') {
+    throw new Error(`${name} must be defined for hosted portal smoke tests.`)
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    throw new Error(`${name} must be defined for hosted portal smoke tests.`)
+  }
+
+  return trimmed
+}
+
+export function getHostedAuthSecret(env: HostedSmokeEnv = process.env): string {
+  const nextAuthSecret = env.NEXTAUTH_SECRET
+  if (typeof nextAuthSecret === 'string') {
+    const trimmed = nextAuthSecret.trim()
+    if (trimmed !== '') {
+      return trimmed
+    }
+  }
+
+  const portalAuthSecret = env.PORTAL_AUTH_SECRET
+  if (typeof portalAuthSecret === 'string') {
+    const trimmed = portalAuthSecret.trim()
+    if (trimmed !== '') {
+      return trimmed
+    }
+  }
+
+  throw new Error('NEXTAUTH_SECRET or PORTAL_AUTH_SECRET must be defined for hosted portal smoke tests.')
+}
+
+export function buildHostedSmokeAuthz() {
+  const apps = Object.fromEntries(
+    hostedSmokeAppGrants.map((grant) => [
+      grant.appSlug,
+      {
+        departments: grant.departments,
+        tenantMemberships: grant.tenantMemberships,
+      },
+    ]),
+  )
+
+  return {
+    version: 1,
+    globalRoles: ['platform_admin'],
+    apps,
+  }
+}
+
+export function buildHostedSmokeSessionTokenPayload(env: HostedSmokeEnv = process.env) {
+  const authz = buildHostedSmokeAuthz()
+
+  return {
+    sub: requireHostedSmokeEnv('E2E_PORTAL_USER_ID', env),
+    email: requireHostedSmokeEnv('E2E_PORTAL_EMAIL', env),
+    name: requireHostedSmokeEnv('E2E_PORTAL_NAME', env),
+    authz,
+    roles: authz.apps,
+    globalRoles: authz.globalRoles,
+    authzVersion: authz.version,
+    apps: Object.keys(authz.apps),
+    activeTenant: requireHostedSmokeEnv('E2E_ACTIVE_TENANT', env),
+    entitlements_ver: Date.now(),
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -776,6 +776,9 @@ importers:
       '@types/react-dom':
         specifier: 19.1.6
         version: 19.1.6(@types/react@19.1.10)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3


### PR DESCRIPTION
## What changed
- made hosted smoke app grants and session payload construction explicit in SSO fixtures
- added `entitlements_ver` to the hosted session payload so auth does not immediately refresh from database state
- stabilized hosted smoke CI by declaring the missing `tsx` dependency in `@targon/sso`
- made hosted smoke grant verification order-insensitive for departments and tenant memberships
- added focused regression coverage for the hosted grant verifier and auth contract script

## Why
The hosted smoke suite was not hermetic and CI was brittle. The fixture depended on ambient DB entitlements, GitHub-hosted CI could not run the new contract test command because `tsx` was undeclared in `@targon/sso`, and the self-hosted user provisioning check treated identical membership sets as different when the array order changed.

## Validation
- `pnpm run test:auth-contracts`
- `pnpm run type-check`
- `pnpm run test:auth-smoke`
- `pnpm install --frozen-lockfile`
- PR CI run `24610870865` passed on `dev`