### PR TITLE
fix(talos): use live Amazon fees and remove snapshot persistence

### DIFF
--- a/apps/talos/prisma/migrations/20260419105435_remove_sku_amazon_fba_fulfillment_fee/migration.sql
+++ b/apps/talos/prisma/migrations/20260419105435_remove_sku_amazon_fba_fulfillment_fee/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "skus" DROP COLUMN "amazon_fba_fulfillment_fee";

--- a/apps/talos/prisma/schema.prisma
+++ b/apps/talos/prisma/schema.prisma
@@ -113,7 +113,6 @@ model Sku {
   amazonSubcategory    String?    @map("amazon_subcategory")
   amazonSizeTier       String?    @map("amazon_size_tier")
   amazonReferralFeePercent Decimal? @map("amazon_referral_fee_percent") @db.Decimal(5, 2)
-  amazonFbaFulfillmentFee Decimal? @map("amazon_fba_fulfillment_fee") @db.Decimal(12, 2)
   amazonListingPrice   Decimal?   @map("amazon_listing_price") @db.Decimal(12, 2)
   amazonReferenceWeightKg Decimal? @map("amazon_reference_weight_kg") @db.Decimal(8, 3)
   description         String     @db.VarChar(42)

--- a/apps/talos/scripts/migrations/add-sku-amazon-reference-weight.ts
+++ b/apps/talos/scripts/migrations/add-sku-amazon-reference-weight.ts
@@ -117,10 +117,8 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
   console.log(`[${tenant}] Backfilling skus Amazon reference fields from latest active sku_batches`)
 
   const hasSkuAmazonSizeTier = options.dryRun ? true : await columnExists(prisma, 'skus', 'amazon_size_tier')
-  const hasSkuAmazonFbaFee = options.dryRun ? true : await columnExists(prisma, 'skus', 'amazon_fba_fulfillment_fee')
   const hasSkuUnitWeight = options.dryRun ? true : await columnExists(prisma, 'skus', 'unit_weight_kg')
   const hasBatchAmazonSizeTier = options.dryRun ? true : await columnExists(prisma, 'sku_batches', 'amazon_size_tier')
-  const hasBatchAmazonFbaFee = options.dryRun ? true : await columnExists(prisma, 'sku_batches', 'amazon_fba_fulfillment_fee')
   const hasBatchAmazonRefWeight = options.dryRun
     ? true
     : await columnExists(prisma, 'sku_batches', 'amazon_reference_weight_kg')
@@ -129,9 +127,6 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
   const setClauses = [
     hasSkuAmazonSizeTier && hasBatchAmazonSizeTier
       ? `amazon_size_tier = COALESCE(s.amazon_size_tier, b.amazon_size_tier)`
-      : null,
-    hasSkuAmazonFbaFee && hasBatchAmazonFbaFee
-      ? `amazon_fba_fulfillment_fee = COALESCE(s.amazon_fba_fulfillment_fee, b.amazon_fba_fulfillment_fee)`
       : null,
     `amazon_reference_weight_kg = COALESCE(
       s.amazon_reference_weight_kg,
@@ -149,7 +144,6 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
       SELECT DISTINCT ON (sku_id)
         sku_id
         ${hasBatchAmazonSizeTier ? ', amazon_size_tier' : ''}
-        ${hasBatchAmazonFbaFee ? ', amazon_fba_fulfillment_fee' : ''}
         ${hasBatchAmazonRefWeight ? ', amazon_reference_weight_kg' : ''}
         ${hasBatchUnitWeight ? ', unit_weight_kg' : ''}
       FROM sku_batches
@@ -185,4 +179,3 @@ main().catch(error => {
   console.error(error)
   process.exitCode = 1
 })
-

--- a/apps/talos/scripts/migrations/add-sku-batch-amazon-default-columns.ts
+++ b/apps/talos/scripts/migrations/add-sku-batch-amazon-default-columns.ts
@@ -102,7 +102,6 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
 
   const ddlStatements = [
     `ALTER TABLE "sku_batches" ADD COLUMN IF NOT EXISTS "amazon_size_tier" text`,
-    `ALTER TABLE "sku_batches" ADD COLUMN IF NOT EXISTS "amazon_fba_fulfillment_fee" DECIMAL(12,2)`,
     `ALTER TABLE "sku_batches" ADD COLUMN IF NOT EXISTS "amazon_reference_weight_kg" DECIMAL(8,3)`,
   ]
 
@@ -117,11 +116,10 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
 
   console.log(`[${tenant}] Backfilling sku_batches Amazon defaults from skus`)
 
-  const [hasSkuAmazonSizeTier, hasSkuAmazonFbaFee, hasSkuUnitWeight] = options.dryRun
-    ? [true, true, true]
+  const [hasSkuAmazonSizeTier, hasSkuUnitWeight] = options.dryRun
+    ? [true, true]
     : await Promise.all([
         columnExists(prisma, 'skus', 'amazon_size_tier'),
-        columnExists(prisma, 'skus', 'amazon_fba_fulfillment_fee'),
         columnExists(prisma, 'skus', 'unit_weight_kg'),
       ])
 
@@ -129,13 +127,10 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
     hasSkuAmazonSizeTier
       ? `amazon_size_tier = COALESCE(b.amazon_size_tier, s.amazon_size_tier)`
       : null,
-    hasSkuAmazonFbaFee
-      ? `amazon_fba_fulfillment_fee = COALESCE(b.amazon_fba_fulfillment_fee, s.amazon_fba_fulfillment_fee)`
-      : null,
     `amazon_reference_weight_kg = COALESCE(b.amazon_reference_weight_kg, b.unit_weight_kg${hasSkuUnitWeight ? ', s.unit_weight_kg' : ''})`,
   ].filter((clause): clause is string => Boolean(clause))
 
-  const needsSkuJoin = hasSkuAmazonSizeTier || hasSkuAmazonFbaFee || hasSkuUnitWeight
+  const needsSkuJoin = hasSkuAmazonSizeTier || hasSkuUnitWeight
 
   const backfillSql = needsSkuJoin
     ? `

--- a/apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts
+++ b/apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts
@@ -317,7 +317,6 @@ const baselineChecks: SchemaCheck[] = [
     'amazon_category',
     'amazon_size_tier',
     'amazon_referral_fee_percent',
-    'amazon_fba_fulfillment_fee',
   ]),
   buildRequiredIndexesCheck('skus supplier indexes', [
     'skus_default_supplier_id_idx',
@@ -637,7 +636,8 @@ async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
     `ALTER TABLE "skus" ADD COLUMN IF NOT EXISTS "amazon_category" text`,
     `ALTER TABLE "skus" ADD COLUMN IF NOT EXISTS "amazon_size_tier" text`,
     `ALTER TABLE "skus" ADD COLUMN IF NOT EXISTS "amazon_referral_fee_percent" numeric(5, 2)`,
-    `ALTER TABLE "skus" ADD COLUMN IF NOT EXISTS "amazon_fba_fulfillment_fee" numeric(12, 2)`,
+    `ALTER TABLE "skus" DROP COLUMN IF EXISTS "amazon_fba_fulfillment_fee"`,
+    `ALTER TABLE IF EXISTS "sku_batches" DROP COLUMN IF EXISTS "amazon_fba_fulfillment_fee"`,
 
     // Track FBA fee mismatch alerts per SKU (one row per SKU)
     `

--- a/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
+++ b/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
@@ -1,6 +1,6 @@
 import { ApiResponses, withRole, z } from '@/lib/api'
 import { parseAmazonProductFees } from '@/lib/amazon/fees'
-import { hydrateComparisonSkuRow } from '@/lib/amazon/fba-fee-discrepancies'
+import { buildComparisonSkuRow, hydrateComparisonSkuRow } from '@/lib/amazon/fba-fee-discrepancies'
 import { getListingPrice, getProductFeesForSku } from '@/lib/amazon/client'
 import { getMarketplaceCurrencyCode } from '@/lib/amazon/fees'
 import { escapeRegex, sanitizeSearchQuery } from '@/lib/security/input-sanitization'
@@ -57,6 +57,7 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
       description: true,
       asin: true,
       category: true,
+      fbaFulfillmentFee: true,
       amazonSizeTier: true,
       // Reference dimensions (user-entered)
       unitDimensionsCm: true,
@@ -81,24 +82,7 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
 
   const feeHydratedSkus = await Promise.all(
     skus.map(async sku => {
-      const resolvedSku = {
-        ...sku,
-        fbaFulfillmentFee: null,
-        amazonListingPrice: null,
-        amazonFbaFulfillmentFee: null,
-        // Reference dimensions are now on SKU
-        referenceItemPackageDimensionsCm: sku.unitDimensionsCm,
-        referenceItemPackageSide1Cm: sku.unitSide1Cm,
-        referenceItemPackageSide2Cm: sku.unitSide2Cm,
-        referenceItemPackageSide3Cm: sku.unitSide3Cm,
-        referenceItemPackageWeightKg: sku.unitWeightKg,
-        // Amazon item package dimensions are now on SKU
-        amazonItemPackageDimensionsCm: sku.amazonItemPackageDimensionsCm,
-        amazonItemPackageSide1Cm: sku.amazonItemPackageSide1Cm,
-        amazonItemPackageSide2Cm: sku.amazonItemPackageSide2Cm,
-        amazonItemPackageSide3Cm: sku.amazonItemPackageSide3Cm,
-        amazonItemPackageWeightKg: sku.amazonReferenceWeightKg,
-      }
+      const resolvedSku = buildComparisonSkuRow(sku)
       return hydrateComparisonSkuRow(resolvedSku, tenantCode, {
         loadListingPrice: getListingPrice,
         loadAmazonFees: async (sellerSku, listingPriceToEstimate, currentTenantCode) => {

--- a/apps/talos/src/app/api/amazon/import-skus/route.ts
+++ b/apps/talos/src/app/api/amazon/import-skus/route.ts
@@ -510,7 +510,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
     unitDimensionsCm?: string | null
     feeDebug?: {
       referralFeePercent: number | null
-      fbaFee: number | null
       sizeTier: string | null
     }
   }> = []
@@ -610,7 +609,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
     let amazonCategory: string | null = null
     let amazonSubcategory: string | null = null
     let amazonReferralFeePercent: number | null = null
-    let amazonFbaFulfillmentFee: number | null = null
     let amazonSizeTier: string | null = null
     let amazonListingPrice: number | null = null
 
@@ -667,7 +665,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
 
       const fees = await getProductFeesForSku(skuCode, fetchedListingPrice, tenantCode)
       const parsedFees = parseAmazonProductFees(fees)
-      amazonFbaFulfillmentFee = roundToTwoDecimals(parsedFees.fbaFees ?? Number.NaN)
       if (amazonSizeTier === null && parsedFees.sizeTier) {
         amazonSizeTier = parsedFees.sizeTier
       }
@@ -734,7 +731,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
         if (amazonSubcategory !== null) skuUpdateData.amazonSubcategory = amazonSubcategory
         if (amazonSizeTier !== null) skuUpdateData.amazonSizeTier = amazonSizeTier
         if (amazonReferralFeePercent !== null) skuUpdateData.amazonReferralFeePercent = amazonReferralFeePercent
-        if (amazonFbaFulfillmentFee !== null) skuUpdateData.amazonFbaFulfillmentFee = amazonFbaFulfillmentFee
         if (amazonListingPrice !== null) skuUpdateData.amazonListingPrice = amazonListingPrice
 
         if (shouldSetItemDimensions && itemTriplet) {
@@ -789,7 +785,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
           unitDimensionsCm,
           feeDebug: {
             referralFeePercent: amazonReferralFeePercent,
-            fbaFee: amazonFbaFulfillmentFee,
             sizeTier: amazonSizeTier,
           },
         })
@@ -805,7 +800,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
               amazonSubcategory,
               amazonSizeTier,
               amazonReferralFeePercent,
-              amazonFbaFulfillmentFee,
               amazonListingPrice,
               amazonReferenceWeightKg: null,
               packSize: DEFAULT_PACK_SIZE,
@@ -848,7 +842,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
           unitDimensionsCm,
           feeDebug: {
             referralFeePercent: amazonReferralFeePercent,
-            fbaFee: amazonFbaFulfillmentFee,
             sizeTier: amazonSizeTier,
           },
         })

--- a/apps/talos/src/app/api/skus/route.ts
+++ b/apps/talos/src/app/api/skus/route.ts
@@ -124,7 +124,6 @@ const skuSchemaBase = z.object({
       return sanitized ? sanitized : null
     }),
   amazonReferralFeePercent: z.number().min(0).max(100).optional().nullable(),
-  amazonFbaFulfillmentFee: z.number().min(0).optional().nullable(),
   amazonReferenceWeightKg: z.number().positive().optional().nullable(),
   defaultSupplierId: supplierIdSchema,
   secondarySupplierId: supplierIdSchema,
@@ -342,7 +341,6 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
         amazonCategory: validatedData.amazonCategory ?? null,
         amazonSizeTier: validatedData.amazonSizeTier ?? null,
         amazonReferralFeePercent: validatedData.amazonReferralFeePercent ?? null,
-        amazonFbaFulfillmentFee: validatedData.amazonFbaFulfillmentFee ?? null,
         amazonReferenceWeightKg: validatedData.amazonReferenceWeightKg ?? null,
         description: validatedData.description,
         defaultSupplierId: validatedData.defaultSupplierId ?? null,

--- a/apps/talos/src/app/config/products/skus-panel.tsx
+++ b/apps/talos/src/app/config/products/skus-panel.tsx
@@ -160,7 +160,6 @@ interface SkuRow {
   amazonSubcategory?: string | null
   amazonSizeTier?: string | null
   amazonReferralFeePercent?: number | string | null
-  amazonFbaFulfillmentFee?: number | string | null
   amazonListingPrice?: number | string | null
   amazonReferenceWeightKg: number | string | null
   amazonItemPackageDimensionsCm: string | null
@@ -207,7 +206,6 @@ interface SkuFormState {
   amazonSubcategory: string
   amazonSizeTier: string
   amazonReferralFeePercent: string
-  amazonFbaFulfillmentFee: string
   unitSide1Cm: string
   unitSide2Cm: string
   unitSide3Cm: string
@@ -316,7 +314,6 @@ function buildFormState(sku: SkuRow | null | undefined, unitSystem: UnitSystem):
     amazonSubcategory: sku?.amazonSubcategory ?? '',
     amazonSizeTier: sku?.amazonSizeTier ?? '',
     amazonReferralFeePercent: sku?.amazonReferralFeePercent?.toString?.() ?? '',
-    amazonFbaFulfillmentFee: sku?.amazonFbaFulfillmentFee?.toString?.() ?? '',
     unitSide1Cm: unitTriplet ? formatLengthInput(unitTriplet.side1Cm) : '',
     unitSide2Cm: unitTriplet ? formatLengthInput(unitTriplet.side2Cm) : '',
     unitSide3Cm: unitTriplet ? formatLengthInput(unitTriplet.side3Cm) : '',
@@ -1592,15 +1589,6 @@ export default function SkusPanel({ externalModalOpen, externalEditSkuId, onExte
                               <Label>Referral Fee (%)</Label>
                               <Input
                                 value={formState.amazonReferralFeePercent}
-                                disabled
-                                className="bg-slate-100 text-slate-500"
-                                placeholder="—"
-                              />
-                            </div>
-                            <div className="space-y-1">
-                              <Label>FBA Fulfillment Fee</Label>
-                              <Input
-                                value={formState.amazonFbaFulfillmentFee}
                                 disabled
                                 className="bg-slate-100 text-slate-500"
                                 placeholder="—"

--- a/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
+++ b/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
@@ -1,4 +1,4 @@
-import { calculateFbaFeeForTenant, calculateSizeTierForTenant } from '@/lib/amazon/fees'
+import { calculateSizeTierForTenant } from '@/lib/amazon/fees'
 import { LB_PER_KG } from '@/lib/measurements'
 import { resolveDimensionTripletCm } from '@/lib/sku-dimensions'
 import type { TenantCode } from '@/lib/tenant/constants'
@@ -41,6 +41,31 @@ export type ApiSkuRow = {
   itemWeightKg: ApiNumberValue
 }
 
+export type ComparisonSkuSourceRow = {
+  id: string
+  skuCode: string
+  description: string
+  asin: string | null
+  category?: string | null
+  fbaFulfillmentFee: ApiNumberValue
+  amazonSizeTier: string | null
+  unitDimensionsCm: string | null
+  unitSide1Cm: ApiNumberValue
+  unitSide2Cm: ApiNumberValue
+  unitSide3Cm: ApiNumberValue
+  unitWeightKg: ApiNumberValue
+  itemDimensionsCm: string | null
+  itemSide1Cm: ApiNumberValue
+  itemSide2Cm: ApiNumberValue
+  itemSide3Cm: ApiNumberValue
+  itemWeightKg: ApiNumberValue
+  amazonItemPackageDimensionsCm: string | null
+  amazonItemPackageSide1Cm: ApiNumberValue
+  amazonItemPackageSide2Cm: ApiNumberValue
+  amazonItemPackageSide3Cm: ApiNumberValue
+  amazonReferenceWeightKg: ApiNumberValue
+}
+
 export type DimensionTriplet = { side1Cm: number; side2Cm: number; side3Cm: number }
 
 export type ShippingWeights = {
@@ -81,6 +106,24 @@ export type ComparisonRowHydratorDeps = {
 
 const DIMENSION_TOLERANCE_CM = 0.05
 const WEIGHT_TOLERANCE_KG = 0.005
+
+export function buildComparisonSkuRow(row: ComparisonSkuSourceRow): ApiSkuRow {
+  return {
+    ...row,
+    amazonListingPrice: null,
+    amazonFbaFulfillmentFee: null,
+    referenceItemPackageDimensionsCm: row.unitDimensionsCm,
+    referenceItemPackageSide1Cm: row.unitSide1Cm,
+    referenceItemPackageSide2Cm: row.unitSide2Cm,
+    referenceItemPackageSide3Cm: row.unitSide3Cm,
+    referenceItemPackageWeightKg: row.unitWeightKg,
+    amazonItemPackageDimensionsCm: row.amazonItemPackageDimensionsCm,
+    amazonItemPackageSide1Cm: row.amazonItemPackageSide1Cm,
+    amazonItemPackageSide2Cm: row.amazonItemPackageSide2Cm,
+    amazonItemPackageSide3Cm: row.amazonItemPackageSide3Cm,
+    amazonItemPackageWeightKg: row.amazonReferenceWeightKg,
+  }
+}
 
 export function parseDecimalNumber(value: unknown): number | null {
   if (value === null || value === undefined) return null
@@ -264,43 +307,17 @@ function resolveReferenceSizeTier(row: ApiSkuRow, tenantCode: TenantCode): {
   }
 }
 
-function deriveReferenceFee(row: ApiSkuRow, tenantCode: TenantCode, listingPrice: number | null): number | null {
-  if (listingPrice === null) return null
-
-  const { referenceTriplet, referenceWeightKg, referenceSizeTier } = resolveReferenceSizeTier(row, tenantCode)
-  if (referenceTriplet === null) return null
-  if (referenceWeightKg === null) return null
-  if (referenceSizeTier === null) return null
-
-  let category: string | undefined
-  if (typeof row.category === 'string') {
-    const trimmed = row.category.trim()
-    if (trimmed) category = trimmed
-  }
-
-  return calculateFbaFeeForTenant(tenantCode, {
-    side1Cm: referenceTriplet.side1Cm,
-    side2Cm: referenceTriplet.side2Cm,
-    side3Cm: referenceTriplet.side3Cm,
-    unitWeightKg: referenceWeightKg,
-    listingPrice,
-    sizeTier: referenceSizeTier,
-    category,
-  })
-}
-
 export async function hydrateComparisonSkuRow(
   row: ApiSkuRow,
   tenantCode: TenantCode,
   deps: ComparisonRowHydratorDeps
 ): Promise<ApiSkuRow> {
-  if (typeof row.asin !== 'string') return { ...row, fbaFulfillmentFee: null, amazonFbaFulfillmentFee: null, amazonListingPrice: null }
+  if (typeof row.asin !== 'string') return { ...row, amazonFbaFulfillmentFee: null, amazonListingPrice: null }
 
   const asin = row.asin.trim()
-  if (!asin) return { ...row, fbaFulfillmentFee: null, amazonFbaFulfillmentFee: null, amazonListingPrice: null }
+  if (!asin) return { ...row, amazonFbaFulfillmentFee: null, amazonListingPrice: null }
 
   const listingPrice = await deps.loadListingPrice(asin, tenantCode)
-  const expectedFee = deriveReferenceFee(row, tenantCode, listingPrice)
 
   let amazonFee: number | null = null
   let amazonSizeTier = row.amazonSizeTier
@@ -314,7 +331,6 @@ export async function hydrateComparisonSkuRow(
 
   return {
     ...row,
-    fbaFulfillmentFee: expectedFee,
     amazonFbaFulfillmentFee: amazonFee,
     amazonListingPrice: listingPrice,
     amazonSizeTier,

--- a/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
@@ -2,8 +2,11 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import * as discrepancies from '../../src/lib/amazon/fba-fee-discrepancies'
-import type { ApiSkuRow } from '../../src/lib/amazon/fba-fee-discrepancies'
-import { calculateFbaFeeForTenant, calculateSizeTierForTenant } from '../../src/lib/amazon/fees'
+import type {
+  ApiSkuRow,
+  ComparisonSkuSourceRow,
+} from '../../src/lib/amazon/fba-fee-discrepancies'
+import { calculateSizeTierForTenant } from '../../src/lib/amazon/fees'
 
 function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
   const referenceTriplet = {
@@ -43,6 +46,49 @@ function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
     itemSide2Cm: null,
     itemSide3Cm: null,
     itemWeightKg: null,
+    ...overrides,
+  }
+}
+
+function createComparisonSkuSourceRow(
+  overrides: Partial<ComparisonSkuSourceRow> = {}
+): ComparisonSkuSourceRow {
+  const referenceTriplet = {
+    side1Cm: 10,
+    side2Cm: 10,
+    side3Cm: 10,
+  }
+  const referenceWeightKg = 0.2
+
+  return {
+    id: 'sku_1',
+    skuCode: 'CS-010',
+    description: 'Test SKU',
+    asin: 'B000TEST01',
+    category: 'Toys',
+    fbaFulfillmentFee: 3.21,
+    amazonSizeTier: calculateSizeTierForTenant(
+      'US',
+      referenceTriplet.side1Cm,
+      referenceTriplet.side2Cm,
+      referenceTriplet.side3Cm,
+      referenceWeightKg
+    ),
+    unitDimensionsCm: null,
+    unitSide1Cm: referenceTriplet.side1Cm,
+    unitSide2Cm: referenceTriplet.side2Cm,
+    unitSide3Cm: referenceTriplet.side3Cm,
+    unitWeightKg: referenceWeightKg,
+    itemDimensionsCm: null,
+    itemSide1Cm: null,
+    itemSide2Cm: null,
+    itemSide3Cm: null,
+    itemWeightKg: null,
+    amazonItemPackageDimensionsCm: null,
+    amazonItemPackageSide1Cm: referenceTriplet.side1Cm,
+    amazonItemPackageSide2Cm: referenceTriplet.side2Cm,
+    amazonItemPackageSide3Cm: referenceTriplet.side3Cm,
+    amazonReferenceWeightKg: referenceWeightKg,
     ...overrides,
   }
 }
@@ -104,50 +150,32 @@ test('status label shows overcharge when only the fee differs', () => {
   assert.equal(discrepancies.getComparisonStatusLabel(comparison), 'Overcharge')
 })
 
-test('hydrateComparisonSkuRow derives the reference fee instead of trusting the stored value', async () => {
-  assert.equal(typeof discrepancies.hydrateComparisonSkuRow, 'function')
-  if (typeof discrepancies.hydrateComparisonSkuRow !== 'function') return
+test('buildComparisonSkuRow keeps the stored reference fee from the API selection', () => {
+  assert.equal(typeof discrepancies.buildComparisonSkuRow, 'function')
+  if (typeof discrepancies.buildComparisonSkuRow !== 'function') return
 
-  const listingPrice = 19.99
-  const sizeTier = calculateSizeTierForTenant('US', 10, 10, 10, 0.2)
-  assert.notEqual(sizeTier, null)
-  if (sizeTier === null) return
-
-  const expectedReferenceFee = calculateFbaFeeForTenant('US', {
-    side1Cm: 10,
-    side2Cm: 10,
-    side3Cm: 10,
-    unitWeightKg: 0.2,
-    listingPrice,
-    sizeTier,
-  })
-
-  const hydrated = await discrepancies.hydrateComparisonSkuRow(
-    createSkuRow({
-      fbaFulfillmentFee: 99.99,
-      amazonFbaFulfillmentFee: 88.88,
-    }),
-    'US',
-    {
-      loadListingPrice: async () => listingPrice,
-      loadAmazonFees: async () => ({ fbaFees: 7.77, sizeTier: null }),
-    }
+  const resolved = discrepancies.buildComparisonSkuRow(
+    createComparisonSkuSourceRow({
+      fbaFulfillmentFee: 9.87,
+    })
   )
 
-  assert.equal(hydrated.fbaFulfillmentFee, expectedReferenceFee)
-  assert.equal(hydrated.amazonFbaFulfillmentFee, 7.77)
+  assert.equal(resolved.fbaFulfillmentFee, 9.87)
+  assert.equal(resolved.amazonFbaFulfillmentFee, null)
+  assert.equal(resolved.referenceItemPackageWeightKg, 0.2)
 })
 
-test('hydrateComparisonSkuRow uses the live Amazon fee even when the stored fee disagrees', async () => {
+test('hydrateComparisonSkuRow keeps the stored reference fee and refreshes only Amazon fee data', async () => {
   assert.equal(typeof discrepancies.hydrateComparisonSkuRow, 'function')
   if (typeof discrepancies.hydrateComparisonSkuRow !== 'function') return
 
   const hydrated = await discrepancies.hydrateComparisonSkuRow(
-    createSkuRow({
-      fbaFulfillmentFee: 2.22,
-      amazonFbaFulfillmentFee: 55.55,
+    discrepancies.buildComparisonSkuRow(
+      createComparisonSkuSourceRow({
+      fbaFulfillmentFee: 99.99,
       amazonSizeTier: 'Large Standard-Size',
-    }),
+      })
+    ),
     'US',
     {
       loadListingPrice: async () => 24.5,
@@ -155,6 +183,7 @@ test('hydrateComparisonSkuRow uses the live Amazon fee even when the stored fee 
     }
   )
 
+  assert.equal(hydrated.fbaFulfillmentFee, 99.99)
   assert.equal(hydrated.amazonFbaFulfillmentFee, 6.66)
   assert.equal(hydrated.amazonSizeTier, 'Small Bulky')
 })

--- a/apps/talos/tests/unit/amazon-fba-fee-persistence.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-persistence.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const talosRoot = path.resolve(__dirname, '..', '..')
+
+test('Talos does not persist Amazon FBA fee snapshots on SKUs', () => {
+  const sourceFiles = [
+    'src/app/api/skus/route.ts',
+    'src/app/api/amazon/import-skus/route.ts',
+    'src/app/config/products/skus-panel.tsx',
+  ]
+  const scriptChecks = [
+    {
+      relativePath: 'scripts/migrations/ensure-talos-tenant-schema.ts',
+      bannedPatterns: [
+        /buildRequiredColumnsCheck\('skus amazon fee columns', 'skus', \[\s*'amazon_category',\s*'amazon_size_tier',\s*'amazon_referral_fee_percent',\s*'amazon_fba_fulfillment_fee',\s*\]\)/m,
+        /ALTER TABLE "skus" ADD COLUMN IF NOT EXISTS "amazon_fba_fulfillment_fee"/,
+      ],
+      requiredPatterns: [
+        /ALTER TABLE "skus" DROP COLUMN IF EXISTS "amazon_fba_fulfillment_fee"/,
+        /ALTER TABLE IF EXISTS "sku_batches" DROP COLUMN IF EXISTS "amazon_fba_fulfillment_fee"/,
+      ],
+    },
+    {
+      relativePath: 'scripts/migrations/add-sku-batch-amazon-default-columns.ts',
+      bannedPatterns: [
+        /amazon_fba_fulfillment_fee/,
+      ],
+    },
+    {
+      relativePath: 'scripts/migrations/add-sku-amazon-reference-weight.ts',
+      bannedPatterns: [
+        /columnExists\(prisma, 'skus', 'amazon_fba_fulfillment_fee'\)/,
+        /s\.amazon_fba_fulfillment_fee/,
+      ],
+    },
+  ]
+
+  for (const relativePath of sourceFiles) {
+    const source = readFileSync(path.join(talosRoot, relativePath), 'utf8')
+    assert.equal(
+      source.includes('amazonFbaFulfillmentFee'),
+      false,
+      `${relativePath} still persists or exposes amazonFbaFulfillmentFee`
+    )
+  }
+
+  for (const scriptCheck of scriptChecks) {
+    const source = readFileSync(path.join(talosRoot, scriptCheck.relativePath), 'utf8')
+    for (const bannedPattern of scriptCheck.bannedPatterns) {
+      assert.equal(
+        bannedPattern.test(source),
+        false,
+        `${scriptCheck.relativePath} still recreates or backfills skus.amazon_fba_fulfillment_fee`
+      )
+    }
+    for (const requiredPattern of scriptCheck.requiredPatterns ?? []) {
+      assert.equal(
+        requiredPattern.test(source),
+        true,
+        `${scriptCheck.relativePath} no longer drops stale amazon_fba_fulfillment_fee columns during tenant-schema rollout`
+      )
+    }
+  }
+
+  const schema = readFileSync(path.join(talosRoot, 'prisma/schema.prisma'), 'utf8')
+  const skuBlock = schema.match(/model Sku \{[\s\S]*?\n\}/)?.[0] ?? ''
+  assert.equal(
+    skuBlock.includes('amazonFbaFulfillmentFee'),
+    false,
+    'Sku model still stores amazonFbaFulfillmentFee'
+  )
+})


### PR DESCRIPTION
## Summary
- promote the Talos live-Amazon-fee discrepancy fix from `dev` to `main`
- remove persisted SKU Amazon fee snapshot usage and roll out the stale-column cleanup path
- keep discrepancy comparisons anchored to the stored user reference fee and live Amazon SP-API fee data

## Verification
- CI on the merged `dev` PR #5053 passed before this promotion PR was opened