### PR TITLE
fix(argus): standardize wpr dashboard state

### DIFF
--- a/apps/argus/components/wpr/chart-change-markers.test.ts
+++ b/apps/argus/components/wpr/chart-change-markers.test.ts
@@ -9,6 +9,7 @@ import {
   buildDailyChangeMarkers,
   buildWeeklyChangeMarkers,
   formatChangeMarkerLabel,
+  summarizeChangeMarkers,
   WprChangeTooltipContent,
 } from './chart-change-markers'
 
@@ -100,6 +101,13 @@ test('formatChangeMarkerLabel includes tracked changes in hover labels', () => {
     'W14 · 2 changes · Content update across 4 ASINs · Price update across 4 ASINs',
   )
   assert.equal(formatChangeMarkerLabel('W16', undefined), 'W16')
+})
+
+test('summarizeChangeMarkers reports all tracked changes and marked buckets', () => {
+  const weeklyMarkers = buildWeeklyChangeMarkers(weeklyEntries)
+
+  assert.equal(summarizeChangeMarkers(weeklyMarkers, 'week'), '3 changes · 2 marked weeks')
+  assert.equal(summarizeChangeMarkers([], 'day'), 'No marked days')
 })
 
 test('buildChangeMarkerLabelParts keeps standardized change copy split into display lines', () => {

--- a/apps/argus/components/wpr/chart-change-markers.tsx
+++ b/apps/argus/components/wpr/chart-change-markers.tsx
@@ -81,6 +81,21 @@ export function formatChangeMarkerCount(count: number): string {
   return `${count} ${noun}`
 }
 
+export function summarizeChangeMarkers(
+  markers: ChartChangeMarker[],
+  markerUnit: 'week' | 'day',
+): string {
+  const markerCount = markers.length
+  if (markerCount === 0) {
+    return `No marked ${markerUnit}s`
+  }
+
+  const totalChangeCount = markers.reduce((sum, marker) => sum + marker.count, 0)
+  const markerLabel = markerCount === 1 ? `${markerCount} marked ${markerUnit}` : `${markerCount} marked ${markerUnit}s`
+
+  return `${formatChangeMarkerCount(totalChangeCount)} · ${markerLabel}`
+}
+
 export function buildChangeMarkerLabelParts(
   label: string | number,
   marker: ChartChangeMarker | undefined,

--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState, type JSX, type RefObject } from 'react'
-import { Box, Button, Stack, Typography } from '@mui/material'
+import { Box, Button, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
 import {
   Bar,
   CartesianGrid,
@@ -17,24 +17,18 @@ import {
   buildChangeMarkerLookup,
   buildDailyChangeMarkers,
   buildWeeklyChangeMarkers,
+  summarizeChangeMarkers,
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
+import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
 import type { WprBrWowVisible } from '@/lib/wpr/dashboard-state'
-import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
 import {
   createBusinessReportsSelectionViewModel,
   selectedWeekBusinessRecord,
   type BusinessReportsSelectionViewModel,
 } from '@/lib/wpr/business-reports-view-model'
 import { formatCount, formatPercent } from '@/lib/wpr/format'
-import {
-  chartControlRailSx,
-  chartToggleButtonSx,
-  panelSx,
-  subtleBorder,
-  textMuted,
-  textSecondary,
-} from '@/lib/wpr/panel-tokens'
+import { chartToggleButtonSx, panelSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
 import type { WprBusinessDailyPoint, WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
 import BusinessReportsSelectionTable from './business-reports-selection-table'
@@ -44,6 +38,35 @@ type BusinessReportsViewMode = 'weekly' | 'daily'
 type BusinessReportsHeroContent = {
   name: string
   meta: string[]
+}
+
+const businessReportsViewToggleGroupSx = {
+  '& .MuiToggleButtonGroup-grouped': {
+    minWidth: 76,
+    px: 1.5,
+    py: 0.65,
+    borderColor: 'rgba(255,255,255,0.18)',
+    borderRadius: '10px',
+    textTransform: 'none' as const,
+    fontSize: '0.78rem',
+    fontWeight: 700,
+    letterSpacing: '0.01em',
+    color: 'rgba(255,255,255,0.76)',
+    bgcolor: 'rgba(255,255,255,0.045)',
+    '&.Mui-selected': {
+      borderColor: '#00C2B988',
+      bgcolor: 'rgba(0, 194, 185, 0.14)',
+      color: 'rgba(255,255,255,0.95)',
+    },
+    '&.Mui-selected:hover': {
+      borderColor: '#00C2B9aa',
+      bgcolor: 'rgba(0, 194, 185, 0.18)',
+    },
+    '&:hover': {
+      borderColor: 'rgba(255,255,255,0.28)',
+      bgcolor: 'rgba(255,255,255,0.07)',
+    },
+  },
 }
 
 function blankMetricValue(): string {
@@ -312,60 +335,18 @@ function BusinessReportsChart({
     (value): value is { key: 'sessions' | 'order_items' | 'unit_session'; label: string; color: string } =>
       value !== null,
   )
+  const changeMarkers =
+    viewMode === 'weekly'
+      ? buildWeeklyChangeMarkers(changeEntries)
+      : buildDailyChangeMarkers(dailySeries)
   let chartBody: JSX.Element
   if (visibleSeries.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        Turn on at least one series to view the Business Reports chart.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>Turn on at least one series to view the Business Reports chart.</WprChartEmptyState>
   } else if (viewMode === 'daily' && dailySeries.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        No Business Reports ByDate data is available for the selected week.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>No Business Reports ByDate data is available for the selected week.</WprChartEmptyState>
   } else if (viewMode === 'weekly' && weekly.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        No ASINs selected. Use the table below to filter Business Reports rows.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>No ASINs selected. Use the table below to filter Business Reports rows.</WprChartEmptyState>
   } else {
-    const changeMarkers =
-      viewMode === 'weekly'
-        ? buildWeeklyChangeMarkers(changeEntries)
-        : buildDailyChangeMarkers(dailySeries)
     const changeMarkersByLabel = buildChangeMarkerLookup(changeMarkers)
     let chartRows: Array<{
       label: string
@@ -394,7 +375,7 @@ function BusinessReportsChart({
     }
 
     chartBody = (
-      <Box ref={chartRootRef} sx={{ position: 'relative', height: WPR_CHART_HEIGHT }}>
+      <Box ref={chartRootRef} sx={{ position: 'relative', height: '100%' }}>
         <ResponsiveContainer width="100%" height="100%">
           <ComposedChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
@@ -487,43 +468,31 @@ function BusinessReportsChart({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-      <Box
-        sx={{
-          ...chartControlRailSx,
-          alignItems: 'flex-start',
-        }}
-      >
-        <Stack spacing={0.35}>
-          <Typography sx={{ fontSize: '0.74rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)' }}>
-            {viewMode === 'weekly' ? 'Week over week' : 'Day by day'}
-          </Typography>
-          <Typography sx={{ fontSize: '0.68rem', color: textMuted }}>
-            {viewMode === 'weekly' ? 'Counts + retail conversion rates' : 'Selected-week daily trend'}
-          </Typography>
-        </Stack>
-
-        <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap" alignItems="center">
-          <Button
+    <WprChartShell
+      title={viewMode === 'weekly' ? 'Week over week' : 'Day by day'}
+      description={viewMode === 'weekly' ? 'Counts + retail conversion rates' : 'Selected-week daily trend'}
+      changeSummary={summarizeChangeMarkers(changeMarkers, viewMode === 'weekly' ? 'week' : 'day')}
+      primaryControls={
+        <WprChartControlGroup label="View">
+          <ToggleButtonGroup
+            value={viewMode}
+            exclusive
             size="small"
-            variant="outlined"
-            onClick={() => {
-              setViewMode('weekly')
+            aria-label="Business Reports view mode"
+            onChange={(_event, nextMode: BusinessReportsViewMode | null) => {
+              if (nextMode !== null) {
+                setViewMode(nextMode)
+              }
             }}
-            sx={chartToggleButtonSx(viewMode === 'weekly', '#00C2B9')}
+            sx={businessReportsViewToggleGroupSx}
           >
-            Weekly
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setViewMode('daily')
-            }}
-            sx={chartToggleButtonSx(viewMode === 'daily', '#00C2B9')}
-          >
-            Daily
-          </Button>
+            <ToggleButton value="weekly">Weekly</ToggleButton>
+            <ToggleButton value="daily">Daily</ToggleButton>
+          </ToggleButtonGroup>
+        </WprChartControlGroup>
+      }
+      secondaryControls={
+        <WprChartControlGroup label="Metrics">
           <Button
             size="small"
             variant="outlined"
@@ -563,11 +532,11 @@ function BusinessReportsChart({
           >
             Unit Session %
           </Button>
-        </Stack>
-      </Box>
-
+        </WprChartControlGroup>
+      }
+    >
       {chartBody}
-    </Box>
+    </WprChartShell>
   )
 }
 

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -15,20 +15,14 @@ import {
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
   RechartsChangeMarkers,
+  summarizeChangeMarkers,
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
+import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
 import type { WprScpWowVisible } from '@/lib/wpr/dashboard-state'
-import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
 import { formatCount, formatMoney } from '@/lib/wpr/format'
 import { createScpSelectionViewModel, type ScpSelectionViewModel } from '@/lib/wpr/scp-view-model'
-import {
-  chartControlRailSx,
-  chartToggleButtonSx,
-  panelSx,
-  subtleBorder,
-  textMuted,
-  textSecondary,
-} from '@/lib/wpr/panel-tokens'
+import { chartToggleButtonSx, panelSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
 import ScpSelectionTable from './scp-selection-table'
@@ -140,41 +134,13 @@ function ScpWeeklyChart({
     wowVisible.purch ? { key: 'purch', label: 'Purch Rate', color: '#77dfd0' } : null,
     wowVisible.cvr ? { key: 'cvr', label: 'CVR', color: '#d5ff62' } : null,
   ].filter((value): value is { key: 'ctr' | 'atc' | 'purch' | 'cvr'; label: string; color: string } => value !== null)
+  const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
   let chartBody: JSX.Element
   if (weekly.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        No SCP rows selected. Use the table below to filter SCP rows.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>No SCP rows selected. Use the table below to filter SCP rows.</WprChartEmptyState>
   } else if (visibleSeries.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        Turn on at least one series to view the SCP history chart.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>Turn on at least one series to view the SCP history chart.</WprChartEmptyState>
   } else {
-    const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
     const changeMarkersByLabel = buildChangeMarkerLookup(changeMarkers)
     const chartRows = weekly.map((week) => ({
       weekLabel: week.week_label,
@@ -185,7 +151,7 @@ function ScpWeeklyChart({
     }))
 
     chartBody = (
-      <Box sx={{ height: WPR_CHART_HEIGHT }}>
+      <Box sx={{ height: '100%' }}>
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
@@ -247,23 +213,12 @@ function ScpWeeklyChart({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-      <Box
-        sx={{
-          ...chartControlRailSx,
-          alignItems: 'flex-start',
-        }}
-      >
-        <Stack spacing={0.35}>
-          <Typography sx={{ fontSize: '0.74rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)' }}>
-            Week over week
-          </Typography>
-          <Typography sx={{ fontSize: '0.68rem', color: textMuted }}>
-            Search funnel rates
-          </Typography>
-        </Stack>
-
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+    <WprChartShell
+      title="Week over week"
+      description="Catalog search funnel rates"
+      changeSummary={summarizeChangeMarkers(changeMarkers, 'week')}
+      secondaryControls={
+        <WprChartControlGroup label="Metrics">
           <Button
             size="small"
             variant="outlined"
@@ -316,11 +271,11 @@ function ScpWeeklyChart({
           >
             CVR
           </Button>
-        </Box>
-      </Box>
-
+        </WprChartControlGroup>
+      }
+    >
       {chartBody}
-    </Box>
+    </WprChartShell>
   )
 }
 

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
@@ -117,9 +117,10 @@ test('SQP weekly chart omits hover tooltip markup when no week is active', () =>
   assert.doesNotMatch(markup, /Impr Share/)
 })
 
-test('SQP weekly chart keeps the toggle rail grouped on the left', () => {
+test('SQP weekly chart uses the shared shell with grouped metrics and visible change summary', () => {
   const source = readFileSync(new URL('./sqp-weekly-panel.tsx', import.meta.url), 'utf8')
 
-  assert.match(source, /\.\.\.chartControlRailSx,\s+justifyContent: 'flex-start'/)
-  assert.match(source, /<Box sx=\{\{ display: 'flex', gap: 1, flexWrap: 'wrap' \}\}>/)
+  assert.match(source, /<WprChartShell/)
+  assert.match(source, /changeSummary=\{summarizeChangeMarkers\(changeMarkers, 'week'\)\}/)
+  assert.match(source, /<WprChartControlGroup label="Metrics">/)
 })

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -7,11 +7,12 @@ import {
   buildChangeMarkerLabelParts,
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
+  summarizeChangeMarkers,
 } from '@/components/wpr/chart-change-markers'
+import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
 import type { WprSqpWowVisible } from '@/lib/wpr/dashboard-state'
-import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
 import { formatCompactNumber, formatCount } from '@/lib/wpr/format'
-import { chartControlRailSx, chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
+import { chartToggleButtonSx, panelSx, subtleBorder, textSecondary } from '@/lib/wpr/panel-tokens'
 import {
   rateRatio,
   type SqpAggregatedMetrics,
@@ -19,13 +20,6 @@ import {
   type SqpWeeklyPoint,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry } from '@/lib/wpr/types'
-
-const PANEL_SX = {
-  bgcolor: 'rgba(0, 20, 35, 0.85)',
-  border: '1px solid rgba(255,255,255,0.07)',
-  borderRadius: '12px',
-  overflow: 'hidden',
-} as const
 
 type SqpHeroContent = {
   name: string
@@ -623,42 +617,15 @@ function SqpWeeklyChart({
 }) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
   const visibleSeries = SQP_WOW_SERIES.filter((series) => wowVisible[series.key])
+  const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
   let chartBody: JSX.Element
   if (weekly.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        No weekly SQP history for this selection.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>No weekly SQP history for this selection.</WprChartEmptyState>
   } else if (visibleSeries.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        Turn on at least one series to view the SQP history chart.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>Turn on at least one series to view the SQP history chart.</WprChartEmptyState>
   } else {
     chartBody = (
-      <ResponsiveChartFrame height={WPR_CHART_HEIGHT}>
+      <ResponsiveChartFrame height="100%">
         <SqpWeeklySvg
           weekly={weekly}
           changeEntries={changeEntries}
@@ -671,14 +638,12 @@ function SqpWeeklyChart({
   }
 
   return (
-    <Stack spacing={1.5}>
-      <Box
-        sx={{
-          ...chartControlRailSx,
-          justifyContent: 'flex-start',
-        }}
-      >
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+    <WprChartShell
+      title="Week over week"
+      description="Query-share and conversion deltas"
+      changeSummary={summarizeChangeMarkers(changeMarkers, 'week')}
+      secondaryControls={
+        <WprChartControlGroup label="Metrics">
           {SQP_WOW_SERIES.map((series) => (
             <Button
               key={series.key}
@@ -695,11 +660,11 @@ function SqpWeeklyChart({
               {series.label}
             </Button>
           ))}
-        </Box>
-      </Box>
-
+        </WprChartControlGroup>
+      }
+    >
       {chartBody}
-    </Stack>
+    </WprChartShell>
   )
 }
 
@@ -733,50 +698,39 @@ export default function SqpWeeklyPanel({
   historyLabel: string
 }) {
   return (
-    <Box sx={PANEL_SX}>
+    <Box sx={panelSx}>
       <Box
         sx={{
           px: 2.5,
-          pt: 2.2,
-          pb: 1.4,
+          pt: 2,
+          pb: 1.25,
+          borderBottom: subtleBorder,
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
         }}
       >
-        <Typography
-          sx={{
-            fontSize: '1.35rem',
-            fontWeight: 800,
-            letterSpacing: '-0.04em',
-            color: 'rgba(255,255,255,0.95)',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {heroContent.name}
-        </Typography>
-        <Typography
-          sx={{
-            fontSize: '0.72rem',
-            color: 'rgba(255,255,255,0.6)',
-            mt: 0.4,
-            minHeight: '1.1rem',
-            whiteSpace: 'nowrap',
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-          }}
-        >
-          {heroContent.meta.join(' · ')}
-        </Typography>
+        <Stack spacing={0.45}>
+          <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
+            {heroContent.name}
+          </Typography>
+          <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
+            {heroContent.meta.join(' · ')}
+          </Typography>
+        </Stack>
+      </Box>
 
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(3, minmax(0, 1fr))',
-            gap: { xs: 1.5, sm: 4 },
-            mt: 1.8,
-            minHeight: '3.1rem',
-          }}
-        >
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
+          gap: 1.5,
+          px: 2.5,
+          py: 1.75,
+          borderBottom: subtleBorder,
+        }}
+      >
           <MetricChip
             label="Query Volume"
             value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCompactNumber(currentMetrics.query_volume)}
@@ -789,7 +743,6 @@ export default function SqpWeeklyPanel({
             label="Our Purchases"
             value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.asin_purchases)}
           />
-        </Box>
       </Box>
 
       <Box sx={{ px: 2.5, pb: 2.2 }}>

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -16,14 +16,14 @@ import {
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
   RechartsChangeMarkers,
+  summarizeChangeMarkers,
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
+import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
 import type { WprCompWowVisible } from '@/lib/wpr/dashboard-state'
-import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
 import type { TstSelectionViewModel } from '@/lib/wpr/tst-view-model'
 import type { WprChangeLogEntry, WprCompetitorSummary } from '@/lib/wpr/types'
 import {
-  chartControlRailSx,
   chartToggleButtonSx,
   panelSx,
   subtleBorder,
@@ -127,41 +127,13 @@ function WeeklyGapChart({
     wowVisible.click ? { key: 'clickGap', label: 'Click Gap', color: '#77dfd0' } : null,
     wowVisible.purch ? { key: 'purchaseGap', label: 'Purch Gap', color: '#d5ff62' } : null,
   ].filter((value): value is { key: 'clickGap' | 'purchaseGap'; label: string; color: string } => value !== null)
+  const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
   let chartBody: JSX.Element
   if (weekly.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        No weekly TST history for this selection.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>No weekly TST history for this selection.</WprChartEmptyState>
   } else if (visibleSeries.length === 0) {
-    chartBody = (
-      <Box
-        sx={{
-          height: WPR_CHART_HEIGHT,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          color: 'rgba(255,255,255,0.54)',
-          fontSize: '0.78rem',
-          letterSpacing: '0.03em',
-        }}
-      >
-        Turn on at least one series to view the TST history chart.
-      </Box>
-    )
+    chartBody = <WprChartEmptyState>Turn on at least one series to view the TST history chart.</WprChartEmptyState>
   } else {
-    const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
     const changeMarkersByLabel = buildChangeMarkerLookup(changeMarkers)
     const chartRows = weekly.map((week) => ({
       weekLabel: week.week_label,
@@ -170,7 +142,7 @@ function WeeklyGapChart({
     }))
 
     chartBody = (
-      <Box sx={{ height: WPR_CHART_HEIGHT }}>
+      <Box sx={{ height: '100%' }}>
         <ResponsiveContainer width="100%" height="100%">
           <LineChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
@@ -231,23 +203,12 @@ function WeeklyGapChart({
   }
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-      <Box
-        sx={{
-          ...chartControlRailSx,
-          alignItems: 'flex-start',
-        }}
-      >
-        <Stack spacing={0.35}>
-          <Typography sx={{ fontSize: '0.74rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)' }}>
-            Week over week
-          </Typography>
-          <Typography sx={{ fontSize: '0.68rem', color: textMuted }}>
-            {`${competitor.brand} share gap shown in pts`}
-          </Typography>
-        </Stack>
-
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+    <WprChartShell
+      title="Week over week"
+      description={`${competitor.brand} share gap shown in pts`}
+      changeSummary={summarizeChangeMarkers(changeMarkers, 'week')}
+      secondaryControls={
+        <WprChartControlGroup label="Metrics">
           <Button
             size="small"
             variant="outlined"
@@ -274,11 +235,11 @@ function WeeklyGapChart({
           >
             Purch Gap
           </Button>
-        </Box>
-      </Box>
-
+        </WprChartControlGroup>
+      }
+    >
       {chartBody}
-    </Box>
+    </WprChartShell>
   )
 }
 

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -34,6 +34,34 @@ test('business reports chart keeps a dedicated SVG change overlay', () => {
   assert.match(tabSource, /<BusinessReportsChangeOverlay chartRootRef=\{chartRootRef\} markers=\{changeMarkers\} \/>/)
 })
 
+test('business reports uses one exclusive selector for weekly versus daily view mode', () => {
+  const tabSource = readFileSync(new URL('./tabs/business-reports-tab.tsx', import.meta.url), 'utf8')
+
+  assert.match(tabSource, /<ToggleButtonGroup/)
+  assert.match(tabSource, /aria-label="Business Reports view mode"/)
+  assert.match(tabSource, /exclusive/)
+  assert.match(tabSource, /<ToggleButton value="weekly">Weekly<\/ToggleButton>/)
+  assert.match(tabSource, /<ToggleButton value="daily">Daily<\/ToggleButton>/)
+})
+
+test('SQP, SCP, BR, and TST use the shared chart shell with visible change summaries', () => {
+  const sqpSource = readFileSync(new URL('./tabs/sqp-weekly-panel.tsx', import.meta.url), 'utf8')
+  const scpSource = readFileSync(new URL('./tabs/scp-tab.tsx', import.meta.url), 'utf8')
+  const tstSource = readFileSync(new URL('./tabs/tst-weekly-panel.tsx', import.meta.url), 'utf8')
+  const brSource = readFileSync(new URL('./tabs/business-reports-tab.tsx', import.meta.url), 'utf8')
+  const shellSource = readFileSync(new URL('./wpr-chart-shell.tsx', import.meta.url), 'utf8')
+
+  assert.match(shellSource, /data-change-visibility="wpr"/)
+  assert.match(sqpSource, /<WprChartShell/)
+  assert.match(scpSource, /<WprChartShell/)
+  assert.match(tstSource, /<WprChartShell/)
+  assert.match(brSource, /<WprChartShell/)
+  assert.match(sqpSource, /summarizeChangeMarkers\(changeMarkers, 'week'\)/)
+  assert.match(scpSource, /summarizeChangeMarkers\(changeMarkers, 'week'\)/)
+  assert.match(tstSource, /summarizeChangeMarkers\(changeMarkers, 'week'\)/)
+  assert.match(brSource, /summarizeChangeMarkers\(changeMarkers, viewMode === 'weekly' \? 'week' : 'day'\)/)
+})
+
 test('all week-based WPR charts use the shared change tooltip renderer', () => {
   const scpSource = readFileSync(new URL('./tabs/scp-tab.tsx', import.meta.url), 'utf8')
   const tstSource = readFileSync(new URL('./tabs/tst-weekly-panel.tsx', import.meta.url), 'utf8')

--- a/apps/argus/components/wpr/wpr-chart-shell.tsx
+++ b/apps/argus/components/wpr/wpr-chart-shell.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Box, Stack, Typography } from '@mui/material'
+import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
+import { chartControlRailSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
+
+const chartViewportSx = {
+  height: WPR_CHART_HEIGHT,
+  minHeight: WPR_CHART_HEIGHT,
+  border: subtleBorder,
+  borderRadius: '12px',
+  bgcolor: 'rgba(255,255,255,0.018)',
+  overflow: 'hidden',
+}
+
+const controlGroupLabelSx = {
+  fontSize: '0.58rem',
+  fontWeight: 700,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.12em',
+  color: textMuted,
+}
+
+export function WprChartControlGroup({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <Stack spacing={0.45}>
+      <Typography sx={controlGroupLabelSx}>{label}</Typography>
+      <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', alignItems: 'center' }}>{children}</Box>
+    </Stack>
+  )
+}
+
+export function WprChartEmptyState({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: 'rgba(255,255,255,0.54)',
+        fontSize: '0.78rem',
+        letterSpacing: '0.03em',
+        px: 2,
+        textAlign: 'center',
+      }}
+    >
+      {children}
+    </Box>
+  )
+}
+
+export function WprChartShell({
+  title,
+  description,
+  changeSummary,
+  primaryControls,
+  secondaryControls,
+  children,
+}: {
+  title: string
+  description: string
+  changeSummary: string
+  primaryControls?: ReactNode
+  secondaryControls?: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+      <Box
+        sx={{
+          ...chartControlRailSx,
+          alignItems: 'flex-start',
+        }}
+      >
+        <Stack direction="row" spacing={1.5} useFlexGap flexWrap="wrap" alignItems="flex-start">
+          <Stack spacing={0.35}>
+            <Typography sx={{ fontSize: '0.74rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)' }}>
+              {title}
+            </Typography>
+            <Typography sx={{ fontSize: '0.68rem', color: textSecondary }}>
+              {description}
+            </Typography>
+          </Stack>
+
+          <Box
+            data-change-visibility="wpr"
+            sx={{
+              px: 1.1,
+              py: 0.75,
+              border: subtleBorder,
+              borderRadius: '10px',
+              bgcolor: 'rgba(255,255,255,0.03)',
+            }}
+          >
+            <Typography sx={controlGroupLabelSx}>Change log</Typography>
+            <Typography sx={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.82)', mt: 0.25 }}>
+              {changeSummary}
+            </Typography>
+          </Box>
+
+          {primaryControls}
+        </Stack>
+
+        {secondaryControls}
+      </Box>
+
+      <Box sx={chartViewportSx}>{children}</Box>
+    </Box>
+  )
+}

--- a/apps/argus/lib/wpr/dashboard-state.test.ts
+++ b/apps/argus/lib/wpr/dashboard-state.test.ts
@@ -1,10 +1,15 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  applyWeekScopedPatch,
+  captureWeekScopedState,
   createInitialDashboardState,
   getInitialWprTab,
   getLegacyWprRedirect,
+  switchDashboardWeek,
   toggleSetMember,
+  wprStateReviver,
+  wprStateReplacer,
   type WprTab,
 } from './dashboard-state'
 
@@ -16,6 +21,7 @@ test('createInitialDashboardState matches the HTML defaults', () => {
   assert.equal(state.selectedClusterId, null)
   assert.deepEqual([...state.selectedSqpRootIds], [])
   assert.equal(state.compareOrganicMode, 'map')
+  assert.deepEqual(state.weekStateByWeek, {})
   assert.deepEqual(state.scpWowVisible, {
     ctr: true,
     atc: true,
@@ -38,4 +44,93 @@ test('legacy competitor route maps to the TST tab', () => {
 
 test('missing query params default the shell to SQP', () => {
   assert.equal(getInitialWprTab(new URLSearchParams()), 'sqp')
+})
+
+test('switchDashboardWeek snapshots the current week and clears state for an uncached week', () => {
+  const state = createInitialDashboardState('W16')
+  state.selectedClusterId = 'cluster-a'
+  state.selectedSqpRootIds = new Set(['cluster-a'])
+  state.selectedSqpTermIds = new Set(['term-a'])
+  state.expandedSqpRootIds = new Set(['cluster-a'])
+  state.hasInitializedSqpSelection = true
+  state.selectedScpAsinIds = new Set(['asin-a'])
+  state.hasInitializedScpSelection = true
+
+  const next = switchDashboardWeek(state, 'W15')
+
+  assert.equal(next.selectedWeek, 'W15')
+  assert.deepEqual([...next.selectedSqpRootIds], [])
+  assert.deepEqual([...next.selectedSqpTermIds], [])
+  assert.equal(next.hasInitializedSqpSelection, false)
+  assert.deepEqual([...next.selectedScpAsinIds], [])
+  assert.equal(next.hasInitializedScpSelection, false)
+
+  const previousWeekState = next.weekStateByWeek.W16
+  if (previousWeekState === undefined) {
+    throw new Error('Missing previous week snapshot')
+  }
+
+  assert.equal(previousWeekState.selectedClusterId, 'cluster-a')
+  assert.deepEqual([...previousWeekState.selectedSqpRootIds], ['cluster-a'])
+  assert.deepEqual([...previousWeekState.selectedScpAsinIds], ['asin-a'])
+})
+
+test('switchDashboardWeek restores a cached week snapshot', () => {
+  const state = createInitialDashboardState('W16')
+  state.weekStateByWeek.W14 = {
+    ...captureWeekScopedState(state),
+    selectedClusterId: 'cluster-b',
+    selectedSqpRootIds: new Set(['cluster-b']),
+    selectedSqpTermIds: new Set(['term-b']),
+    hasInitializedSqpSelection: true,
+    selectedCompetitorRootIds: new Set(['root-b']),
+    hasInitializedCompetitorSelection: true,
+  }
+
+  const next = switchDashboardWeek(state, 'W14')
+
+  assert.equal(next.selectedWeek, 'W14')
+  assert.equal(next.selectedClusterId, 'cluster-b')
+  assert.deepEqual([...next.selectedSqpRootIds], ['cluster-b'])
+  assert.deepEqual([...next.selectedSqpTermIds], ['term-b'])
+  assert.equal(next.hasInitializedSqpSelection, true)
+  assert.deepEqual([...next.selectedCompetitorRootIds], ['root-b'])
+  assert.equal(next.hasInitializedCompetitorSelection, true)
+})
+
+test('applyWeekScopedPatch keeps the current week snapshot in sync', () => {
+  const state = createInitialDashboardState('W16')
+
+  const patch = applyWeekScopedPatch(state, {
+    selectedClusterId: 'cluster-c',
+    selectedSqpRootIds: new Set(['cluster-c']),
+    selectedSqpTermIds: new Set(['term-c']),
+    hasInitializedSqpSelection: true,
+  })
+
+  const cachedWeekState = patch.weekStateByWeek?.W16
+  if (cachedWeekState === undefined) {
+    throw new Error('Missing synced week snapshot')
+  }
+
+  assert.equal(cachedWeekState.selectedClusterId, 'cluster-c')
+  assert.deepEqual([...cachedWeekState.selectedSqpRootIds], ['cluster-c'])
+  assert.deepEqual([...cachedWeekState.selectedSqpTermIds], ['term-c'])
+  assert.equal(cachedWeekState.hasInitializedSqpSelection, true)
+})
+
+test('WPR state JSON replacer and reviver preserve Set-backed fields', () => {
+  const state = createInitialDashboardState('W16')
+  state.selectedSqpRootIds = new Set(['cluster-a'])
+  state.weekStateByWeek.W16 = captureWeekScopedState(state)
+
+  const roundTrip = JSON.parse(
+    JSON.stringify(state, wprStateReplacer),
+    wprStateReviver,
+  ) as typeof state
+
+  assert.ok(roundTrip.selectedSqpRootIds instanceof Set)
+  assert.deepEqual([...roundTrip.selectedSqpRootIds], ['cluster-a'])
+  assert.ok(roundTrip.weekStateByWeek.W16?.selectedSqpRootIds instanceof Set)
+  assert.deepEqual([...roundTrip.weekStateByWeek.W16!.selectedSqpRootIds], ['cluster-a'])
 })

--- a/apps/argus/lib/wpr/dashboard-state.ts
+++ b/apps/argus/lib/wpr/dashboard-state.ts
@@ -38,19 +38,7 @@ export interface WprCompWowVisible {
   purch: boolean
 }
 
-export const WPR_TABS = [
-  { id: 'sqp', label: 'SQP' },
-  { id: 'scp', label: 'SCP' },
-  { id: 'br', label: 'BR' },
-  { id: 'tst', label: 'TST' },
-  { id: 'changelog', label: 'Change Log' },
-  { id: 'compare', label: 'Compare' },
-  { id: 'sources', label: 'Sources' },
-] as const satisfies ReadonlyArray<{ id: WprTab; label: string }>
-
-export interface WprDashboardState {
-  activeTab: WprTab
-  selectedWeek: WeekLabel | null
+export interface WprWeekScopedState {
   selectedClusterId: string | null
   selectedSqpRootIds: Set<string>
   selectedSqpTermIds: Set<string>
@@ -64,6 +52,22 @@ export interface WprDashboardState {
   selectedCompetitorTermIds: Set<string>
   expandedCompetitorRootIds: Set<string>
   hasInitializedCompetitorSelection: boolean
+}
+
+export const WPR_TABS = [
+  { id: 'sqp', label: 'SQP' },
+  { id: 'scp', label: 'SCP' },
+  { id: 'br', label: 'BR' },
+  { id: 'tst', label: 'TST' },
+  { id: 'changelog', label: 'Change Log' },
+  { id: 'compare', label: 'Compare' },
+  { id: 'sources', label: 'Sources' },
+] as const satisfies ReadonlyArray<{ id: WprTab; label: string }>
+
+export interface WprDashboardState extends WprWeekScopedState {
+  activeTab: WprTab
+  selectedWeek: WeekLabel | null
+  weekStateByWeek: Partial<Record<WeekLabel, WprWeekScopedState>>
   compareOrganicMode: WprCompareOrganicMode
   sqpTableSort: WprSortState
   scpTableSort: WprSortState
@@ -75,10 +79,26 @@ export interface WprDashboardState {
   compWowVisible: WprCompWowVisible
 }
 
-export function createInitialDashboardState(defaultWeek: WeekLabel | null): WprDashboardState {
+const WPR_SET_TAG = '__wprSetValues'
+
+type SerializedWprSet = {
+  [WPR_SET_TAG]: string[]
+}
+
+function cloneSet(ids: Set<string>): Set<string> {
+  return new Set(ids)
+}
+
+function isSerializedWprSet(value: unknown): value is SerializedWprSet {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  return WPR_SET_TAG in value && Array.isArray((value as SerializedWprSet)[WPR_SET_TAG])
+}
+
+export function createEmptyWeekScopedState(): WprWeekScopedState {
   return {
-    activeTab: 'sqp',
-    selectedWeek: defaultWeek,
     selectedClusterId: null,
     selectedSqpRootIds: new Set<string>(),
     selectedSqpTermIds: new Set<string>(),
@@ -92,6 +112,101 @@ export function createInitialDashboardState(defaultWeek: WeekLabel | null): WprD
     selectedCompetitorTermIds: new Set<string>(),
     expandedCompetitorRootIds: new Set<string>(),
     hasInitializedCompetitorSelection: false,
+  }
+}
+
+export function captureWeekScopedState(state: WprWeekScopedState): WprWeekScopedState {
+  return {
+    selectedClusterId: state.selectedClusterId,
+    selectedSqpRootIds: cloneSet(state.selectedSqpRootIds),
+    selectedSqpTermIds: cloneSet(state.selectedSqpTermIds),
+    expandedSqpRootIds: cloneSet(state.expandedSqpRootIds),
+    hasInitializedSqpSelection: state.hasInitializedSqpSelection,
+    selectedScpAsinIds: cloneSet(state.selectedScpAsinIds),
+    hasInitializedScpSelection: state.hasInitializedScpSelection,
+    selectedBusinessReportAsinIds: cloneSet(state.selectedBusinessReportAsinIds),
+    hasInitializedBusinessReportSelection: state.hasInitializedBusinessReportSelection,
+    selectedCompetitorRootIds: cloneSet(state.selectedCompetitorRootIds),
+    selectedCompetitorTermIds: cloneSet(state.selectedCompetitorTermIds),
+    expandedCompetitorRootIds: cloneSet(state.expandedCompetitorRootIds),
+    hasInitializedCompetitorSelection: state.hasInitializedCompetitorSelection,
+  }
+}
+
+export function applyWeekScopedPatch(
+  state: WprDashboardState,
+  patch: Partial<WprDashboardState>,
+): Partial<WprDashboardState> {
+  const mergedState = {
+    ...state,
+    ...patch,
+  } satisfies WprDashboardState
+
+  if (mergedState.selectedWeek === null) {
+    return patch
+  }
+
+  return {
+    ...patch,
+    weekStateByWeek: {
+      ...mergedState.weekStateByWeek,
+      [mergedState.selectedWeek]: captureWeekScopedState(mergedState),
+    },
+  }
+}
+
+export function switchDashboardWeek(
+  state: WprDashboardState,
+  nextWeek: WeekLabel,
+): Pick<WprDashboardState, 'selectedWeek' | 'weekStateByWeek'> & WprWeekScopedState {
+  if (state.selectedWeek === nextWeek) {
+    return {
+      selectedWeek: nextWeek,
+      weekStateByWeek: state.weekStateByWeek,
+      ...captureWeekScopedState(state),
+    }
+  }
+
+  const weekStateByWeek: Partial<Record<WeekLabel, WprWeekScopedState>> = {
+    ...state.weekStateByWeek,
+  }
+  if (state.selectedWeek !== null) {
+    weekStateByWeek[state.selectedWeek] = captureWeekScopedState(state)
+  }
+
+  const nextWeekState = weekStateByWeek[nextWeek]
+
+  return {
+    selectedWeek: nextWeek,
+    weekStateByWeek,
+    ...(nextWeekState === undefined ? createEmptyWeekScopedState() : captureWeekScopedState(nextWeekState)),
+  }
+}
+
+export function wprStateReplacer(_key: string, value: unknown): unknown {
+  if (value instanceof Set) {
+    return {
+      [WPR_SET_TAG]: Array.from(value),
+    }
+  }
+
+  return value
+}
+
+export function wprStateReviver(_key: string, value: unknown): unknown {
+  if (isSerializedWprSet(value)) {
+    return new Set(value[WPR_SET_TAG])
+  }
+
+  return value
+}
+
+export function createInitialDashboardState(defaultWeek: WeekLabel | null): WprDashboardState {
+  return {
+    activeTab: 'sqp',
+    selectedWeek: defaultWeek,
+    weekStateByWeek: {},
+    ...createEmptyWeekScopedState(),
     compareOrganicMode: 'map',
     sqpTableSort: { key: 'query_volume', dir: 'desc' },
     scpTableSort: { key: 'purchases', dir: 'desc' },

--- a/apps/argus/stores/wpr-store.ts
+++ b/apps/argus/stores/wpr-store.ts
@@ -1,9 +1,15 @@
 'use client';
 
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 import {
+  applyWeekScopedPatch,
+  captureWeekScopedState,
   createInitialDashboardState,
+  switchDashboardWeek,
   toggleSetMember,
+  wprStateReplacer,
+  wprStateReviver,
   type WprBrWowVisible,
   type WprCompWowVisible,
   type WprCompareOrganicMode,
@@ -51,121 +57,159 @@ type WprStore = WprDashboardState & {
   setCompWowVisible: (compWowVisible: WprCompWowVisible) => void;
 };
 
-export const useWprStore = create<WprStore>((set) => ({
-  ...createInitialDashboardState(null),
-  replaceState: (nextState) => {
-    set(nextState);
-  },
-  setActiveTab: (activeTab) => {
-    set({ activeTab });
-  },
-  setSelectedWeek: (selectedWeek) => {
-    set({ selectedWeek });
-  },
-  setSelectedClusterId: (selectedClusterId) => {
-    set({ selectedClusterId });
-  },
-  setSelectedSqpRootIds: (rootIds) => {
-    set({ selectedSqpRootIds: new Set(rootIds) });
-  },
-  setSelectedSqpTermIds: (termIds) => {
-    set({ selectedSqpTermIds: new Set(termIds) });
-  },
-  setExpandedSqpRootIds: (rootIds) => {
-    set({ expandedSqpRootIds: new Set(rootIds) });
-  },
-  toggleSelectedSqpRootId: (rootId) => {
-    set((state) => ({
-      selectedSqpRootIds: toggleSetMember(state.selectedSqpRootIds, rootId),
-    }));
-  },
-  toggleSelectedSqpTermId: (termId) => {
-    set((state) => ({
-      selectedSqpTermIds: toggleSetMember(state.selectedSqpTermIds, termId),
-    }));
-  },
-  toggleExpandedSqpRootId: (rootId) => {
-    set((state) => ({
-      expandedSqpRootIds: toggleSetMember(state.expandedSqpRootIds, rootId),
-    }));
-  },
-  setHasInitializedSqpSelection: (value) => {
-    set({ hasInitializedSqpSelection: value });
-  },
-  toggleSelectedScpAsinId: (asinId) => {
-    set((state) => ({
-      selectedScpAsinIds: toggleSetMember(state.selectedScpAsinIds, asinId),
-    }));
-  },
-  setSelectedScpAsinIds: (asinIds) => {
-    set({ selectedScpAsinIds: new Set(asinIds) });
-  },
-  setHasInitializedScpSelection: (value) => {
-    set({ hasInitializedScpSelection: value });
-  },
-  toggleSelectedBusinessReportAsinId: (asinId) => {
-    set((state) => ({
-      selectedBusinessReportAsinIds: toggleSetMember(state.selectedBusinessReportAsinIds, asinId),
-    }));
-  },
-  setSelectedBusinessReportAsinIds: (asinIds) => {
-    set({ selectedBusinessReportAsinIds: new Set(asinIds) });
-  },
-  setHasInitializedBusinessReportSelection: (value) => {
-    set({ hasInitializedBusinessReportSelection: value });
-  },
-  toggleSelectedCompetitorRootId: (rootId) => {
-    set((state) => ({
-      selectedCompetitorRootIds: toggleSetMember(state.selectedCompetitorRootIds, rootId),
-    }));
-  },
-  toggleSelectedCompetitorTermId: (termId) => {
-    set((state) => ({
-      selectedCompetitorTermIds: toggleSetMember(state.selectedCompetitorTermIds, termId),
-    }));
-  },
-  toggleExpandedCompetitorRootId: (rootId) => {
-    set((state) => ({
-      expandedCompetitorRootIds: toggleSetMember(state.expandedCompetitorRootIds, rootId),
-    }));
-  },
-  setSelectedCompetitorRootIds: (rootIds) => {
-    set({ selectedCompetitorRootIds: new Set(rootIds) });
-  },
-  setSelectedCompetitorTermIds: (termIds) => {
-    set({ selectedCompetitorTermIds: new Set(termIds) });
-  },
-  setExpandedCompetitorRootIds: (rootIds) => {
-    set({ expandedCompetitorRootIds: new Set(rootIds) });
-  },
-  setHasInitializedCompetitorSelection: (value) => {
-    set({ hasInitializedCompetitorSelection: value });
-  },
-  setCompareOrganicMode: (compareOrganicMode) => {
-    set({ compareOrganicMode });
-  },
-  setSqpTableSort: (sqpTableSort) => {
-    set({ sqpTableSort });
-  },
-  setScpTableSort: (scpTableSort) => {
-    set({ scpTableSort });
-  },
-  setBrTableSort: (brTableSort) => {
-    set({ brTableSort });
-  },
-  setCompetitorTableSort: (competitorTableSort) => {
-    set({ competitorTableSort });
-  },
-  setSqpWowVisible: (sqpWowVisible) => {
-    set({ sqpWowVisible });
-  },
-  setScpWowVisible: (scpWowVisible) => {
-    set({ scpWowVisible });
-  },
-  setBrWowVisible: (brWowVisible) => {
-    set({ brWowVisible });
-  },
-  setCompWowVisible: (compWowVisible) => {
-    set({ compWowVisible });
-  },
-}));
+export const useWprStore = create<WprStore>()(
+  persist(
+    (set) => {
+      const setDashboardState = (
+        patch: Partial<WprDashboardState> | ((state: WprStore) => Partial<WprDashboardState>),
+      ) => {
+        set((state) => {
+          const nextPatch = typeof patch === 'function' ? patch(state) : patch;
+          return applyWeekScopedPatch(state, nextPatch);
+        });
+      };
+
+      return {
+        ...createInitialDashboardState(null),
+        replaceState: (nextState) => {
+          setDashboardState(nextState);
+        },
+        setActiveTab: (activeTab) => {
+          setDashboardState({ activeTab });
+        },
+        setSelectedWeek: (selectedWeek) => {
+          set((state) => switchDashboardWeek(state, selectedWeek));
+        },
+        setSelectedClusterId: (selectedClusterId) => {
+          setDashboardState({ selectedClusterId });
+        },
+        setSelectedSqpRootIds: (rootIds) => {
+          setDashboardState({ selectedSqpRootIds: new Set(rootIds) });
+        },
+        setSelectedSqpTermIds: (termIds) => {
+          setDashboardState({ selectedSqpTermIds: new Set(termIds) });
+        },
+        setExpandedSqpRootIds: (rootIds) => {
+          setDashboardState({ expandedSqpRootIds: new Set(rootIds) });
+        },
+        toggleSelectedSqpRootId: (rootId) => {
+          setDashboardState((state) => ({
+            selectedSqpRootIds: toggleSetMember(state.selectedSqpRootIds, rootId),
+          }));
+        },
+        toggleSelectedSqpTermId: (termId) => {
+          setDashboardState((state) => ({
+            selectedSqpTermIds: toggleSetMember(state.selectedSqpTermIds, termId),
+          }));
+        },
+        toggleExpandedSqpRootId: (rootId) => {
+          setDashboardState((state) => ({
+            expandedSqpRootIds: toggleSetMember(state.expandedSqpRootIds, rootId),
+          }));
+        },
+        setHasInitializedSqpSelection: (value) => {
+          setDashboardState({ hasInitializedSqpSelection: value });
+        },
+        toggleSelectedScpAsinId: (asinId) => {
+          setDashboardState((state) => ({
+            selectedScpAsinIds: toggleSetMember(state.selectedScpAsinIds, asinId),
+          }));
+        },
+        setSelectedScpAsinIds: (asinIds) => {
+          setDashboardState({ selectedScpAsinIds: new Set(asinIds) });
+        },
+        setHasInitializedScpSelection: (value) => {
+          setDashboardState({ hasInitializedScpSelection: value });
+        },
+        toggleSelectedBusinessReportAsinId: (asinId) => {
+          setDashboardState((state) => ({
+            selectedBusinessReportAsinIds: toggleSetMember(state.selectedBusinessReportAsinIds, asinId),
+          }));
+        },
+        setSelectedBusinessReportAsinIds: (asinIds) => {
+          setDashboardState({ selectedBusinessReportAsinIds: new Set(asinIds) });
+        },
+        setHasInitializedBusinessReportSelection: (value) => {
+          setDashboardState({ hasInitializedBusinessReportSelection: value });
+        },
+        toggleSelectedCompetitorRootId: (rootId) => {
+          setDashboardState((state) => ({
+            selectedCompetitorRootIds: toggleSetMember(state.selectedCompetitorRootIds, rootId),
+          }));
+        },
+        toggleSelectedCompetitorTermId: (termId) => {
+          setDashboardState((state) => ({
+            selectedCompetitorTermIds: toggleSetMember(state.selectedCompetitorTermIds, termId),
+          }));
+        },
+        toggleExpandedCompetitorRootId: (rootId) => {
+          setDashboardState((state) => ({
+            expandedCompetitorRootIds: toggleSetMember(state.expandedCompetitorRootIds, rootId),
+          }));
+        },
+        setSelectedCompetitorRootIds: (rootIds) => {
+          setDashboardState({ selectedCompetitorRootIds: new Set(rootIds) });
+        },
+        setSelectedCompetitorTermIds: (termIds) => {
+          setDashboardState({ selectedCompetitorTermIds: new Set(termIds) });
+        },
+        setExpandedCompetitorRootIds: (rootIds) => {
+          setDashboardState({ expandedCompetitorRootIds: new Set(rootIds) });
+        },
+        setHasInitializedCompetitorSelection: (value) => {
+          setDashboardState({ hasInitializedCompetitorSelection: value });
+        },
+        setCompareOrganicMode: (compareOrganicMode) => {
+          setDashboardState({ compareOrganicMode });
+        },
+        setSqpTableSort: (sqpTableSort) => {
+          setDashboardState({ sqpTableSort });
+        },
+        setScpTableSort: (scpTableSort) => {
+          setDashboardState({ scpTableSort });
+        },
+        setBrTableSort: (brTableSort) => {
+          setDashboardState({ brTableSort });
+        },
+        setCompetitorTableSort: (competitorTableSort) => {
+          setDashboardState({ competitorTableSort });
+        },
+        setSqpWowVisible: (sqpWowVisible) => {
+          setDashboardState({ sqpWowVisible });
+        },
+        setScpWowVisible: (scpWowVisible) => {
+          setDashboardState({ scpWowVisible });
+        },
+        setBrWowVisible: (brWowVisible) => {
+          setDashboardState({ brWowVisible });
+        },
+        setCompWowVisible: (compWowVisible) => {
+          setDashboardState({ compWowVisible });
+        },
+      };
+    },
+    {
+      name: 'argus-wpr-dashboard',
+      version: 1,
+      storage: createJSONStorage(() => localStorage, {
+        replacer: wprStateReplacer,
+        reviver: wprStateReviver,
+      }),
+      partialize: (state) => ({
+        activeTab: state.activeTab,
+        selectedWeek: state.selectedWeek,
+        weekStateByWeek: state.weekStateByWeek,
+        ...captureWeekScopedState(state),
+        compareOrganicMode: state.compareOrganicMode,
+        sqpTableSort: state.sqpTableSort,
+        scpTableSort: state.scpTableSort,
+        brTableSort: state.brTableSort,
+        competitorTableSort: state.competitorTableSort,
+        sqpWowVisible: state.sqpWowVisible,
+        scpWowVisible: state.scpWowVisible,
+        brWowVisible: state.brWowVisible,
+        compWowVisible: state.compWowVisible,
+      }),
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- add week-scoped WPR dashboard state helpers and persisted Zustand snapshots
- keep chart shells and change summaries standardized across SQP, SCP, BR, and TST
- preserve WPR selections and toggles per week instead of bleeding state across weeks

## Testing
- pnpm exec tsx --test components/wpr/chart-change-markers.test.ts components/wpr/wpr-change-props.test.ts components/wpr/tabs/sqp-weekly-panel.test.tsx lib/wpr/dashboard-state.test.ts
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/argus type-check
