### PR TITLE
fix(talos): refresh live fba fee discrepancies

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -38,9 +38,16 @@ const PAGE_KEY = '/amazon/fba-fee-discrepancies'
 const SKUS_PER_PAGE = 10
 
 const ALLOWED_ROLES = ['admin', 'staff'] as const
-function formatFee(value: number | string | null | undefined, currency: string) {
+function formatFee(value: unknown, currency: string) {
   if (value === null || value === undefined || value === '') return '—'
-  const amount = typeof value === 'number' ? value : Number.parseFloat(value)
+  let amount = Number.NaN
+  if (typeof value === 'number') {
+    amount = value
+  } else if (typeof value === 'string') {
+    amount = Number.parseFloat(value)
+  } else if (typeof value === 'object' && value !== null && 'toString' in value) {
+    amount = Number.parseFloat(String(value))
+  }
   if (!Number.isFinite(amount)) return '—'
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -75,6 +82,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
   const [loading, setLoading] = useState(false)
   const [skus, setSkus] = useState<ApiSkuRow[]>([])
   const [currencyCode, setCurrencyCode] = useState<string>('USD')
+  const [totalRows, setTotalRows] = useState(0)
   const search = pageState.search ?? ''
   const setSearch = pageState.setSearch
   const statusFilter = (pageState.custom?.statusFilter as AlertStatus | 'ALL') ?? 'ALL'
@@ -107,6 +115,8 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
     try {
       const params = new URLSearchParams()
       if (search.trim()) params.set('search', search.trim())
+      params.set('page', String(currentPage))
+      params.set('pageSize', String(SKUS_PER_PAGE))
 
       const response = await fetch(withBasePath(`/api/amazon/fba-fee-discrepancies?${params.toString()}`), {
         credentials: 'include',
@@ -119,19 +129,31 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
       const payload = await response.json()
       setCurrencyCode(payload?.currencyCode ?? 'USD')
       setSkus(Array.isArray(payload?.skus) ? payload.skus : [])
+      setTotalRows(typeof payload?.total === 'number' ? payload.total : 0)
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to load fee discrepancies')
       setSkus([])
+      setTotalRows(0)
     } finally {
       setLoading(false)
     }
-  }, [search])
+  }, [currentPage, search])
 
   useEffect(() => {
     if (status !== 'loading' && session && isAllowed) {
       void fetchRows()
     }
   }, [fetchRows, isAllowed, session, status])
+
+  useEffect(() => {
+    pageState.setPagination(1, SKUS_PER_PAGE)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset on search change
+  }, [search])
+
+  useEffect(() => {
+    pageState.setPagination(1, SKUS_PER_PAGE)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset on filter change
+  }, [statusFilter])
 
   const computedRows = useMemo(() => {
     return skus.map(sku => ({
@@ -140,22 +162,11 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
     }))
   }, [skus, tenantCode])
 
