### PR TITLE
fix(argus): harden weekly monitoring jobs

### DIFF
--- a/apps/argus/scripts/browser/browser-automation-config.mjs
+++ b/apps/argus/scripts/browser/browser-automation-config.mjs
@@ -1,0 +1,39 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../../../..')
+
+export function defaultChromeBrowserUrl(env = process.env) {
+  const explicit = env.ARGUS_CHROME_BROWSER_URL
+  if (explicit && explicit.trim()) {
+    return explicit.trim()
+  }
+  return 'http://127.0.0.1:9223'
+}
+
+export function defaultChromeStartScriptPath(env = process.env) {
+  const explicit = env.ARGUS_CHROME_START_SCRIPT
+  if (explicit && explicit.trim()) {
+    return explicit.trim()
+  }
+  return path.join(REPO_ROOT, 'apps/argus/scripts/browser/start-devtools-chrome.sh')
+}
+
+export function bitwardenSecretDir(env = process.env) {
+  const explicit = env.ARGUS_BITWARDEN_SECRET_DIR
+  if (explicit && explicit.trim()) {
+    return explicit.trim()
+  }
+
+  const homeDir = env.HOME
+  if (!homeDir || !homeDir.trim()) {
+    throw new Error('HOME is required to resolve the Argus Bitwarden secret directory.')
+  }
+  return path.join(homeDir, '.config/codex/secrets')
+}
+
+export function bitwardenSecretPath(secretName, env = process.env) {
+  return path.join(bitwardenSecretDir(env), secretName)
+}

--- a/apps/argus/scripts/browser/browser-automation-config.test.mjs
+++ b/apps/argus/scripts/browser/browser-automation-config.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import {
+  bitwardenSecretDir,
+  bitwardenSecretPath,
+  defaultChromeBrowserUrl,
+  defaultChromeStartScriptPath,
+} from './browser-automation-config.mjs'
+
+test('defaultChromeBrowserUrl uses the dedicated local devtools endpoint', () => {
+  assert.equal(defaultChromeBrowserUrl({}), 'http://127.0.0.1:9223')
+})
+
+test('defaultChromeBrowserUrl respects explicit env override', () => {
+  assert.equal(defaultChromeBrowserUrl({ ARGUS_CHROME_BROWSER_URL: 'http://127.0.0.1:9333' }), 'http://127.0.0.1:9333')
+})
+
+test('defaultChromeStartScriptPath points to the repo-local launcher', () => {
+  assert.equal(defaultChromeStartScriptPath({}), path.join(process.cwd(), 'apps/argus/scripts/browser/start-devtools-chrome.sh'))
+})
+
+test('bitwarden secret helpers use the codex secrets directory', () => {
+  const env = { HOME: '/tmp/example-home' }
+  assert.equal(bitwardenSecretDir(env), '/tmp/example-home/.config/codex/secrets')
+  assert.equal(
+    bitwardenSecretPath('bitwarden-master-password', env),
+    '/tmp/example-home/.config/codex/secrets/bitwarden-master-password',
+  )
+})
+
+test('bitwarden secret helpers respect explicit env override', () => {
+  const env = { ARGUS_BITWARDEN_SECRET_DIR: '/tmp/argus-secrets', HOME: '/tmp/example-home' }
+  assert.equal(bitwardenSecretDir(env), '/tmp/argus-secrets')
+  assert.equal(bitwardenSecretPath('bitwarden-cli-session', env), '/tmp/argus-secrets/bitwarden-cli-session')
+})

--- a/apps/argus/scripts/browser/chrome-devtools-helper.mjs
+++ b/apps/argus/scripts/browser/chrome-devtools-helper.mjs
@@ -3,9 +3,10 @@
 import { execFileSync } from 'node:child_process'
 import { setTimeout as delay } from 'node:timers/promises'
 import process from 'node:process'
