### PR TITLE
fix(argus): read deterministic case snapshots

### DIFF
--- a/apps/argus/lib/cases/reader-core.ts
+++ b/apps/argus/lib/cases/reader-core.ts
@@ -1,8 +1,6 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
-const CASE_REPORT_HEADER =
-  '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |';
 const REPORT_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/u;
 const CASE_REPORT_ACTION_KINDS = [
   'monitor',
@@ -101,26 +99,6 @@ function resolveMarketConfig(marketSlug: CaseReportMarketSlug) {
   return market;
 }
 
-function parseReportHeading(line: string): { reportDate: string; marketCode: string } {
-  const match = /^## Case Report - (\d{4}-\d{2}-\d{2}) \(([A-Z]{2})\)$/u.exec(line.trim());
-  if (match === null) {
-    throw new Error(`Invalid case report heading: ${line}`);
-  }
-  return {
-    reportDate: match[1],
-    marketCode: match[2],
-  };
-}
-
-function parseTableCells(line: string): string[] {
-  return line
-    .trim()
-    .replace(/^\|/u, '')
-    .replace(/\|$/u, '')
-    .split('|')
-    .map((cell) => cell.trim());
-}
-
 function readRequiredObject(
   value: unknown,
   errorMessage: string,
@@ -152,6 +130,19 @@ function readRequiredBoolean(
 ): boolean {
   const value = record[fieldName];
   if (typeof value !== 'boolean') {
+    throw new Error(errorMessage);
+  }
+
+  return value;
+}
+
+function readRequiredArray(
+  record: Record<string, unknown>,
+  fieldName: string,
+  errorMessage: string,
+): unknown[] {
+  const value = record[fieldName];
+  if (Array.isArray(value) === false) {
     throw new Error(errorMessage);
   }
 
@@ -312,69 +303,109 @@ function parseCaseRecordsById(
   );
 }
 
-export function parseCaseReportMarkdown(markdown: string): ParsedCaseReport {
-  const lines = markdown.split(/\r?\n/u);
-  const headingLine = lines.find((line) => line.startsWith('## Case Report - '));
-  if (headingLine === undefined) {
-    throw new Error('Case report heading not found.');
+function parseCaseReportSnapshotRow(
+  value: unknown,
+  sectionEntity: string,
+  rowIndex: number,
+): CaseReportRow {
+  const row = readRequiredObject(
+    value,
+    `Invalid case report snapshot row ${rowIndex} for section ${sectionEntity}`,
+  );
+
+  return {
+    category: readRequiredString(
+      row,
+      'category',
+      `Missing required case report snapshot row field category for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    issue: readRequiredString(
+      row,
+      'issue',
+      `Missing required case report snapshot row field issue for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    caseId: readRequiredString(
+      row,
+      'case_id',
+      `Missing required case report snapshot row field case_id for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    daysAgo: readRequiredString(
+      row,
+      'days_ago',
+      `Missing required case report snapshot row field days_ago for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    status: readRequiredString(
+      row,
+      'status',
+      `Missing required case report snapshot row field status for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    evidence: readRequiredString(
+      row,
+      'evidence',
+      `Missing required case report snapshot row field evidence for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    assessment: readRequiredString(
+      row,
+      'assessment',
+      `Missing required case report snapshot row field assessment for section ${sectionEntity} row ${rowIndex}`,
+    ),
+    nextStep: readRequiredString(
+      row,
+      'next_step',
+      `Missing required case report snapshot row field next_step for section ${sectionEntity} row ${rowIndex}`,
+    ),
+  };
+}
+
+function parseCaseReportSnapshotSection(value: unknown, sectionIndex: number): CaseReportSection {
+  const section = readRequiredObject(value, `Invalid case report snapshot section ${sectionIndex}`);
+  const entity = readRequiredString(
+    section,
+    'entity',
+    `Missing required case report snapshot section field entity at index ${sectionIndex}`,
+  );
+  const rows = readRequiredArray(
+    section,
+    'rows',
+    `Missing required case report snapshot section rows at index ${sectionIndex}`,
+  ).map((row, rowIndex) => parseCaseReportSnapshotRow(row, entity, rowIndex));
+
+  if (rows.length === 0) {
+    throw new Error(`Case report snapshot section ${entity} contains no rows`);
   }
 
-  const { reportDate, marketCode } = parseReportHeading(headingLine);
-  const sections: CaseReportSection[] = [];
-  let currentSection: CaseReportSection | null = null;
-  let readingTable = false;
+  return {
+    entity,
+    rows,
+  };
+}
 
-  for (const line of lines) {
-    if (line.startsWith('### ')) {
-      if (currentSection !== null) {
-        sections.push(currentSection);
-      }
-      currentSection = {
-        entity: line.replace(/^### /u, '').trim(),
-        rows: [],
-      };
-      readingTable = false;
-      continue;
-    }
-
-    if (currentSection === null) {
-      continue;
-    }
-
-    if (line.startsWith(CASE_REPORT_HEADER)) {
-      readingTable = true;
-      continue;
-    }
-
-    if (readingTable && line.startsWith('|---')) {
-      continue;
-    }
-
-    if (readingTable && line.trim().startsWith('|')) {
-      const cells = parseTableCells(line);
-      if (cells.length !== 8) {
-        throw new Error(`Unexpected case report row: ${line}`);
-      }
-      currentSection.rows.push({
-        category: cells[0],
-        issue: cells[1],
-        caseId: cells[2],
-        daysAgo: cells[3],
-        status: cells[4],
-        evidence: cells[5],
-        assessment: cells[6],
-        nextStep: cells[7],
-      });
-      continue;
-    }
+export function parseCaseReportSnapshotJson(snapshotJson: string): ParsedCaseReport {
+  const snapshot = readRequiredObject(
+    JSON.parse(snapshotJson),
+    'Invalid case report snapshot root object',
+  );
+  const reportDate = readRequiredString(
+    snapshot,
+    'report_date',
+    'Missing required case report snapshot field report_date',
+  );
+  if (REPORT_DATE_PATTERN.test(reportDate) === false) {
+    throw new Error(`Invalid case report snapshot date: ${reportDate}`);
   }
-
-  if (currentSection !== null) {
-    sections.push(currentSection);
-  }
+  const marketCode = readRequiredString(
+    snapshot,
+    'market',
+    'Missing required case report snapshot field market',
+  );
+  const sections = readRequiredArray(
+    snapshot,
+    'sections',
+    'Missing required case report snapshot field sections',
+  ).map((section, sectionIndex) => parseCaseReportSnapshotSection(section, sectionIndex));
 
   if (sections.length === 0) {
-    throw new Error('Case report contains no entity sections.');
+    throw new Error('Case report snapshot contains no entity sections.');
   }
 
   return {
@@ -390,8 +421,8 @@ async function listAvailableReportDates(caseRoot: string): Promise<string[]> {
   return entries
     .filter((entry) => entry.isFile())
     .map((entry) => entry.name)
-    .filter((fileName) => fileName.endsWith('.md'))
-    .map((fileName) => fileName.replace(/\.md$/u, ''))
+    .filter((fileName) => fileName.endsWith('.json'))
+    .map((fileName) => fileName.replace(/\.json$/u, ''))
     .filter((reportDate) => REPORT_DATE_PATTERN.test(reportDate))
     .sort((left, right) => right.localeCompare(left));
 }
@@ -444,9 +475,9 @@ async function readParsedReportsByDate(
 ): Promise<Record<string, ParsedCaseReport>> {
   const reports = await Promise.all(
     availableReportDates.map(async (reportDate) => {
-      const reportPath = path.join(caseRoot, 'reports', `${reportDate}.md`);
-      const markdown = await fs.readFile(reportPath, 'utf8');
-      const parsedReport = parseCaseReportMarkdown(markdown);
+      const reportPath = path.join(caseRoot, 'reports', `${reportDate}.json`);
+      const snapshotJson = await fs.readFile(reportPath, 'utf8');
+      const parsedReport = parseCaseReportSnapshotJson(snapshotJson);
 
       if (parsedReport.reportDate !== reportDate) {
         throw new Error(`Case report date mismatch: expected ${reportDate}, got ${parsedReport.reportDate}`);
@@ -512,7 +543,7 @@ export async function readCaseReportBundleFromCaseRoot(
     throw new Error(`Invalid case report date: ${reportDate}`);
   }
 
-  const reportPath = path.join(caseRoot, 'reports', `${reportDate}.md`);
+  const reportPath = path.join(caseRoot, 'reports', `${reportDate}.json`);
   const caseJsonPath = path.join(caseRoot, 'case.json');
   if (requestedReportDate !== undefined && availableReportDates.includes(reportDate) === false) {
     await fs.readFile(reportPath, 'utf8');

--- a/apps/argus/lib/cases/reader.test.ts
+++ b/apps/argus/lib/cases/reader.test.ts
@@ -4,28 +4,80 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import {
-  parseCaseReportMarkdown,
+  parseCaseReportSnapshotJson,
   readCaseReportBundleFromCaseRoot,
 } from './reader-core'
 
-test('parseCaseReportMarkdown extracts entity sections and case rows', () => {
-  const report = parseCaseReportMarkdown(
-    [
-      '## Case Report - 2026-04-08 (UK)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Action due | Account verification status / failed verification | 12339319152 | 0 days ago | Answered | Amazon replied on Apr 8. | Seller action is required now. | Reply from the primary inbox. |',
-      '',
-      '### NIGS LTD',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Weights and dimensions review | 12006221712 | 21 days ago | Transferred / locked | No new case reply. | Keep monitoring. | None. |',
-      '',
-    ].join('\n'),
+function writeReportSnapshot(
+  reportsDir: string,
+  reportDate: string,
+  market: string,
+  sections: Array<{
+    entity: string
+    rows: Array<{
+      category: string
+      issue: string
+      case_id: string
+      days_ago: string
+      status: string
+      evidence: string
+      assessment: string
+      next_step: string
+    }>
+  }>,
+) {
+  writeFileSync(
+    path.join(reportsDir, `${reportDate}.json`),
+    JSON.stringify(
+      {
+        report_date: reportDate,
+        market,
+        sections,
+      },
+      null,
+      2,
+    ),
+  )
+}
+
+test('parseCaseReportSnapshotJson extracts entity sections and case rows', () => {
+  const report = parseCaseReportSnapshotJson(
+    JSON.stringify({
+      report_date: '2026-04-08',
+      market: 'UK',
+      sections: [
+        {
+          entity: 'TARGON',
+          rows: [
+            {
+              category: 'Action due',
+              issue: 'Account verification status / failed verification',
+              case_id: '12339319152',
+              days_ago: '0 days ago',
+              status: 'Answered',
+              evidence: 'Amazon replied on Apr 8.',
+              assessment: 'Seller action is required now.',
+              next_step: 'Reply from the primary inbox.',
+            },
+          ],
+        },
+        {
+          entity: 'NIGS LTD',
+          rows: [
+            {
+              category: 'Watching',
+              issue: 'Weights and dimensions review',
+              case_id: '12006221712',
+              days_ago: '21 days ago',
+              status: 'Transferred / locked',
+              evidence: 'No new case reply.',
+              assessment: 'Keep monitoring.',
+              next_step: 'None.',
+            },
+          ],
+        },
+      ],
+    }),
   )
 
   assert.equal(report.reportDate, '2026-04-08')
@@ -80,33 +132,41 @@ test('readCaseReportBundleFromCaseRoot resolves the latest dated report and trac
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-07.md'),
-    [
-      '## Case Report - 2026-04-07 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Action due | Old issue | 19550165441 | 1 day ago | Answered | Old evidence. | Old assessment. | Old next step. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-07', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Action due',
+          issue: 'Old issue',
+          case_id: '19550165441',
+          days_ago: '1 day ago',
+          status: 'Answered',
+          evidence: 'Old evidence.',
+          assessment: 'Old assessment.',
+          next_step: 'Old next step.',
+        },
+      ],
+    },
+  ])
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   const bundle = await readCaseReportBundleFromCaseRoot(caseRoot, 'us')
 
@@ -222,33 +282,41 @@ test('readCaseReportBundleFromCaseRoot loads a historical report date when the h
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-07.md'),
-    [
-      '## Case Report - 2026-04-07 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Action due | Older case no longer in live case.json | 19096712151 | 1 day ago | Answered | Old evidence. | Old assessment. | Old next step. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-07', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Action due',
+          issue: 'Older case no longer in live case.json',
+          case_id: '19096712151',
+          days_ago: '1 day ago',
+          status: 'Answered',
+          evidence: 'Old evidence.',
+          assessment: 'Old assessment.',
+          next_step: 'Old next step.',
+        },
+      ],
+    },
+  ])
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   const bundle = await readCaseReportBundleFromCaseRoot(caseRoot, 'us', '2026-04-07')
 
@@ -291,19 +359,23 @@ test('readCaseReportBundleFromCaseRoot throws when tracked_case_ids is missing',
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),
@@ -345,19 +417,23 @@ test('readCaseReportBundleFromCaseRoot throws when tracked_case_ids is malformed
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),
@@ -399,19 +475,23 @@ test('readCaseReportBundleFromCaseRoot throws when a tracked case id is missing 
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),
@@ -453,19 +533,23 @@ test('readCaseReportBundleFromCaseRoot throws when a case record is missing requ
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),
@@ -508,19 +592,23 @@ test('readCaseReportBundleFromCaseRoot throws when action_kind is not an allowed
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),
@@ -562,19 +650,23 @@ test('readCaseReportBundleFromCaseRoot throws when approval is required for a no
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),
@@ -617,19 +709,23 @@ test('readCaseReportBundleFromCaseRoot throws when a cases map key does not matc
     ),
   )
 
-  writeFileSync(
-    path.join(reportsDir, '2026-04-08.md'),
-    [
-      '## Case Report - 2026-04-08 (US)',
-      '',
-      '### TARGON',
-      '',
-      '| Category | Issue | Case ID | Days Ago | Status | Evidence / What Changed | Assessment | Next Step |',
-      '|---|---|---|---|---|---|---|---|',
-      '| Watching | Shipping label refund ($2,583.96) | 19550165441 | 2 days ago | Work in progress | No new case-thread activity. | Four shipments are still unresolved. | Confirm the approved reimbursement posts in Payments. |',
-      '',
-    ].join('\n'),
-  )
+  writeReportSnapshot(reportsDir, '2026-04-08', 'US', [
+    {
+      entity: 'TARGON',
+      rows: [
+        {
+          category: 'Watching',
+          issue: 'Shipping label refund ($2,583.96)',
+          case_id: '19550165441',
+          days_ago: '2 days ago',
+          status: 'Work in progress',
+          evidence: 'No new case-thread activity.',
+          assessment: 'Four shipments are still unresolved.',
+          next_step: 'Confirm the approved reimbursement posts in Payments.',
+        },
+      ],
+    },
+  ])
 
   await assert.rejects(
     () => readCaseReportBundleFromCaseRoot(caseRoot, 'us'),

--- a/apps/argus/lib/cases/view-model.test.ts
+++ b/apps/argus/lib/cases/view-model.test.ts
@@ -80,7 +80,7 @@ function buildBundle(): CaseReportBundle {
     marketSlug: 'us',
     marketLabel: 'USA - Dust Sheets',
     caseRoot: '/tmp/cases',
-    reportPath: '/tmp/cases/reports/2026-04-14.md',
+    reportPath: '/tmp/cases/reports/2026-04-14.json',
     caseJsonPath: '/tmp/cases/case.json',
     availableReportDates: ['2026-04-14', '2026-04-13', '2026-04-12'],
     reportSectionsByDate: {
@@ -283,7 +283,7 @@ function selectReportDate(bundle: CaseReportBundle, reportDate: string): CaseRep
   return {
     ...bundle,
     reportDate,
-    reportPath: `/tmp/cases/reports/${reportDate}.md`,
+    reportPath: `/tmp/cases/reports/${reportDate}.json`,
     sections,
   }
 }


### PR DESCRIPTION
## Summary
- switch Argus case history reads from markdown reports to deterministic `reports/*.json` snapshots
- validate the JSON snapshot schema in `reader-core` and keep active-case metadata coming from `case.json`
- update reader and view-model tests to exercise the JSON snapshot contract

## Validation
- `pnpm --dir apps/argus exec tsx --test lib/cases/reader.test.ts lib/cases/view-model.test.ts lib/cases/theme.test.ts`
- `pnpm --dir apps/argus lint`
- `pnpm --dir apps/argus type-check`
- live-root sanity read through `readCaseReportBundle('us')` and `readCaseReportBundle('uk')` after backfilling report JSON sidecars