### PR TITLE
fix(argus): speed up initial WPR load

### DIFF
--- a/apps/argus/app/api/wpr/changelog-week-route.test.ts
+++ b/apps/argus/app/api/wpr/changelog-week-route.test.ts
@@ -1,0 +1,180 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+function buildScpMetrics() {
+  return {
+    asin_count: 0,
+    impressions: 0,
+    clicks: 0,
+    cart_adds: 0,
+    purchases: 0,
+    sales: 0,
+    ctr: 0,
+    atc_rate: 0,
+    purchase_rate: 0,
+    cvr: 0,
+  }
+}
+
+function buildScpWindow() {
+  return {
+    meta: {
+      targetAsin: 'B000000001',
+      recentWindow: ['W15', 'W16'],
+      baselineWindow: ['W03', 'W16'],
+    },
+    current_week: buildScpMetrics(),
+    recent_4w: buildScpMetrics(),
+    baseline_to_anchor: buildScpMetrics(),
+    weekly: [],
+    asins: [],
+  }
+}
+
+function buildBusinessMetrics() {
+  return {
+    asin_count: 0,
+    sessions: 0,
+    page_views: 0,
+    order_items: 0,
+    units_ordered: 0,
+    sales: 0,
+    order_item_session_percentage: 0,
+    unit_session_percentage: 0,
+    buy_box_percentage: 0,
+  }
+}
+
+function buildBusinessReportsWindow() {
+  return {
+    meta: {
+      targetAsin: 'B000000001',
+      selectedWeek: 'W16',
+      availableWeeks: ['W15', 'W16'],
+    },
+    current_week: buildBusinessMetrics(),
+    baseline_to_anchor: buildBusinessMetrics(),
+    weekly: [],
+    dailyByWeek: {},
+    asins: [],
+  }
+}
+
+function buildWeekBundle() {
+  return {
+    meta: {
+      anchorWeek: 'W16',
+      competitorBrand: 'Competitor',
+      competitorAsin: 'B000000002',
+      benchmarkPolicy: 'policy',
+      competitor: {
+        brand: 'Competitor',
+        asin: 'B000000002',
+        config_source: 'config',
+      },
+      recentWindow: ['W15', 'W16'],
+      baselineWindow: ['W03', 'W16'],
+      policy: {
+        primary_window: 'recent_4w',
+        baseline_window: 'baseline_13w',
+        term_truth_set: 'tst',
+        dashboard_policy: 'dashboard',
+        benchmark_policy: 'benchmark',
+      },
+    },
+    weeks: ['W15', 'W16'],
+    clusters: [],
+    scatterClusterIds: [],
+    lineClusterIds: [],
+    shareClusterIds: [],
+    ppcClusterIds: [],
+    defaultClusterIds: [],
+    sqpTerms: [],
+    sqpClusterTerms: {},
+    sqpGlobalTermIds: [],
+    regression: {
+      slope: 0,
+      intercept: 0,
+    },
+    brandMetricsWindow: {},
+    brandMetrics: {},
+    competitorWeekly: [],
+    scp: buildScpWindow(),
+    businessReports: buildBusinessReportsWindow(),
+  }
+}
+
+function buildPayload() {
+  return {
+    ...buildWeekBundle(),
+    defaultWeek: 'W16',
+    weekStartDates: {
+      W15: '2026-04-05',
+      W16: '2026-04-12',
+    },
+    sourceOverview: {
+      week_labels: ['W15', 'W16'],
+      latest_week: 'W16',
+      weeks_with_data: 2,
+      source_completeness: 'ok',
+      critical_gaps: [],
+      matrix: [],
+    },
+    windowsByWeek: {
+      W15: buildWeekBundle(),
+      W16: buildWeekBundle(),
+    },
+    changeLogByWeek: {
+      W15: [{ id: 'chg-15', kind: 'listing', source: 'LISTING ATTRIBUTES', week_label: 'W15', week_number: 15, timestamp: '2026-04-09T00:00:00Z', date_label: '09 Apr 2026', title: 'Week 15 title', summary: 'Week 15 summary', category: 'CONTENT', asins: ['B000000001'] }],
+      W16: [{ id: 'chg-16', kind: 'listing', source: 'LISTING ATTRIBUTES', week_label: 'W16', week_number: 16, timestamp: '2026-04-16T00:00:00Z', date_label: '16 Apr 2026', title: 'Week 16 title', summary: 'Week 16 summary', category: 'CONTENT', asins: ['B000000001'] }],
+    },
+    audit: {},
+  }
+}
+
+test('GET /api/wpr/changelog/[week] returns only the requested week entries', async () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-changelog-week-route-'))
+  process.env.WPR_DATA_DIR = dataDir
+  writeFileSync(path.join(dataDir, 'wpr-data-latest.json'), JSON.stringify(buildPayload()))
+
+  const mod = await import('./changelog/[week]/route')
+  const response = await mod.GET(new Request('http://localhost/api/wpr/changelog/W16'), {
+    params: Promise.resolve({ week: 'W16' }),
+  })
+  const payload = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.deepEqual(payload, [
+    {
+      id: 'chg-16',
+      kind: 'listing',
+      source: 'LISTING ATTRIBUTES',
+      week_label: 'W16',
+      week_number: 16,
+      timestamp: '2026-04-16T00:00:00Z',
+      date_label: '16 Apr 2026',
+      title: 'Week 16 title',
+      summary: 'Week 16 summary',
+      category: 'CONTENT',
+      asins: ['B000000001'],
+    },
+  ])
+})
+
+test('GET /api/wpr/changelog/[week] returns 404 for an unknown week', async () => {
+  const dataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-changelog-week-route-'))
+  process.env.WPR_DATA_DIR = dataDir
+  writeFileSync(path.join(dataDir, 'wpr-data-latest.json'), JSON.stringify(buildPayload()))
+
+  const mod = await import('./changelog/[week]/route')
+  const response = await mod.GET(new Request('http://localhost/api/wpr/changelog/W99'), {
+    params: Promise.resolve({ week: 'W99' }),
+  })
+  const payload = await response.json()
+
+  assert.equal(response.status, 404)
+  assert.equal(payload.error, 'Unknown WPR week: W99')
+})

