### PR TITLE
[codex] Replace Targon Global references with Targon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TargonOS
 
-TargonOS is a pnpm + Turborepo monorepo for Targon Global's internal apps and website.
+TargonOS is a pnpm + Turborepo monorepo for Targon's internal apps and website.
 
 ## Apps
 

--- a/apps/archived/argus-v1/lib/email/template.ts
+++ b/apps/archived/argus-v1/lib/email/template.ts
@@ -221,7 +221,7 @@ export function buildAlertEmailHtml(
 <tr>
 <td style="background:#f8fafc; border:1px solid ${BORDER}; border-top:none; padding:16px 24px; text-align:center;">
   <div style="font-family:${FONT}; font-size:11px; color:${TEXT_TERTIARY}; line-height:1.6;">
-    Automated alert from Argus &middot; Targon Global
+    Automated alert from Argus &middot; Targon
   </div>
 </td>
 </tr>

--- a/apps/archived/argus-v1/scripts/api/hourly-listing-attributes/collect.mjs
+++ b/apps/archived/argus-v1/scripts/api/hourly-listing-attributes/collect.mjs
@@ -1787,7 +1787,7 @@ ${overflowRow}
 <tr>
 <td style="background:#f8fafc; border:1px solid ${BORDER}; border-top:none; padding:14px 24px; text-align:center;">
   <div style="font-family:${F}; font-size:11px; color:#94a3b8;">
-    Automated alert from Argus &middot; Targon Global
+    Automated alert from Argus &middot; Targon
   </div>
 </td>
 </tr>

--- a/apps/argus/lib/email/template.ts
+++ b/apps/argus/lib/email/template.ts
@@ -221,7 +221,7 @@ export function buildAlertEmailHtml(
 <tr>
 <td style="background:#f8fafc; border:1px solid ${BORDER}; border-top:none; padding:16px 24px; text-align:center;">
   <div style="font-family:${FONT}; font-size:11px; color:${TEXT_TERTIARY}; line-height:1.6;">
-    Automated alert from Argus &middot; Targon Global
+    Automated alert from Argus &middot; Targon
   </div>
 </td>
 </tr>

--- a/apps/argus/scripts/api/hourly-listing-attributes/collect.mjs
+++ b/apps/argus/scripts/api/hourly-listing-attributes/collect.mjs
@@ -1787,7 +1787,7 @@ ${overflowRow}
 <tr>
 <td style="background:#f8fafc; border:1px solid ${BORDER}; border-top:none; padding:14px 24px; text-align:center;">
   <div style="font-family:${F}; font-size:11px; color:#94a3b8;">
-    Automated alert from Argus &middot; Targon Global
+    Automated alert from Argus &middot; Targon
   </div>
 </td>
 </tr>

--- a/apps/atlas/plans/org-chart-revamp/org-chart-final.jsx
+++ b/apps/atlas/plans/org-chart-revamp/org-chart-final.jsx
@@ -474,7 +474,7 @@ export default function OrgChart() {
               <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke={COLORS.white} strokeWidth="2.5" strokeLinecap="round"><circle cx="12" cy="6" r="2.5" /><circle cx="6" cy="17" r="2.5" /><circle cx="18" cy="17" r="2.5" /><path d="M12 8.5V12M12 12L6 14.5M12 12L18 14.5" /></svg>
             </div>
             <div>
-              <h1 style={{ fontSize: 18, fontWeight: 700, color: COLORS.navy, margin: 0, lineHeight: 1.2 }}>Targon Global</h1>
+              <h1 style={{ fontSize: 18, fontWeight: 700, color: COLORS.navy, margin: 0, lineHeight: 1.2 }}>Targon</h1>
               <p style={{ fontSize: 12, color: COLORS.slate, margin: 0 }}>{employees.length} people · {departments.length} teams</p>
             </div>
           </div>

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,6 +1,6 @@
-# Targon Global
+# Targon
 
-> Targon Global is an AI-driven manufacturing and design company. Its public website currently centers on Caelum Star extra large drop cloths and dust sheets, with region-specific pages for the United States and United Kingdom.
+> Targon is an AI-driven manufacturing and design company. Its public website currently centers on Caelum Star extra large drop cloths and dust sheets, with region-specific pages for the United States and United Kingdom.
 
 Important notes:
 - Use region-specific pages, since the United States and United Kingdom assortments differ.


### PR DESCRIPTION
## What changed
- replaced `Targon Global` with `Targon` in the repo README
- updated Argus email footer text in both live and archived paths
- updated the Atlas org chart plan heading
- updated the website `llms.txt` brand name and summary line

## Why
The repo still had literal `Targon Global` branding in tracked files. The requested naming standard is `Targon` only.

## Impact
- removes the outdated company name from repo-facing brand text
- keeps the change set limited to 7 tracked files with no unrelated auth or UI work mixed in

## Validation
- `rg -n -S --hidden --glob '!**/.git/**' 'Targon Global' /Users/jarraramjad/.codex/worktrees/codex-remove-targon`
- `git -C /Users/jarraramjad/.codex/worktrees/codex-remove-targon diff --cached --check`
