### PR TITLE
chore(sso): streamline ci promotion checks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -357,6 +357,26 @@ jobs:
           echo "Saving PM2 state once"
           pm2 save
 
+  hosted-auth-health:
+    needs: [detect-changes, deploy]
+    if: github.event_name == 'push' && github.ref_name == 'dev' && needs.detect-changes.outputs.any_app == 'true'
+    continue-on-error: true
+    runs-on: [self-hosted, macOS, ARM64]
+    steps:
+      - name: Setup pnpm
+        shell: bash
+        run: corepack enable && corepack prepare pnpm@10.21.0 --activate
+
+      - name: Run hosted auth health smoke against deployed dev
+        shell: bash
+        env:
+          TARGONOS_DEV_DIR: ${{ vars.TARGONOS_DEV_DIR }}
+        run: |
+          set -euo pipefail
+          : "${TARGONOS_DEV_DIR:?Set TARGONOS_DEV_DIR on the self-hosted runner (or as a GitHub Actions repo variable)}"
+          cd "$TARGONOS_DEV_DIR"
+          bash scripts/run-hosted-auth-health.sh dev
+
   # ===========================================
   # MANUAL DEPLOY - For workflow_dispatch
   # ===========================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,24 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - dev
   workflow_dispatch:
+    inputs:
+      run_self_hosted_live_auth:
+        description: Run live hosted auth smoke on the self-hosted macOS runner
+        required: false
+        default: false
+        type: boolean
+      hosted_environment:
+        description: Hosted environment for live auth smoke
+        required: false
+        default: dev
+        type: choice
+        options:
+          - dev
+          - main
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
@@ -10,9 +27,37 @@ concurrency:
 
 jobs:
   build-test-self-hosted:
-    if: vars.USE_SELF_HOSTED == 'true'
+    if: vars.USE_SELF_HOSTED == 'true' && github.event_name == 'workflow_dispatch' && github.event.inputs.run_self_hosted_live_auth == 'true'
     runs-on: [self-hosted, macOS, ARM64]
-    steps: &build-test-steps
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.21.0
+          dest: ${{ runner.temp }}/setup-pnpm-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc.ci
+        run: |
+          cat > "$NPM_CONFIG_USERCONFIG" <<'EOF'
+          registry=https://registry.npmjs.org/
+          @jsr:registry=https://npm.jsr.io/
+          always-auth=false
+          EOF
+          pnpm install --frozen-lockfile
+      - name: Run live hosted auth smoke
+        shell: bash
+        run: bash scripts/run-hosted-auth-health.sh "${{ github.event.inputs.hosted_environment }}"
+
+  build-test-github-hosted:
+    if: github.event_name != 'pull_request' || github.base_ref != 'main'
+    runs-on: ubuntu-latest
+    steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -61,6 +106,8 @@ jobs:
           cp apps/plutus/.env.dev.ci apps/plutus/.env.local
           cp apps/argus/.env.dev.ci apps/argus/.env.dev
           cp apps/argus/.env.dev.ci apps/argus/.env.local
+      - name: Verify CI env contracts
+        run: node scripts/verify-ci-env-contracts.mjs
       - name: Verify dev environment configuration
         run: bash scripts/verify-dev-env.sh
       - name: Generate Prisma clients (parallel)
@@ -91,35 +138,21 @@ jobs:
         env:
           APP_CHANGED_SINCE: ${{ steps.changes.outputs.sha }}
       - name: Install Playwright browsers
-        if: runner.os == 'Linux'
         run: pnpm exec playwright install --with-deps chromium
       - name: Run changed workspace tests
         run: pnpm test
         env:
           APP_CHANGED_SINCE: ${{ steps.changes.outputs.sha }}
-      - name: Run auth topology contract tests
+      - name: Run CI contract tests
+        run: |
+          pnpm run test:auth-topology
+          node --test scripts/verify-ci-env-contracts.test.mjs
+      - name: Run auth contract tests
         run: |
           pnpm --filter @targon/auth test
           node --test ecosystem.topology.test.cjs