--- a/apps/argus/app/api/wpr/changelog/[week]/route.ts
+++ b/apps/argus/app/api/wpr/changelog/[week]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { getWprChangeLogWeek } from '@/lib/wpr/reader';
+
+type RouteContext = {
+  params: Promise<{ week: string }>;
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  try {
+    const { week } = await context.params;
+    const entries = await getWprChangeLogWeek(week);
+    return NextResponse.json(entries);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load the requested WPR changelog week.';
+    const status = message.startsWith('Unknown WPR week:') ? 404 : 500;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/apps/argus/components/wpr/tabs/compare-tab.test.ts
+++ b/apps/argus/components/wpr/tabs/compare-tab.test.ts
@@ -10,3 +10,13 @@ test('compare tab uses custom legend content for chart legends', () => {
   assert.equal(legendUsages.length, 3)
   assert.equal(customLegendUsages.length, 3)
 })
+
+test('compare tab applies shared dark tooltip styling to all chart tooltips', () => {
+  const source = readFileSync(new URL('./compare-tab.tsx', import.meta.url), 'utf8')
+  const tooltipUsages = source.match(/<Tooltip\b[\s\S]*?\/>/g) ?? []
+  const sharedTooltipUsages = tooltipUsages.filter((usage) => usage.includes('{...compareTooltipProps}'))
+
+  assert.match(source, /const compareTooltipProps = \{/)
+  assert.equal(tooltipUsages.length, 4)
+  assert.equal(sharedTooltipUsages.length, 4)
+})

--- a/apps/argus/components/wpr/tabs/compare-tab.tsx
+++ b/apps/argus/components/wpr/tabs/compare-tab.tsx
@@ -33,6 +33,7 @@ import {
   panelSx,
   panelTitleSx,
   textMuted,
+  textPrimary,
   textSecondary,
 } from '@/lib/wpr/panel-tokens'
 import {
@@ -45,6 +46,20 @@ import {
 import { CompareChartLegend } from './compare-chart-legend'
 
 const LINE_COLORS = ['#00C2B9', '#f5a623', '#8fc7ff', '#a78bfa', '#d5ff62', '#ff8a80']
+
+const compareTooltipProps = {
+  contentStyle: {
+    background: 'rgba(0,20,35,0.96)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: 8,
+  },
+  labelStyle: {
+    color: textPrimary,
+  },
+  itemStyle: {
+    color: textSecondary,
+  },
+}
 
 function colorForRank(rank: number | null): string {
   if (rank === null) {
@@ -251,7 +266,10 @@ export default function CompareTab({
                   <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
                   <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
                   <YAxis tickFormatter={(value) => formatCompactNumber(value)} tick={{ fontSize: 10 }} />
-                  <Tooltip labelFormatter={(label) => formatChangeMarkerLabel(label, weeklyChangeMarkersByLabel.get(String(label)))} />
+                  <Tooltip
+                    {...compareTooltipProps}
+                    labelFormatter={(label) => formatChangeMarkerLabel(label, weeklyChangeMarkersByLabel.get(String(label)))}
+                  />
                   <RechartsChangeMarkers markers={weeklyChangeMarkers} />
                   <Legend content={<CompareChartLegend />} />
                   <Line type="monotone" dataKey="awareness" name="Awareness" stroke="#8fc7ff" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#8fc7ff' }} activeDot={{ r: 3.5 }} />
@@ -337,7 +355,7 @@ export default function CompareTab({
                       tick={{ fontSize: 10 }}
                     />
                     <ZAxis dataKey="market_purchases" range={[90, 360]} name="Root demand" />
-                    <Tooltip cursor={{ strokeDasharray: '3 3' }} formatter={scatterTooltipFormatter} />
+                    <Tooltip {...compareTooltipProps} cursor={{ strokeDasharray: '3 3' }} formatter={scatterTooltipFormatter} />
                     <Scatter data={scatterRows} fill="#00C2B9" stroke="#0E3A60" strokeOpacity={0.18} />
                   </ScatterChart>
                 </ResponsiveChartFrame>
@@ -378,6 +396,7 @@ export default function CompareTab({
                       <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
                       <YAxis reversed tickFormatter={(value) => formatDecimal(value, 1)} tick={{ fontSize: 10 }} />
                       <Tooltip
+                        {...compareTooltipProps}
                         formatter={rankTooltipFormatter}
                         labelFormatter={(label) => formatChangeMarkerLabel(label, weeklyChangeMarkersByLabel.get(String(label)))}
                       />
@@ -441,7 +460,7 @@ export default function CompareTab({
                     tick={{ fontSize: 10 }}
                     tickFormatter={(value: string) => (value.length > 18 ? `${value.slice(0, 18)}...` : value)}
                   />
-                  <Tooltip formatter={ppcTooltipFormatter} />
+                  <Tooltip {...compareTooltipProps} formatter={ppcTooltipFormatter} />
                   <Legend content={<CompareChartLegend />} />
                   <Bar dataKey="ppc_spend" fill="#0E3A60" radius={[0, 6, 6, 0]} name="PPC spend" />
                   <Bar dataKey="ppc_sales" fill="#00C2B9" radius={[0, 6, 6, 0]} name="PPC sales" />

--- a/apps/argus/components/wpr/tabs/sources-tab.tsx
+++ b/apps/argus/components/wpr/tabs/sources-tab.tsx
@@ -1,6 +1,6 @@
 import SourceHeatmap from '@/components/wpr/source-heatmap';
-import type { WprPayload } from '@/lib/wpr/types';
+import type { WprSourceOverview } from '@/lib/wpr/types';
 
-export default function SourcesTab({ payload }: { payload: WprPayload }) {
-  return <SourceHeatmap overview={payload.sourceOverview} />;
+export default function SourcesTab({ overview }: { overview: WprSourceOverview }) {
+  return <SourceHeatmap overview={overview} />;
 }

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
@@ -1,0 +1,122 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { emptySqpMetrics, type SqpWeeklyPoint } from '../../../lib/wpr/sqp-view-model'
+import type { WprChangeLogEntry } from '../../../lib/wpr/types'
+import { SQP_WOW_SERIES, SqpWeeklySvg } from './sqp-weekly-panel'
+
+function buildMetrics(overrides: Partial<SqpWeeklyPoint['metrics']>): SqpWeeklyPoint['metrics'] {
+  return {
+    ...emptySqpMetrics(),
+    ...overrides,
+  }
+}
+
+const weekly: SqpWeeklyPoint[] = [
+  {
+    week_label: 'W01',
+    week_number: 1,
+    start_date: '2026-01-01',
+    metrics: buildMetrics({
+      impression_share: 0.08,
+      asin_ctr: 0.12,
+      market_ctr: 0.1,
+      asin_cart_add_rate: 0.09,
+      cart_add_rate: 0.08,
+      asin_cvr: 0.07,
+      market_cvr: 0.05,
+    }),
+  },
+  {
+    week_label: 'W02',
+    week_number: 2,
+    start_date: '2026-01-08',
+    metrics: buildMetrics({
+      impression_share: 0.12,
+      asin_ctr: 0.15,
+      market_ctr: 0.1,
+      asin_cart_add_rate: 0.11,
+      cart_add_rate: 0.1,
+      asin_cvr: 0.08,
+      market_cvr: 0.05,
+    }),
+  },
+]
+
+const changeEntries: WprChangeLogEntry[] = [
+  {
+    id: 'chg-1',
+    kind: 'listing',
+    source: 'LISTING ATTRIBUTES',
+    week_label: 'W02',
+    week_number: 2,
+    timestamp: '2026-01-08T00:00:00Z',
+    date_label: '08 Jan 2026',
+    title: 'Content update across 4 ASINs',
+    summary: 'Backend terms',
+    category: 'CONTENT',
+    asins: ['B09HXC3NL8'],
+    field_labels: ['Backend terms'],
+  },
+  {
+    id: 'chg-2',
+    kind: 'listing',
+    source: 'LISTING ATTRIBUTES',
+    week_label: 'W02',
+    week_number: 2,
+    timestamp: '2026-01-08T00:00:00Z',
+    date_label: '08 Jan 2026',
+    title: 'Price update across 4 ASINs',
+    summary: 'Buy box landed price',
+    category: 'PRICING',
+    asins: ['B09HXC3NL8'],
+    field_labels: ['Buy box landed price'],
+  },
+]
+
+test('SQP weekly chart renders hover tooltip content for the active week', () => {
+  const markup = renderToStaticMarkup(
+    <SqpWeeklySvg
+      weekly={weekly}
+      changeEntries={changeEntries}
+      visibleSeries={SQP_WOW_SERIES}
+      width={800}
+      height={320}
+      hoveredIndex={1}
+      onHoverIndexChange={() => {}}
+    />,
+  )
+
+  assert.match(markup, /data-hover-tooltip=\"sqp\"/)
+  assert.match(markup, /W02 · 2 changes/)
+  assert.match(markup, /Impr Share/)
+  assert.match(markup, /CTR x/)
+  assert.match(markup, /1\.50x/)
+})
+
+test('SQP weekly chart omits hover tooltip markup when no week is active', () => {
+  const markup = renderToStaticMarkup(
+    <SqpWeeklySvg
+      weekly={weekly}
+      changeEntries={changeEntries}
+      visibleSeries={SQP_WOW_SERIES}
+      width={800}
+      height={320}
+      hoveredIndex={null}
+      onHoverIndexChange={() => {}}
+    />,
+  )
+
+  assert.doesNotMatch(markup, /data-hover-tooltip=\"sqp\"/)
+  assert.doesNotMatch(markup, /W02 · 2 changes/)
+  assert.doesNotMatch(markup, /Impr Share/)
+})
+
+test('SQP weekly chart keeps the toggle rail grouped on the left', () => {
+  const source = readFileSync(new URL('./sqp-weekly-panel.tsx', import.meta.url), 'utf8')
+
+  assert.match(source, /\.\.\.chartControlRailSx,\s+justifyContent: 'flex-start'/)
+  assert.match(source, /<Box sx=\{\{ display: 'flex', gap: 1, flexWrap: 'wrap' \}\}>/)
+})

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { JSX } from 'react'
+import React, { useState, type JSX } from 'react'
 import { Box, Button, Stack, Typography } from '@mui/material'
 import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
 import type { WprSqpWowVisible } from '@/lib/wpr/dashboard-state'
@@ -47,7 +47,7 @@ type ChartSeriesMeta = {
   ratioField?: keyof Pick<ChartPoint, 'ctr_ratio' | 'atc_ratio' | 'cvr_ratio'>
 }
 
-const SQP_WOW_SERIES: ChartSeriesMeta[] = [
+export const SQP_WOW_SERIES: ChartSeriesMeta[] = [
   { key: 'impr', label: 'Impr Share', color: '#8fc7ff', kind: 'points', valueField: 'impr_points' },
   { key: 'ctr', label: 'CTR x', color: '#e0a4ff', kind: 'ratio', valueField: 'ctr_adv', ratioField: 'ctr_ratio' },
   { key: 'atc', label: 'ATC x', color: '#f5a623', kind: 'ratio', valueField: 'atc_adv', ratioField: 'atc_ratio' },
@@ -240,18 +240,44 @@ function buildRatioFillPolygons(
   return polygons
 }
 
-function SqpWeeklySvg({
+function formatTooltipHeader(weekLabel: string, changeMarker: { count: number } | undefined): string {
+  if (changeMarker === undefined) {
+    return weekLabel
+  }
+
+  const changeNoun = changeMarker.count === 1 ? 'change' : 'changes'
+  return `${weekLabel} · ${changeMarker.count} ${changeNoun}`
+}
+
+function formatSeriesTooltipValue(point: ChartPoint, series: ChartSeriesMeta): string {
+  if (series.kind === 'points') {
+    return formatPoints(point[series.valueField])
+  }
+
+  const ratioField = series.ratioField
+  if (ratioField === undefined) {
+    throw new Error(`Missing SQP ratio field for ${series.key}`)
+  }
+
+  return formatRatio(point[ratioField])
+}
+
+export function SqpWeeklySvg({
   weekly,
   changeEntries,
   visibleSeries,
   width,
   height,
+  hoveredIndex,
+  onHoverIndexChange,
 }: {
   weekly: SqpWeeklyPoint[]
   changeEntries: WprChangeLogEntry[]
   visibleSeries: ChartSeriesMeta[]
   width?: number
   height?: number
+  hoveredIndex: number | null
+  onHoverIndexChange: (index: number | null) => void
 }) {
   if (width === undefined || height === undefined) {
     throw new Error('Missing SQP weekly chart frame size')
@@ -326,9 +352,140 @@ function SqpWeeklySvg({
   const valueFontSize = crampedLayout ? 8 : 9
   const weekFontSize = crampedLayout ? 8 : 9
   const valueLabelX = width - margin.right + (crampedLayout ? 4 : 8)
+  let activeHoverIndex: number | null = null
+  if (hoveredIndex !== null && hoveredIndex >= 0 && hoveredIndex < points.length) {
+    activeHoverIndex = hoveredIndex
+  }
+
+  let hoverTooltip: JSX.Element | null = null
+  if (activeHoverIndex !== null) {
+    const hoveredPoint = points[activeHoverIndex]
+    if (hoveredPoint === undefined) {
+      throw new Error(`Missing SQP hover point at index ${activeHoverIndex}`)
+    }
+
+    const hoveredMarker = changeMarkers.get(hoveredPoint.week_label)
+    const tooltipRows = visibleSeries.map((series) => ({
+      key: series.key,
+      label: series.label,
+      color: series.color,
+      value: formatSeriesTooltipValue(hoveredPoint, series),
+    }))
+    const tooltipWidth = crampedLayout ? 138 : compactLayout ? 154 : 170
+    const tooltipHeaderFontSize = crampedLayout ? 8 : 9
+    const tooltipRowFontSize = crampedLayout ? 7 : 8
+    const tooltipRowHeight = crampedLayout ? 13 : 15
+    const tooltipPaddingX = crampedLayout ? 8 : 10
+    const tooltipTop = margin.top + 8
+    const changeLineCount = hoveredMarker === undefined ? 0 : 1
+    const tooltipHeight = 22 + tooltipRows.length * tooltipRowHeight + changeLineCount * tooltipRowHeight + 8
+    const tooltipMinX = margin.left + 4
+    let tooltipMaxX = width - margin.right - tooltipWidth
+    if (tooltipMaxX < tooltipMinX) {
+      tooltipMaxX = tooltipMinX
+    }
+    let tooltipX = xPosition(activeHoverIndex) + 12
+    if (tooltipX < tooltipMinX) {
+      tooltipX = tooltipMinX
+    }
+    if (tooltipX > tooltipMaxX) {
+      tooltipX = tooltipMaxX
+    }
+
+    const tooltipHeader = formatTooltipHeader(hoveredPoint.week_label, hoveredMarker)
+    const activeX = xPosition(activeHoverIndex)
+
+    hoverTooltip = (
+      <g data-hover-tooltip="sqp" pointerEvents="none">
+        <line
+          x1={activeX}
+          x2={activeX}
+          y1={margin.top}
+          y2={height - margin.bottom}
+          stroke="rgba(255,255,255,0.22)"
+          strokeWidth="1.2"
+          strokeDasharray="4 4"
+        />
+        <g transform={`translate(${tooltipX}, ${tooltipTop})`}>
+          <rect
+            width={tooltipWidth}
+            height={tooltipHeight}
+            rx="9"
+            fill="rgba(0,20,35,0.96)"
+            stroke="rgba(255,255,255,0.08)"
+          />
+          <text
+            x={tooltipPaddingX}
+            y={15}
+            fill="rgba(255,255,255,0.92)"
+            fontSize={tooltipHeaderFontSize}
+            fontWeight="700"
+          >
+            {tooltipHeader}
+          </text>
+          {tooltipRows.map((row, rowIndex) => {
+            const rowY = 30 + rowIndex * tooltipRowHeight
+            return (
+              <g key={row.key}>
+                <circle cx={tooltipPaddingX + 3} cy={rowY - 3} r="2.6" fill={row.color} />
+                <text
+                  x={tooltipPaddingX + 10}
+                  y={rowY}
+                  fill="rgba(255,255,255,0.74)"
+                  fontSize={tooltipRowFontSize}
+                >
+                  {row.label}
+                </text>
+                <text
+                  x={tooltipWidth - tooltipPaddingX}
+                  y={rowY}
+                  fill="rgba(255,255,255,0.9)"
+                  fontSize={tooltipRowFontSize}
+                  fontWeight="700"
+                  textAnchor="end"
+                >
+                  {row.value}
+                </text>
+              </g>
+            )
+          })}
+          {hoveredMarker !== undefined ? (
+            <text
+              x={tooltipPaddingX}
+              y={30 + tooltipRows.length * tooltipRowHeight}
+              fill="rgba(255,255,255,0.58)"
+              fontSize={tooltipRowFontSize}
+            >
+              {`${hoveredMarker.count} tracked changes`}
+            </text>
+          ) : null}
+        </g>
+        {visibleSeries.map((series) => (
+          <circle
+            key={`active-${series.key}`}
+            cx={activeX}
+            cy={yPosition(hoveredPoint[series.valueField])}
+            r={4.2}
+            fill={series.color}
+            stroke="#09100f"
+            strokeWidth="1.8"
+          />
+        ))}
+      </g>
+    )
+  }
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`} width="100%" height="100%" role="img" aria-label="SQP weekly performance chart">
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width="100%"
+      height="100%"
+      role="img"
+      aria-label="SQP weekly performance chart"
+      onMouseLeave={() => {
+        onHoverIndexChange(null)
+      }}
+    >
       {minValue < 0 ? (
         <line
           x1={margin.left}
@@ -427,18 +584,44 @@ function SqpWeeklySvg({
         )
       })}
 
+      {hoverTooltip}
+
       {weekly.map((week, index) => (
         <text
           key={week.week_label}
           x={xPosition(index)}
           y={height - 6}
-          fill="#93a399"
+          fill={activeHoverIndex === index ? 'rgba(255,255,255,0.86)' : '#93a399'}
           fontSize={weekFontSize}
+          fontWeight={activeHoverIndex === index ? '700' : '500'}
           textAnchor="middle"
         >
           {week.week_label}
         </text>
       ))}
+
+      {points.map((point, index) => {
+        const currentX = xPosition(index)
+        const previousX = index === 0 ? margin.left : (xPosition(index - 1) + currentX) / 2
+        const nextX = index === points.length - 1 ? width - margin.right : (currentX + xPosition(index + 1)) / 2
+        return (
+          <rect
+            key={`hover-zone-${point.week_label}`}
+            x={previousX}
+            y={margin.top}
+            width={nextX - previousX}
+            height={plotHeight}
+            fill="transparent"
+            pointerEvents="all"
+            onMouseEnter={() => {
+              onHoverIndexChange(index)
+            }}
+            onMouseMove={() => {
+              onHoverIndexChange(index)
+            }}
+          />
+        )
+      })}
     </svg>
   )
 }
@@ -454,6 +637,7 @@ function SqpWeeklyChart({
   wowVisible: WprSqpWowVisible
   setWowVisible: (nextState: WprSqpWowVisible) => void
 }) {
+  const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const visibleSeries = SQP_WOW_SERIES.filter((series) => wowVisible[series.key])
   let chartBody: JSX.Element
   if (weekly.length === 0) {
@@ -491,30 +675,43 @@ function SqpWeeklyChart({
   } else {
     chartBody = (
       <ResponsiveChartFrame height={WPR_CHART_HEIGHT}>
-        <SqpWeeklySvg weekly={weekly} changeEntries={changeEntries} visibleSeries={visibleSeries} />
+        <SqpWeeklySvg
+          weekly={weekly}
+          changeEntries={changeEntries}
+          visibleSeries={visibleSeries}
+          hoveredIndex={hoveredIndex}
+          onHoverIndexChange={setHoveredIndex}
+        />
       </ResponsiveChartFrame>
     )
   }
 
   return (
     <Stack spacing={1.5}>
-      <Box sx={chartControlRailSx}>
-        {SQP_WOW_SERIES.map((series) => (
-          <Button
-            key={series.key}
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                [series.key]: !wowVisible[series.key],
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible[series.key], series.color)}
-          >
-            {series.label}
-          </Button>
-        ))}
+      <Box
+        sx={{
+          ...chartControlRailSx,
+          justifyContent: 'flex-start',
+        }}
+      >
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {SQP_WOW_SERIES.map((series) => (
+            <Button
+              key={series.key}
+              size="small"
+              variant="outlined"
+              onClick={() => {
+                setWowVisible({
+                  ...wowVisible,
+                  [series.key]: !wowVisible[series.key],
+                })
+              }}
+              sx={chartToggleButtonSx(wowVisible[series.key], series.color)}
+            >
+              {series.label}
+            </Button>
+          ))}
+        </Box>
       </Box>
 
       {chartBody}

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -10,6 +10,16 @@ test('dashboard shell passes change entries into all week-based WPR tabs', () =>
   assert.match(shellSource, /<CompareTab bundle=\{bundle\} changeEntries=\{changeEntries\} \/>/)
 })
 
+test('dashboard shell loads weeks and the selected week bundle instead of the full WPR payload', () => {
+  const shellSource = readFileSync(new URL('./wpr-dashboard-shell.tsx', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(shellSource, /useWprPayloadQuery/)
+  assert.match(shellSource, /useWprWeeksQuery/)
+  assert.match(shellSource, /useWprWeekBundleQuery/)
+  assert.match(shellSource, /useWprChangeLogWeekQuery/)
+  assert.match(shellSource, /useWprSourcesQuery\(activeTab === 'sources'\)/)
+})
+
 test('tst tab forwards change entries into the weekly panel', () => {
   const tabSource = readFileSync(new URL('./tabs/tst-tab.tsx', import.meta.url), 'utf8')
 

--- a/apps/argus/components/wpr/wpr-dashboard-shell.tsx
+++ b/apps/argus/components/wpr/wpr-dashboard-shell.tsx
@@ -3,7 +3,12 @@
 import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Alert, Box, CircularProgress } from '@mui/material';
-import { useWprPayloadQuery } from '@/hooks/use-wpr';
+import {
+  useWprChangeLogWeekQuery,
+  useWprSourcesQuery,
+  useWprWeekBundleQuery,
+  useWprWeeksQuery,
+} from '@/hooks/use-wpr';
 import { getInitialWprTab } from '@/lib/wpr/dashboard-state';
 import { useWprStore } from '@/stores/wpr-store';
 import BusinessReportsTab from './tabs/business-reports-tab';
@@ -18,11 +23,16 @@ import WprTopBar from './wpr-top-bar';
 export default function WprDashboardShell() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data, isLoading, error } = useWprPayloadQuery();
   const activeTab = useWprStore((state) => state.activeTab);
   const selectedWeek = useWprStore((state) => state.selectedWeek);
   const setActiveTab = useWprStore((state) => state.setActiveTab);
   const setSelectedWeek = useWprStore((state) => state.setSelectedWeek);
+  const weeksQuery = useWprWeeksQuery();
+  const needsBundle = activeTab === 'sqp' || activeTab === 'scp' || activeTab === 'br' || activeTab === 'tst' || activeTab === 'compare';
+  const needsChangeEntries = activeTab === 'sqp' || activeTab === 'scp' || activeTab === 'br' || activeTab === 'tst' || activeTab === 'changelog' || activeTab === 'compare';
+  const bundleQuery = useWprWeekBundleQuery(selectedWeek, needsBundle);
+  const changeLogQuery = useWprChangeLogWeekQuery(selectedWeek, needsChangeEntries);
+  const sourcesQuery = useWprSourcesQuery(activeTab === 'sources');
 
   const tabFromQuery = getInitialWprTab(searchParams);
 
@@ -33,16 +43,16 @@ export default function WprDashboardShell() {
   }, [activeTab, setActiveTab, tabFromQuery]);
 
   useEffect(() => {
-    if (data === undefined) {
+    if (weeksQuery.data === undefined) {
       return;
     }
 
-    if (selectedWeek !== null && data.weeks.includes(selectedWeek)) {
+    if (selectedWeek !== null && weeksQuery.data.weeks.includes(selectedWeek)) {
       return;
     }
 
-    setSelectedWeek(data.defaultWeek);
-  }, [data, selectedWeek, setSelectedWeek]);
+    setSelectedWeek(weeksQuery.data.defaultWeek);
+  }, [weeksQuery.data, selectedWeek, setSelectedWeek]);
 
   const handleSelectTab = (tab: typeof activeTab) => {
     if (tab === activeTab) {
@@ -53,7 +63,23 @@ export default function WprDashboardShell() {
     router.replace(tab === 'sqp' ? '/wpr' : `/wpr?tab=${tab}`);
   };
 
-  if (isLoading || data === undefined || selectedWeek === null) {
+  if (weeksQuery.error instanceof Error) {
+    return <Alert severity="error">{weeksQuery.error.message}</Alert>;
+  }
+
+  if (bundleQuery.error instanceof Error) {
+    return <Alert severity="error">{bundleQuery.error.message}</Alert>;
+  }
+
+  if (changeLogQuery.error instanceof Error) {
+    return <Alert severity="error">{changeLogQuery.error.message}</Alert>;
+  }
+
+  if (sourcesQuery.error instanceof Error) {
+    return <Alert severity="error">{sourcesQuery.error.message}</Alert>;
+  }
+
+  if (weeksQuery.isLoading || weeksQuery.data === undefined || selectedWeek === null) {
     return (
       <Box sx={{ py: 10, display: 'flex', justifyContent: 'center' }}>
         <CircularProgress />
@@ -61,18 +87,30 @@ export default function WprDashboardShell() {
     );
   }
 
-  if (error instanceof Error) {
-    return <Alert severity="error">{error.message}</Alert>;
+  const bundle = bundleQuery.data;
+  if (needsBundle && bundle === undefined) {
+    return (
+      <Box sx={{ py: 10, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
   }
 
-  const bundle = data.windowsByWeek[selectedWeek];
-  if (bundle === undefined) {
-    return <Alert severity="error">Unknown WPR week: {selectedWeek}</Alert>;
+  const changeEntries = changeLogQuery.data
+  if (needsChangeEntries && changeEntries === undefined) {
+    return (
+      <Box sx={{ py: 10, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
   }
 
-  const changeEntries = data.changeLogByWeek[selectedWeek]
-  if (changeEntries === undefined) {
-    return <Alert severity="error">Missing WPR change log for {selectedWeek}</Alert>
+  if (activeTab === 'sources' && sourcesQuery.data === undefined) {
+    return (
+      <Box sx={{ py: 10, display: 'flex', justifyContent: 'center' }}>
+        <CircularProgress />
+      </Box>
+    );
   }
 
   return (
@@ -80,18 +118,18 @@ export default function WprDashboardShell() {
       <WprTopBar
         activeTab={activeTab}
         selectedWeek={selectedWeek}
-        weeks={data.weeks}
+        weeks={weeksQuery.data.weeks}
         onSelectTab={handleSelectTab}
         onSelectWeek={setSelectedWeek}
       />
       <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', px: 0, py: 1.5 }}>
-        {activeTab === 'sqp' ? <SqpTab bundle={bundle} changeEntries={changeEntries} /> : null}
-        {activeTab === 'scp' ? <ScpTab bundle={bundle} changeEntries={changeEntries} /> : null}
-        {activeTab === 'br' ? <BusinessReportsTab bundle={bundle} changeEntries={changeEntries} /> : null}
-        {activeTab === 'tst' ? <TstTab bundle={bundle} changeEntries={changeEntries} /> : null}
-        {activeTab === 'changelog' ? <ChangelogTab entries={changeEntries} selectedWeekLabel={selectedWeek} /> : null}
-        {activeTab === 'compare' ? <CompareTab bundle={bundle} changeEntries={changeEntries} /> : null}
-        {activeTab === 'sources' ? <SourcesTab payload={data} /> : null}
+        {activeTab === 'sqp' && bundle !== undefined && changeEntries !== undefined ? <SqpTab bundle={bundle} changeEntries={changeEntries} /> : null}
+        {activeTab === 'scp' && bundle !== undefined && changeEntries !== undefined ? <ScpTab bundle={bundle} changeEntries={changeEntries} /> : null}
+        {activeTab === 'br' && bundle !== undefined && changeEntries !== undefined ? <BusinessReportsTab bundle={bundle} changeEntries={changeEntries} /> : null}
+        {activeTab === 'tst' && bundle !== undefined && changeEntries !== undefined ? <TstTab bundle={bundle} changeEntries={changeEntries} /> : null}
+        {activeTab === 'changelog' && changeEntries !== undefined ? <ChangelogTab entries={changeEntries} selectedWeekLabel={selectedWeek} /> : null}
+        {activeTab === 'compare' && bundle !== undefined && changeEntries !== undefined ? <CompareTab bundle={bundle} changeEntries={changeEntries} /> : null}
+        {activeTab === 'sources' && sourcesQuery.data !== undefined ? <SourcesTab overview={sourcesQuery.data} /> : null}
       </Box>
     </Box>
   );

--- a/apps/argus/hooks/use-wpr.ts
+++ b/apps/argus/hooks/use-wpr.ts
@@ -5,7 +5,6 @@ import { getPublicBasePath } from '@/lib/base-path';
 import type {
   WprChangeLogEntry,
   WeekLabel,
-  WprPayload,
   WprSourceOverview,
   WprWeekBundle,
   WprWeekSummaryResponse,
@@ -33,24 +32,18 @@ export function useWprWeeksQuery() {
   });
 }
 
-export function useWprPayloadQuery() {
-  return useQuery({
-    queryKey: ['wpr', 'payload'],
-    queryFn: () => getJson<WprPayload>('/api/wpr/payload'),
-  });
-}
-
-export function useWprWeekBundleQuery(week: WeekLabel | null) {
+export function useWprWeekBundleQuery(week: WeekLabel | null, enabled = true) {
   return useQuery({
     queryKey: ['wpr', 'weeks', week],
-    enabled: week !== null,
+    enabled: enabled && week !== null,
     queryFn: () => getJson<WprWeekBundle>(`/api/wpr/weeks/${week}`),
   });
 }
 
-export function useWprSourcesQuery() {
+export function useWprSourcesQuery(enabled = true) {
   return useQuery({
     queryKey: ['wpr', 'sources'],
+    enabled,
     queryFn: () => getJson<WprSourceOverview>('/api/wpr/sources'),
   });
 }
@@ -59,5 +52,13 @@ export function useWprChangeLogQuery() {
   return useQuery({
     queryKey: ['wpr', 'changelog'],
     queryFn: () => getJson<Record<WeekLabel, WprChangeLogEntry[]>>('/api/wpr/changelog'),
+  });
+}
+
+export function useWprChangeLogWeekQuery(week: WeekLabel | null, enabled = true) {
+  return useQuery({
+    queryKey: ['wpr', 'changelog', week],
+    enabled: enabled && week !== null,
+    queryFn: () => getJson<WprChangeLogEntry[]>(`/api/wpr/changelog/${week}`),
   });
 }

--- a/apps/argus/lib/wpr/reader.ts
+++ b/apps/argus/lib/wpr/reader.ts
@@ -87,3 +87,13 @@ export async function getWprChangeLog(): Promise<Record<WeekLabel, WprChangeLogE
   const payload = await loadPayload();
   return payload.changeLogByWeek;
 }
+
+export async function getWprChangeLogWeek(week: WeekLabel): Promise<WprChangeLogEntry[]> {
+  const payload = await loadPayload();
+  const entries = payload.changeLogByWeek[week];
+  if (entries === undefined) {
+    throw new Error(`Unknown WPR week: ${week}`);
+  }
+
+  return entries;
+}


### PR DESCRIPTION
## Summary
- stop `/argus/wpr` from fetching the full 93.7 MB WPR payload on initial load
- load weeks first, then fetch only the selected week bundle and selected week changelog
- lazy-load source coverage for the Sources tab and keep the recent SQP/Compare WPR UI fixes in the same Argus change set

## Evidence
- local WPR payload file: 93,729,059 bytes
- current selected-week bundle: 9,112,391 bytes
- selected-week changelog: 5,622 bytes
- recent Argus log samples showed `/api/wpr/payload` at roughly 298ms, 393ms, 771ms, and 794ms server time before browser transfer/parse

## Checks
- `pnpm exec tsx --test components/wpr/wpr-change-props.test.ts app/api/wpr/changelog-week-route.test.ts app/api/wpr/payload/route.test.ts components/wpr/tabs/compare-tab.test.ts components/wpr/tabs/sqp-weekly-panel.test.tsx`
- `pnpm --filter @targon/argus lint`
- `pnpm --filter @targon/argus type-check`