### PR TITLE
feat(talos): add inventory pipeline analytics

### DIFF
--- a/apps/talos/src/app/operations/inventory/page.tsx
+++ b/apps/talos/src/app/operations/inventory/page.tsx
@@ -6,24 +6,24 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
 import {
-  Search,
-  Building,
-  Package,
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
   Filter,
   BookOpen,
+  Building,
 } from '@/lib/lucide-icons'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
-import { StatsCard, StatsCardGrid } from '@/components/ui/stats-card'
 import { Badge } from '@/components/ui/badge'
 import { LoadingSpinner, PageLoading } from '@/components/ui/loading-spinner'
+import { PageTabs } from '@/components/ui/page-tabs'
+import { InventoryPipelineTab } from '@/components/operations/inventory-pipeline-tab'
 import { toast } from 'react-hot-toast'
 import { format } from 'date-fns'
 import { redirectToPortal } from '@/lib/portal'
 import { withBasePath } from '@/lib/utils/base-path'
+import { usePageState } from '@/lib/store/page-state'
 import {
   useInventoryFilters,
   type InventoryBalance,
@@ -59,12 +59,16 @@ interface InventoryResponse {
   summary?: InventorySummary
 }
 
+type InventoryTab = 'ledger' | 'analytics'
+
 const PAGE_KEY = '/operations/inventory'
 
 function InventoryPage() {
   const { data: session, status } = useSession()
   const router = useRouter()
+  const pageState = usePageState(PAGE_KEY)
   const [loading, setLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState<InventoryTab>('ledger')
   const [balances, setBalances] = useState<InventoryBalance[]>([])
   const [summary, setSummary] = useState<InventorySummary | null>(null)
 
@@ -121,7 +125,7 @@ function InventoryPage() {
         setBalances(payload)
         setSummary(null)
       } else {
-        setBalances(payload.data || [])
+        setBalances(payload.data)
         setSummary(payload.summary ?? null)
       }
     } catch (_error) {
@@ -137,6 +141,17 @@ function InventoryPage() {
       fetchBalances()
     }
   }, [fetchBalances, status])
+
+  useEffect(() => {
+    if (pageState.activeTab === 'analytics') {
+      setActiveTab('analytics')
+      return
+    }
+
+    if (pageState.activeTab === 'ledger') {
+      setActiveTab('ledger')
+    }
+  }, [pageState.activeTab])
 
   const tableTotals = useMemo(() => {
     return processedBalances.reduce(
@@ -192,6 +207,24 @@ function InventoryPage() {
     }
   }, [balances, summary])
 
+  const inventoryTabs = useMemo(
+    () => [
+      {
+        value: 'ledger',
+        label: 'Ledger',
+        icon: BookOpen,
+        count: balances.length,
+      },
+      {
+        value: 'analytics',
+        label: 'Analytics',
+        icon: Building,
+        count: metrics.uniqueWarehouses,
+      },
+    ],
+    [balances.length, metrics.uniqueWarehouses]
+  )
+
   const baseFilterInputClass =
     'w-full rounded-md border border-slate-200 dark:border-slate-700 px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary'
 
@@ -205,571 +238,596 @@ function InventoryPage() {
 
   return (
     <PageContainer>
-      <PageHeaderSection title="Inventory Ledger" description="Operations" icon={BookOpen} />
+      <PageHeaderSection title="Inventory" description="Operations" icon={BookOpen} />
       <PageContent className="flex-1 overflow-hidden px-4 py-6 sm:px-6 lg:px-8 flex flex-col">
         <div className="flex flex-col gap-6 flex-1 min-h-0">
+          <div className="flex items-center justify-between gap-4">
+            <PageTabs
+              tabs={inventoryTabs}
+              value={activeTab}
+              onChange={(value) => {
+                pageState.setActiveTab(value)
+                setActiveTab(value as InventoryTab)
+              }}
+              variant="underline"
+            />
+          </div>
 
-          <div className="flex min-h-0 flex-col rounded-xl border bg-white dark:bg-slate-800 shadow-soft overflow-hidden flex-1">
-            {/* Scrollable table area */}
-            <div className="relative min-h-0 overflow-auto scrollbar-gutter-stable flex-1">
-              <table className="w-full min-w-[1100px] table-auto text-sm">
-                <thead>
-                  <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-                    <th className="w-24 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <span>Source</span>
-                    </th>
-                    <th className="w-28 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <div className="flex items-center justify-between gap-1">
+          {activeTab === 'analytics' ? (
+            <InventoryPipelineTab
+              balances={balances}
+              loadingBalances={loading}
+              enabled={activeTab === 'analytics'}
+            />
+          ) : (
+            <div className="flex min-h-0 flex-col rounded-xl border bg-white dark:bg-slate-800 shadow-soft overflow-hidden flex-1">
+              <div className="relative min-h-0 overflow-auto scrollbar-gutter-stable flex-1">
+                <table className="w-full min-w-[1100px] table-auto text-sm">
+                  <thead>
+                    <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
+                      <th className="w-24 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <span>Source</span>
+                      </th>
+                      <th className="w-28 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <div className="flex items-center justify-between gap-1">
+                          <button
+                            type="button"
+                            className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
+                            onClick={() => handleSort('warehouse')}
+                          >
+                            Warehouse
+                            {getSortIcon('warehouse')}
+                          </button>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Filter warehouses"
+                                className={cn(
+                                  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                                  isFilterActive(['warehouse'])
+                                    ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                                    : 'hover:bg-muted hover:text-primary'
+                                )}
+                              >
+                                <Filter className="h-3.5 w-3.5" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent align="end" className="w-64 space-y-3">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-foreground">
+                                  Warehouse filter
+                                </span>
+                                <button
+                                  type="button"
+                                  className="text-xs font-medium text-primary hover:underline"
+                                  onClick={() => clearColumnFilter(['warehouse'])}
+                                >
+                                  Clear
+                                </button>
+                              </div>
+                              <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
+                                {uniqueWarehouseOptions.map(option => (
+                                  <label
+                                    key={option.value}
+                                    className="flex items-center gap-2 text-sm text-foreground"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={columnFilters.warehouse.includes(option.value)}
+                                      onChange={() =>
+                                        toggleMultiValueFilter('warehouse', option.value)
+                                      }
+                                      className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                                    />
+                                    <span className="flex-1 text-sm">{option.label}</span>
+                                  </label>
+                                ))}
+                                {uniqueWarehouseOptions.length === 0 && (
+                                  <p className="text-xs text-muted-foreground">
+                                    No warehouse options available.
+                                  </p>
+                                )}
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </th>
+                      <th className="w-28 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <div className="flex items-center justify-between gap-1">
+                          <button
+                            type="button"
+                            className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
+                            onClick={() => handleSort('sku')}
+                          >
+                            SKU
+                            {getSortIcon('sku')}
+                          </button>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Filter SKUs"
+                                className={cn(
+                                  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                                  isFilterActive(['sku'])
+                                    ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                                    : 'hover:bg-muted hover:text-primary'
+                                )}
+                              >
+                                <Filter className="h-3.5 w-3.5" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent align="end" className="w-64 space-y-3">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-foreground">
+                                  SKU filter
+                                </span>
+                                <button
+                                  type="button"
+                                  className="text-xs font-medium text-primary hover:underline"
+                                  onClick={() => clearColumnFilter(['sku'])}
+                                >
+                                  Clear
+                                </button>
+                              </div>
+                              <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
+                                {uniqueSkuOptions.map(option => (
+                                  <label
+                                    key={option.value}
+                                    className="flex items-center gap-2 text-sm text-foreground"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={columnFilters.sku.includes(option.value)}
+                                      onChange={() => toggleMultiValueFilter('sku', option.value)}
+                                      className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                                    />
+                                    <span className="flex-1 text-sm">{option.label}</span>
+                                  </label>
+                                ))}
+                                {uniqueSkuOptions.length === 0 && (
+                                  <p className="text-xs text-muted-foreground">
+                                    No SKU options available.
+                                  </p>
+                                )}
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </th>
+                      <th className="w-48 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <div className="flex items-center gap-1">
+                          <span>Description</span>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Filter SKU descriptions"
+                                className={cn(
+                                  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                                  isFilterActive(['skuDescription'])
+                                    ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                                    : 'hover:bg-muted hover:text-primary'
+                                )}
+                              >
+                                <Filter className="h-3.5 w-3.5" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent align="start" className="w-64 space-y-3">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-foreground">
+                                  SKU description filter
+                                </span>
+                                <button
+                                  type="button"
+                                  className="text-xs font-medium text-primary hover:underline"
+                                  onClick={() => clearColumnFilter(['skuDescription'])}
+                                >
+                                  Clear
+                                </button>
+                              </div>
+                              <input
+                                type="text"
+                                value={columnFilters.skuDescription}
+                                onChange={event =>
+                                  updateColumnFilter('skuDescription', event.target.value)
+                                }
+                                placeholder="Search SKU description"
+                                className={baseFilterInputClass}
+                              />
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </th>
+                      <th className="w-24 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <div className="flex items-center justify-between gap-1">
+                          <button
+                            type="button"
+                            className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
+                            onClick={() => handleSort('lot')}
+                          >
+                            Lot
+                            {getSortIcon('lot')}
+                          </button>
+                          <Popover>
+                            <PopoverTrigger asChild>
+                              <button
+                                type="button"
+                                aria-label="Filter lot values"
+                                className={cn(
+                                  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                                  isFilterActive(['lot'])
+                                    ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                                    : 'hover:bg-muted hover:text-primary'
+                                )}
+                              >
+                                <Filter className="h-3.5 w-3.5" />
+                              </button>
+                            </PopoverTrigger>
+                            <PopoverContent align="end" className="w-64 space-y-3">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-foreground">
+                                  Lot filter
+                                </span>
+                                <button
+                                  type="button"
+                                  className="text-xs font-medium text-primary hover:underline"
+                                  onClick={() => clearColumnFilter(['lot'])}
+                                >
+                                  Clear
+                                </button>
+                              </div>
+                              <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
+                                {uniqueLotOptions.map(option => (
+                                  <label
+                                    key={option.value}
+                                    className="flex items-center gap-2 text-sm text-foreground"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={columnFilters.lot.includes(option.value)}
+                                      onChange={() => toggleMultiValueFilter('lot', option.value)}
+                                      className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                                    />
+                                    <span className="flex-1 text-sm">{option.label}</span>
+                                  </label>
+                                ))}
+                                {uniqueLotOptions.length === 0 && (
+                                  <p className="text-xs text-muted-foreground">
+                                    No lot options available.
+                                  </p>
+                                )}
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </th>
+                      <th className="w-28 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <span>Ref ID</span>
+                      </th>
+                      <th className="w-20 px-2 py-2 text-right text-xs font-medium text-muted-foreground whitespace-nowrap">
                         <button
                           type="button"
-                          className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
-                          onClick={() => handleSort('warehouse')}
+                          className="flex w-full items-center justify-end gap-1 hover:text-primary focus:outline-none"
+                          onClick={() => handleSort('cartons')}
                         >
-                          Warehouse
-                          {getSortIcon('warehouse')}
+                          Ctns
+                          {getSortIcon('cartons')}
                         </button>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Filter warehouses"
-                              className={cn(
-                                'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
-                                isFilterActive(['warehouse'])
-                                  ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted hover:text-primary'
-                              )}
-                            >
-                              <Filter className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent align="end" className="w-64 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-medium text-foreground">
-                                Warehouse filter
-                              </span>
-                              <button
-                                type="button"
-                                className="text-xs font-medium text-primary hover:underline"
-                                onClick={() => clearColumnFilter(['warehouse'])}
-                              >
-                                Clear
-                              </button>
-                            </div>
-                            <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
-                              {uniqueWarehouseOptions.map(option => (
-                                <label
-                                  key={option.value}
-                                  className="flex items-center gap-2 text-sm text-foreground"
-                                >
-                                  <input
-                                    type="checkbox"
-                                    checked={columnFilters.warehouse.includes(option.value)}
-                                    onChange={() =>
-                                      toggleMultiValueFilter('warehouse', option.value)
-                                    }
-                                    className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
-                                  />
-                                  <span className="flex-1 text-sm">{option.label}</span>
-                                </label>
-                              ))}
-                              {uniqueWarehouseOptions.length === 0 && (
-                                <p className="text-xs text-muted-foreground">
-                                  No warehouse options available.
-                                </p>
-                              )}
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </th>
-                    <th className="w-28 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <div className="flex items-center justify-between gap-1">
+                      </th>
+                      <th className="w-20 px-2 py-2 text-right text-xs font-medium text-muted-foreground whitespace-nowrap">
                         <button
                           type="button"
-                          className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
-                          onClick={() => handleSort('sku')}
+                          className="flex w-full items-center justify-end gap-1 hover:text-primary focus:outline-none"
+                          onClick={() => handleSort('pallets')}
                         >
-                          SKU
-                          {getSortIcon('sku')}
+                          Plts
+                          {getSortIcon('pallets')}
                         </button>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Filter SKUs"
-                              className={cn(
-                                'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
-                                isFilterActive(['sku'])
-                                  ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted hover:text-primary'
-                              )}
-                            >
-                              <Filter className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent align="end" className="w-64 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-medium text-foreground">
-                                SKU filter
-                              </span>
-                              <button
-                                type="button"
-                                className="text-xs font-medium text-primary hover:underline"
-                                onClick={() => clearColumnFilter(['sku'])}
-                              >
-                                Clear
-                              </button>
-                            </div>
-                            <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
-                              {uniqueSkuOptions.map(option => (
-                                <label
-                                  key={option.value}
-                                  className="flex items-center gap-2 text-sm text-foreground"
-                                >
-                                  <input
-                                    type="checkbox"
-                                    checked={columnFilters.sku.includes(option.value)}
-                                    onChange={() => toggleMultiValueFilter('sku', option.value)}
-                                    className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
-                                  />
-                                  <span className="flex-1 text-sm">{option.label}</span>
-                                </label>
-                              ))}
-                              {uniqueSkuOptions.length === 0 && (
-                                <p className="text-xs text-muted-foreground">
-                                  No SKU options available.
-                                </p>
-                              )}
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </th>
-                    <th className="w-48 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <div className="flex items-center gap-1">
-                        <span>Description</span>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Filter SKU descriptions"
-                              className={cn(
-                                'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
-                                isFilterActive(['skuDescription'])
-                                  ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted hover:text-primary'
-                              )}
-                            >
-                              <Filter className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent align="start" className="w-64 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-medium text-foreground">
-                                SKU description filter
-                              </span>
-                              <button
-                                type="button"
-                                className="text-xs font-medium text-primary hover:underline"
-                                onClick={() => clearColumnFilter(['skuDescription'])}
-                              >
-                                Clear
-                              </button>
-                            </div>
-                            <input
-                              type="text"
-                              value={columnFilters.skuDescription}
-                              onChange={event =>
-                                updateColumnFilter('skuDescription', event.target.value)
-                              }
-                              placeholder="Search SKU description"
-                              className={baseFilterInputClass}
-                            />
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </th>
-                    <th className="w-24 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <div className="flex items-center justify-between gap-1">
+                      </th>
+                      <th className="w-24 px-2 py-2 text-right text-xs font-medium text-muted-foreground whitespace-nowrap">
                         <button
                           type="button"
-                          className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
-                          onClick={() => handleSort('lot')}
+                          className="flex w-full items-center justify-end gap-1 hover:text-primary focus:outline-none"
+                          onClick={() => handleSort('units')}
                         >
-                          Lot
-                          {getSortIcon('lot')}
+                          Units
+                          {getSortIcon('units')}
                         </button>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Filter lot values"
-                              className={cn(
-                                'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
-                                isFilterActive(['lot'])
-                                  ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted hover:text-primary'
-                              )}
-                            >
-                              <Filter className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent align="end" className="w-64 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-medium text-foreground">
-                                Lot filter
-                              </span>
+                      </th>
+                      <th className="w-24 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <div className="flex items-center justify-between gap-1">
+                          <span>Type</span>
+                          <Popover>
+                            <PopoverTrigger asChild>
                               <button
                                 type="button"
-                                className="text-xs font-medium text-primary hover:underline"
-                                onClick={() => clearColumnFilter(['lot'])}
+                                aria-label="Filter type"
+                                className={cn(
+                                  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                                  isFilterActive(['movement'])
+                                    ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                                    : 'hover:bg-muted hover:text-primary'
+                                )}
                               >
-                                Clear
+                                <Filter className="h-3.5 w-3.5" />
                               </button>
-                            </div>
-                            <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
-                              {uniqueLotOptions.map(option => (
-                                <label
-                                  key={option.value}
-                                  className="flex items-center gap-2 text-sm text-foreground"
+                            </PopoverTrigger>
+                            <PopoverContent align="end" className="w-48 space-y-3">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-foreground">
+                                  Type filter
+                                </span>
+                                <button
+                                  type="button"
+                                  className="text-xs font-medium text-primary hover:underline"
+                                  onClick={() => clearColumnFilter(['movement'])}
                                 >
-                                  <input
-                                    type="checkbox"
-                                    checked={columnFilters.lot.includes(option.value)}
-                                    onChange={() => toggleMultiValueFilter('lot', option.value)}
-                                    className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
-                                  />
-                                  <span className="flex-1 text-sm">{option.label}</span>
-                                </label>
-                              ))}
-                              {uniqueLotOptions.length === 0 && (
-                                <p className="text-xs text-muted-foreground">
-                                  No lot options available.
-                                </p>
-                              )}
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </th>
-                    <th className="w-28 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <span>Ref ID</span>
-                    </th>
-                    <th className="w-20 px-2 py-2 text-right text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <button
-                        type="button"
-                        className="flex w-full items-center justify-end gap-1 hover:text-primary focus:outline-none"
-                        onClick={() => handleSort('cartons')}
-                      >
-                        Ctns
-                        {getSortIcon('cartons')}
-                      </button>
-                    </th>
-                    <th className="w-20 px-2 py-2 text-right text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <button
-                        type="button"
-                        className="flex w-full items-center justify-end gap-1 hover:text-primary focus:outline-none"
-                        onClick={() => handleSort('pallets')}
-                      >
-                        Plts
-                        {getSortIcon('pallets')}
-                      </button>
-                    </th>
-                    <th className="w-24 px-2 py-2 text-right text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <button
-                        type="button"
-                        className="flex w-full items-center justify-end gap-1 hover:text-primary focus:outline-none"
-                        onClick={() => handleSort('units')}
-                      >
-                        Units
-                        {getSortIcon('units')}
-                      </button>
-                    </th>
-                    <th className="w-24 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <div className="flex items-center justify-between gap-1">
-                        <span>Type</span>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Filter type"
-                              className={cn(
-                                'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
-                                isFilterActive(['movement'])
-                                  ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted hover:text-primary'
-                              )}
-                            >
-                              <Filter className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent align="end" className="w-48 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-medium text-foreground">
-                                Type filter
-                              </span>
+                                  Clear
+                                </button>
+                              </div>
+                              <div className="space-y-2">
+                                {([
+                                  { value: 'positive' as const, label: 'Inbound' },
+                                  { value: 'negative' as const, label: 'Outbound' },
+                                ]).map(option => (
+                                  <label
+                                    key={option.value}
+                                    className="flex items-center gap-2 text-sm text-foreground"
+                                  >
+                                    <input
+                                      type="checkbox"
+                                      checked={columnFilters.movement.includes(option.value)}
+                                      onChange={() =>
+                                        updateColumnFilter(
+                                          'movement',
+                                          columnFilters.movement.includes(option.value)
+                                            ? columnFilters.movement.filter(v => v !== option.value)
+                                            : [...columnFilters.movement, option.value]
+                                        )
+                                      }
+                                      className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
+                                    />
+                                    <span className="flex-1 text-sm">{option.label}</span>
+                                  </label>
+                                ))}
+                              </div>
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </th>
+                      <th className="w-40 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
+                        <div className="flex items-center justify-between gap-1">
+                          <button
+                            type="button"
+                            className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
+                            onClick={() => handleSort('lastTransaction')}
+                          >
+                            Transaction Date
+                            {getSortIcon('lastTransaction')}
+                          </button>
+                          <Popover>
+                            <PopoverTrigger asChild>
                               <button
                                 type="button"
-                                className="text-xs font-medium text-primary hover:underline"
-                                onClick={() => clearColumnFilter(['movement'])}
+                                aria-label="Filter latest transactions"
+                                className={cn(
+                                  'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                                  isFilterActive(['lastTransaction'])
+                                    ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                                    : 'hover:bg-muted hover:text-primary'
+                                )}
                               >
-                                Clear
+                                <Filter className="h-3.5 w-3.5" />
                               </button>
-                            </div>
-                            <div className="space-y-2">
-                              {([
-                                { value: 'positive' as const, label: 'Inbound' },
-                                { value: 'negative' as const, label: 'Outbound' },
-                              ]).map(option => (
-                                <label
-                                  key={option.value}
-                                  className="flex items-center gap-2 text-sm text-foreground"
+                            </PopoverTrigger>
+                            <PopoverContent align="end" className="w-64 space-y-3">
+                              <div className="flex items-center justify-between">
+                                <span className="text-sm font-medium text-foreground">
+                                  Transaction filter
+                                </span>
+                                <button
+                                  type="button"
+                                  className="text-xs font-medium text-primary hover:underline"
+                                  onClick={() => clearColumnFilter(['lastTransaction'])}
                                 >
-                                  <input
-                                    type="checkbox"
-                                    checked={columnFilters.movement.includes(option.value)}
-                                    onChange={() =>
-                                      updateColumnFilter(
-                                        'movement',
-                                        columnFilters.movement.includes(option.value)
-                                          ? columnFilters.movement.filter(v => v !== option.value)
-                                          : [...columnFilters.movement, option.value]
-                                      )
-                                    }
-                                    className="h-4 w-4 rounded border-slate-300 text-primary focus:ring-primary"
-                                  />
-                                  <span className="flex-1 text-sm">{option.label}</span>
-                                </label>
-                              ))}
-                            </div>
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </th>
-                    <th className="w-40 px-2 py-2 text-left text-xs font-medium text-muted-foreground whitespace-nowrap">
-                      <div className="flex items-center justify-between gap-1">
-                        <button
-                          type="button"
-                          className="flex flex-1 items-center gap-1 text-left hover:text-primary focus:outline-none"
-                          onClick={() => handleSort('lastTransaction')}
-                        >
-                          Transaction Date
-                          {getSortIcon('lastTransaction')}
-                        </button>
-                        <Popover>
-                          <PopoverTrigger asChild>
-                            <button
-                              type="button"
-                              aria-label="Filter latest transactions"
-                              className={cn(
-                                'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
-                                isFilterActive(['lastTransaction'])
-                                  ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted hover:text-primary'
-                              )}
-                            >
-                              <Filter className="h-3.5 w-3.5" />
-                            </button>
-                          </PopoverTrigger>
-                          <PopoverContent align="end" className="w-64 space-y-3">
-                            <div className="flex items-center justify-between">
-                              <span className="text-sm font-medium text-foreground">
-                                Transaction filter
-                              </span>
-                              <button
-                                type="button"
-                                className="text-xs font-medium text-primary hover:underline"
-                                onClick={() => clearColumnFilter(['lastTransaction'])}
-                              >
-                                Clear
-                              </button>
-                            </div>
-                            <input
-                              type="text"
-                              value={columnFilters.lastTransaction}
-                              onChange={event =>
-                                updateColumnFilter('lastTransaction', event.target.value)
-                              }
-                              placeholder="Search type or date"
-                              className={baseFilterInputClass}
-                            />
-                          </PopoverContent>
-                        </Popover>
-                      </div>
-                    </th>
-                  </tr>
-                </thead>
-
-                <tbody>
-                  {loading && processedBalances.length === 0 && (
-                    <tr>
-                      <td colSpan={11} className="px-4 py-8 text-center text-muted-foreground">
-                        <span className="inline-flex items-center gap-2">
-                          <LoadingSpinner size="sm" />
-                          Loading inventory…
-                        </span>
-                      </td>
+                                  Clear
+                                </button>
+                              </div>
+                              <input
+                                type="text"
+                                value={columnFilters.lastTransaction}
+                                onChange={event =>
+                                  updateColumnFilter('lastTransaction', event.target.value)
+                                }
+                                placeholder="Search type or date"
+                                className={baseFilterInputClass}
+                              />
+                            </PopoverContent>
+                          </Popover>
+                        </div>
+                      </th>
                     </tr>
-                  )}
+                  </thead>
 
-                  {!loading && processedBalances.length === 0 && (
-                    <tr>
-                      <td colSpan={11} className="px-4 py-6 text-center text-muted-foreground">
-                        No on-hand inventory.
-                      </td>
-                    </tr>
-                  )}
-
-                  {processedBalances.map(balance => {
-                    const lastTransactionDisplay = formatLedgerTimestamp(
-                      balance.lastTransactionDate
-                    )
-                    const movementType = getMovementTypeFromTransaction(balance.lastTransactionType)
-                    const movementMultiplier = getMovementMultiplier(balance.lastTransactionType)
-                    const signedCartons =
-                      movementMultiplier === 0
-                        ? balance.currentCartons
-                        : movementMultiplier * Math.abs(balance.currentCartons)
-                    const signedPallets =
-                      movementMultiplier === 0
-                        ? balance.currentPallets
-                        : movementMultiplier * Math.abs(balance.currentPallets)
-                    const signedUnits =
-                      movementMultiplier === 0
-                        ? balance.currentUnits
-                        : movementMultiplier * Math.abs(balance.currentUnits)
-                    const movementLabel =
-                      movementType === 'positive'
-                        ? 'Inbound'
-                        : movementType === 'negative'
-                          ? 'Outbound'
-                          : 'Flat'
-                    const movementBadgeVariant =
-                      movementType === 'positive'
-                        ? ('success' as const)
-                        : movementType === 'negative'
-                          ? ('danger' as const)
-                          : ('neutral' as const)
-
-                    const sourceNumber =
-                      balance.fulfillmentOrderNumber ?? balance.purchaseOrderNumber ?? null
-                    const sourceHref = balance.fulfillmentOrderId
-                      ? `/operations/fulfillment-orders/${balance.fulfillmentOrderId}`
-                      : balance.purchaseOrderId
-                        ? `/operations/purchase-orders/${balance.purchaseOrderId}`
-                        : null
-                    const sourceDisplay = sourceNumber ?? (sourceHref ? 'View' : '—')
-                    const firstReceiveMeta = balance.receiveTransaction
-                      ? `First receive: ${formatLedgerTimestamp(balance.receiveTransaction.transactionDate) ?? '—'} by ${balance.receiveTransaction.createdBy?.fullName ?? 'Unknown'}`
-                      : null
-
-                    return (
-                      <tr
-                        key={balance.id}
-                        className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50"
-                      >
-                        <td
-                          className="px-2 py-2 text-sm font-semibold text-foreground truncate"
-                          title={
-                            [sourceNumber, firstReceiveMeta].filter(Boolean).join('\n') || undefined
-                          }
-                        >
-                          {sourceHref ? (
-                            <Link
-                              href={sourceHref}
-                              className="text-primary hover:underline"
-                              prefetch={false}
-                            >
-                              {sourceDisplay}
-                            </Link>
-                          ) : (
-                            sourceDisplay
-                          )}
-                        </td>
-                        <td className="px-2 py-2 text-sm font-medium text-foreground truncate">
-                          {balance.warehouse.code || balance.warehouse.name || '—'}
-                        </td>
-                        <td className="px-2 py-2 text-sm font-semibold text-foreground truncate">
-                          {balance.sku.skuCode}
-                        </td>
-                        <td
-                          className="px-2 py-2 text-sm text-muted-foreground truncate"
-                          title={balance.sku.description || undefined}
-                        >
-                          {balance.sku.description || '—'}
-                        </td>
-                        <td
-                          className="px-2 py-2 text-xs text-muted-foreground uppercase truncate"
-                          title={balance.lotRef}
-                        >
-                          {balance.lotRef}
-                        </td>
-                        <td
-                          className="px-2 py-2 text-sm text-muted-foreground truncate"
-                          title={
-                            [balance.lastTransactionReference, balance.lastTransactionId]
-                              .filter(Boolean)
-                              .join('\n') || undefined
-                          }
-                        >
-                          {balance.lastTransactionId ? (
-                            <Link
-                              href={`/operations/transactions/${balance.lastTransactionId}`}
-                              className="text-primary hover:underline"
-                              prefetch={false}
-                            >
-                              {balance.lastTransactionReference ?? 'View'}
-                            </Link>
-                          ) : (
-                            (balance.lastTransactionReference ?? '—')
-                          )}
-                        </td>
-                        <td className="px-2 py-2 text-right text-sm font-semibold text-primary whitespace-nowrap">
-                          {signedCartons.toLocaleString()}
-                        </td>
-                        <td className="px-2 py-2 text-right text-sm whitespace-nowrap">
-                          {signedPallets.toLocaleString()}
-                        </td>
-                        <td className="px-2 py-2 text-right text-sm whitespace-nowrap">
-                          {signedUnits.toLocaleString()}
-                        </td>
-                        <td className="px-2 py-2 text-sm whitespace-nowrap">
-                          <Badge variant={movementBadgeVariant} className="uppercase text-[10px]">
-                            {movementLabel}
-                          </Badge>
-                        </td>
-                        <td className="px-2 py-2 text-xs text-muted-foreground truncate">
-                          {lastTransactionDisplay ?? '—'}
+                  <tbody>
+                    {loading && processedBalances.length === 0 && (
+                      <tr>
+                        <td colSpan={11} className="px-4 py-8 text-center text-muted-foreground">
+                          <span className="inline-flex items-center gap-2">
+                            <LoadingSpinner size="sm" />
+                            Loading inventory…
+                          </span>
                         </td>
                       </tr>
-                    )
-                  })}
-                </tbody>
-                <tfoot>
-                  <tr className="border-t bg-muted/80 text-xs uppercase tracking-wide text-muted-foreground">
-                    <td colSpan={2} className="px-2 py-2 font-semibold text-left">
-                      Totals
-                    </td>
-                    <td className="px-2 py-2 font-medium whitespace-nowrap">
-                      {metrics.summary.totalSkuCount} SKUs
-                    </td>
-                    <td colSpan={3} />
-                    <td className="px-2 py-2 text-right font-medium text-primary whitespace-nowrap">
-                      {tableTotals.cartons.toLocaleString()}
-                    </td>
-                    <td className="px-2 py-2 text-right font-medium whitespace-nowrap">
-                      {tableTotals.pallets.toLocaleString()}
-                    </td>
-                    <td className="px-2 py-2 text-right font-medium whitespace-nowrap">
-                      {tableTotals.units.toLocaleString()}
-                    </td>
-                    <td colSpan={2} />
-                  </tr>
-                </tfoot>
-              </table>
+                    )}
+
+                    {!loading && processedBalances.length === 0 && (
+                      <tr>
+                        <td colSpan={11} className="px-4 py-6 text-center text-muted-foreground">
+                          No on-hand inventory.
+                        </td>
+                      </tr>
+                    )}
+
+                    {processedBalances.map(balance => {
+                      const lastTransactionDisplay = formatLedgerTimestamp(
+                        balance.lastTransactionDate
+                      )
+                      const movementType = getMovementTypeFromTransaction(balance.lastTransactionType)
+                      const movementMultiplier = getMovementMultiplier(balance.lastTransactionType)
+                      const signedCartons =
+                        movementMultiplier === 0
+                          ? balance.currentCartons
+                          : movementMultiplier * Math.abs(balance.currentCartons)
+                      const signedPallets =
+                        movementMultiplier === 0
+                          ? balance.currentPallets
+                          : movementMultiplier * Math.abs(balance.currentPallets)
+                      const signedUnits =
+                        movementMultiplier === 0
+                          ? balance.currentUnits
+                          : movementMultiplier * Math.abs(balance.currentUnits)
+                      const movementLabel =
+                        movementType === 'positive'
+                          ? 'Inbound'
+                          : movementType === 'negative'
+                            ? 'Outbound'
+                            : 'Flat'
+                      const movementBadgeVariant =
+                        movementType === 'positive'
+                          ? ('success' as const)
+                          : movementType === 'negative'
+                            ? ('danger' as const)
+                            : ('neutral' as const)
+
+                      const sourceNumber =
+                        balance.fulfillmentOrderNumber ?? balance.purchaseOrderNumber ?? null
+                      const sourceHref = balance.fulfillmentOrderId
+                        ? `/operations/fulfillment-orders/${balance.fulfillmentOrderId}`
+                        : balance.purchaseOrderId
+                          ? `/operations/purchase-orders/${balance.purchaseOrderId}`
+                          : null
+                      const sourceDisplay = sourceNumber ?? (sourceHref ? 'View' : '—')
+                      const firstReceiveMeta = balance.receiveTransaction
+                        ? `First receive: ${formatLedgerTimestamp(balance.receiveTransaction.transactionDate) ?? '—'} by ${balance.receiveTransaction.createdBy?.fullName ?? 'Unknown'}`
+                        : null
+                      let warehouseDisplay = balance.warehouse.code
+                      if (warehouseDisplay.length === 0) {
+                        warehouseDisplay = balance.warehouse.name
+                      }
+                      if (warehouseDisplay.length === 0) {
+                        warehouseDisplay = '—'
+                      }
+
+                      return (
+                        <tr
+                          key={balance.id}
+                          className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50"
+                        >
+                          <td
+                            className="px-2 py-2 text-sm font-semibold text-foreground truncate"
+                            title={
+                              [sourceNumber, firstReceiveMeta].filter(Boolean).join('\n') || undefined
+                            }
+                          >
+                            {sourceHref ? (
+                              <Link
+                                href={sourceHref}
+                                className="text-primary hover:underline"
+                                prefetch={false}
+                              >
+                                {sourceDisplay}
+                              </Link>
+                            ) : (
+                              sourceDisplay
+                            )}
+                          </td>
+                          <td className="px-2 py-2 text-sm font-medium text-foreground truncate">
+                            {warehouseDisplay}
+                          </td>
+                          <td className="px-2 py-2 text-sm font-semibold text-foreground truncate">
+                            {balance.sku.skuCode}
+                          </td>
+                          <td
+                            className="px-2 py-2 text-sm text-muted-foreground truncate"
+                            title={balance.sku.description || undefined}
+                          >
+                            {balance.sku.description || '—'}
+                          </td>
+                          <td
+                            className="px-2 py-2 text-xs text-muted-foreground uppercase truncate"
+                            title={balance.lotRef}
+                          >
+                            {balance.lotRef}
+                          </td>
+                          <td
+                            className="px-2 py-2 text-sm text-muted-foreground truncate"
+                            title={
+                              [balance.lastTransactionReference, balance.lastTransactionId]
+                                .filter(Boolean)
+                                .join('\n') || undefined
+                            }
+                          >
+                            {balance.lastTransactionId ? (
+                              <Link
+                                href={`/operations/transactions/${balance.lastTransactionId}`}
+                                className="text-primary hover:underline"
+                                prefetch={false}
+                              >
+                                {balance.lastTransactionReference ?? 'View'}
+                              </Link>
+                            ) : (
+                              (balance.lastTransactionReference ?? '—')
+                            )}
+                          </td>
+                          <td className="px-2 py-2 text-right text-sm font-semibold text-primary whitespace-nowrap">
+                            {signedCartons.toLocaleString()}
+                          </td>
+                          <td className="px-2 py-2 text-right text-sm whitespace-nowrap">
+                            {signedPallets.toLocaleString()}
+                          </td>
+                          <td className="px-2 py-2 text-right text-sm whitespace-nowrap">
+                            {signedUnits.toLocaleString()}
+                          </td>
+                          <td className="px-2 py-2 text-sm whitespace-nowrap">
+                            <Badge variant={movementBadgeVariant} className="uppercase text-[10px]">
+                              {movementLabel}
+                            </Badge>
+                          </td>
+                          <td className="px-2 py-2 text-xs text-muted-foreground truncate">
+                            {lastTransactionDisplay ?? '—'}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                  <tfoot>
+                    <tr className="border-t bg-muted/80 text-xs uppercase tracking-wide text-muted-foreground">
+                      <td colSpan={2} className="px-2 py-2 font-semibold text-left">
+                        Totals
+                      </td>
+                      <td className="px-2 py-2 font-medium whitespace-nowrap">
+                        {metrics.summary.totalSkuCount} SKUs
+                      </td>
+                      <td colSpan={3} />
+                      <td className="px-2 py-2 text-right font-medium text-primary whitespace-nowrap">
+                        {tableTotals.cartons.toLocaleString()}
+                      </td>
+                      <td className="px-2 py-2 text-right font-medium whitespace-nowrap">
+                        {tableTotals.pallets.toLocaleString()}
+                      </td>
+                      <td className="px-2 py-2 text-right font-medium whitespace-nowrap">
+                        {tableTotals.units.toLocaleString()}
+                      </td>
+                      <td colSpan={2} />
+                    </tr>
+                  </tfoot>
+                </table>
+              </div>
             </div>
-          </div>
+          )}
         </div>
       </PageContent>
     </PageContainer>

--- a/apps/talos/src/components/operations/inventory-pipeline-tab.tsx
+++ b/apps/talos/src/components/operations/inventory-pipeline-tab.tsx
@@ -1,0 +1,496 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'react-hot-toast'
+import { format } from 'date-fns'
+import { Factory, Package, Ship, Warehouse } from '@/lib/lucide-icons'
+import { withBasePath } from '@/lib/utils/base-path'
+import { StatsCard } from '@/components/ui/stats-card'
+import { Badge } from '@/components/ui/badge'
+import { LoadingSpinner } from '@/components/ui/loading-spinner'
+import type { InventoryBalance } from '@/hooks/useInventoryFilters'
+import {
+  buildInventoryPipelineSnapshot,
+  type InventoryPipelinePurchaseOrderInput,
+} from '@/lib/inventory/pipeline'
+
+type SelectedPipelineStage = 'manufacturing' | 'transit' | 'warehouse'
+
+interface InventoryPipelineTabProps {
+  balances: InventoryBalance[]
+  loadingBalances: boolean
+  enabled: boolean
+}
+
+interface PurchaseOrdersResponse {
+  data: Array<{
+    id: string
+    orderNumber: string
+    status: string
+    counterpartyName: string | null
+    warehouseCode: string | null
+    warehouseName: string | null
+    stageData: {
+      manufacturing: {
+        factoryName: string | null
+        expectedCompletionDate: string | null
+        totalCartons: number | null
+      }
+      ocean: {
+        portOfLoading: string | null
+        portOfDischarge: string | null
+        estimatedArrival: string | null
+      }
+      warehouse: {
+        warehouseCode: string | null
+        warehouseName: string | null
+      }
+    }
+    lines: Array<{
+      skuCode: string
+      quantity: number
+      unitsOrdered: number
+    }>
+  }>
+}
+
+const STAGE_META = {
+  manufacturing: {
+    label: 'Manufacturing',
+    icon: Factory,
+    description: 'Stock still with supplier or factory.',
+  },
+  transit: {
+    label: 'Transit',
+    icon: Ship,
+    description: 'Stock moving toward warehouse.',
+  },
+  warehouse: {
+    label: 'Warehouse',
+    icon: Warehouse,
+    description: 'Stock physically on hand in Talos warehouses.',
+  },
+} as const
+
+function formatPipelineDate(value: string | null) {
+  if (!value) {
+    return '—'
+  }
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return '—'
+  }
+
+  return format(parsed, 'MMM d, yyyy')
+}
+
+function mapPurchaseOrders(
+  orders: PurchaseOrdersResponse['data']
+): InventoryPipelinePurchaseOrderInput[] {
+  return orders.map((order) => ({
+    id: order.id,
+    orderNumber: order.orderNumber,
+    status: order.status,
+    counterpartyName: order.counterpartyName,
+    warehouseCode: order.warehouseCode,
+    warehouseName: order.warehouseName,
+    stageData: order.stageData,
+    lines: order.lines.map((line) => ({
+      skuCode: line.skuCode,
+      quantity: line.quantity,
+      unitsOrdered: line.unitsOrdered,
+    })),
+  }))
+}
+
+export function InventoryPipelineTab({
+  balances,
+  loadingBalances,
+  enabled,
+}: InventoryPipelineTabProps) {
+  const [purchaseOrders, setPurchaseOrders] = useState<InventoryPipelinePurchaseOrderInput[]>([])
+  const [loadingPurchaseOrders, setLoadingPurchaseOrders] = useState(false)
+  const [hasLoadedPurchaseOrders, setHasLoadedPurchaseOrders] = useState(false)
+  const [selectedStage, setSelectedStage] = useState<SelectedPipelineStage>('warehouse')
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+    if (hasLoadedPurchaseOrders) {
+      return
+    }
+
+    let cancelled = false
+
+    const fetchPurchaseOrders = async () => {
+      try {
+        setLoadingPurchaseOrders(true)
+        const response = await fetch(withBasePath('/api/purchase-orders'), {
+          credentials: 'include',
+        })
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
+          toast.error(`Failed to load purchase orders: ${errorData.error ?? response.statusText}`)
+          return
+        }
+
+        const payload = (await response.json()) as PurchaseOrdersResponse
+        if (cancelled) {
+          return
+        }
+
+        setPurchaseOrders(mapPurchaseOrders(payload.data))
+        setHasLoadedPurchaseOrders(true)
+      } catch (_error) {
+        toast.error('Failed to load inventory pipeline')
+      } finally {
+        if (!cancelled) {
+          setLoadingPurchaseOrders(false)
+        }
+      }
+    }
+
+    void fetchPurchaseOrders()
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, hasLoadedPurchaseOrders])
+
+  const snapshot = useMemo(() => {
+    return buildInventoryPipelineSnapshot({
+      purchaseOrders,
+      balances,
+    })
+  }, [balances, purchaseOrders])
+
+  const selectedStageMeta = STAGE_META[selectedStage]
+  const selectedStageSummary = snapshot.stages[selectedStage]
+  const loading = loadingBalances || loadingPurchaseOrders
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
+        <StatsCard
+          title="Units"
+          value={snapshot.summary.totalUnits}
+          subtitle="Across pipeline"
+          size="sm"
+          variant="info"
+          icon={Package}
+        />
+        <StatsCard
+          title="Cartons"
+          value={snapshot.summary.totalCartons}
+          subtitle="Across pipeline"
+          size="sm"
+        />
+        <StatsCard
+          title="SKUs"
+          value={snapshot.summary.activeSkus}
+          subtitle="Active in flow"
+          size="sm"
+        />
+        <StatsCard
+          title="Open POs"
+          value={snapshot.summary.purchaseOrderCount}
+          subtitle="Manufacturing + transit"
+          size="sm"
+        />
+        <StatsCard
+          title="Warehouses"
+          value={snapshot.summary.warehouseCount}
+          subtitle="With stock on hand"
+          size="sm"
+        />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        {(Object.keys(STAGE_META) as SelectedPipelineStage[]).map((stageKey) => {
+          const meta = STAGE_META[stageKey]
+          const stage = snapshot.stages[stageKey]
+          const Icon = meta.icon
+          const isActive = selectedStage === stageKey
+          const countLabel =
+            stageKey === 'warehouse' ? `${stage.count} locations` : `${stage.count} POs`
+
+          return (
+            <button
+              key={stageKey}
+              type="button"
+              onClick={() => setSelectedStage(stageKey)}
+              className={[
+                'rounded-2xl border bg-white p-5 text-left shadow-soft transition-all dark:bg-slate-800',
+                isActive
+                  ? 'border-primary ring-1 ring-primary/30'
+                  : 'border-slate-200 hover:border-slate-300 dark:border-slate-700 dark:hover:border-slate-600',
+              ].join(' ')}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <Icon className="h-4 w-4 text-primary" />
+                    <p className="text-sm font-semibold text-foreground">{meta.label}</p>
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{meta.description}</p>
+                </div>
+                <Badge variant={isActive ? 'info' : 'neutral'}>{countLabel}</Badge>
+              </div>
+
+              <div className="mt-5 grid grid-cols-3 gap-3">
+                <div>
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    Cartons
+                  </p>
+                  <p className="mt-1 text-lg font-semibold text-foreground">
+                    {stage.cartons.toLocaleString()}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    Units
+                  </p>
+                  <p className="mt-1 text-lg font-semibold text-foreground">
+                    {stage.units.toLocaleString()}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    SKUs
+                  </p>
+                  <p className="mt-1 text-lg font-semibold text-foreground">
+                    {stage.skuCount.toLocaleString()}
+                  </p>
+                </div>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="rounded-2xl border bg-white shadow-soft dark:bg-slate-800">
+        <div className="flex items-center justify-between gap-4 border-b px-4 py-3 dark:border-slate-700">
+          <div>
+            <div className="flex items-center gap-2">
+              <selectedStageMeta.icon className="h-4 w-4 text-primary" />
+              <h2 className="text-sm font-semibold text-foreground">{selectedStageMeta.label}</h2>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">{selectedStageMeta.description}</p>
+          </div>
+          <Badge variant="outline">
+            {selectedStageSummary.cartons.toLocaleString()} cartons
+          </Badge>
+        </div>
+
+        {loading ? (
+          <div className="px-4 py-10 text-center text-muted-foreground">
+            <span className="inline-flex items-center gap-2">
+              <LoadingSpinner size="sm" />
+              Loading inventory pipeline…
+            </span>
+          </div>
+        ) : null}
+
+        {!loading && selectedStage === 'manufacturing' ? (
+          <div className="overflow-auto">
+            <table className="w-full min-w-[960px] table-auto text-sm">
+              <thead>
+                <tr className="border-b bg-slate-50/60 dark:bg-slate-700/50">
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    PO
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Supplier
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Factory
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    SKUs
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Cartons
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Units
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Exp. Complete
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.manufacturingRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                      No stock currently in manufacturing.
+                    </td>
+                  </tr>
+                ) : null}
+                {snapshot.manufacturingRows.map((row) => (
+                  <tr key={row.id} className="border-t border-slate-200 dark:border-slate-700">
+                    <td className="px-4 py-3 font-medium text-foreground">{row.orderNumber}</td>
+                    <td className="px-3 py-3 text-foreground">{row.supplierName ?? '—'}</td>
+                    <td className="px-3 py-3 text-muted-foreground">{row.locationLabel ?? '—'}</td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.skuCount.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right font-medium text-primary">
+                      {row.cartons.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.units.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-right text-muted-foreground">
+                      {formatPipelineDate(row.expectedDate)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
+        {!loading && selectedStage === 'transit' ? (
+          <div className="overflow-auto">
+            <table className="w-full min-w-[980px] table-auto text-sm">
+              <thead>
+                <tr className="border-b bg-slate-50/60 dark:bg-slate-700/50">
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    PO
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Supplier
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Route
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Destination
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Cartons
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Units
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    ETA
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.transitRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                      No stock currently in transit.
+                    </td>
+                  </tr>
+                ) : null}
+                {snapshot.transitRows.map((row) => (
+                  <tr key={row.id} className="border-t border-slate-200 dark:border-slate-700">
+                    <td className="px-4 py-3 font-medium text-foreground">{row.orderNumber}</td>
+                    <td className="px-3 py-3 text-foreground">{row.supplierName ?? '—'}</td>
+                    <td className="px-3 py-3 text-muted-foreground">{row.routeLabel ?? '—'}</td>
+                    <td className="px-3 py-3 text-muted-foreground">
+                      {row.warehouseCode ?? row.warehouseName ?? '—'}
+                    </td>
+                    <td className="px-3 py-3 text-right font-medium text-primary">
+                      {row.cartons.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.units.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-right text-muted-foreground">
+                      {formatPipelineDate(row.eta)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+
+        {!loading && selectedStage === 'warehouse' ? (
+          <div className="overflow-auto">
+            <table className="w-full min-w-[860px] table-auto text-sm">
+              <thead>
+                <tr className="border-b bg-slate-50/60 dark:bg-slate-700/50">
+                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Warehouse
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    SKUs
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Lots
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Cartons
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Pallets
+                  </th>
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Units
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    Share
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {snapshot.warehouseRows.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-muted-foreground">
+                      No stock currently on hand.
+                    </td>
+                  </tr>
+                ) : null}
+                {snapshot.warehouseRows.map((row) => (
+                  <tr
+                    key={`${row.warehouseCode}-${row.warehouseName}`}
+                    className="border-t border-slate-200 dark:border-slate-700"
+                  >
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-3">
+                        <div className="rounded-lg border border-slate-200 bg-slate-50 px-2.5 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200">
+                          {row.warehouseCode}
+                        </div>
+                        <div className="min-w-0">
+                          <p className="truncate font-medium text-foreground">{row.warehouseName}</p>
+                          <p className="text-xs text-muted-foreground">On hand</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.skuCount.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.lotCount.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right font-medium text-primary">
+                      {row.cartons.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.pallets.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-3 text-right text-foreground">
+                      {row.units.toLocaleString()}
+                    </td>
+                    <td className="px-4 py-3 text-right">
+                      <Badge variant="outline">{row.shareOfUnits.toFixed(1)}%</Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/talos/src/lib/inventory/pipeline.test.ts
+++ b/apps/talos/src/lib/inventory/pipeline.test.ts
@@ -1,0 +1,144 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildInventoryPipelineSnapshot } from './pipeline'
+
+test('buildInventoryPipelineSnapshot groups stock by stage and warehouse', () => {
+  const snapshot = buildInventoryPipelineSnapshot({
+    purchaseOrders: [
+      {
+        id: 'po-mfg',
+        orderNumber: 'PO-1001',
+        status: 'MANUFACTURING',
+        counterpartyName: 'Factory Alpha',
+        warehouseCode: null,
+        warehouseName: null,
+        stageData: {
+          manufacturing: {
+            factoryName: 'Shenzhen Alpha',
+            expectedCompletionDate: '2026-04-28T00:00:00.000Z',
+            totalCartons: 100,
+          },
+          ocean: {
+            portOfLoading: null,
+            portOfDischarge: null,
+            estimatedArrival: null,
+          },
+          warehouse: {
+            warehouseCode: null,
+            warehouseName: null,
+          },
+        },
+        lines: [
+          { skuCode: 'SKU-RED', quantity: 70, unitsOrdered: 840 },
+          { skuCode: 'SKU-BLUE', quantity: 30, unitsOrdered: 360 },
+        ],
+      },
+      {
+        id: 'po-ocean',
+        orderNumber: 'PO-2001',
+        status: 'OCEAN',
+        counterpartyName: 'Factory Beta',
+        warehouseCode: null,
+        warehouseName: null,
+        stageData: {
+          manufacturing: {
+            factoryName: null,
+            expectedCompletionDate: null,
+            totalCartons: null,
+          },
+          ocean: {
+            portOfLoading: 'SHA',
+            portOfDischarge: 'LAX',
+            estimatedArrival: '2026-05-02T00:00:00.000Z',
+          },
+          warehouse: {
+            warehouseCode: null,
+            warehouseName: null,
+          },
+        },
+        lines: [{ skuCode: 'SKU-GREEN', quantity: 50, unitsOrdered: 600 }],
+      },
+    ],
+    balances: [
+      {
+        warehouseId: 'wh-lax',
+        warehouse: { code: 'LAX', name: 'Los Angeles' },
+        sku: { skuCode: 'SKU-RED' },
+        lotRef: 'LOT-001',
+        currentCartons: 20,
+        currentPallets: 2,
+        currentUnits: 240,
+      },
+      {
+        warehouseId: 'wh-lax',
+        warehouse: { code: 'LAX', name: 'Los Angeles' },
+        sku: { skuCode: 'SKU-BLUE' },
+        lotRef: 'LOT-002',
+        currentCartons: 10,
+        currentPallets: 1,
+        currentUnits: 120,
+      },
+      {
+        warehouseId: 'wh-dal',
+        warehouse: { code: 'DAL', name: 'Dallas' },
+        sku: { skuCode: 'SKU-RED' },
+        lotRef: 'LOT-003',
+        currentCartons: 5,
+        currentPallets: 1,
+        currentUnits: 60,
+      },
+    ],
+  })
+
+  assert.deepEqual(snapshot.summary, {
+    totalCartons: 185,
+    totalUnits: 2220,
+    activeSkus: 3,
+    purchaseOrderCount: 2,
+    warehouseCount: 2,
+  })
+
+  assert.deepEqual(snapshot.stages, {
+    manufacturing: {
+      key: 'manufacturing',
+      label: 'Manufacturing',
+      count: 1,
+      cartons: 100,
+      units: 1200,
+      skuCount: 2,
+    },
+    transit: {
+      key: 'transit',
+      label: 'Transit',
+      count: 1,
+      cartons: 50,
+      units: 600,
+      skuCount: 1,
+    },
+    warehouse: {
+      key: 'warehouse',
+      label: 'Warehouse',
+      count: 2,
+      cartons: 35,
+      units: 420,
+      skuCount: 2,
+    },
+  })
+
+  assert.equal(snapshot.manufacturingRows[0]?.locationLabel, 'Shenzhen Alpha')
+  assert.equal(snapshot.manufacturingRows[0]?.expectedDate, '2026-04-28T00:00:00.000Z')
+  assert.equal(snapshot.transitRows[0]?.routeLabel, 'SHA → LAX')
+  assert.equal(snapshot.transitRows[0]?.eta, '2026-05-02T00:00:00.000Z')
+
+  assert.deepEqual(snapshot.warehouseRows[0], {
+    warehouseCode: 'LAX',
+    warehouseName: 'Los Angeles',
+    skuCount: 2,
+    lotCount: 2,
+    cartons: 30,
+    pallets: 3,
+    units: 360,
+    shareOfUnits: 85.71428571428571,
+  })
+})

--- a/apps/talos/src/lib/inventory/pipeline.ts
+++ b/apps/talos/src/lib/inventory/pipeline.ts
@@ -1,0 +1,331 @@
+export interface InventoryPipelinePurchaseOrderLineInput {
+  skuCode: string
+  quantity: number
+  unitsOrdered: number
+}
+
+export interface InventoryPipelinePurchaseOrderInput {
+  id: string
+  orderNumber: string
+  status: string
+  counterpartyName: string | null
+  warehouseCode: string | null
+  warehouseName: string | null
+  stageData: {
+    manufacturing: {
+      factoryName: string | null
+      expectedCompletionDate: string | null
+      totalCartons: number | null
+    }
+    ocean: {
+      portOfLoading: string | null
+      portOfDischarge: string | null
+      estimatedArrival: string | null
+    }
+    warehouse: {
+      warehouseCode: string | null
+      warehouseName: string | null
+    }
+  }
+  lines: InventoryPipelinePurchaseOrderLineInput[]
+}
+
+export interface InventoryPipelineBalanceInput {
+  warehouseId: string | null
+  warehouse: {
+    code: string
+    name: string
+  }
+  sku: {
+    skuCode: string
+  }
+  lotRef: string
+  currentCartons: number
+  currentPallets: number
+  currentUnits: number
+}
+
+interface InventoryPipelineStageSummary {
+  key: 'manufacturing' | 'transit' | 'warehouse'
+  label: string
+  count: number
+  cartons: number
+  units: number
+  skuCount: number
+}
+
+export interface InventoryPipelineOrderRow {
+  id: string
+  orderNumber: string
+  supplierName: string | null
+  skuCount: number
+  cartons: number
+  units: number
+  locationLabel: string | null
+  expectedDate: string | null
+  routeLabel: string | null
+  eta: string | null
+  warehouseCode: string | null
+  warehouseName: string | null
+}
+
+export interface InventoryPipelineWarehouseRow {
+  warehouseCode: string
+  warehouseName: string
+  skuCount: number
+  lotCount: number
+  cartons: number
+  pallets: number
+  units: number
+  shareOfUnits: number
+}
+
+export interface InventoryPipelineSnapshot {
+  summary: {
+    totalCartons: number
+    totalUnits: number
+    activeSkus: number
+    purchaseOrderCount: number
+    warehouseCount: number
+  }
+  stages: {
+    manufacturing: InventoryPipelineStageSummary
+    transit: InventoryPipelineStageSummary
+    warehouse: InventoryPipelineStageSummary
+  }
+  manufacturingRows: InventoryPipelineOrderRow[]
+  transitRows: InventoryPipelineOrderRow[]
+  warehouseRows: InventoryPipelineWarehouseRow[]
+}
+
+interface StageAccumulator {
+  count: number
+  cartons: number
+  units: number
+  skuCodes: Set<string>
+}
+
+function createStageAccumulator(): StageAccumulator {
+  return {
+    count: 0,
+    cartons: 0,
+    units: 0,
+    skuCodes: new Set<string>(),
+  }
+}
+
+function sumOrderCartons(order: InventoryPipelinePurchaseOrderInput) {
+  const manufacturingTotalCartons = order.stageData.manufacturing.totalCartons
+  if (typeof manufacturingTotalCartons === 'number' && manufacturingTotalCartons > 0) {
+    return manufacturingTotalCartons
+  }
+
+  return order.lines.reduce((sum, line) => sum + line.quantity, 0)
+}
+
+function sumOrderUnits(order: InventoryPipelinePurchaseOrderInput) {
+  return order.lines.reduce((sum, line) => sum + line.unitsOrdered, 0)
+}
+
+function buildOrderSkuSet(order: InventoryPipelinePurchaseOrderInput) {
+  const skuCodes = new Set<string>()
+  order.lines.forEach((line) => {
+    skuCodes.add(line.skuCode)
+  })
+  return skuCodes
+}
+
+function buildRouteLabel(order: InventoryPipelinePurchaseOrderInput) {
+  const portOfLoading = order.stageData.ocean.portOfLoading
+  const portOfDischarge = order.stageData.ocean.portOfDischarge
+
+  if (portOfLoading && portOfDischarge) {
+    return `${portOfLoading} → ${portOfDischarge}`
+  }
+  if (portOfLoading) {
+    return portOfLoading
+  }
+  if (portOfDischarge) {
+    return portOfDischarge
+  }
+  return null
+}
+
+function buildStageOrderRow(order: InventoryPipelinePurchaseOrderInput): InventoryPipelineOrderRow {
+  const skuCodes = buildOrderSkuSet(order)
+
+  return {
+    id: order.id,
+    orderNumber: order.orderNumber,
+    supplierName: order.counterpartyName,
+    skuCount: skuCodes.size,
+    cartons: sumOrderCartons(order),
+    units: sumOrderUnits(order),
+    locationLabel: order.stageData.manufacturing.factoryName,
+    expectedDate: order.stageData.manufacturing.expectedCompletionDate,
+    routeLabel: buildRouteLabel(order),
+    eta: order.stageData.ocean.estimatedArrival,
+    warehouseCode: order.stageData.warehouse.warehouseCode,
+    warehouseName: order.stageData.warehouse.warehouseName,
+  }
+}
+
+function addOrderToStage(stage: StageAccumulator, order: InventoryPipelinePurchaseOrderInput) {
+  stage.count += 1
+  stage.cartons += sumOrderCartons(order)
+  stage.units += sumOrderUnits(order)
+  buildOrderSkuSet(order).forEach((skuCode) => {
+    stage.skuCodes.add(skuCode)
+  })
+}
+
+function hasOnHandInventory(balance: InventoryPipelineBalanceInput) {
+  if (balance.currentCartons > 0) {
+    return true
+  }
+  if (balance.currentPallets > 0) {
+    return true
+  }
+  return balance.currentUnits > 0
+}
+
+function getWarehouseGroupKey(balance: InventoryPipelineBalanceInput) {
+  if (balance.warehouse.code.trim().length > 0) {
+    return balance.warehouse.code.trim()
+  }
+  if (balance.warehouse.name.trim().length > 0) {
+    return balance.warehouse.name.trim()
+  }
+  if (balance.warehouseId) {
+    return balance.warehouseId
+  }
+  return balance.lotRef
+}
+
+function createStageSummary(
+  key: InventoryPipelineStageSummary['key'],
+  label: string,
+  stage: StageAccumulator
+): InventoryPipelineStageSummary {
+  return {
+    key,
+    label,
+    count: stage.count,
+    cartons: stage.cartons,
+    units: stage.units,
+    skuCount: stage.skuCodes.size,
+  }
+}
+
+export function buildInventoryPipelineSnapshot(input: {
+  purchaseOrders: InventoryPipelinePurchaseOrderInput[]
+  balances: InventoryPipelineBalanceInput[]
+}): InventoryPipelineSnapshot {
+  const manufacturing = createStageAccumulator()
+  const transit = createStageAccumulator()
+  const warehouse = createStageAccumulator()
+
+  const activeSkuCodes = new Set<string>()
+  const manufacturingRows: InventoryPipelineOrderRow[] = []
+  const transitRows: InventoryPipelineOrderRow[] = []
+
+  input.purchaseOrders.forEach((order) => {
+    const row = buildStageOrderRow(order)
+    buildOrderSkuSet(order).forEach((skuCode) => {
+      activeSkuCodes.add(skuCode)
+    })
+
+    if (order.status === 'MANUFACTURING') {
+      addOrderToStage(manufacturing, order)
+      manufacturingRows.push(row)
+    }
+
+    if (order.status === 'OCEAN') {
+      addOrderToStage(transit, order)
+      transitRows.push(row)
+    }
+  })
+
+  const groupedWarehouses = new Map<
+    string,
+    {
+      warehouseCode: string
+      warehouseName: string
+      skuCodes: Set<string>
+      lotRefs: Set<string>
+      cartons: number
+      pallets: number
+      units: number
+    }
+  >()
+
+  input.balances.forEach((balance) => {
+    if (!hasOnHandInventory(balance)) {
+      return
+    }
+
+    activeSkuCodes.add(balance.sku.skuCode)
+    warehouse.count += 0
+    warehouse.cartons += Math.max(0, balance.currentCartons)
+    warehouse.units += Math.max(0, balance.currentUnits)
+    warehouse.skuCodes.add(balance.sku.skuCode)
+
+    const warehouseKey = getWarehouseGroupKey(balance)
+    const existingWarehouse = groupedWarehouses.get(warehouseKey)
+
+    if (existingWarehouse) {
+      existingWarehouse.skuCodes.add(balance.sku.skuCode)
+      existingWarehouse.lotRefs.add(balance.lotRef)
+      existingWarehouse.cartons += Math.max(0, balance.currentCartons)
+      existingWarehouse.pallets += Math.max(0, balance.currentPallets)
+      existingWarehouse.units += Math.max(0, balance.currentUnits)
+      return
+    }
+
+    groupedWarehouses.set(warehouseKey, {
+      warehouseCode: balance.warehouse.code,
+      warehouseName: balance.warehouse.name,
+      skuCodes: new Set([balance.sku.skuCode]),
+      lotRefs: new Set([balance.lotRef]),
+      cartons: Math.max(0, balance.currentCartons),
+      pallets: Math.max(0, balance.currentPallets),
+      units: Math.max(0, balance.currentUnits),
+    })
+  })
+
+  warehouse.count = groupedWarehouses.size
+
+  const warehouseRows = Array.from(groupedWarehouses.values())
+    .map((row): InventoryPipelineWarehouseRow => ({
+      warehouseCode: row.warehouseCode,
+      warehouseName: row.warehouseName,
+      skuCount: row.skuCodes.size,
+      lotCount: row.lotRefs.size,
+      cartons: row.cartons,
+      pallets: row.pallets,
+      units: row.units,
+      shareOfUnits: warehouse.units > 0 ? (row.units / warehouse.units) * 100 : 0,
+    }))
+    .sort((left, right) => right.units - left.units)
+
+  manufacturingRows.sort((left, right) => right.units - left.units)
+  transitRows.sort((left, right) => right.units - left.units)
+
+  return {
+    summary: {
+      totalCartons: manufacturing.cartons + transit.cartons + warehouse.cartons,
+      totalUnits: manufacturing.units + transit.units + warehouse.units,
+      activeSkus: activeSkuCodes.size,
+      purchaseOrderCount: manufacturing.count + transit.count,
+      warehouseCount: warehouse.count,
+    },
+    stages: {
+      manufacturing: createStageSummary('manufacturing', 'Manufacturing', manufacturing),
+      transit: createStageSummary('transit', 'Transit', transit),
+      warehouse: createStageSummary('warehouse', 'Warehouse', warehouse),
+    },
+    manufacturingRows,
+    transitRows,
+    warehouseRows,
+  }
+}


### PR DESCRIPTION
## Summary
- replace warehouse-only inventory analytics with a stage-based pipeline view
- add tested inventory pipeline aggregation for manufacturing, transit, and warehouse stock
- keep the existing ledger view intact while adding the new analytics tab detail tables

## Verification
- pnpm --filter @targon/talos exec tsx src/lib/inventory/pipeline.test.ts
- pnpm --filter @targon/talos type-check
- pnpm --filter @targon/talos exec eslint src/app/operations/inventory/page.tsx src/components/operations/inventory-pipeline-tab.tsx src/lib/inventory/pipeline.ts src/lib/inventory/pipeline.test.ts
- pnpm --filter @targon/talos test