-  const filteredRows = useMemo(() => {
+  const pageRows = useMemo(() => {
     if (statusFilter === 'ALL') return computedRows
     return computedRows.filter(row => row.comparison.status === statusFilter)
   }, [computedRows, statusFilter])
-
-  // Reset to page 1 when filter changes
-  useEffect(() => {
-    pageState.setPagination(1, SKUS_PER_PAGE)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only reset on filter change
-  }, [statusFilter])
-
-  const totalPages = Math.ceil(filteredRows.length / SKUS_PER_PAGE)
-  const paginatedRows = useMemo(() => {
-    const start = (currentPage - 1) * SKUS_PER_PAGE
-    return filteredRows.slice(start, start + SKUS_PER_PAGE)
-  }, [filteredRows, currentPage])
+  const totalPages = Math.max(1, Math.ceil(totalRows / SKUS_PER_PAGE))
 
   const summary = useMemo(() => {
     const counts = { mismatch: 0, match: 0, warning: 0, pending: 0 }
@@ -222,12 +233,12 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
               </select>
             </div>
             <div className="flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400">
-              <span className="text-red-600 dark:text-red-400">{summary.mismatch} discrepancies</span>
+              <span className="text-red-600 dark:text-red-400">{summary.mismatch} discrepancies on this page</span>
               <span className="text-emerald-600 dark:text-emerald-400">{summary.match} matches</span>
               <span className="text-amber-600 dark:text-amber-400">{summary.warning} warnings</span>
               <span>{summary.pending} pending</span>
               <span className="text-slate-400 dark:text-slate-500">·</span>
-              <span>{filteredRows.length} SKUs · Page {currentPage} of {totalPages || 1}</span>
+              <span>{pageRows.length} shown · {totalRows} total SKUs · Page {currentPage} of {totalPages}</span>
             </div>
           </div>
 
@@ -236,9 +247,9 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
             <div className="flex h-64 items-center justify-center">
               <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
             </div>
-          ) : paginatedRows.length === 0 ? (
+          ) : pageRows.length === 0 ? (
             <div className="px-6 py-16">
-              <EmptyState title="No SKUs found" description="Try adjusting your search or filter." icon={DollarSign} />
+              <EmptyState title="No SKUs found" description="Try adjusting your search, page, or filter." icon={DollarSign} />
             </div>
           ) : (
             <div className="overflow-x-auto p-4">
@@ -246,7 +257,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                 <thead>
                   <tr className="border-b border-slate-100 dark:border-slate-700 bg-slate-50/80 dark:bg-slate-900/80 text-left text-xs font-medium uppercase tracking-wider text-slate-500 dark:text-slate-400">
                     <th className="px-4 py-3 sticky left-0 bg-slate-50/80 dark:bg-slate-900/80 z-10">Attribute</th>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <th key={row.sku.id} className="px-4 py-3 text-center whitespace-nowrap min-w-[140px]">
                         <Link 
                           href={`/config/products?editSkuId=${encodeURIComponent(row.sku.id)}`}
@@ -262,7 +273,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   {/* Reference section header */}
                   <tr>
                     <td
-                      colSpan={paginatedRows.length + 1}
+                      colSpan={pageRows.length + 1}
                       className="px-4 py-2 text-xs font-semibold uppercase tracking-wider bg-cyan-600 dark:bg-cyan-700 text-white"
                     >
                       Reference Data
@@ -270,7 +281,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">ASIN</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center font-mono text-xs text-slate-600 dark:text-slate-400">
                         {row.sku.asin ?? '—'}
                       </td>
@@ -278,7 +289,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Package Dimensions</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatDimensionTripletDisplayFromCm(row.comparison.reference.triplet, unitSystem)}
                       </td>
@@ -286,7 +297,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Package Weight</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatWeightDisplayFromKg(row.comparison.reference.shipping.unitWeightKg, unitSystem, 3)}
                       </td>
@@ -294,7 +305,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Dimensional Weight</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatWeightDisplayFromKg(row.comparison.reference.shipping.dimensionalWeightKg, unitSystem, 3)}
                       </td>
@@ -302,7 +313,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Shipping Weight</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatWeightDisplayFromKg(row.comparison.reference.shipping.shippingWeightKg, unitSystem, 2)}
                       </td>
@@ -310,7 +321,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Size Tier</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center text-slate-700 dark:text-slate-300 text-xs">
                         {row.comparison.reference.sizeTier ?? '—'}
                       </td>
@@ -318,7 +329,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Expected Fee</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 font-medium">
                         {formatFee(row.comparison.reference.expectedFee, currencyCode)}
                       </td>
@@ -328,7 +339,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   {/* Amazon section header */}
                   <tr>
                     <td
-                      colSpan={paginatedRows.length + 1}
+                      colSpan={pageRows.length + 1}
                       className="px-4 py-2 text-xs font-semibold uppercase tracking-wider bg-slate-600 dark:bg-slate-700 text-white"
                     >
                       Amazon Data
@@ -336,7 +347,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Listing Price</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatFee(row.sku.amazonListingPrice, currencyCode)}
                       </td>
@@ -344,7 +355,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Package Dimensions</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatDimensionTripletDisplayFromCm(row.comparison.amazon.triplet, unitSystem)}
                       </td>
@@ -352,7 +363,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Package Weight</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatWeightDisplayFromKg(row.comparison.amazon.shipping.unitWeightKg, unitSystem, 3)}
                       </td>
@@ -360,7 +371,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Dimensional Weight</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatWeightDisplayFromKg(row.comparison.amazon.shipping.dimensionalWeightKg, unitSystem, 3)}
                       </td>
@@ -368,7 +379,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Shipping Weight</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs">
                         {formatWeightDisplayFromKg(row.comparison.amazon.shipping.shippingWeightKg, unitSystem, 2)}
                       </td>
@@ -376,7 +387,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Size Tier</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center text-slate-700 dark:text-slate-300 text-xs">
                         {row.comparison.amazon.sizeTier ?? '—'}
                       </td>