+import { defaultChromeBrowserUrl, defaultChromeStartScriptPath } from './browser-automation-config.mjs'
 
-const BROWSER_URL = process.env.ARGUS_CHROME_BROWSER_URL ?? 'http://127.0.0.1:9223'
-const START_SCRIPT = process.env.ARGUS_CHROME_START_SCRIPT ?? '/Users/jarraramjad/bin/start-codex-chrome.sh'
+const BROWSER_URL = defaultChromeBrowserUrl(process.env)
+const START_SCRIPT = defaultChromeStartScriptPath(process.env)
 const WAIT_TIMEOUT_MS = 60_000
 
 export function parseHosts(hostListText) {

--- a/apps/argus/scripts/browser/common.sh
+++ b/apps/argus/scripts/browser/common.sh
@@ -12,12 +12,80 @@ if ! NODE_BIN="$(command -v node)"; then
   exit 1
 fi
 
+if [ -z "${BW_BIN:-}" ]; then
+  if ! BW_BIN="$(command -v bw)"; then
+    echo "Bitwarden CLI not found in PATH=$PATH" >&2
+    exit 1
+  fi
+fi
+
 run_chrome_helper() {
   "$NODE_BIN" "$CHROME_HELPER" "$@"
 }
 
 ensure_chrome_browser() {
   run_chrome_helper ensure-browser >/dev/null
+}
+
+bitwarden_secret_dir() {
+  if [ -n "${ARGUS_BITWARDEN_SECRET_DIR:-}" ]; then
+    printf '%s' "$ARGUS_BITWARDEN_SECRET_DIR"
+    return 0
+  fi
+  printf '%s' "$HOME/.config/codex/secrets"
+}
+
+bitwarden_secret_path() {
+  local secret_name="$1"
+  printf '%s/%s' "$(bitwarden_secret_dir)" "$secret_name"
+}
+
+read_bitwarden_secret() {
+  local secret_name="$1"
+  local secret_path
+
+  secret_path="$(bitwarden_secret_path "$secret_name")"
+  if [ ! -f "$secret_path" ]; then
+    return 1
+  fi
+
+  cat "$secret_path"
+}
+
+write_bitwarden_secret() {
+  local secret_name="$1"
+  local secret_value="$2"
+  local secret_dir
+  local secret_path
+
+  secret_dir="$(bitwarden_secret_dir)"
+  secret_path="$(bitwarden_secret_path "$secret_name")"
+  mkdir -p "$secret_dir"
+  umask 077
+  printf '%s' "$secret_value" > "$secret_path"
+  chmod 600 "$secret_path"
+}
+
+bitwarden_email() {
+  if [ -n "${ARGUS_BITWARDEN_EMAIL:-}" ]; then
+    printf '%s' "$ARGUS_BITWARDEN_EMAIL"
+    return 0
+  fi
+  printf '%s' 'jarrar@targonglobal.com'
+}
+
+bitwarden_status_field() {
+  local field_name="$1"
+  local payload="$2"
+
+  FIELD_NAME="$field_name" PAYLOAD="$payload" "$PYTHON_BIN" - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["PAYLOAD"])
+value = payload.get(os.environ["FIELD_NAME"], "")
+print("" if value is None else value)
+PY
 }
 
 bitwarden_session() {
@@ -28,16 +96,25 @@ bitwarden_session() {
 
   local password
   local session
+  local status_json
+  local status_value
 
-  password="$(security find-generic-password -a "$USER" -s bitwarden-master-password -w)"
-  session="$(BW_PASSWORD="$password" bw unlock --passwordenv BW_PASSWORD --raw)"
+  status_json="$("$BW_BIN" status)"
+  status_value="$(bitwarden_status_field status "$status_json")"
+
+  password="$(read_bitwarden_secret bitwarden-master-password)"
+  if [ "$status_value" = "unauthenticated" ]; then
+    BW_PASSWORD="$password" "$BW_BIN" login "$(bitwarden_email)" --passwordenv BW_PASSWORD >/dev/null
+  fi
+
+  session="$(BW_PASSWORD="$password" "$BW_BIN" unlock --passwordenv BW_PASSWORD --raw)"
   export BW_SESSION="$session"
-  security add-generic-password -U -a "$USER" -s bitwarden-cli-session -w "$session" >/dev/null
+  write_bitwarden_secret bitwarden-cli-session "$session"
   printf '%s' "$session"
 }
 
 bitwarden_login_field() {
-  local item_name="$1"
+  local item_query="$1"
   local login_username="$2"
   local field_name="$3"
   local payload
@@ -45,24 +122,40 @@ bitwarden_login_field() {
 
   session="$(bitwarden_session)"
   export BW_SESSION="$session"
-  payload="$(BW_SESSION="$session" bw list items --search "$item_name")"
+  payload="$(BW_SESSION="$session" "$BW_BIN" list items --search "$item_query")"
 
-  ITEM_NAME="$item_name" LOGIN_USERNAME="$login_username" FIELD_NAME="$field_name" PAYLOAD="$payload" "$PYTHON_BIN" - <<'PY'
+  ITEM_QUERY="$item_query" LOGIN_USERNAME="$login_username" FIELD_NAME="$field_name" PAYLOAD="$payload" "$PYTHON_BIN" - <<'PY'
 import json
 import os
-import sys
+from urllib.parse import urlparse
 
 items = json.loads(os.environ["PAYLOAD"])
-item_name = os.environ["ITEM_NAME"]
+item_query = os.environ["ITEM_QUERY"].strip().lower()
 login_username = os.environ["LOGIN_USERNAME"]
 field_name = os.environ["FIELD_NAME"]
 
-for item in items:
-    if item.get("name") != item_name:
-        continue
+def matches_item(item, query):
+    item_name = (item.get("name") or "").strip().lower()
+    if item_name == query:
+        return True
 
     login = item.get("login") or {}
+    for uri_entry in login.get("uris") or []:
+        uri = (uri_entry or {}).get("uri") or ""
+        if uri.strip().lower() == query:
+            return True
+        try:
+            if (urlparse(uri).hostname or "").strip().lower() == query:
+                return True
+        except ValueError:
+            continue
+    return False
+
+for item in items:
+    login = item.get("login") or {}
     if login.get("username") != login_username:
+        continue
+    if not matches_item(item, item_query):
         continue
 
     if field_name == "username":
@@ -83,30 +176,46 @@ PY
 }
 
 bitwarden_login_item_id() {
-  local item_name="$1"
+  local item_query="$1"
   local login_username="$2"
   local payload
   local session
 
   session="$(bitwarden_session)"
   export BW_SESSION="$session"
-  payload="$(BW_SESSION="$session" bw list items --search "$item_name")"
+  payload="$(BW_SESSION="$session" "$BW_BIN" list items --search "$item_query")"
 
-  ITEM_NAME="$item_name" LOGIN_USERNAME="$login_username" PAYLOAD="$payload" "$PYTHON_BIN" - <<'PY'
+  ITEM_QUERY="$item_query" LOGIN_USERNAME="$login_username" PAYLOAD="$payload" "$PYTHON_BIN" - <<'PY'
 import json
 import os
-import sys
+from urllib.parse import urlparse
 
 items = json.loads(os.environ["PAYLOAD"])
-item_name = os.environ["ITEM_NAME"]
+item_query = os.environ["ITEM_QUERY"].strip().lower()
 login_username = os.environ["LOGIN_USERNAME"]
 
-for item in items:
-    if item.get("name") != item_name:
-        continue
+def matches_item(item, query):
+    item_name = (item.get("name") or "").strip().lower()
+    if item_name == query:
+        return True
 
     login = item.get("login") or {}
+    for uri_entry in login.get("uris") or []:
+        uri = (uri_entry or {}).get("uri") or ""
+        if uri.strip().lower() == query:
+            return True
+        try:
+            if (urlparse(uri).hostname or "").strip().lower() == query:
+                return True
+        except ValueError:
+            continue
+    return False
+
+for item in items:
+    login = item.get("login") or {}
     if login.get("username") != login_username:
+        continue
+    if not matches_item(item, item_query):
         continue
 
     item_id = item.get("id")
@@ -139,7 +248,7 @@ bitwarden_login_totp() {
   session="$(bitwarden_session)"
   export BW_SESSION="$session"
   item_id="$(bitwarden_login_item_id "$item_name" "$login_username")"
-  item_json="$(BW_SESSION="$session" bw get item "$item_id")"
+  item_json="$(BW_SESSION="$session" "$BW_BIN" get item "$item_id")"
   totp_value="$(printf '%s' "$item_json" | jq -r '.login.totp // ""')"
 
   if [ -z "$totp_value" ]; then
@@ -353,6 +462,8 @@ else:
     glob_pattern = pattern
 
 deadline = time.time() + timeout_seconds
+stable_signature = None
+stable_seen_at = 0.0
 while time.time() <= deadline:
     matches = sorted(
         (
@@ -374,8 +485,16 @@ while time.time() <= deadline:
             or latest_ctime > baseline_ctime
             or latest_size != baseline_size
         ):
-            print(str(latest))
-            raise SystemExit(0)
+            signature = (str(latest), latest_mtime, latest_ctime, latest_size)
+            if signature == stable_signature and time.time() - stable_seen_at >= 2:
+                print(str(latest))
+                raise SystemExit(0)
+            stable_signature = signature
+            stable_seen_at = time.time()
+            time.sleep(2)
+            continue
+    stable_signature = None
+    stable_seen_at = 0.0
     time.sleep(2)
 
 raise SystemExit(1)

--- a/apps/argus/scripts/browser/common.test.sh
+++ b/apps/argus/scripts/browser/common.test.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_HOME="$TMP_DIR/home"
+FAKE_SECRET_DIR="$FAKE_HOME/.config/codex/secrets"
+FAKE_BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$FAKE_SECRET_DIR" "$FAKE_BIN_DIR"
+
+cat > "$FAKE_SECRET_DIR/bitwarden-master-password" <<'EOF'
+test-master-password
+EOF
+
+cat > "$FAKE_BIN_DIR/bw" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+COUNT_FILE="${TEST_BW_COUNT_FILE:?}"
+
+if [ "$1" = "status" ]; then
+  printf '{"status":"locked","userEmail":"jarrar@targonglobal.com","serverUrl":"https://vault.bitwarden.com"}'
+  exit 0
+fi
+
+if [ "$1" = "list" ] && [ "$2" = "items" ] && [ "$3" = "--search" ] && [ "$4" = "sellercentral.amazon.com" ]; then
+  cat <<'JSON'
+[{"id":"sellercentral-item","name":"Seller Central / UK + US / shoaib","login":{"username":"shoaibgondal@targonglobal.com","password":"sellercentral-password","uris":[{"uri":"https://sellercentral.amazon.com/"},{"uri":"https://sellercentral.amazon.co.uk/"}]}}]
+JSON
+  exit 0
+fi
+
+if [ "$1" = "get" ] && [ "$2" = "item" ] && [ "$3" = "sellercentral-item" ]; then
+  cat <<'JSON'
+{"login":{"totp":"BASE32SECRET"}}
+JSON
+  exit 0
+fi
+
+if [ "$1" = "unlock" ] && [ "$2" = "--passwordenv" ] && [ "$3" = "BW_PASSWORD" ] && [ "$4" = "--raw" ]; then
+  count="$(cat "$COUNT_FILE")"
+  printf '%s' $((count + 1)) > "$COUNT_FILE"
+  if [ "${BW_PASSWORD:-}" != "test-master-password" ]; then
+    echo "unexpected password: ${BW_PASSWORD:-}" >&2
+    exit 1
+  fi
+  printf 'session-from-unlock'
+  exit 0
+fi
+
+echo "unexpected bw invocation: $*" >&2
+exit 1
+EOF
+chmod +x "$FAKE_BIN_DIR/bw"
+printf '0' > "$TMP_DIR/bw-count"
+
+HOME="$FAKE_HOME" \
+ARGUS_BITWARDEN_SECRET_DIR="$FAKE_SECRET_DIR" \
+BW_BIN="$FAKE_BIN_DIR/bw" \
+TEST_BW_COUNT_FILE="$TMP_DIR/bw-count" \
+bash -lc '
+set -euo pipefail
+source "'"$SCRIPT_DIR"'/common.sh"
+
+bitwarden_session >/dev/null
+if [ "${BW_SESSION:-}" != "session-from-unlock" ]; then
+  echo "expected unlock session, got: ${BW_SESSION:-}" >&2
+  exit 1
+fi
+
+bitwarden_session >/dev/null
+if [ "${BW_SESSION:-}" != "session-from-unlock" ]; then
+  echo "expected env session reuse, got: ${BW_SESSION:-}" >&2
+  exit 1
+fi
+
+cached_session="$(cat "'"$FAKE_SECRET_DIR"'/bitwarden-cli-session")"
+if [ "$cached_session" != "session-from-unlock" ]; then
+  echo "expected cached session file" >&2
+  exit 1
+fi
+' >/dev/null
+
+if [ "$(cat "$TMP_DIR/bw-count")" != "1" ]; then
+  echo "expected bw unlock to run once per shell session" >&2
+  exit 1
+fi
+
+HOME="$FAKE_HOME" \
+ARGUS_BITWARDEN_SECRET_DIR="$FAKE_SECRET_DIR" \
+BW_BIN="$FAKE_BIN_DIR/bw" \
+TEST_BW_COUNT_FILE="$TMP_DIR/bw-count" \
+bash -lc '
+set -euo pipefail
+source "'"$SCRIPT_DIR"'/common.sh"
+
+if [ "$(bitwarden_login_username "sellercentral.amazon.com" "shoaibgondal@targonglobal.com")" != "shoaibgondal@targonglobal.com" ]; then
+  echo "expected sellercentral URI host match for username lookup" >&2
+  exit 1
+fi
+
+if [ "$(bitwarden_login_password "sellercentral.amazon.com" "shoaibgondal@targonglobal.com")" != "sellercentral-password" ]; then
+  echo "expected sellercentral URI host match for password lookup" >&2
+  exit 1
+fi
+
+if [ "$(bitwarden_login_item_id "sellercentral.amazon.com" "shoaibgondal@targonglobal.com")" != "sellercentral-item" ]; then
+  echo "expected sellercentral URI host match for item id lookup" >&2
+  exit 1
+fi
+' >/dev/null
+
+WAIT_DIR="$TMP_DIR/wait-for-download"
+mkdir -p "$WAIT_DIR"
+(
+  sleep 1
+  printf 'part' > "$WAIT_DIR/test.csv"
+  sleep 3
+  printf 'ial' >> "$WAIT_DIR/test.csv"
+) &
+WAIT_WRITER_PID=$!
+
+HOME="$FAKE_HOME" \
+ARGUS_BITWARDEN_SECRET_DIR="$FAKE_SECRET_DIR" \
+BW_BIN="$FAKE_BIN_DIR/bw" \
+TEST_BW_COUNT_FILE="$TMP_DIR/bw-count" \
+bash -lc '
+set -euo pipefail
+source "'"$SCRIPT_DIR"'/common.sh"
+
+downloaded_file="$(wait_for_new_matching_file "'"$WAIT_DIR"'/*.csv" "" 0 0 0 12)"
+if [ "$downloaded_file" != "'"$WAIT_DIR"'/test.csv" ]; then
+  echo "expected stable download path, got: $downloaded_file" >&2
+  exit 1
+fi
+
+download_size="$(wc -c < "$downloaded_file" | tr -d '[:space:]')"
+if [ "$download_size" != "7" ]; then
+  echo "expected wait_for_new_matching_file to wait for final size, got: $download_size" >&2
+  exit 1
+fi
+' >/dev/null
+
+wait "$WAIT_WRITER_PID"
+
+echo "common.sh tests passed"

--- a/apps/argus/scripts/browser/install.sh
+++ b/apps/argus/scripts/browser/install.sh
@@ -32,6 +32,7 @@ cleanup_legacy_daily_account_health_agent() {
 
 # Make all scripts executable
 chmod +x "$SCRIPT_DIR/chrome-devtools-helper.mjs"
+chmod +x "$SCRIPT_DIR/start-devtools-chrome.sh"
 chmod +x "$SCRIPT_DIR/relogin.sh"
 chmod +x "$SCRIPT_DIR/run-weekly.sh"
 chmod +x "$SCRIPT_DIR/common.sh"

--- a/apps/argus/scripts/browser/relogin.sh
+++ b/apps/argus/scripts/browser/relogin.sh
@@ -8,10 +8,11 @@ source "$SCRIPT_DIR/common.sh"
 
 TARGET_URL="${1:-https://sellercentral.amazon.com/home}"
 SELLER_CENTRAL_LOGIN_USERNAME="shoaibgondal@targonglobal.com"
+SELLER_CENTRAL_LOGIN_QUERY="${ARGUS_SELLER_CENTRAL_BITWARDEN_QUERY:-sellercentral.amazon.com}"
 SELLER_CENTRAL_ACCOUNT_LABEL="Targon LLC"
 SELLER_CENTRAL_MARKETPLACE_LABEL="United States"
-SC_EMAIL="$(bitwarden_login_username "sellercentral.amazon.com" "$SELLER_CENTRAL_LOGIN_USERNAME")"
-SC_PASSWORD="$(bitwarden_login_password "sellercentral.amazon.com" "$SELLER_CENTRAL_LOGIN_USERNAME")"
+SC_EMAIL="$(bitwarden_login_username "$SELLER_CENTRAL_LOGIN_QUERY" "$SELLER_CENTRAL_LOGIN_USERNAME")"
+SC_PASSWORD="$(bitwarden_login_password "$SELLER_CENTRAL_LOGIN_QUERY" "$SELLER_CENTRAL_LOGIN_USERNAME")"
 LOG="/tmp/sc-relogin.log"
 SELLER_TAB_ID=""
 
@@ -239,7 +240,7 @@ for _ in $(seq 1 60); do
       ;;
     AUTH_APP_OTP)
       log "Submitting authenticator OTP"
-      if ! otp_code="$(bitwarden_login_totp "sellercentral.amazon.com" "$SELLER_CENTRAL_LOGIN_USERNAME")"; then
+      if ! otp_code="$(bitwarden_login_totp "$SELLER_CENTRAL_LOGIN_QUERY" "$SELLER_CENTRAL_LOGIN_USERNAME")"; then
         log "FAILED: Seller Central Bitwarden TOTP unavailable"
         exit 1
       fi

--- a/apps/argus/scripts/browser/start-devtools-chrome.sh
+++ b/apps/argus/scripts/browser/start-devtools-chrome.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DEBUG_PORT="${ARGUS_CHROME_DEBUG_PORT:-9223}"
+BROWSER_URL="${ARGUS_CHROME_BROWSER_URL:-http://127.0.0.1:${DEBUG_PORT}}"
+PROFILE_DIR="${ARGUS_CHROME_USER_DATA_DIR:-$HOME/.chrome-devtools-mcp-profile}"
+
+if curl -fsS "${BROWSER_URL}/json/version" >/dev/null 2>&1; then
+  exit 0
+fi
+
+mkdir -p "$PROFILE_DIR"
+
+open -na "Google Chrome" --args \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port="$DEBUG_PORT" \
+  --user-data-dir="$PROFILE_DIR" \
+  --no-first-run \
+  --no-default-browser-check \
+  about:blank >/dev/null
+
+for _ in $(seq 1 60); do
+  if curl -fsS "${BROWSER_URL}/json/version" >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Chrome DevTools endpoint did not become ready at ${BROWSER_URL}" >&2
+exit 1

--- a/apps/argus/scripts/browser/weekly-brand-metrics/collect.sh
+++ b/apps/argus/scripts/browser/weekly-brand-metrics/collect.sh
@@ -249,6 +249,19 @@ print("true" if (end - start).days == 6 else "false")
 PY
 }
 
+url_date_range() {
+  "$PYTHON_BIN" - "$1" <<'PY'
+from urllib.parse import parse_qs, urlparse
+import sys
+
+parsed = urlparse(sys.argv[1])
+params = parse_qs(parsed.query)
+start = params.get("startDate", [""])[0]
+end = params.get("endDate", [""])[0]
+print(f"{start}|{end}")
+PY
+}
+
 download_export() {
   local expected_start="${1:-}"
   local expected_end="${2:-}"
@@ -264,6 +277,8 @@ download_export() {
   local end_iso=""
   local is_full_week=""
   local row_count=""
+
+  delete_matching_files "$DOWNLOAD_PATTERN"
 
   for attempt in $(seq 1 3); do
     baseline_info="$(latest_matching_file "$DOWNLOAD_PATTERN")"
@@ -366,6 +381,21 @@ actual_url="$(json_field "$settled_state" href)"
 current_period="$(json_field "$settled_state" currentPeriod)"
 date_button_text="$(json_field "$settled_state" dateButtonText)"
 log "Settled Brand Metrics page: ${date_button_text:-unknown} | ${current_period:-unknown} | ${actual_url:-unknown}"
+
+if [ "$REQUEST_MODE" = "last-available-week" ]; then
+  IFS='|' read -r published_start_date published_end_date <<<"$(url_date_range "$actual_url")"
+  if [ -n "$published_end_date" ]; then
+    IFS='|' read -r WEEK_NUM START_DATE END_DATE PREFIX <<<"$(week_context_for_end_date "$published_end_date")"
+    TARGET_FILE="$DEST/${PREFIX}_BrandMetrics.csv"
+    if [ -f "$TARGET_FILE" ]; then
+      log "Saved: ${PREFIX}_BrandMetrics.csv already current for published range ${published_start_date}..${published_end_date}"
+      log "NOTE: $(brand_metrics_availability_lag_detail "$published_end_date" "$REFERENCE_DATE")"
+      log "Done"
+      tail -100 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+      exit 0
+    fi
+  fi
+fi
 
 if ! download_result="$(download_export "$REQUESTED_START_DATE" "$REQUESTED_END_DATE")"; then
   log "FAILED: Brand Metrics export validation failed"


### PR DESCRIPTION
## Summary
- replace the missing external Chrome launcher dependency with a repo-local launcher and config helpers
- read Bitwarden automation secrets from the Codex secret store and resolve vault items by URI host for Seller Central auth
- harden Brand Metrics download handling so repeated weekly runs do not fail on partial downloads or already-current published weeks

## Verification
- pnpm -C apps/argus lint
- pnpm -C apps/argus type-check
- node --test apps/argus/scripts/browser/browser-automation-config.test.mjs apps/argus/scripts/browser/chrome-devtools-helper.test.mjs
- bash apps/argus/scripts/browser/common.test.sh
- bash apps/argus/scripts/api/weekly-sources/run.sh
- bash apps/argus/scripts/browser/run-weekly.sh