### PR TITLE
chore: promote dev to main

### DIFF
--- a/apps/argus/app/(app)/listings/[id]/amazon-pdp-replica.test.ts
+++ b/apps/argus/app/(app)/listings/[id]/amazon-pdp-replica.test.ts
@@ -1,0 +1,166 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('listing detail sanitizes the replica document before validating the contract', () => {
+  const source = readFileSync(new URL('./listing-detail.tsx', import.meta.url), 'utf8')
+
+  assert.match(source, /sanitizeAmazonPdpReplicaDocument\(doc\)/)
+})
+
+test('listing detail iframe sets an explicit full-width layout contract', () => {
+  const source = readFileSync(new URL('./listing-detail.tsx', import.meta.url), 'utf8')
+
+  assert.match(source, /width: '100%'/)
+  assert.match(source, /display: 'block'/)
+  assert.match(source, /border: 0/)
+})
+
+test('amazon PDP replica sanitizer strips docked Rufus chrome from the iframe document', async () => {
+  const loadedReplicaModule = await import('./amazon-pdp-replica')
+  const sanitize = Reflect.get(loadedReplicaModule, 'sanitizeAmazonPdpReplicaDocument')
+
+  assert.equal(typeof sanitize, 'function')
+
+  const doc = createFakeDocument()
+
+  sanitize(doc as unknown as Document)
+
+  assert.equal(doc.body.classList.contains('rufus-docked-adjustable'), false)
+  assert.equal(doc.body.classList.contains('rufus-docked-right'), false)
+  assert.equal(doc.body.classList.contains('rufus-docked-opening-transition'), false)
+  assert.equal(doc.body.style.getPropertyValue('padding-right'), '')
+  assert.equal(doc.body.style.getPropertyValue('padding-left'), '')
+  assert.equal(doc.body.style.getPropertyValue('width'), '')
+  assert.equal(doc.documentElement.style.getPropertyValue('--rufus-animation-min-height'), '')
+  assert.equal(doc.nodes.rufus.removed, true)
+  assert.equal(doc.nodes.ewc.removed, true)
+  assert.equal(doc.nodes.veepn.removed, true)
+  assert.equal(doc.nodes.navBelt.style.getPropertyValue('width'), '')
+})
+
+class FakeClassList {
+  private readonly values = new Set<string>()
+
+  constructor(initialValues: readonly string[] = []) {
+    for (const value of initialValues) {
+      this.values.add(value)
+    }
+  }
+
+  contains(value: string): boolean {
+    return this.values.has(value)
+  }
+
+  remove(...values: string[]): void {
+    for (const value of values) {
+      this.values.delete(value)
+    }
+  }
+
+  [Symbol.iterator](): Iterator<string> {
+    return this.values[Symbol.iterator]()
+  }
+}
+
+class FakeStyle {
+  private readonly values = new Map<string, string>()
+
+  constructor(initialValues: Record<string, string> = {}) {
+    for (const [name, value] of Object.entries(initialValues)) {
+      this.values.set(name, value)
+    }
+  }
+
+  getPropertyValue(name: string): string {
+    const value = this.values.get(name)
+    if (value === undefined) return ''
+    return value
+  }
+
+  removeProperty(name: string): void {
+    this.values.delete(name)
+  }
+}
+
+class FakeElement {
+  removed = false
+  readonly classList: FakeClassList
+  readonly style: FakeStyle
+  textContent: string | null
+
+  constructor({
+    classes = [],
+    styles = {},
+    textContent = null,
+  }: {
+    classes?: readonly string[]
+    styles?: Record<string, string>
+    textContent?: string | null
+  } = {}) {
+    this.classList = new FakeClassList(classes)
+    this.style = new FakeStyle(styles)
+    this.textContent = textContent
+  }
+
+  remove(): void {
+    this.removed = true
+  }
+}
+
+function createFakeDocument() {
+  const body = new FakeElement({
+    classes: ['rufus-docked-adjustable', 'rufus-docked-right', 'rufus-docked-opening-transition'],
+    styles: {
+      'padding-right': '320px',
+      'padding-left': '24px',
+      width: '320px',
+    },
+  })
+  const documentElement = new FakeElement({
+    styles: {
+      '--rufus-animation-min-height': '120px',
+      '--rufus-docked-panel-width': '320px',
+    },
+  })
+  const rufus = new FakeElement()
+  const ewc = new FakeElement()
+  const veepn = new FakeElement()
+  const extensionStyle = new FakeElement({
+    textContent: '@font-face{src:url(chrome-extension://majdfhpaihoncoakbjgbdhglocklcgno/fonts/FigtreeVF.woff2)}',
+  })
+  const navBelt = new FakeElement({
+    styles: {
+      width: '1180px',
+    },
+  })
+
+  const selectorMap = new Map<string, FakeElement[]>([
+    ['#nav-flyout-rufus', [rufus]],
+    ['#nav-flyout-ewc', [ewc]],
+    ['veepn-lock-screen', [veepn]],
+    ['style', [extensionStyle]],
+    ['#nav-belt', [navBelt]],
+  ])
+
+  return {
+    body,
+    documentElement,
+    nodes: {
+      rufus,
+      ewc,
+      veepn,
+      extensionStyle,
+      navBelt,
+    },
+    querySelectorAll(selector: string): FakeElement[] {
+      const elements = selectorMap.get(selector)
+      if (elements === undefined) return []
+      return elements
+    },
+    getElementById(id: string): FakeElement | null {
+      if (id === 'nav-belt') return navBelt
+      return null
+    },
+  }
+}

