### PR TITLE
fix(talos): clarify FBA physical mismatches

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -9,6 +9,7 @@ import {
   type AlertStatus,
   type ApiSkuRow,
   computeComparison,
+  getComparisonStatusLabel,
 } from '@/lib/amazon/fba-fee-discrepancies'
 import { redirectToPortal } from '@/lib/portal'
 import type { TenantCode } from '@/lib/tenant/constants'
@@ -212,7 +213,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                 className="h-9 rounded-md border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 text-sm text-slate-900 dark:text-slate-100 focus:border-cyan-500 dark:focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-100 dark:focus:ring-cyan-900"
               >
                 <option value="ALL">All statuses</option>
-                <option value="MISMATCH">Over/Undercharge</option>
+                <option value="MISMATCH">Any discrepancy</option>
                 <option value="MATCH">Correct</option>
                 <option value="MISSING_REFERENCE">No ref</option>
                 <option value="NO_ASIN">No ASIN</option>
@@ -221,7 +222,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
               </select>
             </div>
             <div className="flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400">
-              <span className="text-red-600 dark:text-red-400">{summary.mismatch} mismatches</span>
+              <span className="text-red-600 dark:text-red-400">{summary.mismatch} discrepancies</span>
               <span className="text-emerald-600 dark:text-emerald-400">{summary.match} matches</span>
               <span className="text-amber-600 dark:text-amber-400">{summary.warning} warnings</span>
               <span>{summary.pending} pending</span>
@@ -422,22 +423,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                               ? 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300'
                               : 'bg-slate-50 dark:bg-slate-800 text-slate-600 dark:text-slate-400'
 
-                      const label =
-                        s === 'MATCH'
-                          ? 'Correct'
-                          : s === 'MISMATCH'
-                            ? row.comparison.hasPhysicalMismatch || row.comparison.feeDifference === 0
-                              ? 'Mismatch'
-                              : row.comparison.feeDifference !== null && row.comparison.feeDifference > 0
-                                ? 'Overcharge'
-                                : 'Undercharge'
-                            : s === 'MISSING_REFERENCE'
-                              ? 'No ref'
-                              : s === 'NO_ASIN'
-                                ? 'No ASIN'
-                                : s === 'ERROR'
-                                  ? 'Error'
-                                  : 'Pending'
+                      const label = getComparisonStatusLabel(row.comparison)
 
                       return (
                         <td key={row.sku.id} className={`px-4 py-2 text-center text-xs font-medium ${cellStyle}`}>

--- a/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
+++ b/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
@@ -318,3 +318,17 @@ export function computeComparison(row: ApiSkuRow, tenantCode: TenantCode): Compa
     hasPhysicalMismatch,
   }
 }
+
+export function getComparisonStatusLabel(comparison: Comparison): string {
+  if (comparison.status === 'MATCH') return 'Correct'
+  if (comparison.status === 'MISMATCH') {
+    if (comparison.hasPhysicalMismatch) return 'Physical mismatch'
+    if (comparison.feeDifference !== null && comparison.feeDifference > 0) return 'Overcharge'
+    if (comparison.feeDifference !== null && comparison.feeDifference < 0) return 'Undercharge'
+    throw new Error('MISMATCH comparison is missing a physical mismatch or fee delta')
+  }
+  if (comparison.status === 'MISSING_REFERENCE') return 'No ref'
+  if (comparison.status === 'NO_ASIN') return 'No ASIN'
+  if (comparison.status === 'ERROR') return 'Error'
+  return 'Pending'
+}

--- a/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
@@ -1,7 +1,8 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { computeComparison, type ApiSkuRow } from '../../src/lib/amazon/fba-fee-discrepancies'
+import * as discrepancies from '../../src/lib/amazon/fba-fee-discrepancies'
+import type { ApiSkuRow } from '../../src/lib/amazon/fba-fee-discrepancies'
 import { calculateSizeTierForTenant } from '../../src/lib/amazon/fees'
 
 function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
@@ -47,7 +48,7 @@ function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
 }
 
 test('computeComparison marks identical fees with different Amazon package measurements as mismatch', () => {
-  const comparison = computeComparison(
+  const comparison = discrepancies.computeComparison(
     createSkuRow({
       amazonItemPackageSide1Cm: 12,
       amazonItemPackageSide2Cm: 10,
@@ -62,7 +63,7 @@ test('computeComparison marks identical fees with different Amazon package measu
 })
 
 test('computeComparison marks incomplete Amazon comparison data as error', () => {
-  const comparison = computeComparison(
+  const comparison = discrepancies.computeComparison(
     createSkuRow({
       amazonSizeTier: null,
     }),
@@ -71,4 +72,34 @@ test('computeComparison marks incomplete Amazon comparison data as error', () =>
 
   assert.equal(comparison.status, 'ERROR')
   assert.deepEqual(comparison.amazon.missingFields, ['Amazon size tier'])
+})
+
+test('status label shows physical mismatch when fees still align', () => {
+  const comparison = discrepancies.computeComparison(
+    createSkuRow({
+      amazonItemPackageSide1Cm: 12,
+      amazonItemPackageSide2Cm: 10,
+      amazonItemPackageSide3Cm: 10,
+    }),
+    'US'
+  )
+
+  assert.equal(typeof discrepancies.getComparisonStatusLabel, 'function')
+  if (typeof discrepancies.getComparisonStatusLabel !== 'function') return
+
+  assert.equal(discrepancies.getComparisonStatusLabel(comparison), 'Physical mismatch')
+})
+
+test('status label shows overcharge when only the fee differs', () => {
+  const comparison = discrepancies.computeComparison(
+    createSkuRow({
+      amazonFbaFulfillmentFee: 3.71,
+    }),
+    'US'
+  )
+
+  assert.equal(typeof discrepancies.getComparisonStatusLabel, 'function')
+  if (typeof discrepancies.getComparisonStatusLabel !== 'function') return
+
+  assert.equal(discrepancies.getComparisonStatusLabel(comparison), 'Overcharge')
 })


### PR DESCRIPTION
## Summary
- fix the FBA fee discrepancies page so physical package/size-tier mismatches are labeled explicitly instead of appearing as fee-only mismatches
- update the mismatch filter/summary copy so the page no longer implies every mismatch is an overcharge or undercharge
- add regression coverage for physical mismatches with zero fee difference and fee-only overcharges

## Root cause
The discrepancy classifier intentionally treated Amazon physical measurement mismatches as real `MISMATCH` rows even when the FBA fee still matched. The page UI reused that same status bucket with fee-centric labels and filter copy, which made live rows show `Mismatch` alongside a `$0.00` fee difference without explaining that the discrepancy was physical metadata.

## Validation
- `pnpm --dir apps/talos exec tsx tests/unit/amazon-fba-fee-discrepancies.test.ts`
- `pnpm --dir apps/talos type-check`
- `pnpm --dir apps/talos test`
- `pnpm --dir apps/talos lint` (passes this change set; repo still has pre-existing unrelated warnings in other Talos files)