### PR TITLE
fix(talos): keep portal session responses json

### DIFF
--- a/apps/talos/src/app/api/portal/session/route.ts
+++ b/apps/talos/src/app/api/portal/session/route.ts
@@ -1,10 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { auth } from '@/lib/auth'
+import { buildPortalSessionResponse } from './session-response'
 
 export async function GET(_request: NextRequest) {
-  const session = await auth()
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  }
-  return NextResponse.json(session)
+  return buildPortalSessionResponse(auth)
 }

--- a/apps/talos/src/app/api/portal/session/session-response.test.ts
+++ b/apps/talos/src/app/api/portal/session/session-response.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { Session } from 'next-auth'
+import { TenantCode, UserRole } from '@targon/prisma-talos'
+
+import { buildPortalSessionResponse } from './session-response'
+
+test('buildPortalSessionResponse returns the portal session json payload', async () => {
+  const session = {
+    expires: '2026-12-31T23:59:59.000Z',
+    user: {
+      id: 'user_1',
+      email: 'ops@targonglobal.com',
+      name: 'Ops User',
+      role: UserRole.admin,
+      region: TenantCode.US,
+    },
+  } satisfies Session
+
+  const response = await buildPortalSessionResponse(async () => session)
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get('content-type'), 'application/json')
+  assert.deepEqual(await response.json(), session)
+})
+
+test('buildPortalSessionResponse returns unauthorized json when the session is missing', async () => {
+  const response = await buildPortalSessionResponse(async () => null)
+
+  assert.equal(response.status, 401)
+  assert.equal(response.headers.get('content-type'), 'application/json')
+  assert.deepEqual(await response.json(), { error: 'Unauthorized' })
+})
+
+test('buildPortalSessionResponse returns unauthorized json when auth decode fails', async () => {
+  const response = await buildPortalSessionResponse(async () => {
+    const error = new Error('JWTSessionError: decrypt failed')
+    error.name = 'JWTSessionError'
+    throw error
+  })
+
+  assert.equal(response.status, 401)
+  assert.equal(response.headers.get('content-type'), 'application/json')
+  assert.deepEqual(await response.json(), { error: 'Unauthorized' })
+})

--- a/apps/talos/src/app/api/portal/session/session-response.ts
+++ b/apps/talos/src/app/api/portal/session/session-response.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import type { Session } from 'next-auth'
+
+function isRecoverableAuthError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message
+  const name = error.name
+
+  if (message.includes('decrypt')) {
+    return true
+  }
+
+  if (message.includes('JWEDecryptionFailed')) {
+    return true
+  }
+
+  if (message.includes('CSRF')) {
+    return true
+  }
+
+  if (message.includes('JWT')) {
+    return true
+  }
+
+  if (name.includes('JWTSessionError')) {
+    return true
+  }
+
+  return name.includes('MissingCSRF')
+}
+
+export async function buildPortalSessionResponse(
+  readSession: () => Promise<Session | null>,
+): Promise<NextResponse> {
+  try {
+    const session = await readSession()
+    if (!session) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    return NextResponse.json(session)
+  } catch (error) {
+    if (isRecoverableAuthError(error)) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    throw error
+  }
+}

--- a/apps/talos/src/hooks/usePortalSession.test.ts
+++ b/apps/talos/src/hooks/usePortalSession.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import type { Session } from 'next-auth'
+import { TenantCode, UserRole } from '@targon/prisma-talos'
+
+import { parsePortalSessionResponse } from './usePortalSession'
+
+test('parsePortalSessionResponse returns the portal session from a JSON response', async () => {
+  const session = {
+    expires: '2026-12-31T23:59:59.000Z',
+    user: {
+      id: 'user_1',
+      email: 'ops@targonglobal.com',
+      name: 'Ops User',
+      role: UserRole.admin,
+      region: TenantCode.US,
+    },
+  } satisfies Session
+
+  const response = new Response(JSON.stringify(session), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+  })
+
+  assert.deepEqual(await parsePortalSessionResponse(response), session)
+})
+
+test('parsePortalSessionResponse returns null for an unauthorized response', async () => {
+  const response = new Response(JSON.stringify({ error: 'Unauthorized' }), {
+    status: 401,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+    },
+  })
+
+  assert.equal(await parsePortalSessionResponse(response), null)
+})
+
+test('parsePortalSessionResponse returns null when the session endpoint sends html', async () => {
+  const response = new Response('<!DOCTYPE html><html><body>Sign in</body></html>', {
+    status: 200,
+    headers: {
+      'content-type': 'text/html; charset=utf-8',
+    },
+  })
+
+  assert.equal(await parsePortalSessionResponse(response), null)
+})

--- a/apps/talos/src/hooks/usePortalSession.ts
+++ b/apps/talos/src/hooks/usePortalSession.ts
@@ -6,17 +6,35 @@ type Status = 'loading' | 'authenticated' | 'unauthenticated'
 
 const SESSION_QUERY_KEY = ['portal-session'] as const
 
-async function fetchSession(): Promise<Session | null> {
-  const response = await fetch(withBasePath('/api/portal/session'), {
-    credentials: 'include',
-  })
+export async function parsePortalSessionResponse(response: Response): Promise<Session | null> {
   if (!response.ok) {
     if (response.status === 401) {
       return null
     }
+
     throw new Error('Failed to fetch session')
   }
+
+  const contentType = response.headers.get('content-type')
+  if (typeof contentType !== 'string') {
+    return null
+  }
+
+  if (!contentType.includes('application/json')) {
+    return null
+  }
+
   return response.json()
+}
+
+async function fetchSession(): Promise<Session | null> {
+  const response = await fetch(withBasePath('/api/portal/session'), {
+    credentials: 'include',
+    headers: {
+      accept: 'application/json',
+    },
+  })
+  return parsePortalSessionResponse(response)
 }
 
 export function usePortalSession() {


### PR DESCRIPTION
## Summary
- keep Talos `/api/portal/session` on a JSON contract even when auth decode fails
- stop the shared `usePortalSession` hook from trying to `response.json()` an HTML login/error document
- cover both boundaries with focused Talos tests

## Root cause
Talos was assuming the session fetch would always return JSON on a successful response. When the session path ever received an HTML login/error document, the hook threw `Unexpected token '<'` from `response.json()`.

## Verification
- `pnpm --dir apps/talos exec tsx --test src/hooks/usePortalSession.test.ts src/app/api/portal/session/session-response.test.ts`
- `pnpm --dir apps/talos type-check`
- `pnpm --dir apps/talos lint`