### PR TITLE
fix(argus): allow duplicate same-day case activities

### DIFF
--- a/apps/argus/lib/cases/view-model.test.ts
+++ b/apps/argus/lib/cases/view-model.test.ts
@@ -288,6 +288,29 @@ function selectReportDate(bundle: CaseReportBundle, reportDate: string): CaseRep
   }
 }
 
+function buildBundleWithDuplicateSameDayActivity(): CaseReportBundle {
+  const bundle = buildBundle()
+  const duplicateRow = {
+    category: 'Action due',
+    issue: 'Refund follow-up needs the missing invoice page',
+    caseId: 'A-200',
+    daysAgo: '0 days ago',
+    status: 'Checkpoint overdue',
+    evidence: 'Support still needs the missing invoice page.',
+    assessment: 'The follow-up is now overdue on the same day.',
+    nextStep: 'Send the missing invoice page today.',
+  }
+
+  bundle.reportSectionsByDate['2026-04-12'] = [
+    {
+      entity: 'TARGON',
+      rows: [...bundle.reportSectionsByDate['2026-04-12'][0].rows, duplicateRow],
+    },
+  ]
+
+  return bundle
+}
+
 test('createCaseSelectorRows orders the selector by urgency, then caseId, and counts dated activity', () => {
   const rows = createCaseSelectorRows(buildBundle())
 
@@ -346,6 +369,68 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
         amazonStatus: 'Work in progress',
         openSince: '2026-04-12',
         activityCount: 3,
+      },
+    ],
+  )
+})
+
+test('same-day duplicate case activities stay selectable without duplicating the case selector', () => {
+  const bundle = buildBundleWithDuplicateSameDayActivity()
+
+  assert.deepEqual(
+    createCaseSelectorRows(selectReportDate(bundle, '2026-04-12')).map((row) => ({
+      caseId: row.caseId,
+      category: row.category,
+      issue: row.issue,
+      activityCount: row.activityCount,
+    })),
+    [
+      {
+        caseId: 'A-200',
+        category: 'Action due',
+        issue: 'Refund follow-up needs the missing invoice page',
+        activityCount: 4,
+      },
+      {
+        caseId: 'A-100',
+        category: 'Watching',
+        issue: 'Legacy issue still waiting on reimbursement',
+        activityCount: 3,
+      },
+    ],
+  )
+
+  assert.deepEqual(
+    createCaseTimelineRows(bundle, 'A-200').map((row) => ({
+      timelineKey: row.timelineKey,
+      reportDate: row.reportDate,
+      category: row.category,
+      issue: row.issue,
+    })),
+    [
+      {
+        timelineKey: '2026-04-14::A-200::0',
+        reportDate: '2026-04-14',
+        category: 'Action due',
+        issue: 'Refund needs a seller reply',
+      },
+      {
+        timelineKey: '2026-04-13::A-200::0',
+        reportDate: '2026-04-13',
+        category: 'Watching',
+        issue: 'Refund needs a seller reply',
+      },
+      {
+        timelineKey: '2026-04-12::A-200::0',
+        reportDate: '2026-04-12',
+        category: 'Action due',
+        issue: 'Refund follow-up needs the missing invoice page',
+      },
+      {
+        timelineKey: '2026-04-12::A-200::1',
+        reportDate: '2026-04-12',
+        category: 'New case',
+        issue: 'Refund needs a seller reply',
       },
     ],
   )

--- a/apps/argus/lib/cases/view-model.ts
+++ b/apps/argus/lib/cases/view-model.ts
@@ -144,25 +144,40 @@ function getCaseRowsForDate(
   )
 }
 
-function getSingleCaseRowForDate(
+function compareCaseEntries(
+  left: { row: CaseReportRow },
+  right: { row: CaseReportRow },
+): number {
+  const categoryRank = getCaseSelectorCategoryRank(left.row.category) - getCaseSelectorCategoryRank(right.row.category)
+  if (categoryRank !== 0) {
+    return categoryRank
+  }
+
+  const issueRank = left.row.issue.localeCompare(right.row.issue)
+  if (issueRank !== 0) {
+    return issueRank
+  }
+
+  return left.row.status.localeCompare(right.row.status)
+}
+
+function getSortedCaseRowsForDate(
   bundle: CaseReportBundle,
   reportDate: string,
   caseId: string,
-): { entity: string; row: CaseReportRow } | null {
-  const matches = getCaseRowsForDate(bundle, reportDate, caseId)
-  if (matches.length === 0) {
-    return null
-  }
-  if (matches.length > 1) {
-    throw new Error(`Multiple report rows found for case ${caseId} on ${reportDate}`)
-  }
-  return matches[0]
+): Array<{ entity: string; row: CaseReportRow }> {
+  return getCaseRowsForDate(bundle, reportDate, caseId).sort(compareCaseEntries)
 }
 
-function buildCaseTimelineRow(caseId: string, reportDate: string, entry: { entity: string; row: CaseReportRow }): CaseTimelineRow {
+function buildCaseTimelineRow(
+  caseId: string,
+  reportDate: string,
+  entryIndex: number,
+  entry: { entity: string; row: CaseReportRow },
+): CaseTimelineRow {
   return {
     ...entry.row,
-    timelineKey: `${reportDate}::${caseId}`,
+    timelineKey: `${reportDate}::${caseId}::${entryIndex}`,
     reportDate,
     entity: entry.entity,
     signal: entry.row.evidence,
@@ -220,29 +235,42 @@ export function createCaseReportDateOptions(
 }
 
 export function createCaseSelectorRows(bundle: CaseReportBundle): CaseSelectorRow[] {
-  return bundle.sections
-    .flatMap((section) =>
-      section.rows.map((row) => {
-        const caseRecord = getTrackedCaseRecordOrThrow(bundle, row.caseId, 'case selector row')
-        const amazonStatus = caseRecord === undefined ? null : caseRecord.amazonStatus
-        const openSince = caseRecord === undefined ? null : caseRecord.created
-        const nextAction = caseRecord === undefined ? null : caseRecord.nextAction
+  const selectorEntriesByCaseId = new Map<string, Array<{ entity: string; row: CaseReportRow }>>()
 
-        return {
-          caseId: row.caseId,
-          category: row.category,
-          issue: row.issue,
-          entity: section.entity,
-          amazonStatus,
-          openSince,
-          activityCount: createCaseTimelineRows(bundle, row.caseId).length,
-          evidence: row.evidence,
-          assessment: row.assessment,
-          nextStep: row.nextStep,
-          nextAction,
-        }
-      }),
-    )
+  bundle.sections.forEach((section) => {
+    section.rows.forEach((row) => {
+      const existingEntries = selectorEntriesByCaseId.get(row.caseId)
+      if (existingEntries === undefined) {
+        selectorEntriesByCaseId.set(row.caseId, [{ entity: section.entity, row }])
+        return
+      }
+
+      existingEntries.push({ entity: section.entity, row })
+    })
+  })
+
+  return [...selectorEntriesByCaseId.entries()]
+    .map(([caseId, entries]) => {
+      const entry = [...entries].sort(compareCaseEntries)[0]
+      const caseRecord = getTrackedCaseRecordOrThrow(bundle, caseId, 'case selector row')
+      const amazonStatus = caseRecord === undefined ? null : caseRecord.amazonStatus
+      const openSince = caseRecord === undefined ? null : caseRecord.created
+      const nextAction = caseRecord === undefined ? null : caseRecord.nextAction
+
+      return {
+        caseId,
+        category: entry.row.category,
+        issue: entry.row.issue,
+        entity: entry.entity,
+        amazonStatus,
+        openSince,
+        activityCount: createCaseTimelineRows(bundle, caseId).length,
+        evidence: entry.row.evidence,
+        assessment: entry.row.assessment,
+        nextStep: entry.row.nextStep,
+        nextAction,
+      }
+    })
     .sort((left, right) => {
       const categoryRank = getCaseSelectorCategoryRank(left.category) - getCaseSelectorCategoryRank(right.category)
       if (categoryRank !== 0) {
@@ -259,12 +287,12 @@ export function createCaseTimelineRows(bundle: CaseReportBundle, caseId: string)
   const rows = [...bundle.availableReportDates]
     .sort((left, right) => right.localeCompare(left))
     .flatMap((reportDate) => {
-      const entry = getSingleCaseRowForDate(bundle, reportDate, caseId)
-      if (entry === null) {
+      const entries = getSortedCaseRowsForDate(bundle, reportDate, caseId)
+      if (entries.length === 0) {
         return []
       }
 
-      return buildCaseTimelineRow(caseId, reportDate, entry)
+      return entries.map((entry, entryIndex) => buildCaseTimelineRow(caseId, reportDate, entryIndex, entry))
     })
 
   if (rows.length === 0) {


### PR DESCRIPTION
## Summary
- fix the cases drilldown timeline so one case can surface multiple activities on the same report date
- collapse the selector to one representative case row per case id while still counting every activity row
- add regression coverage for the live duplicate-day case shape that broke production

## Regression
- production verification after PR #5061 exposed a client-side error on `/argus/cases/uk/2026-04-19`
- console error: `Multiple report rows found for case 12355033442 on 2026-04-12`

## Verification
- `pnpm --dir apps/argus exec tsx --test lib/cases/reader.test.ts lib/cases/view-model.test.ts lib/cases/theme.test.ts`
- `pnpm --dir apps/argus lint` (passes with existing unrelated `@next/next/no-img-element` warnings in PDP components)
- `pnpm --dir apps/argus type-check`
- `pnpm --dir apps/argus exec tsx -e "...readCaseReportBundle('uk', '2026-04-19')...createCaseTimelineRows(bundle, '12355033442')..."` to confirm the duplicate 2026-04-12 activities now render instead of throwing