### PR TITLE
fix(argus): prevent WPR tooltip crashes and normalize looping cases

### DIFF
--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -34,7 +34,12 @@ import {
 import { formatCount, formatPercent } from '@/lib/wpr/format'
 import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprBusinessDailyPoint, WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
-import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
+import {
+  buildBundleWeekStartDateLookup,
+  formatTooltipWeekLabelFromLookup,
+  formatWeekLabelFromLookup,
+  formatWeekWindowLabel,
+} from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import BusinessReportsSelectionTable from './business-reports-selection-table'
 
@@ -319,7 +324,7 @@ function BusinessReportsChart({
                   active={active}
                   payload={payload}
                   label={label}
-                  labelText={viewMode === 'weekly' ? formatWeekLabelFromLookup(String(label), weekStartDates) : undefined}
+                  labelText={viewMode === 'weekly' ? formatTooltipWeekLabelFromLookup(label, weekStartDates) : undefined}
                   changeMarker={changeMarkersByLabel.get(String(label))}
                   formatRow={(entry) => {
                     const key = entry.dataKey

--- a/apps/argus/components/wpr/tabs/compare-tab.tsx
+++ b/apps/argus/components/wpr/tabs/compare-tab.tsx
@@ -27,7 +27,7 @@ import { WPR_CHART_HEIGHT, WPR_COMPACT_CHART_HEIGHT } from '@/lib/wpr/chart-layo
 import { createCompareViewModel } from '@/lib/wpr/compare-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
-import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup } from '@/lib/wpr/week-display'
+import { buildBundleWeekStartDateLookup, formatTooltipWeekLabelFromLookup, formatWeekLabelFromLookup } from '@/lib/wpr/week-display'
 import {
   panelBadgeSx,
   panelHeadSx,
@@ -268,7 +268,7 @@ export default function CompareTab({
                         active={active}
                         payload={payload}
                         label={label}
-                        labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
+                        labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
                         changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
                         formatRow={(entry) => {
                           const value = entry.value
@@ -426,7 +426,7 @@ export default function CompareTab({
                             active={active}
                             payload={payload}
                             label={label}
-                            labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
+                            labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
                             changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
                             formatRow={(entry) => {
                               const key = entry.dataKey

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -28,7 +28,12 @@ import { formatCount, formatMoney } from '@/lib/wpr/format'
 import { createScpSelectionViewModel, type ScpSelectionViewModel } from '@/lib/wpr/scp-view-model'
 import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
-import { buildBundleWeekStartDateLookup, formatWeekLabelFromLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
+import {
+  buildBundleWeekStartDateLookup,
+  formatTooltipWeekLabelFromLookup,
+  formatWeekLabelFromLookup,
+  formatWeekWindowLabel,
+} from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import ScpSelectionTable from './scp-selection-table'
 
@@ -89,7 +94,7 @@ function ScpWeeklyChart({
                   active={active}
                   payload={payload}
                   label={label}
-                  labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
+                  labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
                   changeMarker={changeMarkersByLabel.get(String(label))}
                   formatRow={(entry) => {
                     const key = entry.dataKey

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -27,7 +27,7 @@ import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/compo
 import type { WprCompWowVisible } from '@/lib/wpr/dashboard-state'
 import type { TstSelectionViewModel } from '@/lib/wpr/tst-view-model'
 import type { WprChangeLogEntry, WprCompetitorSummary } from '@/lib/wpr/types'
-import { formatWeekLabelFromLookup } from '@/lib/wpr/week-display'
+import { formatTooltipWeekLabelFromLookup } from '@/lib/wpr/week-display'
 import {
   chartToggleButtonSx,
 } from '@/lib/wpr/panel-tokens'
@@ -90,7 +90,7 @@ function WeeklyGapChart({
                   active={active}
                   payload={payload}
                   label={label}
-                  labelText={formatWeekLabelFromLookup(String(label), weekStartDates)}
+                  labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
                   changeMarker={changeMarkersByLabel.get(String(label))}
                   formatRow={(entry) => {
                     const key = entry.dataKey

--- a/apps/argus/lib/cases/reader-core.ts
+++ b/apps/argus/lib/cases/reader-core.ts
@@ -139,6 +139,14 @@ function readRequiredBoolean(
   return value;
 }
 
+function normalizeCaseReportCategory(category: string): string {
+  if (category === 'looping') {
+    return 'Watching';
+  }
+
+  return category;
+}
+
 function readRequiredArray(
   record: Record<string, unknown>,
   fieldName: string,
@@ -353,10 +361,12 @@ function parseCaseReportSnapshotRow(
   );
 
   return {
-    category: readRequiredString(
-      row,
-      'category',
-      `Missing required case report snapshot row field category for section ${sectionEntity} row ${rowIndex}`,
+    category: normalizeCaseReportCategory(
+      readRequiredString(
+        row,
+        'category',
+        `Missing required case report snapshot row field category for section ${sectionEntity} row ${rowIndex}`,
+      ),
     ),
     issue: readRequiredString(
       row,

--- a/apps/argus/lib/cases/reader.test.ts
+++ b/apps/argus/lib/cases/reader.test.ts
@@ -93,6 +93,34 @@ test('parseCaseReportSnapshotJson extracts entity sections and case rows', () =>
   assert.equal(report.sections[1]?.rows[0]?.issue, 'Weights and dimensions review')
 })
 
+test('parseCaseReportSnapshotJson normalizes looping rows to Watching', () => {
+  const report = parseCaseReportSnapshotJson(
+    JSON.stringify({
+      report_date: '2026-04-21',
+      market: 'US',
+      sections: [
+        {
+          entity: 'TARGON',
+          rows: [
+            {
+              category: 'looping',
+              issue: 'Shipping label refund ($2,583.96)',
+              case_id: '19550165441',
+              days_ago: '0 days ago',
+              status: 'Work in progress',
+              evidence: 'Forum thread has a new seller follow-up.',
+              assessment: 'Amazon is still looping.',
+              next_step: 'Wait for an Amazon update.',
+            },
+          ],
+        },
+      ],
+    }),
+  )
+
+  assert.equal(report.sections[0]?.rows[0]?.category, 'Watching')
+})
+
 test('readCaseReportBundleFromCaseRoot resolves the latest dated report and tracked cases', async () => {
   const caseRoot = mkdtempSync(path.join(tmpdir(), 'argus-cases-'))
   const reportsDir = path.join(caseRoot, 'reports')

--- a/apps/argus/lib/wpr/week-display.test.ts
+++ b/apps/argus/lib/wpr/week-display.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   buildWeekStartDateLookup,
   formatWeekLabelWithDateRange,
+  formatTooltipWeekLabelFromLookup,
   formatWeekWindowLabel,
 } from './week-display'
 
@@ -31,4 +32,13 @@ test('buildWeekStartDateLookup collects week start dates from weekly series rows
       W16: '2026-04-13',
     },
   )
+})
+
+test('formatTooltipWeekLabelFromLookup skips inactive tooltip labels', () => {
+  const weekStartDates = {
+    W16: '2026-04-13',
+  }
+
+  assert.equal(formatTooltipWeekLabelFromLookup(undefined, weekStartDates), undefined)
+  assert.equal(formatTooltipWeekLabelFromLookup('W16', weekStartDates), 'W16 · 13 Apr - 19 Apr 26')
 })

--- a/apps/argus/lib/wpr/week-display.ts
+++ b/apps/argus/lib/wpr/week-display.ts
@@ -103,6 +103,17 @@ export function formatWeekLabelFromLookup(
   return formatWeekLabelWithDateRange(weekLabel, startDate)
 }
 
+export function formatTooltipWeekLabelFromLookup(
+  weekLabel: WeekLabel | number | undefined,
+  weekStartDates: Readonly<Record<WeekLabel, string>>,
+): string | undefined {
+  if (typeof weekLabel !== 'string') {
+    return undefined
+  }
+
+  return formatWeekLabelFromLookup(weekLabel, weekStartDates)
+}
+
 export function formatWeekWindowLabel(
   weeks: readonly WeekLabel[],
   weekStartDates: Readonly<Record<WeekLabel, string>>,


### PR DESCRIPTION
## Summary
- prevent WPR weekly chart tooltip crashes when Recharts passes an undefined label
- normalize case report rows with category `looping` so `/argus/cases/us` loads again

## Verification
- pnpm exec tsx --test apps/argus/lib/cases/reader.test.ts
- pnpm exec tsx --test apps/argus/lib/wpr/week-display.test.ts apps/argus/components/wpr/tabs/compare-tab.test.ts apps/argus/components/wpr/wpr-change-props.test.ts
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/argus type-check
- local browser smoke for `/argus/wpr?tab=compare` and `/argus/cases/us`
- dev CI run 24790037690
- dev CD run 24790037697
