### PR TITLE
fix(atlas): use hosted urls in ci env

### DIFF
--- a/apps/atlas/.env.dev.ci
+++ b/apps/atlas/.env.dev.ci
@@ -7,16 +7,16 @@ ATLAS_PORT=3106
 DATABASE_URL=postgresql://user:password@localhost:5432/atlas_ci?schema=atlas
 
 # Auth - Portal integration (CI placeholder)
-NEXTAUTH_URL=http://localhost:3106/atlas
+NEXTAUTH_URL=https://dev-os.targonglobal.com/atlas
 NEXTAUTH_SECRET=ci_auth_secret_placeholder
-PORTAL_AUTH_URL=http://localhost:3100
+PORTAL_AUTH_URL=https://dev-os.targonglobal.com
 PORTAL_AUTH_SECRET=ci_auth_secret_placeholder
-COOKIE_DOMAIN=localhost
+COOKIE_DOMAIN=.dev-os.targonglobal.com
 
 # NextAuth Public URLs
-NEXT_PUBLIC_APP_URL=http://localhost:3106/atlas
+NEXT_PUBLIC_APP_URL=https://dev-os.targonglobal.com/atlas
 NEXT_PUBLIC_API_BASE=/atlas
-NEXT_PUBLIC_PORTAL_AUTH_URL=http://localhost:3100
+NEXT_PUBLIC_PORTAL_AUTH_URL=https://dev-os.targonglobal.com
 
 # Google Calendar Integration (CI placeholder)
 GOOGLE_CLIENT_ID=placeholder


### PR DESCRIPTION
## What changed
- switched Atlas CI auth URLs from localhost to the hosted dev domain in `apps/atlas/.env.dev.ci`
- aligned Atlas cookie scope with the hosted dev domain so Playwright hits the same origin as the other hosted apps

## Why
The GitHub-hosted fallback runner does not have Atlas or Portal running on localhost. When self-hosted CI failed and Linux fallback took over, Atlas Playwright immediately died with `ERR_CONNECTION_REFUSED` before the auth assertions could run.

## Validation
- copied `apps/atlas/.env.dev.ci` into `apps/atlas/.env.local` and ran `pnpm -C apps/atlas test`
- ran `pnpm --filter @targon/sso test:hosted-smoke`
