### PR TITLE
chore(argus): promote WPR week date ranges to main

### DIFF
--- a/apps/argus/components/wpr/chart-change-markers.tsx
+++ b/apps/argus/components/wpr/chart-change-markers.tsx
@@ -115,12 +115,14 @@ export function formatChangeMarkerLabel(label: string | number, marker: ChartCha
 export function WprChangeTooltipContent({
   active,
   label,
+  labelText,
   payload,
   changeMarker,
   formatRow,
 }: {
   active?: boolean
   label?: string | number
+  labelText?: string | number
   payload?: readonly WprTooltipPayloadEntry[]
   changeMarker?: ChartChangeMarker
   formatRow: (entry: WprTooltipPayloadEntry) => WprTooltipRow
@@ -129,7 +131,12 @@ export function WprChangeTooltipContent({
     return null
   }
 
-  const labelParts = buildChangeMarkerLabelParts(label, changeMarker)
+  let displayLabel: string | number = label
+  if (labelText !== undefined) {
+    displayLabel = labelText
+  }
+
+  const labelParts = buildChangeMarkerLabelParts(displayLabel, changeMarker)
   const header = labelParts[0]
   if (header === undefined) {
     throw new Error(`Missing tooltip header for ${String(label)}`)

--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -34,6 +34,7 @@ import {
 import { formatCount, formatPercent } from '@/lib/wpr/format'
 import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprBusinessDailyPoint, WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
+import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import BusinessReportsSelectionTable from './business-reports-selection-table'
 
@@ -75,18 +76,6 @@ const businessReportsViewToggleGroupSx = {
 
 function blankMetricValue(): string {
   return '---'
-}
-
-function windowRangeLabel(weeks: string[]): string {
-  if (weeks.length === 0) {
-    return ''
-  }
-
-  if (weeks.length === 1) {
-    return weeks[0]
-  }
-
-  return `${weeks[0]} - ${weeks[weeks.length - 1]}`
 }
 
 function dailyWindowLabel(dailySeries: WprBusinessDailyPoint[]): string {
@@ -247,6 +236,7 @@ function BusinessReportsChangeOverlay({
 function BusinessReportsChart({
   viewMode,
   weekly,
+  weekStartDates,
   dailySeries,
   changeEntries,
   wowVisible,
@@ -255,6 +245,7 @@ function BusinessReportsChart({
 }: {
   viewMode: BusinessReportsViewMode
   weekly: BusinessReportsSelectionViewModel['weekly']
+  weekStartDates: Record<string, string>
   dailySeries: WprBusinessDailyPoint[]
   changeEntries: WprChangeLogEntry[]
   wowVisible: WprBrWowVisible
@@ -328,6 +319,7 @@ function BusinessReportsChart({
                   active={active}
                   payload={payload}
                   label={label}
+                  labelText={viewMode === 'weekly' ? formatWeekLabelFromLookup(String(label), weekStartDates) : undefined}
                   changeMarker={changeMarkersByLabel.get(String(label))}
                   formatRow={(entry) => {
                     const key = entry.dataKey
@@ -553,7 +545,9 @@ export default function BusinessReportsTab({
     )
   }
 
-  const heroContent = buildHeroContent(selectedWeekLabel)
+  const weekStartDates = buildBundleWeekStartDateLookup(bundle)
+  const formattedSelectedWeekLabel = formatWeekLabelFromLookup(selectedWeekLabel, weekStartDates)
+  const heroContent = buildHeroContent(formattedSelectedWeekLabel)
   const selectedRecord = selectedWeekBusinessRecord(viewModel.weekly, selectedWeekLabel)
   const blankTopValues = viewModel.scopeType === 'empty' || selectedRecord === null || viewModel.current === null
   const currentMetrics = viewModel.current
@@ -564,13 +558,13 @@ export default function BusinessReportsTab({
   }
   const chartWindowLabel = viewMode === 'daily'
     ? dailyWindowLabel(dailyChartSeries)
-    : windowRangeLabel(bundle.meta.baselineWindow)
+    : formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
   const footerItems = [
     `Source: Business Reports`,
     `Scope: detail page retail`,
     `ASINs: ${viewModel.selectedIds.length} / ${viewModel.allIds.length}`,
     `Target ASIN: ${bundle.businessReports.meta.targetAsin}`,
-    `Table week: ${selectedWeekLabel}`,
+    `Table week: ${formattedSelectedWeekLabel}`,
     `Chart window: ${chartWindowLabel}`,
   ]
 
@@ -601,6 +595,7 @@ export default function BusinessReportsTab({
         <BusinessReportsChart
           viewMode={viewMode}
           weekly={viewModel.weekly}
+          weekStartDates={weekStartDates}
           dailySeries={dailyChartSeries}
           changeEntries={changeEntries}
           wowVisible={brWowVisible}

--- a/apps/argus/components/wpr/tabs/compare-tab.test.ts
+++ b/apps/argus/components/wpr/tabs/compare-tab.test.ts
@@ -21,4 +21,5 @@ test('compare tab uses shared change tooltips for weekly charts and shared dark 
   assert.equal(tooltipUsages.length, 4)
   assert.equal(sharedTooltipUsages.length, 2)
   assert.equal(changeTooltipUsages.length, 2)
+  assert.equal(source.match(/labelText=\{/g)?.length, 2)
 })

--- a/apps/argus/components/wpr/tabs/compare-tab.tsx
+++ b/apps/argus/components/wpr/tabs/compare-tab.tsx
@@ -27,6 +27,7 @@ import { WPR_CHART_HEIGHT, WPR_COMPACT_CHART_HEIGHT } from '@/lib/wpr/chart-layo
 import { createCompareViewModel } from '@/lib/wpr/compare-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
+import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup } from '@/lib/wpr/week-display'
 import {
   panelBadgeSx,
   panelHeadSx,
@@ -97,9 +98,11 @@ function PanelTitle({
 function RankHeatmap({
   bundle,
   clusterIds,
+  weekStartDates,
 }: {
   bundle: WprWeekBundle
   clusterIds: string[]
+  weekStartDates: Record<string, string>
 }) {
   const clusters = clusterIds
     .map((clusterId) => bundle.clusters.find((cluster) => cluster.id === clusterId))
@@ -168,7 +171,7 @@ function RankHeatmap({
               return (
                 <Box
                   key={`${cluster.id}-${week}`}
-                  title={`${cluster.cluster} · ${week} · Avg rank ${point?.avg_rank ?? '—'} · Purchase share ${formatPercent(point?.purchase_share ?? null, 1)}`}
+                  title={`${cluster.cluster} · ${formatWeekLabelFromLookup(week, weekStartDates)} · Avg rank ${point?.avg_rank ?? '—'} · Purchase share ${formatPercent(point?.purchase_share ?? null, 1)}`}
                   sx={{
                     height: 26,
                     borderRadius: '6px',
@@ -196,6 +199,7 @@ export default function CompareTab({
   const compareOrganicMode = useWprStore((state) => state.compareOrganicMode)
   const setCompareOrganicMode = useWprStore((state) => state.setCompareOrganicMode)
   const viewModel = createCompareViewModel(bundle)
+  const weekStartDates = buildBundleWeekStartDateLookup(bundle)
   const weeklyChangeMarkers = buildWeeklyChangeMarkers(changeEntries)
   const weeklyChangeMarkersByLabel = buildChangeMarkerLookup(weeklyChangeMarkers)
 
@@ -264,6 +268,7 @@ export default function CompareTab({
                         active={active}
                         payload={payload}
                         label={label}
+                        labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
                         changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
                         formatRow={(entry) => {
                           const value = entry.value
@@ -421,6 +426,7 @@ export default function CompareTab({
                             active={active}
                             payload={payload}
                             label={label}
+                            labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
                             changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
                             formatRow={(entry) => {
                               const key = entry.dataKey
@@ -473,7 +479,7 @@ export default function CompareTab({
               <Typography sx={{ fontSize: '0.74rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)', mb: 1 }}>
                 Rank Heatmap
               </Typography>
-              <RankHeatmap bundle={bundle} clusterIds={bundle.lineClusterIds} />
+              <RankHeatmap bundle={bundle} clusterIds={bundle.lineClusterIds} weekStartDates={weekStartDates} />
             </Box>
           </Box>
         )}

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -28,6 +28,7 @@ import { formatCount, formatMoney } from '@/lib/wpr/format'
 import { createScpSelectionViewModel, type ScpSelectionViewModel } from '@/lib/wpr/scp-view-model'
 import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
+import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import ScpSelectionTable from './scp-selection-table'
 
@@ -40,25 +41,15 @@ function blankMetricValue(): string {
   return '---'
 }
 
-function windowRangeLabel(weeks: string[]): string {
-  if (weeks.length === 0) {
-    return ''
-  }
-
-  if (weeks.length === 1) {
-    return weeks[0]
-  }
-
-  return `${weeks[0]} - ${weeks[weeks.length - 1]}`
-}
-
 function ScpWeeklyChart({
   weekly,
+  weekStartDates,
   changeEntries,
   wowVisible,
   setWowVisible,
 }: {
   weekly: ScpSelectionViewModel['weekly']
+  weekStartDates: Record<string, string>
   changeEntries: WprChangeLogEntry[]
   wowVisible: WprScpWowVisible
   setWowVisible: (nextState: WprScpWowVisible) => void
@@ -98,6 +89,7 @@ function ScpWeeklyChart({
                   active={active}
                   payload={payload}
                   label={label}
+                  labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
                   changeMarker={changeMarkersByLabel.get(String(label))}
                   formatRow={(entry) => {
                     const key = entry.dataKey
@@ -291,16 +283,18 @@ export default function ScpTab({
     )
   }
 
-  const heroContent = buildHeroContent(selectedWeekLabel)
+  const weekStartDates = buildBundleWeekStartDateLookup(bundle)
+  const formattedSelectedWeekLabel = formatWeekLabelFromLookup(selectedWeekLabel, weekStartDates)
+  const heroContent = buildHeroContent(formattedSelectedWeekLabel)
   const blankTopValues = viewModel.scopeType === 'empty' || viewModel.current === null
   const currentMetrics = viewModel.current
-  const historyLabel = windowRangeLabel(bundle.scp.meta.baselineWindow)
+  const historyLabel = formatWeekWindowLabel(bundle.scp.meta.baselineWindow, weekStartDates)
   const footerItems = [
     `Source: SCP`,
     `Scope: catalog search`,
     `ASINs: ${viewModel.selectedIds.length} / ${viewModel.allIds.length}`,
     `Target ASIN: ${bundle.scp.meta.targetAsin}`,
-    `Table week: ${selectedWeekLabel}`,
+    `Table week: ${formattedSelectedWeekLabel}`,
     `Chart history: ${historyLabel}`,
   ]
 
@@ -330,6 +324,7 @@ export default function ScpTab({
       >
         <ScpWeeklyChart
           weekly={viewModel.weekly}
+          weekStartDates={weekStartDates}
           changeEntries={changeEntries}
           wowVisible={scpWowVisible}
           setWowVisible={setScpWowVisible}

--- a/apps/argus/components/wpr/tabs/sqp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-tab.tsx
@@ -8,6 +8,7 @@ import {
   type SqpSelectionViewModel,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
+import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import SqpSelectionTable from './sqp-selection-table'
 import SqpWeeklyPanel from './sqp-weekly-panel'
@@ -57,20 +58,11 @@ function allSelectableTermIds(bundle: WprWeekBundle): string[] {
   return termIds
 }
 
-function windowRangeLabel(weeks: string[]): string {
-  if (weeks.length === 0) {
-    return ''
-  }
-
-  if (weeks.length === 1) {
-    return weeks[0]
-  }
-
-  return `${weeks[0]} - ${weeks[weeks.length - 1]}`
-}
-
-function buildHeroContent(bundle: WprWeekBundle, viewModel: SqpSelectionViewModel): { name: string; meta: string[] } {
-  const selectedWeekLabel = bundle.meta.anchorWeek
+function buildHeroContent(
+  bundle: WprWeekBundle,
+  viewModel: SqpSelectionViewModel,
+  selectedWeekLabel: string,
+): { name: string; meta: string[] } {
   if (viewModel.scopeType === 'empty') {
     return {
       name: 'SQP Selection',
@@ -315,8 +307,10 @@ export default function SqpTab({
     }
   }
 
-  const heroContent = buildHeroContent(bundle, viewModel)
-  const historyLabel = windowRangeLabel(bundle.meta.baselineWindow)
+  const weekStartDates = buildBundleWeekStartDateLookup(bundle)
+  const selectedWeekLabel = formatWeekLabelFromLookup(bundle.meta.anchorWeek, weekStartDates)
+  const heroContent = buildHeroContent(bundle, viewModel, selectedWeekLabel)
+  const historyLabel = formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
   const blankTopValues = viewModel.scopeType === 'empty'
   const currentMetrics = viewModel.metrics
 
@@ -439,7 +433,7 @@ export default function SqpTab({
         selectedRootCount={viewModel.selectedRootIds.length}
         selectedTermCount={viewModel.selectedTermIds.length}
         totalTermCount={viewModel.allTermIds.length}
-        selectedWeekLabel={bundle.meta.anchorWeek}
+        selectedWeekLabel={selectedWeekLabel}
         historyLabel={historyLabel}
       />
 

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
@@ -90,7 +90,7 @@ test('SQP weekly chart renders hover tooltip content for the active week', () =>
   )
 
   assert.match(markup, /data-hover-tooltip=\"sqp\"/)
-  assert.match(markup, /W02 · 2 changes/)
+  assert.match(markup, /W02 · 08 Jan - 14 Jan 26 · 2 changes/)
   assert.match(markup, /Content update across 4 ASINs/)
   assert.match(markup, /Price update across 4 ASINs/)
   assert.doesNotMatch(markup, /tracked changes/)
@@ -113,7 +113,7 @@ test('SQP weekly chart omits hover tooltip markup when no week is active', () =>
   )
 
   assert.doesNotMatch(markup, /data-hover-tooltip=\"sqp\"/)
-  assert.doesNotMatch(markup, /W02 · 2 changes/)
+  assert.doesNotMatch(markup, /W02 · 08 Jan - 14 Jan 26 · 2 changes/)
   assert.doesNotMatch(markup, /Impr Share/)
 })
 

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -17,6 +17,7 @@ import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/compo
 import type { WprSqpWowVisible } from '@/lib/wpr/dashboard-state'
 import { formatCompactNumber, formatCount } from '@/lib/wpr/format'
 import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
+import { formatWeekLabelWithDateRange } from '@/lib/wpr/week-display'
 import {
   rateRatio,
   type SqpAggregatedMetrics,
@@ -32,6 +33,7 @@ type SqpHeroContent = {
 
 type ChartPoint = {
   week_label: string
+  start_date: string
   impr_points: number
   ctr_adv: number
   atc_adv: number
@@ -220,6 +222,7 @@ export function SqpWeeklySvg({
 
     return {
       week_label: week.week_label,
+      start_date: week.start_date,
       impr_points: week.metrics.impression_share * 100,
       ctr_ratio: ctrRatio,
       atc_ratio: atcRatio,
@@ -286,7 +289,10 @@ export function SqpWeeklySvg({
       color: series.color,
       value: formatSeriesTooltipValue(hoveredPoint, series),
     }))
-    const tooltipLabelParts = buildChangeMarkerLabelParts(hoveredPoint.week_label, hoveredMarker)
+    const tooltipLabelParts = buildChangeMarkerLabelParts(
+      formatWeekLabelWithDateRange(hoveredPoint.week_label, hoveredPoint.start_date),
+      hoveredMarker,
+    )
     const tooltipHeader = tooltipLabelParts[0]
     if (tooltipHeader === undefined) {
       throw new Error(`Missing SQP tooltip header for ${hoveredPoint.week_label}`)

--- a/apps/argus/components/wpr/tabs/tst-tab.tsx
+++ b/apps/argus/components/wpr/tabs/tst-tab.tsx
@@ -8,6 +8,7 @@ import {
   createTstViewModel,
   type TstSelectionViewModel,
 } from '@/lib/wpr/tst-view-model'
+import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import TstSelectionTable from './tst-selection-table'
 import TstWeeklyPanel from './tst-weekly-panel'
@@ -30,20 +31,11 @@ function filterIds(ids: Set<string>, allowedIds: Set<string>): string[] {
   return Array.from(ids).filter((id) => allowedIds.has(id))
 }
 
-function windowRangeLabel(weeks: string[]): string {
-  if (weeks.length === 0) {
-    return ''
-  }
-
-  if (weeks.length === 1) {
-    return weeks[0]
-  }
-
-  return `${weeks[0]} - ${weeks[weeks.length - 1]}`
-}
-
-function buildHeroContent(bundle: WprWeekBundle, viewModel: TstSelectionViewModel): { name: string; meta: string[] } {
-  const selectedWeekLabel = bundle.meta.anchorWeek
+function buildHeroContent(
+  bundle: WprWeekBundle,
+  viewModel: TstSelectionViewModel,
+  selectedWeekLabel: string,
+): { name: string; meta: string[] } {
   if (viewModel.scopeType === 'empty') {
     return {
       name: 'TST Selection',
@@ -168,8 +160,10 @@ export default function TstTab({
     }
   }
 
-  const heroContent = buildHeroContent(bundle, viewModel)
-  const historyLabel = windowRangeLabel(bundle.meta.baselineWindow)
+  const weekStartDates = buildBundleWeekStartDateLookup(bundle)
+  const selectedWeekLabel = formatWeekLabelFromLookup(bundle.meta.anchorWeek, weekStartDates)
+  const heroContent = buildHeroContent(bundle, viewModel, selectedWeekLabel)
+  const historyLabel = formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
   const competitor = bundle.meta.competitor
 
   const handleSetRootSelection = (rootId: string, shouldSelect: boolean) => {
@@ -248,8 +242,9 @@ export default function TstTab({
         heroContent={heroContent}
         viewModel={viewModel}
         changeEntries={changeEntries}
-        selectedWeekLabel={bundle.meta.anchorWeek}
+        selectedWeekLabel={selectedWeekLabel}
         historyLabel={historyLabel}
+        weekStartDates={weekStartDates}
         wowVisible={compWowVisible}
         setWowVisible={setCompWowVisible}
       />

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -27,6 +27,7 @@ import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/compo
 import type { WprCompWowVisible } from '@/lib/wpr/dashboard-state'
 import type { TstSelectionViewModel } from '@/lib/wpr/tst-view-model'
 import type { WprChangeLogEntry, WprCompetitorSummary } from '@/lib/wpr/types'
+import { formatWeekLabelFromLookup } from '@/lib/wpr/week-display'
 import {
   chartToggleButtonSx,
 } from '@/lib/wpr/panel-tokens'
@@ -43,11 +44,13 @@ function blankMetricValue(): string {
 
 function WeeklyGapChart({
   weekly,
+  weekStartDates,
   changeEntries,
   wowVisible,
   setWowVisible,
 }: {
   weekly: TstSelectionViewModel['weekly']
+  weekStartDates: Record<string, string>
   changeEntries: WprChangeLogEntry[]
   wowVisible: WprCompWowVisible
   setWowVisible: (nextState: WprCompWowVisible) => void
@@ -87,6 +90,7 @@ function WeeklyGapChart({
                   active={active}
                   payload={payload}
                   label={label}
+                  labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
                   changeMarker={changeMarkersByLabel.get(String(label))}
                   formatRow={(entry) => {
                     const key = entry.dataKey
@@ -176,6 +180,7 @@ export default function TstWeeklyPanel({
   changeEntries,
   selectedWeekLabel,
   historyLabel,
+  weekStartDates,
   wowVisible,
   setWowVisible,
 }: {
@@ -185,6 +190,7 @@ export default function TstWeeklyPanel({
   changeEntries: WprChangeLogEntry[]
   selectedWeekLabel: string
   historyLabel: string
+  weekStartDates: Record<string, string>
   wowVisible: WprCompWowVisible
   setWowVisible: (nextState: WprCompWowVisible) => void
 }) {
@@ -240,6 +246,7 @@ export default function TstWeeklyPanel({
     >
       <WeeklyGapChart
         weekly={viewModel.weekly}
+        weekStartDates={weekStartDates}
         changeEntries={changeEntries}
         wowVisible={wowVisible}
         setWowVisible={setWowVisible}

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -18,6 +18,7 @@ test('dashboard shell loads weeks and the selected week bundle instead of the fu
   assert.match(shellSource, /useWprWeekBundleQuery/)
   assert.match(shellSource, /useWprChangeLogWeekQuery/)
   assert.match(shellSource, /useWprSourcesQuery\(activeTab === 'sources'\)/)
+  assert.match(shellSource, /weekStartDates=\{weeksQuery\.data\.weekStartDates\}/)
 })
 
 test('tst tab forwards change entries into the weekly panel', () => {

--- a/apps/argus/components/wpr/wpr-dashboard-shell.tsx
+++ b/apps/argus/components/wpr/wpr-dashboard-shell.tsx
@@ -119,6 +119,7 @@ export default function WprDashboardShell() {
         activeTab={activeTab}
         selectedWeek={selectedWeek}
         weeks={weeksQuery.data.weeks}
+        weekStartDates={weeksQuery.data.weekStartDates}
         onSelectTab={handleSelectTab}
         onSelectWeek={setSelectedWeek}
       />

--- a/apps/argus/components/wpr/wpr-top-bar.tsx
+++ b/apps/argus/components/wpr/wpr-top-bar.tsx
@@ -4,17 +4,20 @@ import { Box, MenuItem, Select, Stack, Typography } from '@mui/material';
 import { WPR_TABS, type WprTab } from '@/lib/wpr/dashboard-state';
 import { panelBgDarker, subtleBorder, teal, textMuted, textPrimary, textSecondary } from '@/lib/wpr/panel-tokens';
 import type { WeekLabel } from '@/lib/wpr/types';
+import { formatWeekLabelFromLookup } from '@/lib/wpr/week-display';
 
 export default function WprTopBar({
   activeTab,
   selectedWeek,
   weeks,
+  weekStartDates,
   onSelectTab,
   onSelectWeek,
 }: {
   activeTab: WprTab;
   selectedWeek: WeekLabel | null;
   weeks: WeekLabel[];
+  weekStartDates: Record<WeekLabel, string>;
   onSelectTab: (tab: WprTab) => void;
   onSelectWeek: (week: WeekLabel) => void;
 }) {
@@ -85,7 +88,7 @@ export default function WprTopBar({
           value={selectedWeek ?? ''}
           onChange={(event) => onSelectWeek(event.target.value)}
           sx={{
-            minWidth: 150,
+            minWidth: 228,
             fontSize: '0.75rem',
             color: textPrimary,
             bgcolor: 'rgba(255,255,255,0.03)',
@@ -105,7 +108,7 @@ export default function WprTopBar({
         >
           {weeks.map((week) => (
             <MenuItem key={week} value={week} sx={{ fontSize: '0.75rem' }}>
-              {week}
+              {formatWeekLabelFromLookup(week, weekStartDates)}
             </MenuItem>
           ))}
         </Select>

--- a/apps/argus/lib/wpr/week-display.test.ts
+++ b/apps/argus/lib/wpr/week-display.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  buildWeekStartDateLookup,
+  formatWeekLabelWithDateRange,
+  formatWeekWindowLabel,
+} from './week-display'
+
+test('formatWeekLabelWithDateRange appends the weekly date span', () => {
+  assert.equal(formatWeekLabelWithDateRange('W16', '2026-04-13'), 'W16 · 13 Apr - 19 Apr 26')
+})
+
+test('formatWeekWindowLabel appends the overall date span for a week window', () => {
+  assert.equal(
+    formatWeekWindowLabel(['W15', 'W16'], {
+      W15: '2026-04-06',
+      W16: '2026-04-13',
+    }),
+    'W15 - W16 · 06 Apr - 19 Apr 26',
+  )
+})
+
+test('buildWeekStartDateLookup collects week start dates from weekly series rows', () => {
+  assert.deepEqual(
+    buildWeekStartDateLookup([
+      { week_label: 'W15', start_date: '2026-04-06' },
+      { week_label: 'W16', start_date: '2026-04-13' },
+    ]),
+    {
+      W15: '2026-04-06',
+      W16: '2026-04-13',
+    },
+  )
+})

--- a/apps/argus/lib/wpr/week-display.ts
+++ b/apps/argus/lib/wpr/week-display.ts
@@ -1,0 +1,140 @@
+import type { WeekLabel, WprWeekBundle } from './types'
+
+type WeekStartDateRow = {
+  week_label: WeekLabel
+  start_date: string
+}
+
+const DAY_MONTH_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  timeZone: 'UTC',
+})
+
+const DAY_MONTH_YEAR_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  day: '2-digit',
+  month: 'short',
+  year: '2-digit',
+  timeZone: 'UTC',
+})
+
+function parseIsoDate(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (match === null) {
+    throw new Error(`Invalid ISO date ${value}`)
+  }
+
+  const year = Number.parseInt(match[1], 10)
+  const month = Number.parseInt(match[2], 10)
+  const day = Number.parseInt(match[3], 10)
+
+  return new Date(Date.UTC(year, month - 1, day))
+}
+
+function addUtcDays(date: Date, days: number): Date {
+  const next = new Date(date.getTime())
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function formatDateSpan(startDate: string, endDate: string): string {
+  return `${DAY_MONTH_FORMATTER.format(parseIsoDate(startDate))} - ${DAY_MONTH_YEAR_FORMATTER.format(parseIsoDate(endDate))}`
+}
+
+export function buildWeekStartDateLookup<T extends WeekStartDateRow>(
+  rows: readonly T[],
+): Record<WeekLabel, string> {
+  const weekStartDates: Record<WeekLabel, string> = {}
+
+  for (const row of rows) {
+    weekStartDates[row.week_label] = row.start_date
+  }
+
+  return weekStartDates
+}
+
+export function buildBundleWeekStartDateLookup(bundle: Pick<WprWeekBundle, 'weeks' | 'clusters' | 'scp' | 'businessReports'>): Record<WeekLabel, string> {
+  const discoveredWeekStartDates: Partial<Record<WeekLabel, string>> = {}
+
+  const registerRows = (rows: readonly WeekStartDateRow[]) => {
+    for (const row of rows) {
+      discoveredWeekStartDates[row.week_label] = row.start_date
+    }
+  }
+
+  for (const cluster of bundle.clusters) {
+    registerRows(cluster.weekly)
+  }
+  registerRows(bundle.scp.weekly)
+  registerRows(bundle.businessReports.weekly)
+
+  const weekStartDates: Record<WeekLabel, string> = {}
+  for (const week of bundle.weeks) {
+    const startDate = discoveredWeekStartDates[week]
+    if (startDate === undefined) {
+      throw new Error(`Missing week start date for ${week}`)
+    }
+
+    weekStartDates[week] = startDate
+  }
+
+  return weekStartDates
+}
+
+export function formatWeekDateRange(startDate: string): string {
+  const endDate = addUtcDays(parseIsoDate(startDate), 6)
+  const endDateIso = endDate.toISOString().slice(0, 10)
+  return formatDateSpan(startDate, endDateIso)
+}
+
+export function formatWeekLabelWithDateRange(weekLabel: WeekLabel, startDate: string): string {
+  return `${weekLabel} · ${formatWeekDateRange(startDate)}`
+}
+
+export function formatWeekLabelFromLookup(
+  weekLabel: WeekLabel,
+  weekStartDates: Readonly<Record<WeekLabel, string>>,
+): string {
+  const startDate = weekStartDates[weekLabel]
+  if (startDate === undefined) {
+    throw new Error(`Missing week start date for ${weekLabel}`)
+  }
+
+  return formatWeekLabelWithDateRange(weekLabel, startDate)
+}
+
+export function formatWeekWindowLabel(
+  weeks: readonly WeekLabel[],
+  weekStartDates: Readonly<Record<WeekLabel, string>>,
+): string {
+  if (weeks.length === 0) {
+    return ''
+  }
+
+  const firstWeek = weeks[0]
+  if (firstWeek === undefined) {
+    throw new Error('Missing first week label')
+  }
+
+  if (weeks.length === 1) {
+    return formatWeekLabelFromLookup(firstWeek, weekStartDates)
+  }
+
+  const lastWeek = weeks[weeks.length - 1]
+  if (lastWeek === undefined) {
+    throw new Error('Missing last week label')
+  }
+
+  const firstStartDate = weekStartDates[firstWeek]
+  if (firstStartDate === undefined) {
+    throw new Error(`Missing week start date for ${firstWeek}`)
+  }
+
+  const lastStartDate = weekStartDates[lastWeek]
+  if (lastStartDate === undefined) {
+    throw new Error(`Missing week start date for ${lastWeek}`)
+  }
+
+  const lastEndDateIso = addUtcDays(parseIsoDate(lastStartDate), 6).toISOString().slice(0, 10)
+  return `${firstWeek} - ${lastWeek} · ${formatDateSpan(firstStartDate, lastEndDateIso)}`
+}


### PR DESCRIPTION
## Summary\n- promote the WPR week date range labels from dev to main\n- keep week references explicit across the top bar, graph chrome, and weekly hover headers\n\n## Source\n- dev merge commit: 46d81e882be4342c0695803ad2c4e1cd68e999d3\n- source PR: #5145\n