-          pnpm run test:auth-topology
       - name: Run SSO auth smoke tests
         run: pnpm --filter @targon/sso test:auth-smoke
-      - name: Run hosted cross-app auth smoke
-        if: runner.os == 'macOS' && vars.USE_SELF_HOSTED == 'true'
-        env:
-          PORTAL_BASE_URL: https://dev-os.targonglobal.com
-          E2E_PORTAL_USER_ID: user-jarrar
-          E2E_PORTAL_EMAIL: jarrar@targonglobal.com
-          E2E_PORTAL_NAME: Jarrar Amjad
-          E2E_ACTIVE_TENANT: US
-        run: |
-          PM2_RUNTIME_JSON="$(pm2 jlist)"
-          NEXTAUTH_SECRET="$(printf '%s' "$PM2_RUNTIME_JSON" | node -e "const fs=require('fs'); const processes=JSON.parse(fs.readFileSync(0,'utf8')); const app=processes.find((entry)=>entry.name==='dev-targonos'); if (!app) { throw new Error('dev-targonos pm2 process not found'); } const secret=app.pm2_env?.NEXTAUTH_SECRET; if (typeof secret !== 'string' || secret.trim() === '') { throw new Error('dev-targonos NEXTAUTH_SECRET is missing'); } process.stdout.write(secret.trim());")"
-          PORTAL_DB_URL="$(printf '%s' "$PM2_RUNTIME_JSON" | node -e "const fs=require('fs'); const processes=JSON.parse(fs.readFileSync(0,'utf8')); const app=processes.find((entry)=>entry.name==='dev-targonos'); if (!app) { throw new Error('dev-targonos pm2 process not found'); } const value=app.pm2_env?.PORTAL_DB_URL; if (typeof value !== 'string' || value.trim() === '') { throw new Error('dev-targonos PORTAL_DB_URL is missing'); } process.stdout.write(value.trim());")"
-          export NEXTAUTH_SECRET
-          export PORTAL_DB_URL
-          pnpm exec tsx apps/sso/scripts/ensure-hosted-smoke-user.ts
-          pnpm --filter @targon/sso test:hosted-smoke
       - name: Assert portal build/runtime topology
         run: |
           pnpm --filter @targon/sso build
@@ -129,24 +162,80 @@ jobs:
           BUILD_PUBLIC_URL="$build_public_url" \
           RUNTIME_PUBLIC_URL="$runtime_public_url" \
           pnpm run assert:auth-topology
-  build-test-github-hosted:
-    needs:
-      - build-test-self-hosted
-    if: always() && (vars.USE_SELF_HOSTED != 'true' || needs.build-test-self-hosted.result != 'success')
+
+  promotion-ready:
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     runs-on: ubuntu-latest
-    steps: *build-test-steps
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Require promotion PR to come from dev
+        shell: bash
+        run: |
+          if [[ "${{ github.head_ref }}" != "dev" ]]; then
+            echo "::error::Promotion PRs to main must come from dev."
+            exit 1
+          fi
+      - name: Require the exact dev SHA to have passed push CI
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner
+            const repo = context.repo.repo
+            const headSha = context.payload.pull_request.head.sha
+            const branch = await github.rest.repos.getBranch({
+              owner,
+              repo,
+              branch: 'dev',
+            })
+
+            if (branch.data.commit.sha !== headSha) {
+              core.setFailed(`Promotion PR head ${headSha} does not match the current dev tip ${branch.data.commit.sha}.`)
+              return
+            }
+
+            const runs = await github.paginate(
+              github.rest.actions.listWorkflowRuns,
+              {
+                owner,
+                repo,
+                workflow_id: 'ci.yml',
+                branch: 'dev',
+                event: 'push',
+                status: 'completed',
+                per_page: 100,
+              },
+              (response) => response.data.workflow_runs,
+            )
+
+            const matchingRun = runs.find((run) => run.head_sha === headSha && run.conclusion === 'success')
+            if (!matchingRun) {
+              core.setFailed(`No successful dev push CI run found for ${headSha}. Merge to dev and wait for CI before promoting to main.`)
+              return
+            }
+
+            core.info(`Found successful dev push CI run ${matchingRun.html_url} for ${headSha}.`)
+
   build-test:
     needs:
