### PR TITLE
fix(sso): repair promotion ci gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
           - main
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  group: ci-${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
@@ -147,6 +147,7 @@ jobs:
         run: |
           pnpm run test:auth-topology
           node --test scripts/verify-ci-env-contracts.test.mjs
+          node --test scripts/verify-promotion-ready.test.mjs
       - name: Run auth contract tests
         run: |
           pnpm --filter @targon/auth test
@@ -170,6 +171,10 @@ jobs:
       actions: read
       contents: read
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Require promotion PR to come from dev
         shell: bash
         run: |
@@ -178,44 +183,14 @@ jobs:
             exit 1
           fi
       - name: Require the exact dev SHA to have passed push CI
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const owner = context.repo.owner
-            const repo = context.repo.repo
-            const headSha = context.payload.pull_request.head.sha
-            const branch = await github.rest.repos.getBranch({
-              owner,
-              repo,
-              branch: 'dev',
-            })
-
-            if (branch.data.commit.sha !== headSha) {
-              core.setFailed(`Promotion PR head ${headSha} does not match the current dev tip ${branch.data.commit.sha}.`)
-              return
-            }
-
-            const runs = await github.paginate(
-              github.rest.actions.listWorkflowRuns,
-              {
-                owner,
-                repo,
-                workflow_id: 'ci.yml',
-                branch: 'dev',
-                event: 'push',
-                status: 'completed',
-                per_page: 100,
-              },
-              (response) => response.data.workflow_runs,
-            )
-
-            const matchingRun = runs.find((run) => run.head_sha === headSha && run.conclusion === 'success')
-            if (!matchingRun) {
-              core.setFailed(`No successful dev push CI run found for ${headSha}. Merge to dev and wait for CI before promoting to main.`)
-              return
-            }
-
-            core.info(`Found successful dev push CI run ${matchingRun.html_url} for ${headSha}.`)
+        env:
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PROMOTION_BRANCH: dev
+          PROMOTION_WORKFLOW_ID: ci.yml
+        run: node scripts/verify-promotion-ready.mjs
 
   build-test:
     needs:

--- a/scripts/verify-promotion-ready.mjs
+++ b/scripts/verify-promotion-ready.mjs
@@ -1,0 +1,154 @@
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+export function findSuccessfulPushRun(workflowRuns, headSha) {
+  for (const run of workflowRuns) {
+    if (!run || typeof run !== 'object') {
+      continue
+    }
+
+    if (run.head_sha !== headSha) {
+      continue
+    }
+
+    if (run.conclusion !== 'success') {
+      continue
+    }
+
+    return run
+  }
+
+  return null
+}
+
+export function assertPromotionReady({ branchSha, headSha, workflowRuns }) {
+  if (branchSha !== headSha) {
+    return {
+      ok: false,
+      reason: `Promotion PR head ${headSha} does not match the current dev tip ${branchSha}.`,
+    }
+  }
+
+  const matchingRun = findSuccessfulPushRun(workflowRuns, headSha)
+  if (!matchingRun) {
+    return {
+      ok: false,
+      reason: `No successful dev push CI run found for ${headSha}. Merge to dev and wait for CI before promoting to main.`,
+    }
+  }
+
+  return {
+    ok: true,
+    matchingRun,
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value || value.trim() === '') {
+    throw new Error(`${name} must be set.`)
+  }
+
+  return value.trim()
+}
+
+async function fetchJson(url, token) {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`GitHub API request failed (${response.status}) for ${url}: ${body}`)
+  }
+
+  return response.json()
+}
+
+async function listCompletedPushWorkflowRuns({
+  apiBaseUrl,
+  owner,
+  repo,
+  workflowId,
+  branch,
+  token,
+}) {
+  const workflowRuns = []
+  let page = 1
+
+  while (true) {
+    const url = new URL(`${apiBaseUrl}/repos/${owner}/${repo}/actions/workflows/${workflowId}/runs`)
+    url.searchParams.set('branch', branch)
+    url.searchParams.set('event', 'push')
+    url.searchParams.set('status', 'completed')
+    url.searchParams.set('per_page', '100')
+    url.searchParams.set('page', String(page))
+
+    const payload = await fetchJson(url, token)
+    const pageRuns = Array.isArray(payload.workflow_runs) ? payload.workflow_runs.filter(Boolean) : []
+    workflowRuns.push(...pageRuns)
+
+    if (pageRuns.length < 100) {
+      return workflowRuns
+    }
+
+    page += 1
+  }
+}
+
+async function main() {
+  const apiBaseUrl = requireEnv('GITHUB_API_URL')
+  const repository = requireEnv('GITHUB_REPOSITORY')
+  const token = requireEnv('GITHUB_TOKEN')
+  const headSha = requireEnv('GITHUB_HEAD_SHA')
+  const branch = requireEnv('PROMOTION_BRANCH')
+  const workflowId = requireEnv('PROMOTION_WORKFLOW_ID')
+
+  const repositoryParts = repository.split('/')
+  if (repositoryParts.length !== 2) {
+    throw new Error(`GITHUB_REPOSITORY must be in owner/repo form, received ${repository}.`)
+  }
+
+  const [owner, repo] = repositoryParts
+  const branchPayload = await fetchJson(
+    `${apiBaseUrl}/repos/${owner}/${repo}/branches/${branch}`,
+    token,
+  )
+
+  const branchSha = branchPayload?.commit?.sha
+  if (typeof branchSha !== 'string' || branchSha.trim() === '') {
+    throw new Error(`GitHub branch payload for ${branch} is missing commit.sha.`)
+  }
+
+  const workflowRuns = await listCompletedPushWorkflowRuns({
+    apiBaseUrl,
+    owner,
+    repo,
+    workflowId,
+    branch,
+    token,
+  })
+
+  const result = assertPromotionReady({
+    branchSha,
+    headSha,
+    workflowRuns,
+  })
+
+  if (!result.ok) {
+    console.error(`::error::${result.reason}`)
+    process.exit(1)
+  }
+
+  console.log(`Found successful dev push CI run ${result.matchingRun.html_url} for ${headSha}.`)
+}
+
+const modulePath = fileURLToPath(import.meta.url)
+
+if (process.argv[1] && path.resolve(process.argv[1]) === modulePath) {
+  await main()
+}

