### PR TITLE
fix(argus): simplify case identity in briefs

### DIFF
--- a/apps/argus/components/cases/case-detail-panel.tsx
+++ b/apps/argus/components/cases/case-detail-panel.tsx
@@ -26,8 +26,8 @@ function formatOptionalValue(value: string | null): string {
   return value
 }
 
-function hasValue(value: string | null): value is string {
-  return value !== null && value !== ''
+function hasIssueContext(detail: CaseDetailModel): boolean {
+  return detail.issue !== detail.subject
 }
 
 function SectionLabel({ children }: { children: ReactNode }) {
@@ -257,8 +257,21 @@ export function CaseDetailPanel({
                 lineHeight: 1.2,
               }}
             >
-              {detail.issue}
+              {detail.subject}
             </Typography>
+
+            {hasIssueContext(detail) ? (
+              <Typography
+                sx={(theme) => ({
+                  mt: 0.7,
+                  color: getCaseQueueMutedTextColor(theme.palette.mode),
+                  fontSize: '0.78rem',
+                  lineHeight: 1.45,
+                })}
+              >
+                {detail.issue}
+              </Typography>
+            ) : null}
           </Box>
 
           <Box>
@@ -383,14 +396,6 @@ export function CaseDetailPanel({
               <MetadataChip label="Our status" value={formatOptionalValue(detail.metadata.ourStatus)} />
               <MetadataChip label="Last reply" value={formatOptionalValue(detail.metadata.lastReply)} mono />
               <MetadataChip label="Created" value={formatOptionalValue(detail.metadata.created)} mono />
-
-              {hasValue(detail.metadata.linkedCases) ? (
-                <MetadataChip label="Linked cases" value={detail.metadata.linkedCases} mono />
-              ) : null}
-
-              {hasValue(detail.metadata.primaryEmail) ? (
-                <MetadataChip label="Primary email" value={detail.metadata.primaryEmail} mono />
-              ) : null}
             </Box>
           </Box>
         </Stack>

--- a/apps/argus/components/cases/case-selector-table.tsx
+++ b/apps/argus/components/cases/case-selector-table.tsx
@@ -137,7 +137,7 @@ export function CaseSelectorTable({
       <Table stickyHeader size="small" sx={{ tableLayout: 'fixed' }}>
         <TableHead>
           <TableRow>
-            <HeaderCell label="Case" />
+            <HeaderCell label="Subject" />
             <HeaderCell label="Entity" />
             <HeaderCell label="Status" />
             <HeaderCell label="Open since" />
@@ -199,7 +199,7 @@ export function CaseSelectorTable({
                       overflow: 'hidden',
                     }}
                   >
-                    {row.issue}
+                    {row.subject}
                   </Typography>
                   <Typography
                     sx={(theme) => ({

--- a/apps/argus/lib/cases/view-model.test.ts
+++ b/apps/argus/lib/cases/view-model.test.ts
@@ -317,8 +317,8 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
   assert.deepEqual(
     rows.map((row) => ({
       caseId: row.caseId,
+      subject: row.subject,
       category: row.category,
-      issue: row.issue,
       entity: row.entity,
       amazonStatus: row.amazonStatus,
       openSince: row.openSince,
@@ -327,8 +327,8 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
     [
       {
         caseId: 'A-150',
+        subject: 'Appeal needs the shipment timeline',
         category: 'Action due',
-        issue: 'Appeal needs the shipment timeline',
         entity: 'TARGON',
         amazonStatus: 'Waiting on seller',
         openSince: '2026-04-14',
@@ -336,8 +336,8 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
       },
       {
         caseId: 'A-200',
+        subject: 'Refund needs a seller reply',
         category: 'Action due',
-        issue: 'Refund needs a seller reply',
         entity: 'TARGON',
         amazonStatus: 'Answered',
         openSince: '2026-04-12',
@@ -345,8 +345,8 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
       },
       {
         caseId: 'A-400',
+        subject: 'Fresh case opened for stranded inventory',
         category: 'New case',
-        issue: 'Fresh case opened for stranded inventory',
         entity: 'NIGS LTD',
         amazonStatus: 'Opened',
         openSince: '2026-04-10',
@@ -354,8 +354,8 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
       },
       {
         caseId: 'A-300',
+        subject: 'Forum escalation mentioned reimbursement lag',
         category: 'Forum watch',
-        issue: 'Forum escalation mentioned reimbursement lag',
         entity: 'NIGS LTD',
         amazonStatus: 'Investigating',
         openSince: '2026-04-08',
@@ -363,8 +363,8 @@ test('createCaseSelectorRows orders the selector by urgency, then caseId, and co
       },
       {
         caseId: 'A-100',
+        subject: 'Legacy issue still waiting on reimbursement',
         category: 'Watching',
-        issue: 'Legacy issue still waiting on reimbursement',
         entity: 'TARGON',
         amazonStatus: 'Work in progress',
         openSince: '2026-04-12',
@@ -380,21 +380,21 @@ test('same-day duplicate case activities stay selectable without duplicating the
   assert.deepEqual(
     createCaseSelectorRows(selectReportDate(bundle, '2026-04-12')).map((row) => ({
       caseId: row.caseId,
+      subject: row.subject,
       category: row.category,
-      issue: row.issue,
       activityCount: row.activityCount,
     })),
     [
       {
         caseId: 'A-200',
+        subject: 'Refund needs a seller reply',
         category: 'Action due',
-        issue: 'Refund follow-up needs the missing invoice page',
         activityCount: 4,
       },
       {
         caseId: 'A-100',
+        subject: 'Legacy issue still waiting on reimbursement',
         category: 'Watching',
-        issue: 'Legacy issue still waiting on reimbursement',
         activityCount: 3,
       },
     ],
@@ -580,6 +580,7 @@ test('createCaseDetailModel joins timeline snapshots with case metadata and gate
   assert.deepEqual(replyDetail, {
     reportDate: '2026-04-14',
     caseId: 'A-200',
+    subject: 'Refund needs a seller reply',
     category: 'Action due',
     issue: 'Refund needs a seller reply',
     status: 'Answered',
@@ -593,8 +594,6 @@ test('createCaseDetailModel joins timeline snapshots with case metadata and gate
       ourStatus: 'waiting_on_us',
       lastReply: '2026-04-14',
       created: '2026-04-12',
-      linkedCases: 'A-199',
-      primaryEmail: 'ops@targonglobal.com',
       nextAction: 'Reply with the invoice attachment.',
       nextActionDate: '2026-04-14',
       actionKind: 'send_case_reply',
@@ -621,6 +620,7 @@ test('createCaseDetailModel returns nullable metadata and no approval for untrac
   assert.deepEqual(detail, {
     reportDate: '2026-04-13',
     caseId: 'A-999',
+    subject: 'Archived reimbursement audit',
     category: 'Watching',
     issue: 'Archived reimbursement audit',
     status: 'Watching',
@@ -634,8 +634,6 @@ test('createCaseDetailModel returns nullable metadata and no approval for untrac
       ourStatus: null,
       lastReply: null,
       created: null,
-      linkedCases: null,
-      primaryEmail: null,
       nextAction: null,
       nextActionDate: null,
       actionKind: null,
@@ -645,13 +643,14 @@ test('createCaseDetailModel returns nullable metadata and no approval for untrac
   })
 })
 
-test('filterCaseSelectorRows searches issue, case id, entity, evidence, assessment, and next step', () => {
+test('filterCaseSelectorRows searches subject, issue, case id, entity, evidence, assessment, and next step', () => {
   const rows = createCaseSelectorRows(buildBundle())
 
   assert.deepEqual(filterCaseSelectorRows(rows, 'invoice').map((row) => row.caseId), ['A-200'])
   assert.deepEqual(filterCaseSelectorRows(rows, 'nigs').map((row) => row.caseId), ['A-400', 'A-300'])
   assert.deepEqual(filterCaseSelectorRows(rows, 'spillover').map((row) => row.caseId), ['A-300'])
   assert.deepEqual(filterCaseSelectorRows(rows, 'track whether').map((row) => row.caseId), ['A-300'])
+  assert.deepEqual(filterCaseSelectorRows(rows, 'shipment timeline').map((row) => row.caseId), ['A-150'])
 })
 
 test('createCaseReportDateOptions condenses day-over-day counts into top-rail labels', () => {

--- a/apps/argus/lib/cases/view-model.ts
+++ b/apps/argus/lib/cases/view-model.ts
@@ -15,6 +15,7 @@ export type CaseReportDateOption = {
 
 export type CaseSelectorRow = {
   caseId: string
+  subject: string
   category: string
   issue: string
   entity: string
@@ -47,8 +48,6 @@ export type CaseDetailMetadata = {
   ourStatus: string | null
   lastReply: string | null
   created: string | null
-  linkedCases: string | null
-  primaryEmail: string | null
   nextAction: string | null
   nextActionDate: string | null
   actionKind: CaseReportActionKind | null
@@ -58,6 +57,7 @@ export type CaseDetailMetadata = {
 export type CaseDetailModel = {
   reportDate: string
   caseId: string
+  subject: string
   category: string
   issue: string
   status: string
@@ -253,12 +253,14 @@ export function createCaseSelectorRows(bundle: CaseReportBundle): CaseSelectorRo
     .map(([caseId, entries]) => {
       const entry = [...entries].sort(compareCaseEntries)[0]
       const caseRecord = getTrackedCaseRecordOrThrow(bundle, caseId, 'case selector row')
+      const subject = caseRecord === undefined ? entry.row.issue : caseRecord.title
       const amazonStatus = caseRecord === undefined ? null : caseRecord.amazonStatus
       const openSince = caseRecord === undefined ? null : caseRecord.created
       const nextAction = caseRecord === undefined ? null : caseRecord.nextAction
 
       return {
         caseId,
+        subject,
         category: entry.row.category,
         issue: entry.row.issue,
         entity: entry.entity,
@@ -304,13 +306,12 @@ export function createCaseTimelineRows(bundle: CaseReportBundle, caseId: string)
 
 export function createCaseDetailModel(bundle: CaseReportBundle, timelineRow: CaseTimelineRow): CaseDetailModel {
   const caseRecord = getTrackedCaseRecordOrThrow(bundle, timelineRow.caseId, 'case detail')
+  const subject = caseRecord === undefined ? timelineRow.issue : caseRecord.title
   const entity = caseRecord === undefined ? timelineRow.entity : caseRecord.entity
   const amazonStatus = caseRecord === undefined ? null : caseRecord.amazonStatus
   const ourStatus = caseRecord === undefined ? null : caseRecord.ourStatus
   const lastReply = caseRecord === undefined ? null : caseRecord.lastReply
   const created = caseRecord === undefined ? null : caseRecord.created
-  const linkedCases = caseRecord === undefined ? null : caseRecord.linkedCases
-  const primaryEmail = caseRecord === undefined ? null : caseRecord.primaryEmail
   const nextAction = caseRecord === undefined ? null : caseRecord.nextAction
   const nextActionDate = caseRecord === undefined ? null : caseRecord.nextActionDate
   const actionKind = caseRecord === undefined ? null : caseRecord.actionKind
@@ -319,6 +320,7 @@ export function createCaseDetailModel(bundle: CaseReportBundle, timelineRow: Cas
   return {
     reportDate: timelineRow.reportDate,
     caseId: timelineRow.caseId,
+    subject,
     category: timelineRow.category,
     issue: timelineRow.issue,
     status: timelineRow.status,
@@ -332,8 +334,6 @@ export function createCaseDetailModel(bundle: CaseReportBundle, timelineRow: Cas
       ourStatus,
       lastReply,
       created,
-      linkedCases,
-      primaryEmail,
       nextAction,
       nextActionDate,
       actionKind,
@@ -351,6 +351,7 @@ export function filterCaseSelectorRows(rows: CaseSelectorRow[], query: string): 
 
   return rows.filter((row) => {
     const searchableFields = [
+      row.subject,
       row.issue,
       row.caseId,
       row.entity,


### PR DESCRIPTION
## Summary
- use the stable case subject from `case.json` for the selector and detail header
- keep dated snapshot issue text only as secondary context when it differs from the stable subject
- remove linked-case and primary-email identity clutter from the case detail metadata chips
- extend case-selector search coverage to include the stable subject

## Verification
- Dev PR `#5076` passed CI and was merged into `dev`
- `pnpm --dir apps/argus exec tsx --test lib/cases/reader.test.ts lib/cases/view-model.test.ts lib/cases/theme.test.ts`
- `pnpm --dir apps/argus lint`
- `pnpm --dir apps/argus type-check`