### PR TITLE
fix(sso): suppress stale session auth noise

### DIFF
--- a/apps/sso/lib/auth-logger.test.ts
+++ b/apps/sso/lib/auth-logger.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { logAuthError, shouldSuppressAuthError } from './auth-logger'
+
+type AuthLoggerErrorInput = Error & {
+  cause?: {
+    err?: Error
+    [key: string]: unknown
+  }
+  type?: string
+}
+
+function createJwtSessionError(message: string): AuthLoggerErrorInput {
+  const error = new Error(
+    'JWTSessionError: Read more at https://errors.authjs.dev#jwtsessionerror',
+  ) as AuthLoggerErrorInput
+  error.cause = { err: new Error(message) }
+  error.type = 'JWTSessionError'
+  return error
+}
+
+test('shouldSuppressAuthError matches the expected stale-session decrypt noise', () => {
+  assert.equal(
+    shouldSuppressAuthError(createJwtSessionError('no matching decryption secret')),
+    true,
+  )
+  assert.equal(
+    shouldSuppressAuthError(createJwtSessionError('decryption operation failed')),
+    true,
+  )
+})
+
+test('shouldSuppressAuthError keeps unrelated auth failures visible', () => {
+  assert.equal(
+    shouldSuppressAuthError(createJwtSessionError('session callback exploded')),
+    false,
+  )
+
+  const callbackError = new Error('OAuth callback failed') as AuthLoggerErrorInput
+  callbackError.cause = { err: new Error('provider exploded') }
+  callbackError.type = 'CallbackRouteError'
+
+  assert.equal(shouldSuppressAuthError(callbackError), false)
+})
+
+test('logAuthError skips console output for the expected stale-session decrypt noise', () => {
+  const captured: unknown[][] = []
+  const logger = {
+    error: (...args: unknown[]) => {
+      captured.push(args)
+    },
+  }
+
+  logAuthError(createJwtSessionError('no matching decryption secret'), logger)
+
+  assert.deepEqual(captured, [])
+})
+
+test('logAuthError preserves default-style output for unexpected auth errors', () => {
+  const captured: unknown[][] = []
+  const logger = {
+    error: (...args: unknown[]) => {
+      captured.push(args)
+    },
+  }
+
+  const error = new Error('OAuth callback failed') as AuthLoggerErrorInput
+  error.cause = {
+    err: new Error('provider exploded'),
+    provider: 'google',
+  }
+  error.type = 'CallbackRouteError'
+
+  logAuthError(error, logger)
+
+  assert.equal(captured.length, 3)
+  assert.match(String(captured[0][0]), /\[auth\]\[error\]/)
+  assert.match(String(captured[0][0]), /CallbackRouteError/)
+  assert.match(String(captured[1][0]), /\[auth\]\[cause\]/)
+  assert.match(String(captured[2][0]), /\[auth\]\[details\]/)
+  assert.match(String(captured[2][1]), /"provider": "google"/)
+})

--- a/apps/sso/lib/auth-logger.ts
+++ b/apps/sso/lib/auth-logger.ts
@@ -1,0 +1,69 @@
+const red = '\x1b[31m'
+const reset = '\x1b[0m'
+
+type AuthLoggerError = Error & {
+  cause?: Record<string, unknown> & {
+    err?: Error
+  }
+  type?: string
+}
+
+function getAuthErrorName(error: Error): string {
+  const authLoggerError = error as AuthLoggerError
+  if (typeof authLoggerError.type === 'string' && authLoggerError.type !== '') {
+    return authLoggerError.type
+  }
+
+  return error.name
+}
+
+export function shouldSuppressAuthError(error: AuthLoggerError): boolean {
+  if (error.type !== 'JWTSessionError') {
+    return false
+  }
+
+  if (!error.cause) {
+    return false
+  }
+
+  const causeError = error.cause.err
+  if (!(causeError instanceof Error)) {
+    return false
+  }
+
+  if (causeError.message.includes('no matching decryption secret')) {
+    return true
+  }
+
+  return causeError.message.includes('decryption operation failed')
+}
+
+export function logAuthError(error: Error, logger: Pick<Console, 'error'> = console): void {
+  const authLoggerError = error as AuthLoggerError
+  if (shouldSuppressAuthError(authLoggerError)) {
+    return
+  }
+
+  const name = getAuthErrorName(error)
+  logger.error(`${red}[auth][error]${reset} ${name}: ${error.message}`)
+
+  if (
+    authLoggerError.cause &&
+    typeof authLoggerError.cause === 'object' &&
+    'err' in authLoggerError.cause &&
+    authLoggerError.cause.err instanceof Error
+  ) {
+    const { err, ...data } = authLoggerError.cause
+    logger.error(`${red}[auth][cause]${reset}:`, err.stack)
+    logger.error(`${red}[auth][details]${reset}:`, JSON.stringify(data, null, 2))
+    return
+  }
+
+  if (typeof error.stack === 'string' && error.stack !== '') {
+    logger.error(error.stack.replace(/.*/, '').substring(1))
+  }
+}
+
+export const authLogger = {
+  error: logAuthError,
+}

--- a/apps/sso/lib/auth.ts
+++ b/apps/sso/lib/auth.ts
@@ -8,6 +8,7 @@ import {
   getUserByEmail,
 } from '@targon/auth/server'
 import { resolvePortalCallbackTarget } from './callback-target'
+import { authLogger } from './auth-logger'
 import { requireAuthEnv } from './required-auth-env'
 
 const ORG_EMAIL_DOMAIN = 'targonglobal.com'
@@ -52,6 +53,7 @@ const baseAuthOptions: NextAuthConfig = {
   trustHost: true,
   session: { strategy: 'jwt', maxAge: 30 * 24 * 60 * 60 },
   secret: sharedSecret,
+  logger: authLogger,
   pages: {
     signIn: '/login',
     signOut: '/logout',

--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start -p 3200",
     "type-check": "tsc --noEmit",
-    "test:auth-contracts": "tsx --test tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts scripts/ensure-hosted-smoke-user-lib.test.ts",
+    "test:auth-contracts": "tsx --test lib/auth-logger.test.ts tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts scripts/ensure-hosted-smoke-user-lib.test.ts",
     "test:auth-smoke": "pnpm run test:auth-contracts && playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",
     "test:e2e": "playwright test",
     "test:hosted-smoke": "pnpm run test:auth-contracts && PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",


### PR DESCRIPTION
## Summary
- add an SSO auth logger that suppresses only the expected stale-session decrypt noise
- keep default-style Auth.js logging for unexpected auth failures
- cover the logger behavior in auth contract tests and include it in the auth smoke contract suite

## Verification
- `pnpm --filter @targon/sso type-check`
- `pnpm --filter @targon/sso test:auth-contracts`
- `pnpm --filter @targon/sso test:auth-smoke`