-      - build-test-self-hosted
       - build-test-github-hosted
+      - promotion-ready
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Validate at least one CI path succeeded
+      - name: Validate the required CI path succeeded
         run: |
-          if [[ "${{ needs.build-test-self-hosted.result }}" == "success" || "${{ needs.build-test-github-hosted.result }}" == "success" ]]; then
-            echo "A CI execution path completed successfully."
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "main" ]]; then
+            if [[ "${{ needs.promotion-ready.result }}" == "success" ]]; then
+              echo "The promotion gate completed successfully."
+            else
+              echo "The promotion gate did not succeed."
+              exit 1
+            fi
+          elif [[ "${{ needs.build-test-github-hosted.result }}" == "success" ]]; then
+            echo "The required CI path completed successfully."
           else
-            echo "No CI execution path succeeded."
+            echo "The required CI path did not succeed."
             exit 1
           fi

--- a/.github/workflows/pr-policy-main-from-dev.yml
+++ b/.github/workflows/pr-policy-main-from-dev.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   require-dev-source:
     name: Require PR head to be dev
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: ubuntu-latest
     steps:
       - name: Validate source branch
         run: |

--- a/README.md
+++ b/README.md
@@ -95,3 +95,127 @@ pnpm codex:env
 - If Talos fails on CSRF or session setup, check Redis.
 - If Prisma fails, generate the client for the affected workspace.
 - Worktree logs are in `.codex/generated/runtime/`.