--- a/scripts/verify-promotion-ready.test.mjs
+++ b/scripts/verify-promotion-ready.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import {
+  assertPromotionReady,
+  findSuccessfulPushRun,
+} from './verify-promotion-ready.mjs'
+
+test('findSuccessfulPushRun ignores undefined entries and matches the exact head sha', () => {
+  const matchingRun = findSuccessfulPushRun([
+    undefined,
+    { head_sha: 'older-sha', conclusion: 'success' },
+    { head_sha: 'target-sha', conclusion: 'failure' },
+    { head_sha: 'target-sha', conclusion: 'success', html_url: 'https://github.com/progami/targonos/actions/runs/1' },
+  ], 'target-sha')
+
+  assert.deepEqual(matchingRun, {
+    head_sha: 'target-sha',
+    conclusion: 'success',
+    html_url: 'https://github.com/progami/targonos/actions/runs/1',
+  })
+})
+
+test('assertPromotionReady rejects a promotion pr when dev moved after the pr was opened', () => {
+  const result = assertPromotionReady({
+    branchSha: 'newer-dev-tip',
+    headSha: 'older-pr-head',
+    workflowRuns: [],
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /does not match the current dev tip/)
+})
+
+test('assertPromotionReady rejects when no successful push ci run exists for the exact sha', () => {
+  const result = assertPromotionReady({
+    branchSha: 'target-sha',
+    headSha: 'target-sha',
+    workflowRuns: [
+      { head_sha: 'target-sha', conclusion: 'cancelled' },
+      { head_sha: 'older-sha', conclusion: 'success' },
+    ],
+  })
+
+  assert.equal(result.ok, false)
+  assert.match(result.reason, /No successful dev push CI run found/)
+})
+
+test('assertPromotionReady accepts an exact-sha successful dev push ci run', () => {
+  const result = assertPromotionReady({
+    branchSha: 'target-sha',
+    headSha: 'target-sha',
+    workflowRuns: [
+      undefined,
+      { head_sha: 'target-sha', conclusion: 'success', html_url: 'https://github.com/progami/targonos/actions/runs/2' },
+    ],
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.matchingRun?.html_url, 'https://github.com/progami/targonos/actions/runs/2')
+})


### PR DESCRIPTION
## What changed
- split CI concurrency by event name so `push` and `pull_request` runs on `dev` stop canceling each other
- replaced the fragile inline promotion gate check with `scripts/verify-promotion-ready.mjs`
- added regression coverage in `scripts/verify-promotion-ready.test.mjs` and wired it into the CI contract tests

## Root cause
The new promotion flow had two bugs:
- the concurrency key used only the branch name, so opening a `dev -> main` PR canceled the in-flight `push` CI run on the same `dev` SHA
- the inline `actions/github-script` promotion check assumed every paginated item had `head_sha`, which crashed the gate before it could report a proper result

## Impact
`dev -> main` promotion PRs can now wait on the exact `dev` push CI result without canceling it, and the promotion gate uses tested logic instead of brittle inline workflow code.

## Validation
- `node --test scripts/verify-promotion-ready.test.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `git diff --check -- .github/workflows/ci.yml scripts/verify-promotion-ready.mjs scripts/verify-promotion-ready.test.mjs`
- `node scripts/verify-ci-env-contracts.mjs`
- `node --test scripts/verify-ci-env-contracts.test.mjs`
- `pnpm run test:auth-topology`
