### PR TITLE
fix(talos): tighten dashboard and table hierarchy

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -207,8 +207,9 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
       <PageContent className="space-y-6">
         <div className="rounded-xl border bg-white dark:bg-slate-800 shadow-soft overflow-hidden">
           {/* Header with search and filter */}
-          <div className="flex flex-col gap-3 border-b border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-900/50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-3">
+          <div className="flex flex-col gap-3 border-b border-slate-100 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-900/50 px-4 py-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
               <div className="relative">
                 <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-slate-500" />
                 <Input
@@ -231,14 +232,24 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
                 <option value="ERROR">Error</option>
                 <option value="UNKNOWN">Pending</option>
               </select>
+              </div>
+              <div className="text-xs text-slate-500 dark:text-slate-400">
+                {pageRows.length} shown · {totalRows} total SKUs · Page {currentPage} of {totalPages}
+              </div>
             </div>
-            <div className="flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400">
-              <span className="text-red-600 dark:text-red-400">{summary.mismatch} discrepancies on this page</span>
-              <span className="text-emerald-600 dark:text-emerald-400">{summary.match} matches</span>
-              <span className="text-amber-600 dark:text-amber-400">{summary.warning} warnings</span>
-              <span>{summary.pending} pending</span>
-              <span className="text-slate-400 dark:text-slate-500">·</span>
-              <span>{pageRows.length} shown · {totalRows} total SKUs · Page {currentPage} of {totalPages}</span>
+            <div className="flex flex-wrap gap-2">
+              <span className="rounded-full border border-red-200 bg-red-50 px-3 py-1 text-xs font-medium text-red-700 dark:border-red-900/70 dark:bg-red-950/40 dark:text-red-300">
+                {summary.mismatch} discrepancies
+              </span>
+              <span className="rounded-full border border-emerald-200 bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700 dark:border-emerald-900/70 dark:bg-emerald-950/40 dark:text-emerald-300">
+                {summary.match} matches
+              </span>
+              <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-1 text-xs font-medium text-amber-700 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-300">
+                {summary.warning} warnings
+              </span>
+              <span className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
+                {summary.pending} pending
+              </span>
             </div>
           </div>
 

