### PR TITLE
fix(argus): stabilize cases layout

### DIFF
--- a/apps/argus/components/cases/case-activity-table.tsx
+++ b/apps/argus/components/cases/case-activity-table.tsx
@@ -17,6 +17,7 @@ import {
   getCaseQueueMutedTextColor,
   getCaseQueueSelectedRowBackground,
 } from '@/lib/cases/theme'
+import { CASE_ACTIVITY_TABLE_DESKTOP_HEIGHT } from '@/lib/cases/layout'
 import type { CaseTimelineRow } from '@/lib/cases/view-model'
 
 type CaseActivityTableProps = {
@@ -111,9 +112,9 @@ export function CaseActivityTable({
         border: '1px solid',
         borderColor: getCaseQueueBorderColor(theme.palette.mode),
         borderRadius: 1,
-        maxHeight: {
+        height: {
           xs: 320,
-          lg: 400,
+          lg: CASE_ACTIVITY_TABLE_DESKTOP_HEIGHT,
         },
         overflow: 'auto',
       })}

--- a/apps/argus/components/cases/case-selector-table.tsx
+++ b/apps/argus/components/cases/case-selector-table.tsx
@@ -17,6 +17,7 @@ import {
   getCaseQueueMutedTextColor,
   getCaseQueueSelectedRowBackground,
 } from '@/lib/cases/theme'
+import { CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS } from '@/lib/cases/layout'
 import type { CaseSelectorRow } from '@/lib/cases/view-model'
 
 type CaseSelectorTableProps = {
@@ -135,6 +136,14 @@ export function CaseSelectorTable({
       })}
     >
       <Table stickyHeader size="small" sx={{ tableLayout: 'fixed' }}>
+        <colgroup>
+          <col style={{ width: CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS[0] }} />
+          <col style={{ width: CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS[1] }} />
+          <col style={{ width: CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS[2] }} />
+          <col style={{ width: CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS[3] }} />
+          <col style={{ width: CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS[4] }} />
+        </colgroup>
+
         <TableHead>
           <TableRow>
             <HeaderCell label="Subject" />
@@ -192,11 +201,12 @@ export function CaseSelectorTable({
                     sx={{
                       fontSize: '0.82rem',
                       fontWeight: 700,
-                      lineHeight: 1.28,
+                      lineHeight: 1.32,
                       display: '-webkit-box',
                       WebkitBoxOrient: 'vertical',
                       WebkitLineClamp: 2,
                       overflow: 'hidden',
+                      overflowWrap: 'anywhere',
                     }}
                   >
                     {row.subject}

--- a/apps/argus/components/cases/cases-drilldown-page.tsx
+++ b/apps/argus/components/cases/cases-drilldown-page.tsx
@@ -13,6 +13,11 @@ import {
   type CaseSelectorRow,
   type CaseTimelineRow,
 } from '@/lib/cases/view-model'
+import {
+  CASES_DRILLDOWN_DESKTOP_GRID_COLUMNS,
+  CASES_DRILLDOWN_RIGHT_RAIL_DESKTOP_ROWS,
+  CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT,
+} from '@/lib/cases/layout'
 import { getCaseQueueBorderColor } from '@/lib/cases/theme'
 import { CaseActivityTable } from './case-activity-table'
 import { CaseDetailPanel, type CaseDetailApprovalState } from './case-detail-panel'
@@ -203,14 +208,10 @@ export function CasesDrilldownPage({ bundle }: { bundle: CaseReportBundle }) {
           display: 'grid',
           gridTemplateColumns: {
             xs: '1fr',
-            lg: 'minmax(360px, 0.92fr) minmax(0, 1.68fr)',
+            lg: CASES_DRILLDOWN_DESKTOP_GRID_COLUMNS,
           },
           gap: 1.5,
-          alignItems: 'stretch',
-          minHeight: {
-            xs: 'auto',
-            lg: 'calc(100vh - 214px)',
-          },
+          alignItems: 'start',
         }}
       >
         <CaseSelectorTable
@@ -219,12 +220,17 @@ export function CasesDrilldownPage({ bundle }: { bundle: CaseReportBundle }) {
           onSelectCase={setSelectedCaseIdState}
         />
 
-        <Stack
-          spacing={1.5}
+        <Box
           sx={{
+            display: 'grid',
+            gap: 1.5,
+            gridTemplateRows: {
+              xs: 'auto auto',
+              lg: CASES_DRILLDOWN_RIGHT_RAIL_DESKTOP_ROWS,
+            },
             minHeight: {
               xs: 'auto',
-              lg: 'calc(100vh - 214px)',
+              lg: CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT,
             },
           }}
         >
@@ -234,14 +240,22 @@ export function CasesDrilldownPage({ bundle }: { bundle: CaseReportBundle }) {
             onSelectTimeline={setSelectedTimelineKeyState}
           />
 
-          <Box sx={{ flex: 1, minHeight: { xs: 'auto', lg: 0 }, display: 'flex' }}>
+          <Box
+            sx={{
+              minHeight: {
+                xs: 280,
+                lg: CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT,
+              },
+              display: 'flex',
+            }}
+          >
             <CaseDetailPanel
               detail={detail}
               approvalState={approvalState}
               onApprovalStateChange={handleApprovalStateChange}
             />
           </Box>
-        </Stack>
+        </Box>
       </Box>
     </Stack>
   )

--- a/apps/argus/lib/cases/layout.test.ts
+++ b/apps/argus/lib/cases/layout.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  CASES_DRILLDOWN_DESKTOP_GRID_COLUMNS,
+  CASES_DRILLDOWN_RIGHT_RAIL_DESKTOP_ROWS,
+  CASE_ACTIVITY_TABLE_DESKTOP_HEIGHT,
+  CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT,
+  CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS,
+} from './layout'
+
+test('case selector desktop widths prioritize subject visibility', () => {
+  assert.deepEqual(CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS, [
+    '46%',
+    '14%',
+    '18%',
+    '14%',
+    '8%',
+  ])
+})
+
+test('cases desktop layout keeps the right rail height stable', () => {
+  assert.equal(CASES_DRILLDOWN_DESKTOP_GRID_COLUMNS, 'minmax(420px, 1.04fr) minmax(0, 1.72fr)')
+  assert.equal(CASE_ACTIVITY_TABLE_DESKTOP_HEIGHT, 440)
+  assert.equal(CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT, 368)
+  assert.equal(CASES_DRILLDOWN_RIGHT_RAIL_DESKTOP_ROWS, '440px minmax(368px, auto)')
+})

--- a/apps/argus/lib/cases/layout.ts
+++ b/apps/argus/lib/cases/layout.ts
@@ -1,0 +1,15 @@
+export const CASE_SELECTOR_DESKTOP_COLUMN_WIDTHS = [
+  '46%',
+  '14%',
+  '18%',
+  '14%',
+  '8%',
+] as const
+
+export const CASES_DRILLDOWN_DESKTOP_GRID_COLUMNS = 'minmax(420px, 1.04fr) minmax(0, 1.72fr)'
+
+export const CASE_ACTIVITY_TABLE_DESKTOP_HEIGHT = 440
+
+export const CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT = 368
+
+export const CASES_DRILLDOWN_RIGHT_RAIL_DESKTOP_ROWS = `${CASE_ACTIVITY_TABLE_DESKTOP_HEIGHT}px minmax(${CASE_DETAIL_PANEL_DESKTOP_MIN_HEIGHT}px, auto)`


### PR DESCRIPTION
## Summary
- give the selector table explicit desktop column widths so Subject gets the space and wraps to two lines
- stabilize the right rail with shared desktop layout constants and a fixed activity-table height
- add a layout contract test for the desktop sizing values

## Verification
- pnpm --dir apps/argus exec tsx --test lib/cases/reader.test.ts lib/cases/view-model.test.ts lib/cases/theme.test.ts lib/cases/layout.test.ts
- pnpm --dir apps/argus lint
- pnpm --dir apps/argus type-check