### PR TITLE
fix(argus): simplify wpr source coverage cells

### DIFF
--- a/apps/argus/components/wpr/source-heatmap.test.ts
+++ b/apps/argus/components/wpr/source-heatmap.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('source heatmap renders presence-only cells without file count badges', () => {
+  const source = readFileSync(new URL('./source-heatmap.tsx', import.meta.url), 'utf8')
+
+  assert.match(source, /const isPresent = cell\.present;/)
+  assert.doesNotMatch(source, /cell\.file_count/)
+  assert.doesNotMatch(source, /\{cell\.file_count\}/)
+})

--- a/apps/argus/components/wpr/source-heatmap.tsx
+++ b/apps/argus/components/wpr/source-heatmap.tsx
@@ -258,20 +258,7 @@ export default function SourceHeatmap({ overview }: { overview: WprSourceOvervie
                             opacity: 0.8,
                           },
                         }}
-                      >
-                        {isPresent && cell.file_count > 1 && (
-                          <Typography
-                            sx={{
-                              fontSize: '0.5rem',
-                              fontWeight: 600,
-                              color: 'rgba(255,255,255,0.6)',
-                              lineHeight: 1,
-                            }}
-                          >
-                            {cell.file_count}
-                          </Typography>
-                        )}
-                      </Box>
+                      />
                     );
                   })}
                 </Box>

--- a/apps/argus/lib/wpr/types.ts
+++ b/apps/argus/lib/wpr/types.ts
@@ -251,8 +251,6 @@ export interface WprCluster {
 
 export interface WprSourceMatrixCell {
   present: boolean;
-  file_count: number;
-  files: string[];
 }
 
 export interface WprSourceMatrixRow {

--- a/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
@@ -575,8 +575,6 @@ def scan_sources(week_meta: dict[str, dict[str, object]]) -> dict[str, object]:
                 matrix.append(entry)
             entry["weeks"][week_label] = {
                 "present": len(files) > 0,
-                "file_count": len(files),
-                "files": [f.name for f in files[:3]],
             }
             if files:
                 has_any = True
@@ -10074,9 +10072,8 @@ def build_html(data: dict[str, object]) -> str:
         }
         if (recentWindowSet.has(w)) cls += " source-window";
         if (w === anchorWeek) cls += " source-anchor";
-        var count = cell ? cell.file_count : 0;
-        var title = present ? count + " file" + (count !== 1 ? "s" : "") + ": " + (cell.files ? cell.files.join(", ") : "") : "Missing";
-        html += '<div class="source-cell ' + cls + '" title="' + escapeHtml(title) + '"></div>';
+        var title = present ? "Present" : "Missing";
+        html += '<div class="source-cell ' + cls + '" title="' + title + '"></div>';
       });
       html += '</div>';
     });

--- a/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
@@ -159,5 +159,41 @@ class ManualChangeLogParsingTest(unittest.TestCase):
             )
 
 
+class SourceOverviewTest(unittest.TestCase):
+    def test_scan_sources_emits_presence_only_cells(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            data_dir.mkdir(parents=True, exist_ok=True)
+
+            week_input_dir = (
+                sales_root
+                / "WPR"
+                / "Week 16 - 2026-04-12 (Sun)"
+                / "input"
+                / "Business Reports (API)"
+                / "Sales & Traffic (API)"
+            )
+            week_input_dir.mkdir(parents=True, exist_ok=True)
+            (week_input_dir / "W16_2026-04-18_SalesTraffic-ByAsin.csv").write_text("asin\nB000000001\n", encoding="utf-8")
+            (week_input_dir / "W16_2026-04-18_SalesTraffic-ByDate.csv").write_text("date\n2026-04-18\n", encoding="utf-8")
+
+            module = load_module(data_dir)
+            overview = module.scan_sources(
+                {
+                    "W16": {
+                        "week_number": 16,
+                        "start_date": "2026-04-12",
+                    }
+                }
+            )
+
+            sales_and_traffic = next(
+                row for row in overview["matrix"]
+                if row["name"] == "Sales & Traffic"
+            )
+            self.assertEqual(sales_and_traffic["weeks"]["W16"], {"present": True})
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- drop redundant per-source file counts and file lists from the WPR source overview payload
- render WPR source heatmap cells as presence-only indicators instead of showing counts like 2
- cover the reduced source payload shape in Python and TS tests

## Verification
- pnpm -C apps/argus lint
- pnpm -C apps/argus type-check
- pnpm -C apps/argus exec tsx --test components/wpr/source-heatmap.test.ts app/api/wpr/payload/route.test.ts lib/wpr/payload-contract.test.ts
- python3 -m unittest apps.argus.scripts.wpr.test_build_intent_cluster_dashboard
- python3 apps/argus/scripts/wpr/build_intent_cluster_dashboard.py with WPR_DATA_DIR from apps/argus/.env.local
- git diff --check