--- a/apps/talos/src/app/config/permissions/page.tsx
+++ b/apps/talos/src/app/config/permissions/page.tsx
@@ -49,7 +49,7 @@ export default function PermissionsPage() {
   return (
     <DashboardLayout>
       <PageContainer>
-        <PageHeaderSection title="Permissions" />
+        <PageHeaderSection title="Permissions" description="Configuration" />
         <PageContent>
           <PermissionsPanel />
         </PageContent>

--- a/apps/talos/src/app/config/permissions/permissions-panel.tsx
+++ b/apps/talos/src/app/config/permissions/permissions-panel.tsx
@@ -255,9 +255,11 @@ export default function PermissionsPanel() {
   return (
     <div className="flex min-h-[640px] flex-col gap-4">
       <div className="flex flex-col gap-3 border-b border-slate-200/80 pb-4 dark:border-slate-700/70 sm:flex-row sm:items-end sm:justify-between">
-        <h2 className="text-3xl font-semibold tracking-tight text-slate-950 dark:text-slate-50">
-          Permissions
-        </h2>
+        <div className="max-w-2xl">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            Manage baseline access and direct overrides without leaving the user roster.
+          </p>
+        </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-slate-500 dark:text-slate-400">
           <span>{summary.userCount} users</span>
           <span>{summary.overrideCount} overrides</span>

--- a/apps/talos/src/app/config/suppliers/suppliers-panel.tsx
+++ b/apps/talos/src/app/config/suppliers/suppliers-panel.tsx
@@ -313,41 +313,41 @@ export default function SuppliersPanel({
             )}
           </div>
         ) : (
-          <div className="overflow-hidden">
-            <table className="w-full table-fixed text-sm">
+          <div className="overflow-x-auto">
+            <table className="min-w-[980px] w-full table-auto text-sm">
               <thead>
                 <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-                  <th className="w-[22%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Name</th>
-                  <th className="w-[10%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Contact</th>
-                  <th className="w-[22%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Email</th>
-                  <th className="w-[14%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Phone</th>
-                  <th className="w-[24%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Default Terms</th>
-                  <th className="w-[8%] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Actions</th>
+                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Name</th>
+                  <th className="min-w-[120px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Contact</th>
+                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Email</th>
+                  <th className="min-w-[140px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Phone</th>
+                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Default Terms</th>
+                  <th className="w-[72px] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredSuppliers.map(supplier => (
-                  <tr key={supplier.id} className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
+                  <tr key={supplier.id} className="border-t border-slate-200 align-top dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
                     <td className="px-3 py-2 font-medium text-foreground">
                       <button
                         type="button"
                         onClick={() => openEdit(supplier)}
-                        className="block w-full text-left truncate hover:text-cyan-600 dark:hover:text-cyan-400 hover:underline transition-colors"
+                        className="block w-full text-left whitespace-normal break-words leading-5 hover:text-cyan-600 dark:hover:text-cyan-400 hover:underline transition-colors"
                         title={supplier.name}
                       >
                         {supplier.name}
                       </button>
                     </td>
-                    <td className="px-3 py-2 text-muted-foreground truncate" title={supplier.contactName ?? undefined}>
+                    <td className="px-3 py-2 text-muted-foreground whitespace-normal break-words leading-5" title={supplier.contactName ?? undefined}>
                       {supplier.contactName ?? '—'}
                     </td>
-                    <td className="px-3 py-2 text-muted-foreground">
+                    <td className="px-3 py-2 text-muted-foreground break-all leading-5">
                       {supplier.email ?? '—'}
                     </td>
                     <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">
                       {supplier.phone ?? '—'}
                     </td>
-                    <td className="px-3 py-2 text-sm text-muted-foreground truncate" title={[supplier.defaultIncoterms, supplier.defaultPaymentTerms].filter(Boolean).join(' · ') || undefined}>
+                    <td className="px-3 py-2 text-sm text-muted-foreground whitespace-normal break-words leading-5" title={[supplier.defaultIncoterms, supplier.defaultPaymentTerms].filter(Boolean).join(' · ') || undefined}>
                       {supplier.defaultPaymentTerms || supplier.defaultIncoterms ? (
                         [supplier.defaultIncoterms, supplier.defaultPaymentTerms].filter(Boolean).join(' · ')
                       ) : (

--- a/apps/talos/src/app/operations/financial-ledger/page.tsx
+++ b/apps/talos/src/app/operations/financial-ledger/page.tsx
@@ -231,21 +231,21 @@ export default function FinancialLedgerPage() {
 
           <div className="flex min-h-0 flex-col rounded-xl border bg-white dark:bg-slate-800 shadow-soft overflow-x-auto flex-1">
             <div className="relative min-h-0 overflow-y-auto scrollbar-gutter-stable flex-1">
-              <table className="w-full min-w-[1200px] table-auto text-sm">
+              <table className="w-full min-w-[1280px] table-auto text-sm">
                 <thead>
                   <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs w-36">Date</th>
-                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs w-28">Category</th>
-                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs w-56">Cost</th>
-                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs w-52">Warehouse</th>
-                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs w-44">SKU / Lot</th>
-                    <th className="text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs w-32">Amount</th>
+                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs min-w-[9rem]">Date</th>
+                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs min-w-[8rem]">Category</th>
+                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs min-w-[16rem]">Cost</th>
+                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs min-w-[14rem]">Warehouse</th>
+                    <th className="text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs min-w-[18rem]">SKU / Lot</th>
+                    <th className="text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs min-w-[8rem]">Amount</th>
                   </tr>
                 </thead>
                 <tbody>
                   {entries.map(row => (
-                    <tr key={row.id} className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
-                      <td className="px-3 py-2 whitespace-nowrap">{row.effectiveAt.slice(0, 10)}</td>
+                    <tr key={row.id} className="border-t border-slate-200 align-top dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
+                      <td className="px-3 py-2 whitespace-nowrap tabular-nums">{row.effectiveAt.slice(0, 10)}</td>
                       <td className="px-3 py-2 whitespace-nowrap">{row.category}</td>
                       <td className="px-3 py-2">
                         <div className="font-medium text-slate-900 dark:text-slate-100">{row.costName}</div>
@@ -253,18 +253,18 @@ export default function FinancialLedgerPage() {
                       </td>
                       <td className="px-3 py-2">
                         <div className="font-medium text-slate-900 dark:text-slate-100">{row.warehouseCode}</div>
-                        <div className="text-xs text-muted-foreground">{row.warehouseName}</div>
+                        <div className="text-xs text-muted-foreground whitespace-normal break-words leading-5">{row.warehouseName}</div>
                       </td>
                       <td className="px-3 py-2">
-                        <div className="font-medium text-slate-900 dark:text-slate-100">
+                        <div className="font-medium text-slate-900 dark:text-slate-100 whitespace-normal break-words leading-5">
                           {row.skuCode ?? '—'}
                           {row.lotRef ? ` — ${row.lotRef}` : ''}
                         </div>
                         {row.skuDescription && (
-                          <div className="text-xs text-muted-foreground">{row.skuDescription}</div>
+                          <div className="text-xs text-muted-foreground whitespace-normal break-words leading-5">{row.skuDescription}</div>
                         )}
                       </td>
-                      <td className="px-3 py-2 text-right font-medium">
+                      <td className="px-3 py-2 text-right font-medium tabular-nums">
                         {formatLedgerAmount(row.amount, row.currency)}
                       </td>
                     </tr>

--- a/apps/talos/src/app/operations/inventory/purchase-orders-panel.tsx
+++ b/apps/talos/src/app/operations/inventory/purchase-orders-panel.tsx
@@ -996,9 +996,9 @@ export function PurchaseOrdersPanel({
       },
       {
         key: 'lifecycle',
-        header: buildColumnHeader(''),
+        header: buildColumnHeader('Flow'),
         fit: true,
-        thClassName: 'w-[40px]',
+        thClassName: 'w-[56px]',
         tdClassName: 'px-1 py-2',
         render: order => (
           <Button

--- a/apps/talos/src/components/dashboard/market-section.tsx
+++ b/apps/talos/src/components/dashboard/market-section.tsx
@@ -8,6 +8,41 @@ import {
  Area
 } from '@/components/charts/RechartsComponents'
 
+function formatAxisDate(value: string) {
+ if (!value) return ''
+ const date = new Date(value)
+ if (isNaN(date.getTime())) return ''
+ return date.toLocaleDateString('en-US', {
+ month: 'short',
+ day: 'numeric',
+ timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+ })
+}
+
+function formatTooltipDate(value: string) {
+ if (!value) return ''
+ const date = new Date(value)
+ if (isNaN(date.getTime())) return ''
+ return date.toLocaleDateString('en-US', {
+ weekday: 'long',
+ year: 'numeric',
+ month: 'long',
+ day: 'numeric',
+ timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
+ })
+}
+
+function getVisibleTickValues(data: Array<{ date: string; inventory: number }>) {
+ if (data.length <= 7) return data.map(point => point.date)
+
+ const step = Math.ceil(data.length / 6)
+ const ticks = data
+ .filter((_, index) => index % step === 0 || index === data.length - 1)
+ .map(point => point.date)
+
+ return Array.from(new Set(ticks))
+}
+
 interface MarketSectionProps {
  data?: {
  amazonMetrics?: {
@@ -31,35 +66,31 @@ export function MarketSection({ data, loading }: MarketSectionProps) {
  )
  }
 
+ const inventoryTrend = data?.inventoryTrend ?? []
+ const visibleTicks = getVisibleTickValues(inventoryTrend)
+
  return (
  <div>
  {/* Inventory Trend Chart */}
- {data?.inventoryTrend && data.inventoryTrend.length > 0 ? (
+ {inventoryTrend.length > 0 ? (
  <div className="h-64 sm:h-72 md:h-80">
  <ResponsiveContainer width="100%" height="100%">
- <AreaChart data={data.inventoryTrend} margin={{ top: 10, right: 30, left: 10, bottom: 20 }}>
+ <AreaChart data={inventoryTrend} margin={{ top: 10, right: 16, left: 8, bottom: 12 }}>
  <defs>
  <linearGradient id="colorInventory" x1="0" y1="0" x2="0" y2="1">
  <stop offset="5%" stopColor="#3B82F6" stopOpacity={0.8}/>
  <stop offset="95%" stopColor="#3B82F6" stopOpacity={0}/>
  </linearGradient>
  </defs>
- <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+ <CartesianGrid vertical={false} strokeDasharray="3 3" stroke="#e5e7eb" />
  <XAxis 
  dataKey="date" 
- tick={{ fontSize: 11 }}
- tickFormatter={(value) => {
- if (!value) return ''
- const date = new Date(value)
- if (isNaN(date.getTime())) return ''
- // Use local timezone formatting
- return date.toLocaleDateString('en-US', { 
- month: 'numeric', 
- day: 'numeric',
- timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
- })
- }}
- interval="preserveStartEnd"
+ ticks={visibleTicks}
+ tick={{ fontSize: 10 }}
+ tickMargin={10}
+ minTickGap={24}
+ tickFormatter={formatAxisDate}
+ interval={0}
  />
  <YAxis 
  tick={{ fontSize: 12 }}
@@ -72,18 +103,7 @@ export function MarketSection({ data, loading }: MarketSectionProps) {
  borderRadius: '6px'
  }}
  formatter={(value: number) => [value.toLocaleString(), 'Inventory']}
- labelFormatter={(label) => {
- if (!label) return ''
- const date = new Date(label)
- if (isNaN(date.getTime())) return ''
- return date.toLocaleDateString('en-US', { 
- weekday: 'long', 
- year: 'numeric', 
- month: 'long', 
- day: 'numeric',
- timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone
- })
- }}
+ labelFormatter={formatTooltipDate}
  />
  <Area 
  type="monotone" 

--- a/apps/talos/src/components/ui/breadcrumb.tsx
+++ b/apps/talos/src/components/ui/breadcrumb.tsx
@@ -47,7 +47,7 @@ export function Breadcrumb() {
  label = 'Transactions'
  break
  case 'inventory':
- label = 'Inventory Ledger'
+ label = 'Inventory'
  break
  default:
  // For IDs and other segments, format them nicely


### PR DESCRIPTION
## Summary
- reduce dashboard chart tick clutter and relabel the purchase-order flow column
- widen supplier and financial-ledger tables so business-critical text stops truncating
- tighten Talos hierarchy for breadcrumbs, permissions, and FBA discrepancies header

## Verification
- pnpm --filter @targon/talos type-check
- pnpm --filter @targon/talos exec eslint src/components/ui/breadcrumb.tsx src/components/dashboard/market-section.tsx src/app/amazon/fba-fee-discrepancies/page.tsx src/app/operations/inventory/purchase-orders-panel.tsx src/app/config/suppliers/suppliers-panel.tsx src/app/operations/financial-ledger/page.tsx src/app/config/permissions/page.tsx src/app/config/permissions/permissions-panel.tsx