+SSO must be running for authentication to work. Start it first, then any app you're working on:
+
+```bash
+# Terminal 1 — SSO (must start first, on 3200)
+pnpm --filter @targon/sso exec next dev -p 3200
+
+# Terminal 2 — whichever app you're working on
+pnpm --filter @targon/talos exec next dev -p 3201
+pnpm --filter @targon/website exec next dev -p 3205
+pnpm --filter @targon/atlas exec next dev --webpack -p 3206
+pnpm --filter @targon/xplan exec next dev -p 3208
+pnpm --filter @targon/kairos exec next dev -p 3210
+pnpm --filter @targon/plutus exec next dev -p 3212
+pnpm --filter @targon/hermes exec next dev -p 3214
+pnpm --filter @targon/argus exec next dev -p 3216
+```
+
+### 6. Access
+
+1. Open `http://localhost:3200` — SSO login page
+2. Sign in with your `@targonglobal.com` Google account
+3. Navigate to the app you're working on (e.g., `http://localhost:3201/talos` for Talos)
+
+### 7. Optional local auth bypass (localhost only)
+
+When you want to work on an app UI/API flow without logging in through SSO each time, set one of these in that app's `.env.local`:
+
+```env
+ALLOW_DEV_AUTH_SESSION_BYPASS=1
+# or
+ALLOW_DEV_AUTH_DEFAULTS=true
+```
+
+Then restart the app's dev server. In non-production, app middleware will skip portal entry checks when either flag is enabled.
+This only affects local development because the bypass is gated by `NODE_ENV !== 'production'`.
+
+### Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| `cloudflared` connection drops | Tunnel host machine may be offline | Confirm with team that the host is running, then restart `cloudflared access tcp ...` |
+| `/talos/talos` double path | `BASE_PATH` is set in `.env.local` | Remove `BASE_PATH` and `NEXT_PUBLIC_BASE_PATH` from your Talos `.env.local` |
+| "no matching decryption secret" | Auth secret mismatch between SSO and app | Ensure `NEXTAUTH_SECRET` and `PORTAL_AUTH_SECRET` are identical across all `.env.local` files |
+| "User region US does not match tenant UK" | `PRISMA_SCHEMA` is set | Remove `PRISMA_SCHEMA` from your Talos `.env.local` — it overrides all tenant schemas |
+| "Your account is not allowed to sign in" | DB connection limit hit or missing permissions | Ask team to check `portal_dev_external` connection limit and `auth_dev` schema grants |
+| Redis connection error | Redis not running | `brew services start redis` |
+| Prisma errors on startup | Prisma client not generated | Run `pnpm --filter <workspace> exec prisma generate` |
+
+## CI/CD (GitHub Actions)
+
+### CI (PR checks)
+
+Workflow: `.github/workflows/ci.yml`
+
+- Runs on `pull_request`
+- Uses `ubuntu-latest` as the required PR path; the self-hosted macOS lane is manual-only for live hosted auth smoke (`workflow_dispatch`)
+- Runs the full Linux validation path on normal PRs and on `push` to `dev`
+- Installs via pnpm and populates `.env.dev`/`.env.local` from `*.env.dev.ci` templates
+- Verifies committed CI env files still point at the dev hosted stack (`scripts/verify-ci-env-contracts.mjs`) before build/test work starts
+- Verifies workspace `package.json` versions are kept in sync (root is the source of truth)
+- Generates Prisma clients
+- Lints / type-checks / builds only the workspaces changed in the PR (via `APP_CHANGED_SINCE` + turbo filters)
+- Runs auth contract coverage in CI
+- Treats `dev -> main` as a promotion gate: the PR checks require the exact `dev` SHA to already have a successful `push` CI run instead of re-running the full validation stack
+
+### CD (deploy to the laptop)
+
+Workflow: `.github/workflows/cd.yml`
+
+- Triggers on `push` to `dev` or `main` and runs deploy steps on a `self-hosted` GitHub Actions runner on the laptop (`~/actions-runner`).
+- Detects which apps/packages changed and deploys only what’s necessary.
+- Uses `scripts/deploy-app.sh` to:
+  - sync the correct worktree (`$TARGONOS_DEV_DIR` or `$TARGONOS_MAIN_DIR`)
+  - run `pnpm install` (once per deploy run)
+  - build the app(s)
+  - restart the matching PM2 process(es)
+  - run `pm2 save` once at the end
+- After `dev` deploys, runs a non-blocking hosted auth health smoke against `https://dev-os.targonglobal.com` on the self-hosted runner so live-environment regressions are checked post-deploy instead of blocking every PR
+- On `main`, computes a semver tag from commit messages and creates a GitHub Release (tags the exact `main` commit SHA even though the repo default branch is `dev`).
+
+### Branch / PR policy
+
+- All work merges into `dev` via PR.
+- Production releases are PRs from `dev` → `main` (enforced by `.github/workflows/pr-policy-main-from-dev.yml`).
+- Direct pushes to `dev`/`main` are blocked (`.github/workflows/block-direct-push.yml`).
+- After merging *non-release* PRs to `main` (i.e., head branch is not `dev`), an automation opens a sync PR `main → dev` (`.github/workflows/auto-sync-dev.yml`).
+
+## Operations (laptop hosting)
+
+### PM2
+
+```bash
+pm2 status
+pm2 logs main-targonos --lines 100
+pm2 restart dev-targonos dev-talos dev-xplan dev-atlas dev-website --update-env
+pm2 restart main-targonos main-talos main-xplan main-atlas main-website --update-env
+pm2 save
+```
+
+### Tunnel health (Cloudflare Error 1033)
+
+`cloudflared` exports a readiness endpoint on `127.0.0.1:20241`:
+
+```bash
+curl -fsS http://127.0.0.1:20241/ready
+```
+
+If it’s unhealthy:
+
+```bash
+launchctl kickstart -k gui/$UID/homebrew.mxcl.cloudflared
+```
+
+Optional watchdog (macOS LaunchAgent) for auto-recovery:
+
+```bash
+scripts/install-cloudflared-watchdog-macos.sh
+```
+
+### Common failure modes
+
+- `502 Bad Gateway`: check nginx (`brew services list`) and the target PM2 process (`pm2 status`, `pm2 logs <name>`).
+- NextAuth `UntrustedHost`: set `AUTH_TRUST_HOST=true` and ensure nginx forwards `X-Forwarded-*` headers.
+- Cookies not shared across apps: ensure `COOKIE_DOMAIN` matches the portal environment scope (`.os.targonglobal.com` for main, `.dev-os.targonglobal.com` for dev) and that all apps share `PORTAL_AUTH_SECRET`.

