### PR TITLE
test(sso): refresh hosted portal smoke copy

### DIFF
--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -18,7 +18,7 @@ type HostedRouteCheck = {
 }
 
 const hostedRouteChecks: HostedRouteCheck[] = [
-  { name: 'portal', path: '/', visibleText: 'TargonOS Portal' },
+  { name: 'portal', path: '/', visibleText: 'Portal launcher' },
   { name: 'atlas', path: '/atlas/employees', visibleText: 'Employees' },
   { name: 'kairos', path: '/kairos/forecasts', visibleText: 'Forecasts' },
   { name: 'xplan', path: '/xplan/1-setup', visibleText: 'Setup' },


### PR DESCRIPTION
## Summary
- update the hosted portal deep-link smoke to assert the renamed launcher copy
- keep the hosted smoke expectation aligned with the polished portal landing page

## Verification
- `pnpm --filter @targon/sso type-check`
- `pnpm --filter @targon/sso exec playwright test tests/e2e.spec.ts --workers=1`
- `pnpm --filter @targon/sso run test:hosted-smoke` *(blocked locally because hosted env like `PORTAL_BASE_URL` is not defined in this worktree; covered by PR CI)*