### PR TITLE
fix(talos): correct S3 bucket defaults

### DIFF
--- a/apps/talos/.env.dev.ci
+++ b/apps/talos/.env.dev.ci
@@ -13,7 +13,7 @@ PORTAL_AUTH_SECRET=ci-portal-auth-secret
 CSRF_ALLOWED_ORIGINS=https://dev-os.targonglobal.com
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/portal_db
 PRISMA_SCHEMA=dev_talos_us
-S3_BUCKET_NAME=ci-talos-bucket
+S3_BUCKET_NAME=wms-development-459288913318
 S3_BUCKET_REGION=us-east-1
 REDIS_URL=redis://localhost:6379
 

--- a/packages/aws-s3/dist/index.js
+++ b/packages/aws-s3/dist/index.js
@@ -12,7 +12,7 @@ export class S3Service {
     constructor() {
         this.region = process.env.AWS_REGION || process.env.S3_BUCKET_REGION || 'us-east-1';
         const environment = process.env.NODE_ENV || 'development';
-        const defaultBucket = environment === 'production' ? 'targon-production' : 'targon-development';
+        const defaultBucket = environment === 'production' ? 'wms-production-459288913318' : 'wms-development-459288913318';
         this.bucket = process.env.S3_BUCKET_NAME || defaultBucket;
         this.urlExpiry = parseInt(process.env.S3_PRESIGNED_URL_EXPIRY || '3600', 10);
         if (!this.bucket) {

--- a/packages/aws-s3/src/index.test.ts
+++ b/packages/aws-s3/src/index.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { S3Service } from './index'
+
+const ORIGINAL_ENV = { ...process.env }
+
+function resetEnv() {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key]
+  }
+  Object.assign(process.env, ORIGINAL_ENV)
+}
+
+function bucketOf(service: S3Service): string {
+  return (service as unknown as { bucket: string }).bucket
+}
+
+test.afterEach(() => {
+  resetEnv()
+})
+
+test('uses the development warehouse bucket by default outside production', () => {
+  resetEnv()
+  process.env.NODE_ENV = 'development'
+  delete process.env.S3_BUCKET_NAME
+  delete process.env.AWS_REGION
+  delete process.env.S3_BUCKET_REGION
+
+  const service = new S3Service()
+
+  assert.equal(bucketOf(service), 'wms-development-459288913318')
+})
+
+test('uses the production warehouse bucket by default in production', () => {
+  resetEnv()
+  process.env.NODE_ENV = 'production'
+  delete process.env.S3_BUCKET_NAME
+  delete process.env.AWS_REGION
+  delete process.env.S3_BUCKET_REGION
+
+  const service = new S3Service()
+
+  assert.equal(bucketOf(service), 'wms-production-459288913318')
+})
+
+test('prefers an explicit S3 bucket env over the default bucket', () => {
+  resetEnv()
+  process.env.NODE_ENV = 'development'
+  process.env.S3_BUCKET_NAME = 'custom-bucket'
+
+  const service = new S3Service()
+
+  assert.equal(bucketOf(service), 'custom-bucket')
+})

--- a/packages/aws-s3/src/index.ts
+++ b/packages/aws-s3/src/index.ts
@@ -93,7 +93,8 @@ export class S3Service {
     this.region = process.env.AWS_REGION || process.env.S3_BUCKET_REGION || 'us-east-1';
 
     const environment = process.env.NODE_ENV || 'development';
-    const defaultBucket = environment === 'production' ? 'targon-production' : 'targon-development';
+    const defaultBucket =
+      environment === 'production' ? 'wms-production-459288913318' : 'wms-development-459288913318';
 
     this.bucket = process.env.S3_BUCKET_NAME || defaultBucket;
     this.urlExpiry = parseInt(process.env.S3_PRESIGNED_URL_EXPIRY || '3600', 10);

--- a/packages/aws-s3/tsconfig.build.json
+++ b/packages/aws-s3/tsconfig.build.json
@@ -6,5 +6,6 @@
     "emitDeclarationOnly": false,
     "noEmit": false
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/scripts/setup-codex-env.mjs
+++ b/scripts/setup-codex-env.mjs
@@ -240,7 +240,7 @@ function buildManagedEntries(context) {
       entries.set('DATABASE_URL_US', withSchema(baseDevDbUrl, 'dev_talos_us'))
       entries.set('DATABASE_URL_UK', withSchema(baseDevDbUrl, 'dev_talos_uk'))
       entries.set('REDIS_URL', sharedValue(sourceValues, appName, 'REDIS_URL', 'redis://localhost:6379'))
-      entries.set('S3_BUCKET_NAME', sharedValue(sourceValues, appName, 'S3_BUCKET_NAME', 'ci-talos-bucket'))
+      entries.set('S3_BUCKET_NAME', sharedValue(sourceValues, appName, 'S3_BUCKET_NAME', 'wms-development-459288913318'))
       entries.set('S3_BUCKET_REGION', sharedValue(sourceValues, appName, 'S3_BUCKET_REGION', 'us-east-1'))
       return entries
     case 'atlas':


### PR DESCRIPTION
## Summary
- replace the dead Talos S3 bucket config with the real development bucket
- update shared S3 fallback bucket defaults for development and production
- cover the fallback selection with a package-level regression test

## Verification
- pnpm exec tsx --test packages/aws-s3/src/index.test.ts
- pnpm --filter @targon/aws-s3 type-check
- pnpm --filter @targon/aws-s3 build
- runtime S3 check against wms-development-459288913318