--- a/scripts/run-hosted-auth-health.sh
+++ b/scripts/run-hosted-auth-health.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target_environment="${1:?Usage: scripts/run-hosted-auth-health.sh <dev|main>}"
+
+case "$target_environment" in
+  dev)
+    portal_base_url="https://dev-os.targonglobal.com"
+    pm2_process_name="dev-targonos"
+    ;;
+  main)
+    portal_base_url="https://os.targonglobal.com"
+    pm2_process_name="main-targonos"
+    ;;
+  *)
+    printf 'Unsupported hosted auth health environment: %s\n' "$target_environment" >&2
+    exit 1
+    ;;
+esac
+
+cd "$repo_root"
+
+pm2_runtime_json="$(pm2 jlist)"
+nextauth_secret="$(
+  printf '%s' "$pm2_runtime_json" | node -e 'const fs=require("fs"); const processes=JSON.parse(fs.readFileSync(0,"utf8")); const app=processes.find((entry)=>entry.name===process.argv[1]); if (!app) { throw new Error(process.argv[1] + " pm2 process not found"); } const secret=app.pm2_env?.NEXTAUTH_SECRET; if (typeof secret !== "string" || secret.trim() === "") { throw new Error(process.argv[1] + " NEXTAUTH_SECRET is missing"); } process.stdout.write(secret.trim());' "$pm2_process_name"
+)"
+portal_db_url="$(
+  printf '%s' "$pm2_runtime_json" | node -e 'const fs=require("fs"); const processes=JSON.parse(fs.readFileSync(0,"utf8")); const app=processes.find((entry)=>entry.name===process.argv[1]); if (!app) { throw new Error(process.argv[1] + " pm2 process not found"); } const value=app.pm2_env?.PORTAL_DB_URL; if (typeof value !== "string" || value.trim() === "") { throw new Error(process.argv[1] + " PORTAL_DB_URL is missing"); } process.stdout.write(value.trim());' "$pm2_process_name"
+)"
+
+export NEXTAUTH_SECRET="$nextauth_secret"
+export PORTAL_DB_URL="$portal_db_url"
+export PORTAL_BASE_URL="$portal_base_url"
+export E2E_PORTAL_USER_ID="user-jarrar"
+export E2E_PORTAL_EMAIL="jarrar@targonglobal.com"
+export E2E_PORTAL_NAME="Jarrar Amjad"
+export E2E_ACTIVE_TENANT="US"
+
+pnpm exec tsx apps/sso/scripts/ensure-hosted-smoke-user.ts
+pnpm --filter @targon/sso test:hosted-smoke