--- a/apps/argus/app/(app)/listings/[id]/amazon-pdp-replica.ts
+++ b/apps/argus/app/(app)/listings/[id]/amazon-pdp-replica.ts
@@ -43,11 +43,79 @@ export type AmazonPdpReplicaContractError = {
 
 export type AmazonPdpReplicaContract = AmazonPdpReplicaContractOk | AmazonPdpReplicaContractError
 
+const REPLICA_RUNTIME_REMOVAL_SELECTORS = [
+  '#nav-flyout-ewc',
+  '#nav-flyout-rufus',
+  '#nav-rufus-disco',
+  'veepn-lock-screen',
+] as const
+
+const REPLICA_RUNTIME_CLASS_PREFIXES = ['rufus-'] as const
+
+const REPLICA_RUNTIME_STYLE_PROPERTIES = [
+  'padding-left',
+  'padding-right',
+  'width',
+  'left',
+  'right',
+  'top',
+  '--rufus-animation-min-height',
+  '--rufus-docked-panel-width',
+] as const
+
+const REPLICA_LAYOUT_ELEMENT_IDS = ['nav-belt', 'navbar', 'nav-main'] as const
+
 function normalizeVersion(value: string | null): string | null {
   if (value === null) return null
   const trimmed = value.trim()
   if (trimmed.length === 0) return null
   return trimmed
+}
+
+function removeClassesByPrefix(element: Element, prefixes: readonly string[]): void {
+  const classNames = Array.from(element.classList)
+  for (const className of classNames) {
+    for (const prefix of prefixes) {
+      if (className.startsWith(prefix)) {
+        element.classList.remove(className)
+      }
+    }
+  }
+}
+
+function removeStyleProperties(element: { style: CSSStyleDeclaration }, properties: readonly string[]): void {
+  for (const property of properties) {
+    element.style.removeProperty(property)
+  }
+}
+
+export function sanitizeAmazonPdpReplicaDocument(doc: Document): void {
+  for (const selector of REPLICA_RUNTIME_REMOVAL_SELECTORS) {
+    const nodes = Array.from(doc.querySelectorAll(selector))
+    for (const node of nodes) {
+      node.remove()
+    }
+  }
+
+  const inlineStyleBlocks = Array.from(doc.querySelectorAll('style'))
+  for (const inlineStyleBlock of inlineStyleBlocks) {
+    const text = inlineStyleBlock.textContent
+    if (text === null) continue
+    if (text.includes('chrome-extension://')) {
+      inlineStyleBlock.remove()
+    }
+  }
+
+  removeClassesByPrefix(doc.body, REPLICA_RUNTIME_CLASS_PREFIXES)
+  removeClassesByPrefix(doc.documentElement, REPLICA_RUNTIME_CLASS_PREFIXES)
+  removeStyleProperties(doc.body, REPLICA_RUNTIME_STYLE_PROPERTIES)
+  removeStyleProperties(doc.documentElement, REPLICA_RUNTIME_STYLE_PROPERTIES)
+
+  for (const elementId of REPLICA_LAYOUT_ELEMENT_IDS) {
+    const element = doc.getElementById(elementId)
+    if (!element) continue
+    removeStyleProperties(element, REPLICA_RUNTIME_STYLE_PROPERTIES)
+  }
 }
 
 export function getDeclaredReplicaVersion(doc: Document): string | null {

--- a/apps/argus/app/(app)/listings/[id]/listing-detail.tsx
+++ b/apps/argus/app/(app)/listings/[id]/listing-detail.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import {
   formatAmazonPdpReplicaContractError,
   getReplicaSlotElement,
+  sanitizeAmazonPdpReplicaDocument,
   validateAmazonPdpReplicaContract,
   type AmazonPdpReplicaContractError,
 } from './amazon-pdp-replica'
@@ -676,6 +677,8 @@ export function ListingDetail({
       iframeDocRef.current = doc
       setIframeEpoch((current) => current + 1)
 
+      sanitizeAmazonPdpReplicaDocument(doc)
+
       const height = doc.documentElement.scrollHeight
       if (height > 0) {
         setIframeHeight(height)
@@ -1079,8 +1082,7 @@ export function ListingDetail({
       <iframe
         ref={iframeRef}
         src={`${basePath}/api/fixture/replica.html`}
-        className="w-full border-0"
-        style={{ height: iframeHeight }}
+        style={{ height: iframeHeight, width: '100%', display: 'block', border: 0 }}
         title={listing ? listing.label : listingId}
         sandbox="allow-same-origin allow-scripts"
       />


### PR DESCRIPTION
## Summary
- promote the validated `dev` branch to `main`
- release the Argus listing replica layout fix that restores full-width rendering on listing detail pages

## Included Change
- `fix(argus): restore listing replica layout` from PR #5143

## Validated Dev SHA
- `1b3e899cfdc7ad2b9f421813557536c6a6714c0e`

## Validation
- PR CI for #5143 passed before merge to `dev`
- push CI on `dev` for `1b3e899cfdc7ad2b9f421813557536c6a6714c0e` passed
- `dev` CD and hosted auth health completed successfully on `1b3e899cfdc7ad2b9f421813557536c6a6714c0e`
- local browser verification on the listing detail route showed the replica rendering full width after the fix