### PR TITLE
fix(argus): standardize wpr panel shells

### DIFF
--- a/apps/argus/components/wpr/tabs/business-reports-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-selection-table.tsx
@@ -1,18 +1,19 @@
 'use client'
 
 import {
-  Box,
   Checkbox,
-  Stack,
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
   TableSortLabel,
-  Typography,
 } from '@mui/material'
+import {
+  WprSelectionPanel,
+  wprSelectionHeaderCellSx,
+  wprSelectionMetricCellSx,
+} from '@/components/wpr/wpr-selection-panel'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import type { WprSortDirection, WprSortState } from '@/lib/wpr/dashboard-state'
 import {
@@ -23,7 +24,6 @@ import {
   sortBusinessReportsRows,
 } from '@/lib/wpr/business-reports-view-model'
 import { formatCount, formatMoney, formatPercent } from '@/lib/wpr/format'
-import { panelSx } from '@/lib/wpr/panel-tokens'
 
 const BR_COLUMNS: Array<{ key: BusinessReportsSortKey; label: string }> = [
   { key: 'asin', label: 'ASIN' },
@@ -65,9 +65,7 @@ function MetricCell({
     <TableCell
       align={align}
       sx={{
-        fontSize: '0.72rem',
-        color: 'rgba(255,255,255,0.76)',
-        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        ...wprSelectionMetricCellSx,
         whiteSpace: 'pre-line',
       }}
     >
@@ -98,47 +96,16 @@ export default function BusinessReportsSelectionTable({
   const rows = sortBusinessReportsRows(viewModel.rows, sortState, selectedWeekLabel)
 
   return (
-    <Box sx={panelSx}>
-      <Box
-        sx={{
-          px: 2,
-          py: 1.3,
-          borderBottom: '1px solid rgba(255,255,255,0.06)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.3}>
-          <Typography
-            sx={{
-              fontSize: '0.64rem',
-              fontWeight: 700,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              color: 'rgba(255,255,255,0.54)',
-            }}
-          >
-            Business Reports Selection
-          </Typography>
-          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: 'rgba(255,255,255,0.88)' }}>
-            {`Selected week · ${viewModel.selectedIds.length} / ${viewModel.allIds.length} ASINs`}
-          </Typography>
-        </Stack>
-      </Box>
-
-      <TableContainer sx={{ maxHeight: 640 }}>
+    <WprSelectionPanel
+      title="Business Reports Selection"
+      summary={`Selected week · ${viewModel.selectedIds.length} / ${viewModel.allIds.length} ASINs`}
+    >
         <Table stickyHeader size="small" sx={{ minWidth: 1120 }}>
           <TableHead>
             <TableRow>
               <TableCell
                 padding="checkbox"
-                sx={{
-                  bgcolor: 'rgba(0, 20, 35, 0.96)',
-                  borderBottom: '1px solid rgba(255,255,255,0.08)',
-                }}
+                sx={wprSelectionHeaderCellSx}
               >
                 <Checkbox
                   size="small"
@@ -158,10 +125,7 @@ export default function BusinessReportsSelectionTable({
                 <TableCell
                   key={column.key}
                   align={column.key === 'asin' ? 'left' : 'right'}
-                  sx={{
-                    bgcolor: 'rgba(0, 20, 35, 0.96)',
-                    borderBottom: '1px solid rgba(255,255,255,0.08)',
-                  }}
+                  sx={wprSelectionHeaderCellSx}
                 >
                   <TableSortLabel
                     active={sortState.key === column.key}
@@ -256,7 +220,6 @@ export default function BusinessReportsSelectionTable({
             })}
           </TableBody>
         </Table>
-      </TableContainer>
-    </Box>
+    </WprSelectionPanel>
   )
 }

--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { useEffect, useRef, useState, type JSX, type RefObject } from 'react'
-import { Box, Button, Stack, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
+import { Box, Button, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
+import {
+  WprAnalyticsFooter,
+  WprAnalyticsMetric,
+  WprAnalyticsPanel,
+} from '@/components/wpr/wpr-analytics-panel'
 import {
   Bar,
   CartesianGrid,
@@ -28,7 +33,7 @@ import {
   type BusinessReportsSelectionViewModel,
 } from '@/lib/wpr/business-reports-view-model'
 import { formatCount, formatPercent } from '@/lib/wpr/format'
-import { chartToggleButtonSx, panelSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
+import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprBusinessDailyPoint, WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
 import BusinessReportsSelectionTable from './business-reports-selection-table'
@@ -97,75 +102,6 @@ function dailyWindowLabel(dailySeries: WprBusinessDailyPoint[]): string {
   }
 
   return `${first.day_label} to ${last.day_label}`
-}
-
-function MetricChip({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <Box>
-      <Typography
-        sx={{
-          fontSize: '0.58rem',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.12em',
-          color: textMuted,
-          mb: 0.35,
-        }}
-      >
-        {label}
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: '1.18rem',
-          fontWeight: 700,
-          letterSpacing: '-0.04em',
-          color: 'rgba(255,255,255,0.92)',
-        }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  )
-}
-
-function Footer({
-  items,
-}: {
-  items: string[]
-}) {
-  return (
-    <Box
-      sx={{
-        px: 2.5,
-        py: 1.2,
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 2,
-        borderTop: subtleBorder,
-        color: textMuted,
-      }}
-    >
-      {items.map((item) => (
-        <Typography
-          key={item}
-          sx={{
-            fontSize: '0.64rem',
-            fontWeight: 600,
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-          }}
-        >
-          {item}
-        </Typography>
-      ))}
-    </Box>
-  )
 }
 
 type OverlayLayout = {
@@ -644,67 +580,38 @@ export default function BusinessReportsTab({
 
   return (
     <Stack spacing={2}>
-      <Box sx={panelSx}>
-        <Box
-          sx={{
-            px: 2.5,
-            pt: 2,
-            pb: 1.25,
-            borderBottom: subtleBorder,
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: 2,
-            flexWrap: 'wrap',
-          }}
-        >
-          <Stack spacing={0.45}>
-            <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
-              {heroContent.name}
-            </Typography>
-            <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
-              {heroContent.meta.join(' · ')}
-            </Typography>
-          </Stack>
-        </Box>
-
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
-            gap: 1.5,
-            px: 2.5,
-            py: 1.75,
-            borderBottom: subtleBorder,
-          }}
-        >
-          <MetricChip
-            label="Sessions"
-            value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.sessions)}
-          />
-          <MetricChip
-            label="Order Item %"
-            value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatPercent(currentMetrics.order_item_session_percentage)}
-          />
-          <MetricChip
-            label="Unit Session %"
-            value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatPercent(currentMetrics.unit_session_percentage)}
-          />
-        </Box>
-
-        <Box sx={{ p: 2.5 }}>
-          <BusinessReportsChart
-            viewMode={viewMode}
-            weekly={viewModel.weekly}
-            dailySeries={dailyChartSeries}
-            changeEntries={changeEntries}
-            wowVisible={brWowVisible}
-            setWowVisible={setBrWowVisible}
-            setViewMode={setViewMode}
-          />
-        </Box>
-
-        <Footer items={footerItems} />
-      </Box>
+      <WprAnalyticsPanel
+        title={heroContent.name}
+        meta={heroContent.meta}
+        metricColumns={{ xs: 2, md: 3 }}
+        metrics={
+          <>
+            <WprAnalyticsMetric
+              label="Sessions"
+              value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.sessions)}
+            />
+            <WprAnalyticsMetric
+              label="Order Item %"
+              value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatPercent(currentMetrics.order_item_session_percentage)}
+            />
+            <WprAnalyticsMetric
+              label="Unit Session %"
+              value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatPercent(currentMetrics.unit_session_percentage)}
+            />
+          </>
+        }
+        footer={<WprAnalyticsFooter items={footerItems} />}
+      >
+        <BusinessReportsChart
+          viewMode={viewMode}
+          weekly={viewModel.weekly}
+          dailySeries={dailyChartSeries}
+          changeEntries={changeEntries}
+          wowVisible={brWowVisible}
+          setWowVisible={setBrWowVisible}
+          setViewMode={setViewMode}
+        />
+      </WprAnalyticsPanel>
 
       <BusinessReportsSelectionTable
         selectedWeekLabel={selectedWeekLabel}

--- a/apps/argus/components/wpr/tabs/scp-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/scp-selection-table.tsx
@@ -1,18 +1,19 @@
 'use client'
 
 import {
-  Box,
   Checkbox,
-  Stack,
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
   TableSortLabel,
-  Typography,
 } from '@mui/material'
+import {
+  WprSelectionPanel,
+  wprSelectionHeaderCellSx,
+  wprSelectionMetricCellSx,
+} from '@/components/wpr/wpr-selection-panel'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import type { WprSortDirection, WprSortState } from '@/lib/wpr/dashboard-state'
 import {
@@ -25,7 +26,6 @@ import {
   sortScpRows,
 } from '@/lib/wpr/scp-view-model'
 import { formatCount, formatMoney, formatPercent } from '@/lib/wpr/format'
-import { panelSx } from '@/lib/wpr/panel-tokens'
 
 const SCP_COLUMNS: Array<{ key: ScpSortKey; label: string }> = [
   { key: 'asin', label: 'ASIN' },
@@ -71,9 +71,7 @@ function MetricCell({
     <TableCell
       align={align}
       sx={{
-        fontSize: '0.72rem',
-        color: 'rgba(255,255,255,0.76)',
-        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        ...wprSelectionMetricCellSx,
         whiteSpace: 'pre-line',
       }}
     >
@@ -105,47 +103,16 @@ export default function ScpSelectionTable({
   const rows = sortScpRows(viewModel.rows, sortState, selectedWeekLabel, viewModel.current)
 
   return (
-    <Box sx={panelSx}>
-      <Box
-        sx={{
-          px: 2,
-          py: 1.3,
-          borderBottom: '1px solid rgba(255,255,255,0.06)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.3}>
-          <Typography
-            sx={{
-              fontSize: '0.64rem',
-              fontWeight: 700,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              color: 'rgba(255,255,255,0.54)',
-            }}
-          >
-            SCP Selection
-          </Typography>
-          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: 'rgba(255,255,255,0.88)' }}>
-            {`Selected week · ${viewModel.selectedIds.length} / ${viewModel.allIds.length} ASINs`}
-          </Typography>
-        </Stack>
-      </Box>
-
-      <TableContainer sx={{ maxHeight: 640 }}>
+    <WprSelectionPanel
+      title="SCP Selection"
+      summary={`Selected week · ${viewModel.selectedIds.length} / ${viewModel.allIds.length} ASINs`}
+    >
         <Table stickyHeader size="small" sx={{ minWidth: 1280 }}>
           <TableHead>
             <TableRow>
               <TableCell
                 padding="checkbox"
-                sx={{
-                  bgcolor: 'rgba(0, 20, 35, 0.96)',
-                  borderBottom: '1px solid rgba(255,255,255,0.08)',
-                }}
+                sx={wprSelectionHeaderCellSx}
               >
                 <Checkbox
                   size="small"
@@ -165,10 +132,7 @@ export default function ScpSelectionTable({
                 <TableCell
                   key={column.key}
                   align={column.key === 'asin' ? 'left' : 'right'}
-                  sx={{
-                    bgcolor: 'rgba(0, 20, 35, 0.96)',
-                    borderBottom: '1px solid rgba(255,255,255,0.08)',
-                  }}
+                  sx={wprSelectionHeaderCellSx}
                 >
                   <TableSortLabel
                     active={sortState.key === column.key}
@@ -246,7 +210,6 @@ export default function ScpSelectionTable({
             })}
           </TableBody>
         </Table>
-      </TableContainer>
-    </Box>
+    </WprSelectionPanel>
   )
 }

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import { useEffect, type JSX } from 'react'
-import { Box, Button, Stack, Typography } from '@mui/material'
+import { Box, Button, Stack } from '@mui/material'
+import {
+  WprAnalyticsFooter,
+  WprAnalyticsMetric,
+  WprAnalyticsPanel,
+} from '@/components/wpr/wpr-analytics-panel'
 import {
   CartesianGrid,
   Line,
@@ -22,7 +27,7 @@ import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/compo
 import type { WprScpWowVisible } from '@/lib/wpr/dashboard-state'
 import { formatCount, formatMoney } from '@/lib/wpr/format'
 import { createScpSelectionViewModel, type ScpSelectionViewModel } from '@/lib/wpr/scp-view-model'
-import { chartToggleButtonSx, panelSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
+import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
 import ScpSelectionTable from './scp-selection-table'
@@ -46,75 +51,6 @@ function windowRangeLabel(weeks: string[]): string {
   }
 
   return `${weeks[0]} - ${weeks[weeks.length - 1]}`
-}
-
-function MetricChip({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <Box>
-      <Typography
-        sx={{
-          fontSize: '0.58rem',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.12em',
-          color: textMuted,
-          mb: 0.35,
-        }}
-      >
-        {label}
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: '1.18rem',
-          fontWeight: 700,
-          letterSpacing: '-0.04em',
-          color: 'rgba(255,255,255,0.92)',
-        }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  )
-}
-
-function Footer({
-  items,
-}: {
-  items: string[]
-}) {
-  return (
-    <Box
-      sx={{
-        px: 2.5,
-        py: 1.2,
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 2,
-        borderTop: subtleBorder,
-        color: textMuted,
-      }}
-    >
-      {items.map((item) => (
-        <Typography
-          key={item}
-          sx={{
-            fontSize: '0.64rem',
-            fontWeight: 600,
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-          }}
-        >
-          {item}
-        </Typography>
-      ))}
-    </Box>
-  )
 }
 
 function ScpWeeklyChart({
@@ -374,64 +310,35 @@ export default function ScpTab({
 
   return (
     <Stack spacing={2}>
-      <Box sx={panelSx}>
-        <Box
-          sx={{
-            px: 2.5,
-            pt: 2,
-            pb: 1.25,
-            borderBottom: subtleBorder,
-            display: 'flex',
-            justifyContent: 'space-between',
-            gap: 2,
-            flexWrap: 'wrap',
-          }}
-        >
-          <Stack spacing={0.45}>
-            <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
-              {heroContent.name}
-            </Typography>
-            <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
-              {heroContent.meta.join(' · ')}
-            </Typography>
-          </Stack>
-        </Box>
-
-        <Box
-          sx={{
-            display: 'grid',
-            gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
-            gap: 1.5,
-            px: 2.5,
-            py: 1.75,
-            borderBottom: subtleBorder,
-          }}
-        >
-          <MetricChip
-            label="Search Impressions"
-            value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.impressions)}
-          />
-          <MetricChip
-            label="Search Purchases"
-            value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.purchases)}
-          />
-          <MetricChip
-            label="Search Sales"
-            value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatMoney(currentMetrics.sales)}
-          />
-        </Box>
-
-        <Box sx={{ p: 2.5 }}>
-          <ScpWeeklyChart
-            weekly={viewModel.weekly}
-            changeEntries={changeEntries}
-            wowVisible={scpWowVisible}
-            setWowVisible={setScpWowVisible}
-          />
-        </Box>
-
-        <Footer items={footerItems} />
-      </Box>
+      <WprAnalyticsPanel
+        title={heroContent.name}
+        meta={heroContent.meta}
+        metricColumns={{ xs: 2, md: 3 }}
+        metrics={
+          <>
+            <WprAnalyticsMetric
+              label="Search Impressions"
+              value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.impressions)}
+            />
+            <WprAnalyticsMetric
+              label="Search Purchases"
+              value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.purchases)}
+            />
+            <WprAnalyticsMetric
+              label="Search Sales"
+              value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatMoney(currentMetrics.sales)}
+            />
+          </>
+        }
+        footer={<WprAnalyticsFooter items={footerItems} />}
+      >
+        <ScpWeeklyChart
+          weekly={viewModel.weekly}
+          changeEntries={changeEntries}
+          wowVisible={scpWowVisible}
+          setWowVisible={setScpWowVisible}
+        />
+      </WprAnalyticsPanel>
 
       <ScpSelectionTable
         selectedWeekLabel={selectedWeekLabel}

--- a/apps/argus/components/wpr/tabs/sqp-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-selection-table.tsx
@@ -8,12 +8,16 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
   TableSortLabel,
   Typography,
 } from '@mui/material'
+import {
+  WprSelectionPanel,
+  wprSelectionHeaderCellSx,
+  wprSelectionMetricCellSx,
+} from '@/components/wpr/wpr-selection-panel'
 import type { WprSortState } from '@/lib/wpr/dashboard-state'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import {
@@ -25,13 +29,6 @@ import {
   type SqpSortKey,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprSortDirection } from '@/lib/wpr/dashboard-state'
-
-const PANEL_SX = {
-  bgcolor: 'rgba(0, 20, 35, 0.85)',
-  border: '1px solid rgba(255,255,255,0.07)',
-  borderRadius: '12px',
-  overflow: 'hidden',
-} as const
 
 const SQP_COLUMNS: Array<{ key: SqpSortKey; label: string }> = [
   { key: 'term', label: 'Term' },
@@ -110,9 +107,7 @@ function MetricCell({
     <TableCell
       align={align}
       sx={{
-        fontSize: '0.72rem',
-        color: 'rgba(255,255,255,0.76)',
-        borderBottom: '1px solid rgba(255,255,255,0.04)',
+        ...wprSelectionMetricCellSx,
       }}
     >
       {children}
@@ -160,47 +155,16 @@ export default function SqpSelectionTable({
   const sortKey = toSqpSortKey(sortState.key)
 
   return (
-    <Box sx={PANEL_SX}>
-      <Box
-        sx={{
-          px: 2,
-          py: 1.3,
-          borderBottom: '1px solid rgba(255,255,255,0.06)',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.3}>
-          <Typography
-            sx={{
-              fontSize: '0.64rem',
-              fontWeight: 700,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              color: 'rgba(255,255,255,0.54)',
-            }}
-          >
-            SQP Selection
-          </Typography>
-          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: 'rgba(255,255,255,0.88)' }}>
-            {`Selected week · ${viewModel.selectedRootIds.length} roots · ${viewModel.selectedTermIds.length} terms`}
-          </Typography>
-        </Stack>
-      </Box>
-
-      <TableContainer sx={{ maxHeight: 640 }}>
+    <WprSelectionPanel
+      title="SQP Selection"
+      summary={`Selected week · ${viewModel.selectedRootIds.length} roots · ${viewModel.selectedTermIds.length} terms`}
+    >
         <Table stickyHeader size="small" sx={{ minWidth: 960 }}>
           <TableHead>
             <TableRow>
               <TableCell
                 padding="checkbox"
-                sx={{
-                  bgcolor: 'rgba(0, 20, 35, 0.96)',
-                  borderBottom: '1px solid rgba(255,255,255,0.08)',
-                }}
+                sx={wprSelectionHeaderCellSx}
               >
                 <Checkbox
                   size="small"
@@ -219,10 +183,7 @@ export default function SqpSelectionTable({
               {SQP_COLUMNS.map((column) => (
                 <TableCell
                   key={column.key}
-                  sx={{
-                    bgcolor: 'rgba(0, 20, 35, 0.96)',
-                    borderBottom: '1px solid rgba(255,255,255,0.08)',
-                  }}
+                  sx={wprSelectionHeaderCellSx}
                   align={column.key === 'term' ? 'left' : 'right'}
                 >
                   <TableSortLabel
@@ -415,7 +376,6 @@ export default function SqpSelectionTable({
             })}
           </TableBody>
         </Table>
-      </TableContainer>
-    </Box>
+    </WprSelectionPanel>
   )
 }

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -1,8 +1,13 @@
 'use client'
 
 import React, { useState, type JSX } from 'react'
-import { Box, Button, Stack, Typography } from '@mui/material'
+import { Button } from '@mui/material'
 import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
+import {
+  WprAnalyticsFooter,
+  WprAnalyticsMetric,
+  WprAnalyticsPanel,
+} from '@/components/wpr/wpr-analytics-panel'
 import {
   buildChangeMarkerLabelParts,
   buildChangeMarkerLookup,
@@ -12,7 +17,7 @@ import {
 import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
 import type { WprSqpWowVisible } from '@/lib/wpr/dashboard-state'
 import { formatCompactNumber, formatCount } from '@/lib/wpr/format'
-import { chartToggleButtonSx, panelSx, subtleBorder, textSecondary } from '@/lib/wpr/panel-tokens'
+import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import {
   rateRatio,
   type SqpAggregatedMetrics,
@@ -73,7 +78,7 @@ function blankMetricValue(): string {
   return '---'
 }
 
-function SqpFooter({
+function buildFooterItems({
   scopeType,
   rootCount,
   termCount,
@@ -97,68 +102,7 @@ function SqpFooter({
     `Chart history: ${historyLabel}`,
   ]
 
-  return (
-    <Box
-      sx={{
-        px: 2.5,
-        py: 1.2,
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 2,
-        borderTop: '1px solid rgba(255,255,255,0.06)',
-        color: 'rgba(255,255,255,0.62)',
-      }}
-    >
-      {footerItems.map((item) => (
-        <Typography
-          key={item}
-          sx={{
-            fontSize: '0.64rem',
-            fontWeight: 600,
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-          }}
-        >
-          {item}
-        </Typography>
-      ))}
-    </Box>
-  )
-}
-
-function MetricChip({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <Box>
-      <Typography
-        sx={{
-          fontSize: '0.58rem',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.12em',
-          color: 'rgba(255,255,255,0.54)',
-          mb: 0.35,
-        }}
-      >
-        {label}
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: '1.18rem',
-          fontWeight: 700,
-          letterSpacing: '-0.04em',
-          color: 'rgba(255,255,255,0.92)',
-        }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  )
+  return footerItems
 }
 
 function buildRatioFillPolygons(
@@ -697,71 +641,44 @@ export default function SqpWeeklyPanel({
   selectedWeekLabel: string
   historyLabel: string
 }) {
-  return (
-    <Box sx={panelSx}>
-      <Box
-        sx={{
-          px: 2.5,
-          pt: 2,
-          pb: 1.25,
-          borderBottom: subtleBorder,
-          display: 'flex',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.45}>
-          <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
-            {heroContent.name}
-          </Typography>
-          <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
-            {heroContent.meta.join(' · ')}
-          </Typography>
-        </Stack>
-      </Box>
+  const footerItems = buildFooterItems({
+    scopeType,
+    rootCount: selectedRootCount,
+    termCount: selectedTermCount,
+    totalTermCount,
+    selectedWeekLabel,
+    historyLabel,
+  })
 
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(3, 1fr)' },
-          gap: 1.5,
-          px: 2.5,
-          py: 1.75,
-          borderBottom: subtleBorder,
-        }}
-      >
-          <MetricChip
+  return (
+    <WprAnalyticsPanel
+      title={heroContent.name}
+      meta={heroContent.meta}
+      metricColumns={{ xs: 2, md: 3 }}
+      metrics={
+        <>
+          <WprAnalyticsMetric
             label="Query Volume"
             value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCompactNumber(currentMetrics.query_volume)}
           />
-          <MetricChip
+          <WprAnalyticsMetric
             label="Market Purchases"
             value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.market_purchases)}
           />
-          <MetricChip
+          <WprAnalyticsMetric
             label="Our Purchases"
             value={blankTopValues || currentMetrics === null ? blankMetricValue() : formatCount(currentMetrics.asin_purchases)}
           />
-      </Box>
-
-      <Box sx={{ px: 2.5, pb: 2.2 }}>
-        <SqpWeeklyChart
-          weekly={weekly}
-          changeEntries={changeEntries}
-          wowVisible={wowVisible}
-          setWowVisible={setWowVisible}
-        />
-      </Box>
-
-      <SqpFooter
-        scopeType={scopeType}
-        rootCount={selectedRootCount}
-        termCount={selectedTermCount}
-        totalTermCount={totalTermCount}
-        selectedWeekLabel={selectedWeekLabel}
-        historyLabel={historyLabel}
+        </>
+      }
+      footer={<WprAnalyticsFooter items={footerItems} />}
+    >
+      <SqpWeeklyChart
+        weekly={weekly}
+        changeEntries={changeEntries}
+        wowVisible={wowVisible}
+        setWowVisible={setWowVisible}
       />
-    </Box>
+    </WprAnalyticsPanel>
   )
 }

--- a/apps/argus/components/wpr/tabs/tst-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/tst-selection-table.tsx
@@ -8,12 +8,16 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableContainer,
   TableHead,
   TableRow,
   TableSortLabel,
   Typography,
 } from '@mui/material'
+import {
+  WprSelectionPanel,
+  wprSelectionHeaderCellSx,
+  wprSelectionMetricCellSx,
+} from '@/components/wpr/wpr-selection-panel'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import type { WprSortDirection, WprSortState } from '@/lib/wpr/dashboard-state'
 import {
@@ -22,7 +26,7 @@ import {
   type TstSelectionTermRow,
   type TstSelectionViewModel,
 } from '@/lib/wpr/tst-view-model'
-import { panelSx, subtleBorder, teal, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
+import { teal, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
 import { formatPercent } from '@/lib/wpr/format'
 
 type TstSortKey =
@@ -434,9 +438,8 @@ function MetricCell({
     <TableCell
       align={align}
       sx={{
-        fontSize: '0.72rem',
+        ...wprSelectionMetricCellSx,
         color: textSecondary,
-        borderBottom: '1px solid rgba(255,255,255,0.04)',
       }}
     >
       {children}
@@ -488,42 +491,14 @@ export default function TstSelectionTable({
   })
 
   return (
-    <Box sx={panelSx}>
-      <Box
-        sx={{
-          px: 2,
-          py: 1.3,
-          borderBottom: subtleBorder,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.3}>
-          <Typography
-            sx={{
-              fontSize: '0.64rem',
-              fontWeight: 700,
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              color: textMuted,
-            }}
-          >
-            TST Selection
-          </Typography>
-          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: 'rgba(255,255,255,0.88)' }}>
-            {`TST selected week · ${viewModel.rootIds.length} roots · ${viewModel.selectedTermIds.length} terms`}
-          </Typography>
-        </Stack>
-      </Box>
-
-      <TableContainer sx={{ maxHeight: 640 }}>
+    <WprSelectionPanel
+      title="TST Selection"
+      summary={`TST selected week · ${viewModel.rootIds.length} roots · ${viewModel.selectedTermIds.length} terms`}
+    >
         <Table stickyHeader size="small" sx={{ minWidth: 1320 }}>
           <TableHead>
             <TableRow>
-              <TableCell padding="checkbox" sx={{ bgcolor: 'rgba(0, 20, 35, 0.96)', borderBottom: subtleBorder }}>
+              <TableCell padding="checkbox" sx={wprSelectionHeaderCellSx}>
                 <Checkbox
                   size="small"
                   checked={allTermsChecked}
@@ -542,7 +517,7 @@ export default function TstSelectionTable({
                 <TableCell
                   key={column.key}
                   align={column.key === 'term' ? 'left' : 'right'}
-                  sx={{ bgcolor: 'rgba(0, 20, 35, 0.96)', borderBottom: subtleBorder }}
+                  sx={wprSelectionHeaderCellSx}
                 >
                   <TableSortLabel
                     active={sortState.key === column.key}
@@ -749,7 +724,6 @@ export default function TstSelectionTable({
             })}
           </TableBody>
         </Table>
-      </TableContainer>
-    </Box>
+    </WprSelectionPanel>
   )
 }

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -1,7 +1,12 @@
 'use client'
 
 import type { JSX } from 'react'
-import { Box, Button, Stack, Typography } from '@mui/material'
+import { Box, Button } from '@mui/material'
+import {
+  WprAnalyticsFooter,
+  WprAnalyticsMetric,
+  WprAnalyticsPanel,
+} from '@/components/wpr/wpr-analytics-panel'
 import {
   CartesianGrid,
   Line,
@@ -25,10 +30,6 @@ import type { TstSelectionViewModel } from '@/lib/wpr/tst-view-model'
 import type { WprChangeLogEntry, WprCompetitorSummary } from '@/lib/wpr/types'
 import {
   chartToggleButtonSx,
-  panelSx,
-  subtleBorder,
-  textMuted,
-  textSecondary,
 } from '@/lib/wpr/panel-tokens'
 import { formatPercent } from '@/lib/wpr/format'
 
@@ -39,75 +40,6 @@ type TstHeroContent = {
 
 function blankMetricValue(): string {
   return '---'
-}
-
-function MetricChip({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <Box>
-      <Typography
-        sx={{
-          fontSize: '0.58rem',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.12em',
-          color: textMuted,
-          mb: 0.35,
-        }}
-      >
-        {label}
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: '1.18rem',
-          fontWeight: 700,
-          letterSpacing: '-0.04em',
-          color: 'rgba(255,255,255,0.92)',
-        }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  )
-}
-
-function Footer({
-  items,
-}: {
-  items: string[]
-}) {
-  return (
-    <Box
-      sx={{
-        px: 2.5,
-        py: 1.2,
-        display: 'flex',
-        flexWrap: 'wrap',
-        gap: 2,
-        borderTop: subtleBorder,
-        color: textMuted,
-      }}
-    >
-      {items.map((item) => (
-        <Typography
-          key={item}
-          sx={{
-            fontSize: '0.64rem',
-            fontWeight: 600,
-            letterSpacing: '0.08em',
-            textTransform: 'uppercase',
-          }}
-        >
-          {item}
-        </Typography>
-      ))}
-    </Box>
-  )
 }
 
 function WeeklyGapChart({
@@ -286,68 +218,39 @@ export default function TstWeeklyPanel({
   }
 
   return (
-    <Box sx={panelSx}>
-      <Box
-        sx={{
-          px: 2.5,
-          pt: 2,
-          pb: 1.25,
-          borderBottom: subtleBorder,
-          display: 'flex',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.45}>
-          <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
-            {heroContent.name}
-          </Typography>
-          <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
-            {heroContent.meta.join(' · ')}
-          </Typography>
-        </Stack>
-      </Box>
-
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: { xs: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' },
-          gap: 1.5,
-          px: 2.5,
-          py: 1.75,
-          borderBottom: subtleBorder,
-        }}
-      >
-        <MetricChip
-          label="Terms Covered"
-          value={blankTopValues || current === null ? blankMetricValue() : String(current.coverage.terms_covered)}
-        />
-        <MetricChip
-          label="Term-Weeks"
-          value={blankTopValues || current === null ? blankMetricValue() : String(current.coverage.term_weeks_covered)}
-        />
-        <MetricChip
-          label="Our Click Share"
-          value={blankTopValues || current === null ? blankMetricValue() : formatPercent(current.observed.our_click_share, 1)}
-        />
-        <MetricChip
-          label={`${competitor.brand} Click Share`}
-          value={blankTopValues || current === null ? blankMetricValue() : formatPercent(current.observed.competitor_click_share, 1)}
-        />
-      </Box>
-
-        <Box sx={{ p: 2.5 }}>
-          <WeeklyGapChart
-            competitor={competitor}
-            weekly={viewModel.weekly}
-            changeEntries={changeEntries}
-            wowVisible={wowVisible}
-            setWowVisible={setWowVisible}
+    <WprAnalyticsPanel
+      title={heroContent.name}
+      meta={heroContent.meta}
+      metricColumns={{ xs: 2, md: 4 }}
+      metrics={
+        <>
+          <WprAnalyticsMetric
+            label="Terms Covered"
+            value={blankTopValues || current === null ? blankMetricValue() : String(current.coverage.terms_covered)}
           />
-        </Box>
-
-      <Footer items={footerItems} />
-    </Box>
+          <WprAnalyticsMetric
+            label="Term-Weeks"
+            value={blankTopValues || current === null ? blankMetricValue() : String(current.coverage.term_weeks_covered)}
+          />
+          <WprAnalyticsMetric
+            label="Our Click Share"
+            value={blankTopValues || current === null ? blankMetricValue() : formatPercent(current.observed.our_click_share, 1)}
+          />
+          <WprAnalyticsMetric
+            label={`${competitor.brand} Click Share`}
+            value={blankTopValues || current === null ? blankMetricValue() : formatPercent(current.observed.competitor_click_share, 1)}
+          />
+        </>
+      }
+      footer={<WprAnalyticsFooter items={footerItems} />}
+    >
+      <WeeklyGapChart
+        competitor={competitor}
+        weekly={viewModel.weekly}
+        changeEntries={changeEntries}
+        wowVisible={wowVisible}
+        setWowVisible={setWowVisible}
+      />
+    </WprAnalyticsPanel>
   )
 }

--- a/apps/argus/components/wpr/wpr-analytics-panel.tsx
+++ b/apps/argus/components/wpr/wpr-analytics-panel.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Box, Stack, Typography } from '@mui/material'
+import { panelSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
+
+type WprAnalyticsMetricColumns = {
+  xs: number
+  md: number
+}
+
+function metricGridTemplateColumns(columns: WprAnalyticsMetricColumns) {
+  return {
+    xs: `repeat(${columns.xs}, minmax(0, 1fr))`,
+    md: `repeat(${columns.md}, minmax(0, 1fr))`,
+  }
+}
+
+export function WprAnalyticsMetric({
+  label,
+  value,
+}: {
+  label: string
+  value: string
+}) {
+  return (
+    <Box
+      sx={{
+        minHeight: 48,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: '0.58rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.12em',
+          color: textMuted,
+          mb: 0.35,
+        }}
+      >
+        {label}
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: '1.18rem',
+          fontWeight: 700,
+          letterSpacing: '-0.04em',
+          color: 'rgba(255,255,255,0.92)',
+        }}
+      >
+        {value}
+      </Typography>
+    </Box>
+  )
+}
+
+export function WprAnalyticsFooter({
+  items,
+}: {
+  items: string[]
+}) {
+  return (
+    <Box
+      sx={{
+        px: 2.5,
+        py: 1.2,
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 2,
+        borderTop: subtleBorder,
+        color: textMuted,
+      }}
+    >
+      {items.map((item) => (
+        <Typography
+          key={item}
+          sx={{
+            fontSize: '0.64rem',
+            fontWeight: 600,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+          }}
+        >
+          {item}
+        </Typography>
+      ))}
+    </Box>
+  )
+}
+
+export function WprAnalyticsPanel({
+  title,
+  meta,
+  metricColumns,
+  metrics,
+  children,
+  footer,
+}: {
+  title: string
+  meta: string[]
+  metricColumns: WprAnalyticsMetricColumns
+  metrics: ReactNode
+  children: ReactNode
+  footer: ReactNode
+}) {
+  return (
+    <Box sx={panelSx}>
+      <Box
+        sx={{
+          px: 2.5,
+          pt: 2,
+          pb: 1.25,
+          borderBottom: subtleBorder,
+          display: 'flex',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Stack spacing={0.45}>
+          <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
+            {title}
+          </Typography>
+          <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
+            {meta.join(' · ')}
+          </Typography>
+        </Stack>
+      </Box>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: metricGridTemplateColumns(metricColumns),
+          gap: 1.5,
+          px: 2.5,
+          py: 1.75,
+          borderBottom: subtleBorder,
+        }}
+      >
+        {metrics}
+      </Box>
+
+      <Box sx={{ p: 2.5 }}>{children}</Box>
+
+      {footer}
+    </Box>
+  )
+}

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -73,3 +73,31 @@ test('all week-based WPR charts use the shared change tooltip renderer', () => {
   assert.match(brSource, /<WprChangeTooltipContent/)
   assert.equal(compareSource.match(/<WprChangeTooltipContent/g)?.length, 2)
 })
+
+test('SQP, SCP, BR, and TST use one shared analytics panel shell', () => {
+  const analyticsPanelSource = readFileSync(new URL('./wpr-analytics-panel.tsx', import.meta.url), 'utf8')
+  const sqpSource = readFileSync(new URL('./tabs/sqp-weekly-panel.tsx', import.meta.url), 'utf8')
+  const scpSource = readFileSync(new URL('./tabs/scp-tab.tsx', import.meta.url), 'utf8')
+  const brSource = readFileSync(new URL('./tabs/business-reports-tab.tsx', import.meta.url), 'utf8')
+  const tstSource = readFileSync(new URL('./tabs/tst-weekly-panel.tsx', import.meta.url), 'utf8')
+
+  assert.match(analyticsPanelSource, /export function WprAnalyticsPanel/)
+  assert.match(sqpSource, /<WprAnalyticsPanel/)
+  assert.match(scpSource, /<WprAnalyticsPanel/)
+  assert.match(brSource, /<WprAnalyticsPanel/)
+  assert.match(tstSource, /<WprAnalyticsPanel/)
+})
+
+test('SQP, SCP, BR, and TST use one shared selection panel shell', () => {
+  const selectionPanelSource = readFileSync(new URL('./wpr-selection-panel.tsx', import.meta.url), 'utf8')
+  const sqpSource = readFileSync(new URL('./tabs/sqp-selection-table.tsx', import.meta.url), 'utf8')
+  const scpSource = readFileSync(new URL('./tabs/scp-selection-table.tsx', import.meta.url), 'utf8')
+  const brSource = readFileSync(new URL('./tabs/business-reports-selection-table.tsx', import.meta.url), 'utf8')
+  const tstSource = readFileSync(new URL('./tabs/tst-selection-table.tsx', import.meta.url), 'utf8')
+
+  assert.match(selectionPanelSource, /export function WprSelectionPanel/)
+  assert.match(sqpSource, /<WprSelectionPanel/)
+  assert.match(scpSource, /<WprSelectionPanel/)
+  assert.match(brSource, /<WprSelectionPanel/)
+  assert.match(tstSource, /<WprSelectionPanel/)
+})

--- a/apps/argus/components/wpr/wpr-selection-panel.tsx
+++ b/apps/argus/components/wpr/wpr-selection-panel.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { Box, TableContainer, Typography } from '@mui/material'
+import { panelSx, subtleBorder, textMuted } from '@/lib/wpr/panel-tokens'
+
+export const wprSelectionHeaderCellSx = {
+  bgcolor: 'rgba(0, 20, 35, 0.96)',
+  borderBottom: '1px solid rgba(255,255,255,0.08)',
+}
+
+export const wprSelectionMetricCellSx = {
+  fontSize: '0.72rem',
+  color: 'rgba(255,255,255,0.76)',
+  borderBottom: '1px solid rgba(255,255,255,0.04)',
+}
+
+export function WprSelectionPanel({
+  title,
+  summary,
+  children,
+  tableMaxHeight = 640,
+}: {
+  title: string
+  summary: string
+  children: ReactNode
+  tableMaxHeight?: number
+}) {
+  return (
+    <Box sx={panelSx}>
+      <Box
+        sx={{
+          px: 2,
+          py: 1.3,
+          borderBottom: subtleBorder,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box>
+          <Typography
+            sx={{
+              fontSize: '0.64rem',
+              fontWeight: 700,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              color: textMuted,
+            }}
+          >
+            {title}
+          </Typography>
+          <Typography sx={{ fontSize: '0.82rem', fontWeight: 600, color: 'rgba(255,255,255,0.88)' }}>
+            {summary}
+          </Typography>
+        </Box>
+      </Box>
+
+      <TableContainer sx={{ maxHeight: tableMaxHeight }}>{children}</TableContainer>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- add shared analytics and selection shell components for WPR tabs
- move SQP, SCP, BR, and TST graph/table panels onto the shared layout shells
- lock the standardization in with WPR structure tests

## Testing
- pnpm exec tsx --test components/wpr/chart-change-markers.test.ts components/wpr/wpr-change-props.test.ts components/wpr/tabs/sqp-weekly-panel.test.tsx lib/wpr/dashboard-state.test.ts
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/argus type-check