--- a/scripts/verify-ci-env-contracts.mjs
+++ b/scripts/verify-ci-env-contracts.mjs
@@ -1,0 +1,107 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const DEV_PORTAL_ORIGIN = 'https://dev-os.targonglobal.com'
+export const DEV_COOKIE_DOMAIN = '.dev-os.targonglobal.com'
+
+const ENV_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
+const EXACT_ORIGIN_KEYS = new Set([
+  'PORTAL_AUTH_URL',
+  'NEXT_PUBLIC_PORTAL_AUTH_URL',
+  'BASE_URL',
+  'CSRF_ALLOWED_ORIGINS',
+])
+const PREFIX_ORIGIN_KEYS = new Set([
+  'NEXTAUTH_URL',
+  'NEXT_PUBLIC_APP_URL',
+  'QBO_REDIRECT_URI',
+])
+
+export function parseEnvFile(text, filePath = '.env.dev.ci') {
+  const entries = new Map()
+
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#')) {
+      continue
+    }
+
+    const match = ENV_ASSIGNMENT.exec(trimmed)
+    if (!match) {
+      throw new Error(`${filePath} contains an invalid env assignment: ${trimmed}`)
+    }
+
+    const [, key, rawValue] = match
+    entries.set(key, rawValue.trim())
+  }
+
+  return entries
+}
+
+export function validateCiEnvEntries(entries, filePath) {
+  const errors = []
+
+  for (const [key, value] of entries.entries()) {
+    if (value.includes('https://os.targonglobal.com')) {
+      errors.push(`${filePath}: ${key} must not point at the main hosted origin`)
+    }
+
+    if (value.includes('http://localhost')) {
+      errors.push(`${filePath}: ${key} must not point at localhost in CI`)
+    }
+
+    if (EXACT_ORIGIN_KEYS.has(key) && value !== DEV_PORTAL_ORIGIN) {
+      errors.push(`${filePath}: ${key} must equal ${DEV_PORTAL_ORIGIN}`)
+    }
+
+    if (PREFIX_ORIGIN_KEYS.has(key) && !value.startsWith(DEV_PORTAL_ORIGIN)) {
+      errors.push(`${filePath}: ${key} must start with ${DEV_PORTAL_ORIGIN}`)
+    }
+
+    if (key === 'COOKIE_DOMAIN' && value !== DEV_COOKIE_DOMAIN) {
+      errors.push(`${filePath}: COOKIE_DOMAIN must equal ${DEV_COOKIE_DOMAIN}`)
+    }
+  }
+
+  return errors
+}
+
+export function collectCiEnvFiles(repoRoot) {
+  const appsDir = path.join(repoRoot, 'apps')
+  return fs.readdirSync(appsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(appsDir, entry.name, '.env.dev.ci'))
+    .filter((filePath) => fs.existsSync(filePath))
+    .sort()
+}
+
+export function verifyCiEnvContracts(repoRoot) {
+  const envFiles = collectCiEnvFiles(repoRoot)
+  const errors = []
+
+  for (const filePath of envFiles) {
+    const relativePath = path.relative(repoRoot, filePath)
+    const text = fs.readFileSync(filePath, 'utf8')
+    const entries = parseEnvFile(text, relativePath)
+    errors.push(...validateCiEnvEntries(entries, relativePath))
+  }
+
+  return { envFiles, errors }
+}
+
+const modulePath = fileURLToPath(import.meta.url)
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  const repoRoot = path.resolve(path.dirname(modulePath), '..')
+  const result = verifyCiEnvContracts(repoRoot)
+
+  if (result.errors.length > 0) {
+    for (const error of result.errors) {
+      console.error(`::error::${error}`)
+    }
+    process.exit(1)
+  }
+
+  process.stdout.write(`Verified ${result.envFiles.length} CI env contract files.\n`)
+}

