### PR TITLE
fix(sso): align hosted talos smoke copy

### DIFF
--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -106,7 +106,8 @@ test.describe('hosted cross-app auth smoke', () => {
       })
 
       await page.goto(hostedRoute('/talos'), { waitUntil: 'domcontentloaded' })
-      await expect(page.getByText('Select your region to continue', { exact: false })).toBeVisible({
+      await expect(page.getByRole('heading', { name: 'TALOS' })).toBeVisible({ timeout: 20_000 })
+      await expect(page.getByText('Select your region', { exact: false })).toBeVisible({
         timeout: 20_000,
       })
 
@@ -114,7 +115,7 @@ test.describe('hosted cross-app auth smoke', () => {
       expect(tenantCurrentResponse.ok()).toBe(true)
 
       const usRegionCard = page.getByRole('button', {
-        name: /US United States America\/Los Angeles Enter/i,
+        name: /US.*United States.*America\s*\/\s*Los Angeles.*Enter region/i,
       })
       await expect(usRegionCard).toBeVisible({ timeout: 20_000 })
       await expect(usRegionCard).toBeEnabled()


### PR DESCRIPTION
## Summary
- update the hosted Talos deep-link smoke to match the new region landing copy
- make the US region card locator match the current card label

## Verification
- pnpm --filter @targon/sso type-check
- hosted Playwright smoke requires hosted env vars and is validated in CI