@@ -384,7 +395,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">FBA Fee</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 font-medium">
                         {formatFee(row.comparison.amazon.fee, currencyCode)}
                       </td>
@@ -394,7 +405,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   {/* Comparison section header */}
                   <tr>
                     <td
-                      colSpan={paginatedRows.length + 1}
+                      colSpan={pageRows.length + 1}
                       className="px-4 py-2 text-xs font-semibold uppercase tracking-wider bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300"
                     >
                       Comparison
@@ -402,7 +413,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Fee Difference</td>
-                    {paginatedRows.map(row => (
+                    {pageRows.map(row => (
                       <td key={row.sku.id} className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300">
                         {row.comparison.feeDifference === null
                           ? '—'
@@ -412,7 +423,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">Status</td>
-                    {paginatedRows.map(row => {
+                    {pageRows.map(row => {
                       const s = row.comparison.status
                       const cellStyle =
                         s === 'MATCH'
@@ -444,7 +455,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
           {totalPages > 1 && (
             <div className="flex items-center justify-between border-t border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-900/50 px-4 py-3">
               <div className="text-xs text-slate-500 dark:text-slate-400">
-                Showing {((currentPage - 1) * SKUS_PER_PAGE) + 1}–{Math.min(currentPage * SKUS_PER_PAGE, filteredRows.length)} of {filteredRows.length} SKUs
+                Showing {((currentPage - 1) * SKUS_PER_PAGE) + 1}–{Math.min((currentPage - 1) * SKUS_PER_PAGE + pageRows.length, totalRows)} of {totalRows} SKUs
               </div>
               <div className="flex items-center gap-2">
                 <Button
@@ -476,7 +487,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
         </div>
 
         <p className="text-center text-xs text-slate-400">
-          Currency: {currencyCode} · {skus.length} SKUs loaded
+          Currency: {currencyCode} · {pageRows.length} SKUs loaded on this page
         </p>
       </PageContent>
     </PageContainer>

--- a/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
+++ b/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
@@ -1,4 +1,7 @@
 import { ApiResponses, withRole, z } from '@/lib/api'
+import { parseAmazonProductFees } from '@/lib/amazon/fees'
+import { hydrateComparisonSkuRow } from '@/lib/amazon/fba-fee-discrepancies'
+import { getListingPrice, getProductFeesForSku } from '@/lib/amazon/client'
 import { getMarketplaceCurrencyCode } from '@/lib/amazon/fees'
 import { escapeRegex, sanitizeSearchQuery } from '@/lib/security/input-sanitization'
 import { getCurrentTenantCode, getTenantPrisma } from '@/lib/tenant/server'
@@ -8,6 +11,8 @@ export const dynamic = 'force-dynamic'
 
 const listQuerySchema = z.object({
   search: z.string().optional(),
+  page: z.coerce.number().int().min(1).default(1),
+  pageSize: z.coerce.number().int().min(1).max(25).default(10),
 })
 
 export const GET = withRole(['admin', 'staff'], async (request, _session) => {
@@ -17,6 +22,7 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
 
   const query = listQuerySchema.parse(Object.fromEntries(request.nextUrl.searchParams))
   const search = query.search ? sanitizeSearchQuery(query.search) : null
+  const { page, pageSize } = query
 
   const whereClauses: Prisma.SkuWhereInput[] = [
     { asin: { not: null } },
@@ -38,18 +44,20 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
     AND: whereClauses,
   }
 
+  const total = await prisma.sku.count({ where })
+  const skip = (page - 1) * pageSize
   const skus = await prisma.sku.findMany({
     where,
     orderBy: { skuCode: 'asc' },
+    skip,
+    take: pageSize,
     select: {
       id: true,
       skuCode: true,
       description: true,
       asin: true,
-      fbaFulfillmentFee: true,
-      amazonListingPrice: true,
+      category: true,
       amazonSizeTier: true,
-      amazonFbaFulfillmentFee: true,
       // Reference dimensions (user-entered)
       unitDimensionsCm: true,
       unitSide1Cm: true,
@@ -71,23 +79,39 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
     },
   })
 
-  const resolvedSkus = skus.map(sku => {
-    return {
-      ...sku,
-      // Reference dimensions are now on SKU
-      referenceItemPackageDimensionsCm: sku.unitDimensionsCm,
-      referenceItemPackageSide1Cm: sku.unitSide1Cm,
-      referenceItemPackageSide2Cm: sku.unitSide2Cm,
-      referenceItemPackageSide3Cm: sku.unitSide3Cm,
-      referenceItemPackageWeightKg: sku.unitWeightKg,
-      // Amazon item package dimensions are now on SKU
-      amazonItemPackageDimensionsCm: sku.amazonItemPackageDimensionsCm,
-      amazonItemPackageSide1Cm: sku.amazonItemPackageSide1Cm,
-      amazonItemPackageSide2Cm: sku.amazonItemPackageSide2Cm,
-      amazonItemPackageSide3Cm: sku.amazonItemPackageSide3Cm,
-      amazonItemPackageWeightKg: sku.amazonReferenceWeightKg,
-    }
-  })
+  const feeHydratedSkus = await Promise.all(
+    skus.map(async sku => {
+      const resolvedSku = {
+        ...sku,
+        fbaFulfillmentFee: null,
+        amazonListingPrice: null,
+        amazonFbaFulfillmentFee: null,
+        // Reference dimensions are now on SKU
+        referenceItemPackageDimensionsCm: sku.unitDimensionsCm,
+        referenceItemPackageSide1Cm: sku.unitSide1Cm,
+        referenceItemPackageSide2Cm: sku.unitSide2Cm,
+        referenceItemPackageSide3Cm: sku.unitSide3Cm,
+        referenceItemPackageWeightKg: sku.unitWeightKg,
+        // Amazon item package dimensions are now on SKU
+        amazonItemPackageDimensionsCm: sku.amazonItemPackageDimensionsCm,
+        amazonItemPackageSide1Cm: sku.amazonItemPackageSide1Cm,
+        amazonItemPackageSide2Cm: sku.amazonItemPackageSide2Cm,
+        amazonItemPackageSide3Cm: sku.amazonItemPackageSide3Cm,
+        amazonItemPackageWeightKg: sku.amazonReferenceWeightKg,
+      }
+      return hydrateComparisonSkuRow(resolvedSku, tenantCode, {
+        loadListingPrice: getListingPrice,
+        loadAmazonFees: async (sellerSku, listingPriceToEstimate, currentTenantCode) => {
+          const rawFees = await getProductFeesForSku(sellerSku, listingPriceToEstimate, currentTenantCode)
+          const parsedFees = parseAmazonProductFees(rawFees)
+          return {
+            fbaFees: parsedFees.fbaFees,
+            sizeTier: parsedFees.sizeTier,
+          }
+        },
+      })
+    })
+  )
 
-  return ApiResponses.success({ currencyCode, skus: resolvedSkus })
+  return ApiResponses.success({ currencyCode, skus: feeHydratedSkus, total, page, pageSize })
 })

--- a/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
+++ b/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
@@ -1,4 +1,4 @@
-import { calculateSizeTierForTenant } from '@/lib/amazon/fees'
+import { calculateFbaFeeForTenant, calculateSizeTierForTenant } from '@/lib/amazon/fees'
 import { LB_PER_KG } from '@/lib/measurements'
 import { resolveDimensionTripletCm } from '@/lib/sku-dimensions'
 import type { TenantCode } from '@/lib/tenant/constants'
@@ -11,30 +11,34 @@ export type AlertStatus =
   | 'MISSING_REFERENCE'
   | 'ERROR'
 
+type DecimalLike = { toString(): string }
+type ApiNumberValue = number | string | DecimalLike | null
+
 export type ApiSkuRow = {
   id: string
   skuCode: string
   description: string
   asin: string | null
-  fbaFulfillmentFee: number | string | null
-  amazonFbaFulfillmentFee: number | string | null
-  amazonListingPrice: number | string | null
+  category?: string | null
+  fbaFulfillmentFee: ApiNumberValue
+  amazonFbaFulfillmentFee: ApiNumberValue
+  amazonListingPrice: ApiNumberValue
   amazonSizeTier: string | null
   referenceItemPackageDimensionsCm: string | null
-  referenceItemPackageSide1Cm: number | string | null
-  referenceItemPackageSide2Cm: number | string | null
-  referenceItemPackageSide3Cm: number | string | null
-  referenceItemPackageWeightKg: number | string | null
+  referenceItemPackageSide1Cm: ApiNumberValue
+  referenceItemPackageSide2Cm: ApiNumberValue
+  referenceItemPackageSide3Cm: ApiNumberValue
+  referenceItemPackageWeightKg: ApiNumberValue
   amazonItemPackageDimensionsCm: string | null
-  amazonItemPackageSide1Cm: number | string | null
-  amazonItemPackageSide2Cm: number | string | null
-  amazonItemPackageSide3Cm: number | string | null
-  amazonItemPackageWeightKg: number | string | null
+  amazonItemPackageSide1Cm: ApiNumberValue
+  amazonItemPackageSide2Cm: ApiNumberValue
+  amazonItemPackageSide3Cm: ApiNumberValue
+  amazonItemPackageWeightKg: ApiNumberValue
   itemDimensionsCm: string | null
-  itemSide1Cm: number | string | null
-  itemSide2Cm: number | string | null
-  itemSide3Cm: number | string | null
-  itemWeightKg: number | string | null
+  itemSide1Cm: ApiNumberValue
+  itemSide2Cm: ApiNumberValue
+  itemSide3Cm: ApiNumberValue
+  itemWeightKg: ApiNumberValue
 }
 
 export type DimensionTriplet = { side1Cm: number; side2Cm: number; side3Cm: number }
@@ -63,6 +67,16 @@ export type Comparison = {
   }
   feeDifference: number | null
   hasPhysicalMismatch: boolean
+}
+
+export type LiveAmazonFeeResult = {
+  fbaFees: number | null
+  sizeTier: string | null
+}
+
+export type ComparisonRowHydratorDeps = {
+  loadListingPrice: (asin: string, tenantCode: TenantCode) => Promise<number | null>
+  loadAmazonFees: (sellerSku: string, listingPrice: number, tenantCode: TenantCode) => Promise<LiveAmazonFeeResult>
 }
 
 const DIMENSION_TOLERANCE_CM = 0.05
@@ -220,7 +234,11 @@ function physicalMeasurementsMatch(params: {
   return true
 }
 
-export function computeComparison(row: ApiSkuRow, tenantCode: TenantCode): Comparison {
+function resolveReferenceSizeTier(row: ApiSkuRow, tenantCode: TenantCode): {
+  referenceTriplet: DimensionTriplet | null
+  referenceWeightKg: number | null
+  referenceSizeTier: string | null
+} {
   const referenceTriplet = resolveDimensionTripletCm({
     side1Cm: row.referenceItemPackageSide1Cm,
     side2Cm: row.referenceItemPackageSide2Cm,
@@ -238,6 +256,73 @@ export function computeComparison(row: ApiSkuRow, tenantCode: TenantCode): Compa
           referenceWeightKg
         )
       : null
+
+  return {
+    referenceTriplet,
+    referenceWeightKg,
+    referenceSizeTier,
+  }
+}
+
+function deriveReferenceFee(row: ApiSkuRow, tenantCode: TenantCode, listingPrice: number | null): number | null {
+  if (listingPrice === null) return null
+
+  const { referenceTriplet, referenceWeightKg, referenceSizeTier } = resolveReferenceSizeTier(row, tenantCode)
+  if (referenceTriplet === null) return null
+  if (referenceWeightKg === null) return null
+  if (referenceSizeTier === null) return null
+
+  let category: string | undefined
+  if (typeof row.category === 'string') {
+    const trimmed = row.category.trim()
+    if (trimmed) category = trimmed
+  }
+
+  return calculateFbaFeeForTenant(tenantCode, {
+    side1Cm: referenceTriplet.side1Cm,
+    side2Cm: referenceTriplet.side2Cm,
+    side3Cm: referenceTriplet.side3Cm,
+    unitWeightKg: referenceWeightKg,
+    listingPrice,
+    sizeTier: referenceSizeTier,
+    category,
+  })
+}
+
+export async function hydrateComparisonSkuRow(
+  row: ApiSkuRow,
+  tenantCode: TenantCode,
+  deps: ComparisonRowHydratorDeps
+): Promise<ApiSkuRow> {
+  if (typeof row.asin !== 'string') return { ...row, fbaFulfillmentFee: null, amazonFbaFulfillmentFee: null, amazonListingPrice: null }
+
+  const asin = row.asin.trim()
+  if (!asin) return { ...row, fbaFulfillmentFee: null, amazonFbaFulfillmentFee: null, amazonListingPrice: null }
+
+  const listingPrice = await deps.loadListingPrice(asin, tenantCode)
+  const expectedFee = deriveReferenceFee(row, tenantCode, listingPrice)
+
+  let amazonFee: number | null = null
+  let amazonSizeTier = row.amazonSizeTier
+  if (listingPrice !== null) {
+    const liveAmazonFees = await deps.loadAmazonFees(row.skuCode, listingPrice, tenantCode)
+    amazonFee = liveAmazonFees.fbaFees
+    if (liveAmazonFees.sizeTier !== null) {
+      amazonSizeTier = liveAmazonFees.sizeTier
+    }
+  }
+
+  return {
+    ...row,
+    fbaFulfillmentFee: expectedFee,
+    amazonFbaFulfillmentFee: amazonFee,
+    amazonListingPrice: listingPrice,
+    amazonSizeTier,
+  }
+}
+
+export function computeComparison(row: ApiSkuRow, tenantCode: TenantCode): Comparison {
+  const { referenceTriplet, referenceWeightKg, referenceSizeTier } = resolveReferenceSizeTier(row, tenantCode)
   const referenceShipping = computeShippingWeights(referenceTriplet, referenceWeightKg, referenceSizeTier, tenantCode)
 
   const amazonTriplet = resolveDimensionTripletCm({

--- a/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
@@ -3,7 +3,7 @@ import test from 'node:test'
 
 import * as discrepancies from '../../src/lib/amazon/fba-fee-discrepancies'
 import type { ApiSkuRow } from '../../src/lib/amazon/fba-fee-discrepancies'
-import { calculateSizeTierForTenant } from '../../src/lib/amazon/fees'
+import { calculateFbaFeeForTenant, calculateSizeTierForTenant } from '../../src/lib/amazon/fees'
 
 function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
   const referenceTriplet = {
@@ -102,4 +102,59 @@ test('status label shows overcharge when only the fee differs', () => {
   if (typeof discrepancies.getComparisonStatusLabel !== 'function') return
 
   assert.equal(discrepancies.getComparisonStatusLabel(comparison), 'Overcharge')
+})
+
+test('hydrateComparisonSkuRow derives the reference fee instead of trusting the stored value', async () => {
+  assert.equal(typeof discrepancies.hydrateComparisonSkuRow, 'function')
+  if (typeof discrepancies.hydrateComparisonSkuRow !== 'function') return
+
+  const listingPrice = 19.99
+  const sizeTier = calculateSizeTierForTenant('US', 10, 10, 10, 0.2)
+  assert.notEqual(sizeTier, null)
+  if (sizeTier === null) return
+
+  const expectedReferenceFee = calculateFbaFeeForTenant('US', {
+    side1Cm: 10,
+    side2Cm: 10,
+    side3Cm: 10,
+    unitWeightKg: 0.2,
+    listingPrice,
+    sizeTier,
+  })
+
+  const hydrated = await discrepancies.hydrateComparisonSkuRow(
+    createSkuRow({
+      fbaFulfillmentFee: 99.99,
+      amazonFbaFulfillmentFee: 88.88,
+    }),
+    'US',
+    {
+      loadListingPrice: async () => listingPrice,
+      loadAmazonFees: async () => ({ fbaFees: 7.77, sizeTier: null }),
+    }
+  )
+
+  assert.equal(hydrated.fbaFulfillmentFee, expectedReferenceFee)
+  assert.equal(hydrated.amazonFbaFulfillmentFee, 7.77)
+})
+
+test('hydrateComparisonSkuRow uses the live Amazon fee even when the stored fee disagrees', async () => {
+  assert.equal(typeof discrepancies.hydrateComparisonSkuRow, 'function')
+  if (typeof discrepancies.hydrateComparisonSkuRow !== 'function') return
+
+  const hydrated = await discrepancies.hydrateComparisonSkuRow(
+    createSkuRow({
+      fbaFulfillmentFee: 2.22,
+      amazonFbaFulfillmentFee: 55.55,
+      amazonSizeTier: 'Large Standard-Size',
+    }),
+    'US',
+    {
+      loadListingPrice: async () => 24.5,
+      loadAmazonFees: async () => ({ fbaFees: 6.66, sizeTier: 'Small Bulky' }),
+    }
+  )
+
+  assert.equal(hydrated.amazonFbaFulfillmentFee, 6.66)
+  assert.equal(hydrated.amazonSizeTier, 'Small Bulky')
 })


### PR DESCRIPTION
## Summary
- stop reading persisted FBA fee values in the discrepancies route and hydrate each server page from live listing price and live Amazon fee data
- derive the reference fee at read time from the current listing price and reference dimensions instead of trusting the stored reference fee column
- keep the discrepancy UI paged from the server and add coverage for the live hydration path

## Verification
- `pnpm --dir apps/talos exec tsx tests/unit/amazon-fba-fee-discrepancies.test.ts`
- `pnpm --dir apps/talos type-check`
- `pnpm --dir apps/talos lint`
- `pnpm --dir apps/talos test`