--- a/scripts/verify-ci-env-contracts.test.mjs
+++ b/scripts/verify-ci-env-contracts.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  DEV_COOKIE_DOMAIN,
+  DEV_PORTAL_ORIGIN,
+  parseEnvFile,
+  validateCiEnvEntries,
+} from './verify-ci-env-contracts.mjs'
+
+test('parseEnvFile ignores comments and blank lines', () => {
+  const entries = parseEnvFile(`
+# comment
+PORTAL_AUTH_URL=${DEV_PORTAL_ORIGIN}
+
+COOKIE_DOMAIN=${DEV_COOKIE_DOMAIN}
+`)
+
+  assert.equal(entries.get('PORTAL_AUTH_URL'), DEV_PORTAL_ORIGIN)
+  assert.equal(entries.get('COOKIE_DOMAIN'), DEV_COOKIE_DOMAIN)
+})
+
+test('validateCiEnvEntries accepts a hosted dev auth configuration', () => {
+  const entries = new Map([
+    ['PORTAL_AUTH_URL', DEV_PORTAL_ORIGIN],
+    ['NEXT_PUBLIC_PORTAL_AUTH_URL', DEV_PORTAL_ORIGIN],
+    ['NEXTAUTH_URL', `${DEV_PORTAL_ORIGIN}/atlas`],
+    ['NEXT_PUBLIC_APP_URL', `${DEV_PORTAL_ORIGIN}/atlas`],
+    ['COOKIE_DOMAIN', DEV_COOKIE_DOMAIN],
+  ])
+
+  assert.deepEqual(validateCiEnvEntries(entries, 'apps/atlas/.env.dev.ci'), [])
+})
+
+test('validateCiEnvEntries rejects localhost auth URLs', () => {
+  const entries = new Map([
+    ['PORTAL_AUTH_URL', 'http://localhost:3100'],
+  ])
+
+  const errors = validateCiEnvEntries(entries, 'apps/atlas/.env.dev.ci')
+  assert.equal(errors.length, 2)
+  assert.match(errors[0], /must not point at localhost/)
+  assert.match(errors[1], /must equal/)
+})
+
+test('validateCiEnvEntries rejects main hosted URLs in dev CI env files', () => {
+  const entries = new Map([
+    ['NEXT_PUBLIC_APP_URL', 'https://os.targonglobal.com/atlas'],
+  ])
+
+  const errors = validateCiEnvEntries(entries, 'apps/atlas/.env.dev.ci')
+  assert.equal(errors.length, 2)
+  assert.match(errors[0], /must not point at the main hosted origin/)
+  assert.match(errors[1], /must start with/)
+})
+
+test('validateCiEnvEntries rejects the wrong dev cookie domain', () => {
+  const entries = new Map([
+    ['COOKIE_DOMAIN', '.os.targonglobal.com'],
+  ])
+
+  const errors = validateCiEnvEntries(entries, 'apps/sso/.env.dev.ci')
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /COOKIE_DOMAIN must equal/)
+})


### PR DESCRIPTION
## What changed
- moved blocking PR CI onto the Linux runner and made the self-hosted macOS live-auth lane manual-only
- added a fast CI env contract validator plus tests so stale `*.env.dev.ci` files fail before build/test work starts
- changed `dev -> main` into a promotion gate that requires the exact `dev` SHA to already have a successful `push` CI run
- moved hosted auth smoke into a reusable script and a non-blocking post-deploy `dev` health job
- moved the `main` PR source-policy check off the self-hosted runner and updated the CI/CD docs

## Why
The repo was paying for the full validation stack twice and was coupling routine PRs to the self-hosted macOS laptop. The main failure pattern was workflow shape, not raw build time.

## Impact
- normal PRs validate on the fast GitHub-hosted path
- promotion PRs stop re-running the full stack and instead verify that `dev` already passed
- hosted environment smoke still exists, but runs post-deploy where it surfaces environment health without blocking routine merges
- CI now fails quickly if a committed dev CI env file points at localhost or the main hosted origin

## Validation
- `ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/cd.yml .github/workflows/pr-policy-main-from-dev.yml].each { |file| YAML.load_file(file) }'`
- `git diff --check -- .github/workflows/ci.yml .github/workflows/cd.yml .github/workflows/pr-policy-main-from-dev.yml README.md scripts/run-hosted-auth-health.sh scripts/verify-ci-env-contracts.mjs scripts/verify-ci-env-contracts.test.mjs`
- `node scripts/verify-ci-env-contracts.mjs`
- `node --test scripts/verify-ci-env-contracts.test.mjs`
- `pnpm run test:auth-topology`
- `pnpm --filter @targon/auth test`
- `node --test ecosystem.topology.test.cjs`

## Known live-env signal
Direct hosted smoke against current `dev` surfaced existing environment issues outside this branch:
- `ensure-hosted-smoke-user.ts` hit Prisma `P1001` against the runner's `PORTAL_DB_URL`
- hosted smoke caught live `500`s from Kairos/XPlan on `dev-os.targonglobal.com`
