### PR TITLE
fix(argus): expand cases timeline table

### DIFF
--- a/apps/argus/components/cases/case-activity-table.tsx
+++ b/apps/argus/components/cases/case-activity-table.tsx
@@ -113,7 +113,7 @@ export function CaseActivityTable({
         borderRadius: 1,
         maxHeight: {
           xs: 320,
-          lg: 248,
+          lg: 400,
         },
         overflow: 'auto',
       })}


### PR DESCRIPTION
## Summary
- increase the desktop height cap for the cases timeline table on the right side of the drilldown
- let the page grow taller so more dated activity rows stay visible before the detail panel begins

## Verification
- CI passed on `#5069`
- `pnpm --dir apps/argus exec tsx --test lib/cases/reader.test.ts lib/cases/view-model.test.ts lib/cases/theme.test.ts`
- `pnpm --dir apps/argus lint`
- `pnpm --dir apps/argus type-check`