### PR TITLE
fix(argus): standardize wpr change tooltips

### DIFF
--- a/apps/argus/components/wpr/chart-change-markers.test.ts
+++ b/apps/argus/components/wpr/chart-change-markers.test.ts
@@ -1,11 +1,15 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import type { WprChangeLogEntry } from '@/lib/wpr/types'
 import {
+  buildChangeMarkerLabelParts,
   buildDailyChangeMarkers,
   buildWeeklyChangeMarkers,
   formatChangeMarkerLabel,
+  WprChangeTooltipContent,
 } from './chart-change-markers'
 
 const weeklyEntries: WprChangeLogEntry[] = [
@@ -96,6 +100,51 @@ test('formatChangeMarkerLabel includes tracked changes in hover labels', () => {
     'W14 · 2 changes · Content update across 4 ASINs · Price update across 4 ASINs',
   )
   assert.equal(formatChangeMarkerLabel('W16', undefined), 'W16')
+})
+
+test('buildChangeMarkerLabelParts keeps standardized change copy split into display lines', () => {
+  const marker = buildWeeklyChangeMarkers(weeklyEntries)[0]
+  if (marker === undefined) {
+    throw new Error('Missing weekly change marker')
+  }
+
+  assert.deepEqual(buildChangeMarkerLabelParts('W14', marker), [
+    'W14 · 2 changes',
+    'Content update across 4 ASINs',
+    'Price update across 4 ASINs',
+  ])
+  assert.deepEqual(buildChangeMarkerLabelParts('W16', undefined), ['W16'])
+})
+
+test('WprChangeTooltipContent renders every change title on its own line', () => {
+  const marker = buildWeeklyChangeMarkers(weeklyEntries)[0]
+  if (marker === undefined) {
+    throw new Error('Missing weekly change marker')
+  }
+
+  const markup = renderToStaticMarkup(
+    React.createElement(WprChangeTooltipContent, {
+      active: true,
+      label: 'W14',
+      changeMarker: marker,
+      payload: [
+        {
+          name: 'CTR',
+          value: '12.4%',
+          color: '#8fc7ff',
+        },
+      ],
+      formatRow: (entry) => ({
+        label: String(entry.name),
+        value: String(entry.value),
+        color: String(entry.color),
+      }),
+    }),
+  )
+
+  assert.match(markup, /W14 · 2 changes/)
+  assert.match(markup, /Content update across 4 ASINs/)
+  assert.match(markup, /Price update across 4 ASINs/)
 })
 
 test('RechartsChangeMarkers renders the reference lines on a front z-index layer', () => {

--- a/apps/argus/components/wpr/chart-change-markers.tsx
+++ b/apps/argus/components/wpr/chart-change-markers.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { ReferenceLine } from 'recharts'
 import type { WprChangeLogEntry } from '@/lib/wpr/types'
 
@@ -5,6 +6,19 @@ export type ChartChangeMarker = {
   label: string
   count: number
   titles: string[]
+}
+
+export type WprTooltipPayloadEntry = {
+  color?: string
+  dataKey?: string | number
+  name?: string | number
+  value?: unknown
+}
+
+export type WprTooltipRow = {
+  color: string
+  label: string
+  value: string
 }
 
 type DailyChangePoint = {
@@ -62,20 +76,163 @@ export function buildDailyChangeMarkers(points: DailyChangePoint[]): ChartChange
   return markers
 }
 
-export function formatChangeMarkerLabel(label: string | number, marker: ChartChangeMarker | undefined): string {
+export function formatChangeMarkerCount(count: number): string {
+  const noun = count === 1 ? 'change' : 'changes'
+  return `${count} ${noun}`
+}
+
+export function buildChangeMarkerLabelParts(
+  label: string | number,
+  marker: ChartChangeMarker | undefined,
+): string[] {
   const baseLabel = String(label)
   if (marker === undefined) {
-    return baseLabel
+    return [baseLabel]
   }
 
-  const noun = marker.count === 1 ? 'change' : 'changes'
-  let summary = `${baseLabel} · ${marker.count} ${noun}`
-  if (marker.titles.length === 0) {
-    return summary
+  return [`${baseLabel} · ${formatChangeMarkerCount(marker.count)}`, ...marker.titles]
+}
+
+export function formatChangeMarkerLabel(label: string | number, marker: ChartChangeMarker | undefined): string {
+  return buildChangeMarkerLabelParts(label, marker).join(' · ')
+}
+
+export function WprChangeTooltipContent({
+  active,
+  label,
+  payload,
+  changeMarker,
+  formatRow,
+}: {
+  active?: boolean
+  label?: string | number
+  payload?: readonly WprTooltipPayloadEntry[]
+  changeMarker?: ChartChangeMarker
+  formatRow: (entry: WprTooltipPayloadEntry) => WprTooltipRow
+}) {
+  if (active !== true || label === undefined || payload === undefined || payload.length === 0) {
+    return null
   }
 
-  summary += ` · ${marker.titles.join(' · ')}`
-  return summary
+  const labelParts = buildChangeMarkerLabelParts(label, changeMarker)
+  const header = labelParts[0]
+  if (header === undefined) {
+    throw new Error(`Missing tooltip header for ${String(label)}`)
+  }
+
+  const changeLines = labelParts.slice(1)
+  const rows = payload.map((entry) => formatRow(entry))
+
+  return (
+    <div
+      style={{
+        minWidth: 184,
+        maxWidth: 320,
+        padding: '10px 12px',
+        background: 'rgba(0,20,35,0.96)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        borderRadius: 8,
+        boxShadow: '0 10px 28px rgba(0,0,0,0.28)',
+      }}
+    >
+      <div
+        style={{
+          color: 'rgba(255,255,255,0.92)',
+          fontSize: 12,
+          fontWeight: 700,
+          lineHeight: 1.3,
+        }}
+      >
+        {header}
+      </div>
+
+      <div
+        style={{
+          display: 'grid',
+          gap: 6,
+          marginTop: 8,
+        }}
+      >
+        {rows.map((row) => (
+          <div
+            key={`${row.label}-${row.value}`}
+            style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              justifyContent: 'space-between',
+              gap: 12,
+            }}
+          >
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                minWidth: 0,
+                flex: 1,
+              }}
+            >
+              <span
+                style={{
+                  width: 8,
+                  height: 8,
+                  marginTop: 3,
+                  borderRadius: '50%',
+                  background: row.color,
+                  flex: '0 0 auto',
+                }}
+              />
+              <span
+                style={{
+                  color: 'rgba(255,255,255,0.74)',
+                  fontSize: 12,
+                  lineHeight: 1.35,
+                }}
+              >
+                {row.label}
+              </span>
+            </div>
+            <span
+              style={{
+                color: 'rgba(255,255,255,0.9)',
+                fontSize: 12,
+                fontWeight: 700,
+                lineHeight: 1.35,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {changeLines.length > 0 ? (
+        <div
+          style={{
+            display: 'grid',
+            gap: 4,
+            marginTop: 8,
+            paddingTop: 8,
+            borderTop: '1px solid rgba(255,255,255,0.06)',
+          }}
+        >
+          {changeLines.map((line, lineIndex) => (
+            <div
+              key={`${header}-change-${lineIndex}`}
+              style={{
+                color: 'rgba(255,255,255,0.58)',
+                fontSize: 11,
+                lineHeight: 1.35,
+              }}
+            >
+              {line}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
 }
 
 export function RechartsChangeMarkers({

--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -17,7 +17,7 @@ import {
   buildChangeMarkerLookup,
   buildDailyChangeMarkers,
   buildWeeklyChangeMarkers,
-  formatChangeMarkerLabel,
+  WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
 import type { WprBrWowVisible } from '@/lib/wpr/dashboard-state'
 import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
@@ -407,21 +407,52 @@ function BusinessReportsChart({
               tickFormatter={(value: number) => `${value.toFixed(0)}%`}
             />
             <Tooltip
-              formatter={(value: number, key: string) => {
-                if (key === 'sessions') {
-                  return [formatCount(value), 'Sessions']
-                }
-                if (key === 'order_items') {
-                  return [`${value.toFixed(1)}%`, 'Order Item %']
-                }
-                return [`${value.toFixed(1)}%`, 'Unit Session %']
-              }}
-              labelFormatter={(label) => formatChangeMarkerLabel(label, changeMarkersByLabel.get(String(label)))}
-              contentStyle={{
-                background: 'rgba(0,20,35,0.96)',
-                border: '1px solid rgba(255,255,255,0.08)',
-                borderRadius: 8,
-              }}
+              content={({ active, payload, label }) => (
+                <WprChangeTooltipContent
+                  active={active}
+                  payload={payload}
+                  label={label}
+                  changeMarker={changeMarkersByLabel.get(String(label))}
+                  formatRow={(entry) => {
+                    const key = entry.dataKey
+                    if (key === undefined) {
+                      throw new Error('Missing Business Reports tooltip data key')
+                    }
+
+                    const value = entry.value
+                    if (typeof value !== 'number') {
+                      throw new Error(`Invalid Business Reports tooltip value for ${String(key)}`)
+                    }
+
+                    const color = entry.color
+                    if (color === undefined) {
+                      throw new Error(`Missing Business Reports tooltip color for ${String(key)}`)
+                    }
+
+                    if (key === 'sessions') {
+                      return {
+                        label: 'Sessions',
+                        value: formatCount(value),
+                        color,
+                      }
+                    }
+
+                    if (key === 'order_items') {
+                      return {
+                        label: 'Order Item %',
+                        value: `${value.toFixed(1)}%`,
+                        color,
+                      }
+                    }
+
+                    return {
+                      label: 'Unit Session %',
+                      value: `${value.toFixed(1)}%`,
+                      color,
+                    }
+                  }}
+                />
+              )}
             />
             {wowVisible.sessions ? (
               <Bar yAxisId="counts" dataKey="sessions" fill="rgba(143,199,255,0.34)" stroke="#8fc7ff" />

--- a/apps/argus/components/wpr/tabs/compare-tab.test.ts
+++ b/apps/argus/components/wpr/tabs/compare-tab.test.ts
@@ -11,12 +11,14 @@ test('compare tab uses custom legend content for chart legends', () => {
   assert.equal(customLegendUsages.length, 3)
 })
 
-test('compare tab applies shared dark tooltip styling to all chart tooltips', () => {
+test('compare tab uses shared change tooltips for weekly charts and shared dark styling for the rest', () => {
   const source = readFileSync(new URL('./compare-tab.tsx', import.meta.url), 'utf8')
   const tooltipUsages = source.match(/<Tooltip\b[\s\S]*?\/>/g) ?? []
   const sharedTooltipUsages = tooltipUsages.filter((usage) => usage.includes('{...compareTooltipProps}'))
+  const changeTooltipUsages = source.match(/<WprChangeTooltipContent\b/g) ?? []
 
   assert.match(source, /const compareTooltipProps = \{/)
   assert.equal(tooltipUsages.length, 4)
-  assert.equal(sharedTooltipUsages.length, 4)
+  assert.equal(sharedTooltipUsages.length, 2)
+  assert.equal(changeTooltipUsages.length, 2)
 })

--- a/apps/argus/components/wpr/tabs/compare-tab.tsx
+++ b/apps/argus/components/wpr/tabs/compare-tab.tsx
@@ -19,8 +19,8 @@ import {
 import {
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
-  formatChangeMarkerLabel,
   RechartsChangeMarkers,
+  WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
 import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
 import { WPR_CHART_HEIGHT, WPR_COMPACT_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
@@ -215,14 +215,6 @@ export default function CompareTab({
     return formatCount(value)
   }
 
-  const rankTooltipFormatter = (value: number | string) => {
-    if (typeof value !== 'number') {
-      return String(value)
-    }
-
-    return formatDecimal(value, 1)
-  }
-
   const ppcTooltipFormatter = (value: number | string, key: string) => {
     if (typeof value !== 'number') {
       return String(value)
@@ -267,8 +259,36 @@ export default function CompareTab({
                   <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
                   <YAxis tickFormatter={(value) => formatCompactNumber(value)} tick={{ fontSize: 10 }} />
                   <Tooltip
-                    {...compareTooltipProps}
-                    labelFormatter={(label) => formatChangeMarkerLabel(label, weeklyChangeMarkersByLabel.get(String(label)))}
+                    content={({ active, payload, label }) => (
+                      <WprChangeTooltipContent
+                        active={active}
+                        payload={payload}
+                        label={label}
+                        changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
+                        formatRow={(entry) => {
+                          const value = entry.value
+                          if (typeof value !== 'number') {
+                            throw new Error(`Invalid Compare brand-metrics tooltip value for ${String(entry.dataKey)}`)
+                          }
+
+                          const color = entry.color
+                          if (color === undefined) {
+                            throw new Error(`Missing Compare brand-metrics tooltip color for ${String(entry.dataKey)}`)
+                          }
+
+                          const name = entry.name
+                          if (name === undefined) {
+                            throw new Error(`Missing Compare brand-metrics tooltip label for ${String(entry.dataKey)}`)
+                          }
+
+                          return {
+                            label: String(name),
+                            value: formatCompactNumber(value),
+                            color,
+                          }
+                        }}
+                      />
+                    )}
                   />
                   <RechartsChangeMarkers markers={weeklyChangeMarkers} />
                   <Legend content={<CompareChartLegend />} />
@@ -396,9 +416,37 @@ export default function CompareTab({
                       <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
                       <YAxis reversed tickFormatter={(value) => formatDecimal(value, 1)} tick={{ fontSize: 10 }} />
                       <Tooltip
-                        {...compareTooltipProps}
-                        formatter={rankTooltipFormatter}
-                        labelFormatter={(label) => formatChangeMarkerLabel(label, weeklyChangeMarkersByLabel.get(String(label)))}
+                        content={({ active, payload, label }) => (
+                          <WprChangeTooltipContent
+                            active={active}
+                            payload={payload}
+                            label={label}
+                            changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
+                            formatRow={(entry) => {
+                              const key = entry.dataKey
+                              if (key === undefined) {
+                                throw new Error('Missing Compare rank-trend tooltip data key')
+                              }
+
+                              const value = entry.value
+                              if (typeof value !== 'number') {
+                                throw new Error(`Invalid Compare rank-trend tooltip value for ${String(key)}`)
+                              }
+
+                              const color = entry.color
+                              if (color === undefined) {
+                                throw new Error(`Missing Compare rank-trend tooltip color for ${String(key)}`)
+                              }
+
+                              const name = entry.name
+                              return {
+                                label: String(name ?? key),
+                                value: formatDecimal(value, 1),
+                                color,
+                              }
+                            }}
+                          />
+                        )}
                       />
                       <ReferenceLine y={10} stroke="rgba(255,255,255,0.08)" />
                       <RechartsChangeMarkers markers={weeklyChangeMarkers} />

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -14,8 +14,8 @@ import {
 import {
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
-  formatChangeMarkerLabel,
   RechartsChangeMarkers,
+  WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
 import type { WprScpWowVisible } from '@/lib/wpr/dashboard-state'
 import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
@@ -192,19 +192,41 @@ function ScpWeeklyChart({
             <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
             <YAxis tick={{ fontSize: 10 }} tickFormatter={(value: number) => `${value.toFixed(0)}%`} />
             <Tooltip
-              formatter={(value: number, key: string) => {
-                let label = 'CVR'
-                if (key === 'ctr') label = 'CTR'
-                if (key === 'atc') label = 'ATC Rate'
-                if (key === 'purch') label = 'Purch Rate'
-                return [`${value.toFixed(1)}%`, label]
-              }}
-              labelFormatter={(label) => formatChangeMarkerLabel(label, changeMarkersByLabel.get(String(label)))}
-              contentStyle={{
-                background: 'rgba(0,20,35,0.96)',
-                border: '1px solid rgba(255,255,255,0.08)',
-                borderRadius: 8,
-              }}
+              content={({ active, payload, label }) => (
+                <WprChangeTooltipContent
+                  active={active}
+                  payload={payload}
+                  label={label}
+                  changeMarker={changeMarkersByLabel.get(String(label))}
+                  formatRow={(entry) => {
+                    const key = entry.dataKey
+                    if (key === undefined) {
+                      throw new Error('Missing SCP tooltip data key')
+                    }
+
+                    const value = entry.value
+                    if (typeof value !== 'number') {
+                      throw new Error(`Invalid SCP tooltip value for ${String(key)}`)
+                    }
+
+                    const color = entry.color
+                    if (color === undefined) {
+                      throw new Error(`Missing SCP tooltip color for ${String(key)}`)
+                    }
+
+                    let rowLabel = 'CVR'
+                    if (key === 'ctr') rowLabel = 'CTR'
+                    if (key === 'atc') rowLabel = 'ATC Rate'
+                    if (key === 'purch') rowLabel = 'Purch Rate'
+
+                    return {
+                      label: rowLabel,
+                      value: `${value.toFixed(1)}%`,
+                      color,
+                    }
+                  }}
+                />
+              )}
             />
             <RechartsChangeMarkers markers={changeMarkers} />
             {visibleSeries.map((series) => (

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
@@ -91,6 +91,9 @@ test('SQP weekly chart renders hover tooltip content for the active week', () =>
 
   assert.match(markup, /data-hover-tooltip=\"sqp\"/)
   assert.match(markup, /W02 · 2 changes/)
+  assert.match(markup, /Content update across 4 ASINs/)
+  assert.match(markup, /Price update across 4 ASINs/)
+  assert.doesNotMatch(markup, /tracked changes/)
   assert.match(markup, /Impr Share/)
   assert.match(markup, /CTR x/)
   assert.match(markup, /1\.50x/)

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -3,6 +3,11 @@
 import React, { useState, type JSX } from 'react'
 import { Box, Button, Stack, Typography } from '@mui/material'
 import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
+import {
+  buildChangeMarkerLabelParts,
+  buildChangeMarkerLookup,
+  buildWeeklyChangeMarkers,
+} from '@/components/wpr/chart-change-markers'
 import type { WprSqpWowVisible } from '@/lib/wpr/dashboard-state'
 import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
 import { formatCompactNumber, formatCount } from '@/lib/wpr/format'
@@ -72,24 +77,6 @@ function formatPoints(value: number): string {
 
 function blankMetricValue(): string {
   return '---'
-}
-
-function buildChangeMarkerMap(changeEntries: WprChangeLogEntry[]): Map<string, { count: number; titles: string[] }> {
-  const info = new Map<string, { count: number; titles: string[] }>()
-  for (const entry of changeEntries) {
-    const existing = info.get(entry.week_label)
-    if (existing === undefined) {
-      info.set(entry.week_label, { count: 1, titles: [entry.title] })
-      continue
-    }
-
-    existing.count += 1
-    if (existing.titles.length < 3) {
-      existing.titles.push(entry.title)
-    }
-  }
-
-  return info
 }
 
 function SqpFooter({
@@ -240,15 +227,6 @@ function buildRatioFillPolygons(
   return polygons
 }
 
-function formatTooltipHeader(weekLabel: string, changeMarker: { count: number } | undefined): string {
-  if (changeMarker === undefined) {
-    return weekLabel
-  }
-
-  const changeNoun = changeMarker.count === 1 ? 'change' : 'changes'
-  return `${weekLabel} · ${changeMarker.count} ${changeNoun}`
-}
-
 function formatSeriesTooltipValue(point: ChartPoint, series: ChartSeriesMeta): string {
   if (series.kind === 'points') {
     return formatPoints(point[series.valueField])
@@ -297,7 +275,7 @@ export function SqpWeeklySvg({
     throw new Error(`Invalid SQP weekly chart frame dimensions ${width}x${height}`)
   }
 
-  const changeMarkers = buildChangeMarkerMap(changeEntries)
+  const changeMarkers = buildChangeMarkerLookup(buildWeeklyChangeMarkers(changeEntries))
   const points: ChartPoint[] = weekly.map((week) => {
     const ctrRatio = rateRatio(week.metrics.asin_ctr, week.metrics.market_ctr)
     const atcRatio = rateRatio(week.metrics.asin_cart_add_rate, week.metrics.cart_add_rate)
@@ -371,13 +349,20 @@ export function SqpWeeklySvg({
       color: series.color,
       value: formatSeriesTooltipValue(hoveredPoint, series),
     }))
-    const tooltipWidth = crampedLayout ? 138 : compactLayout ? 154 : 170
+    const tooltipLabelParts = buildChangeMarkerLabelParts(hoveredPoint.week_label, hoveredMarker)
+    const tooltipHeader = tooltipLabelParts[0]
+    if (tooltipHeader === undefined) {
+      throw new Error(`Missing SQP tooltip header for ${hoveredPoint.week_label}`)
+    }
+
+    const changeDetailLines = tooltipLabelParts.slice(1)
+    const tooltipWidth = crampedLayout ? 146 : compactLayout ? 170 : 188
     const tooltipHeaderFontSize = crampedLayout ? 8 : 9
     const tooltipRowFontSize = crampedLayout ? 7 : 8
     const tooltipRowHeight = crampedLayout ? 13 : 15
     const tooltipPaddingX = crampedLayout ? 8 : 10
     const tooltipTop = margin.top + 8
-    const changeLineCount = hoveredMarker === undefined ? 0 : 1
+    const changeLineCount = changeDetailLines.length
     const tooltipHeight = 22 + tooltipRows.length * tooltipRowHeight + changeLineCount * tooltipRowHeight + 8
     const tooltipMinX = margin.left + 4
     let tooltipMaxX = width - margin.right - tooltipWidth
@@ -391,8 +376,6 @@ export function SqpWeeklySvg({
     if (tooltipX > tooltipMaxX) {
       tooltipX = tooltipMaxX
     }
-
-    const tooltipHeader = formatTooltipHeader(hoveredPoint.week_label, hoveredMarker)
     const activeX = xPosition(activeHoverIndex)
 
     hoverTooltip = (
@@ -449,16 +432,17 @@ export function SqpWeeklySvg({
               </g>
             )
           })}
-          {hoveredMarker !== undefined ? (
+          {changeDetailLines.map((line, lineIndex) => (
             <text
+              key={`${hoveredPoint.week_label}-change-${lineIndex}`}
               x={tooltipPaddingX}
-              y={30 + tooltipRows.length * tooltipRowHeight}
+              y={30 + tooltipRows.length * tooltipRowHeight + lineIndex * tooltipRowHeight}
               fill="rgba(255,255,255,0.58)"
               fontSize={tooltipRowFontSize}
             >
-              {`${hoveredMarker.count} tracked changes`}
+              {line}
             </text>
-          ) : null}
+          ))}
         </g>
         {visibleSeries.map((series) => (
           <circle

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -15,8 +15,8 @@ import {
 import {
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
-  formatChangeMarkerLabel,
   RechartsChangeMarkers,
+  WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
 import type { WprCompWowVisible } from '@/lib/wpr/dashboard-state'
 import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
@@ -181,16 +181,36 @@ function WeeklyGapChart({
             />
             <ReferenceLine y={0} stroke="rgba(255,255,255,0.18)" strokeDasharray="4 4" />
             <Tooltip
-              formatter={(value: number, key: string) => {
-                const label = key === 'clickGap' ? 'Click Gap' : 'Purch Gap'
-                return [`${value.toFixed(1)} pts`, label]
-              }}
-              labelFormatter={(label) => formatChangeMarkerLabel(label, changeMarkersByLabel.get(String(label)))}
-              contentStyle={{
-                background: 'rgba(0,20,35,0.96)',
-                border: '1px solid rgba(255,255,255,0.08)',
-                borderRadius: 8,
-              }}
+              content={({ active, payload, label }) => (
+                <WprChangeTooltipContent
+                  active={active}
+                  payload={payload}
+                  label={label}
+                  changeMarker={changeMarkersByLabel.get(String(label))}
+                  formatRow={(entry) => {
+                    const key = entry.dataKey
+                    if (key === undefined) {
+                      throw new Error('Missing TST tooltip data key')
+                    }
+
+                    const value = entry.value
+                    if (typeof value !== 'number') {
+                      throw new Error(`Invalid TST tooltip value for ${String(key)}`)
+                    }
+
+                    const color = entry.color
+                    if (color === undefined) {
+                      throw new Error(`Missing TST tooltip color for ${String(key)}`)
+                    }
+
+                    return {
+                      label: key === 'clickGap' ? 'Click Gap' : 'Purch Gap',
+                      value: `${value.toFixed(1)} pts`,
+                      color,
+                    }
+                  }}
+                />
+              )}
             />
             <RechartsChangeMarkers markers={changeMarkers} />
             {visibleSeries.map((series) => (

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -33,3 +33,15 @@ test('business reports chart keeps a dedicated SVG change overlay', () => {
   assert.match(tabSource, /data-change-overlay="business-reports"/)
   assert.match(tabSource, /<BusinessReportsChangeOverlay chartRootRef=\{chartRootRef\} markers=\{changeMarkers\} \/>/)
 })
+
+test('all week-based WPR charts use the shared change tooltip renderer', () => {
+  const scpSource = readFileSync(new URL('./tabs/scp-tab.tsx', import.meta.url), 'utf8')
+  const tstSource = readFileSync(new URL('./tabs/tst-weekly-panel.tsx', import.meta.url), 'utf8')
+  const brSource = readFileSync(new URL('./tabs/business-reports-tab.tsx', import.meta.url), 'utf8')
+  const compareSource = readFileSync(new URL('./tabs/compare-tab.tsx', import.meta.url), 'utf8')
+
+  assert.match(scpSource, /<WprChangeTooltipContent/)
+  assert.match(tstSource, /<WprChangeTooltipContent/)
+  assert.match(brSource, /<WprChangeTooltipContent/)
+  assert.equal(compareSource.match(/<WprChangeTooltipContent/g)?.length, 2)
+})


### PR DESCRIPTION
## Summary
- standardize week-based WPR chart tooltips onto one shared change-aware renderer
- show every change title in the hover tooltip instead of truncating or flattening part of the list
- keep SQP on the same change-summary copy path as the Recharts charts

## Root Cause
Week-based charts were mixing a shared change-marker formatter with chart-specific tooltip rendering. SQP had its own tooltip copy, and the Recharts charts were flattening all change titles into a single label string, which made long change lists hard to read and effectively hid some entries.

## Validation
- `pnpm exec tsx --test components/wpr/chart-change-markers.test.ts components/wpr/wpr-change-props.test.ts components/wpr/tabs/compare-tab.test.ts components/wpr/tabs/sqp-weekly-panel.test.tsx`
- `pnpm --filter @targon/argus lint`
- `pnpm --filter @targon/argus type-check`
