### PR TITLE
fix(argus): force fresh monitoring json fetches

### DIFF
--- a/apps/argus/lib/fetch-json.test.ts
+++ b/apps/argus/lib/fetch-json.test.ts
@@ -15,15 +15,49 @@ test('buildAppPath uses the normalized public base path', () => {
 
 test('readJsonOrThrow parses a successful JSON response', async () => {
   const previousFetch = globalThis.fetch
-  globalThis.fetch = async () =>
-    new Response(JSON.stringify({ ok: true }), {
+  let receivedInit: RequestInit | undefined
+  globalThis.fetch = async (_input, init) => {
+    receivedInit = init
+
+    return new Response(JSON.stringify({ ok: true }), {
       status: 200,
       headers: { 'content-type': 'application/json; charset=utf-8' },
     })
+  }
 
   try {
     const payload = await readJsonOrThrow<{ ok: boolean }>('/api/test')
     assert.deepEqual(payload, { ok: true })
+    assert.equal(receivedInit?.cache, 'no-store')
+    assert.equal(new Headers(receivedInit?.headers).get('accept'), 'application/json')
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})
+
+test('readJsonOrThrow preserves caller headers while forcing JSON no-store requests', async () => {
+  const previousFetch = globalThis.fetch
+  let receivedInit: RequestInit | undefined
+  globalThis.fetch = async (_input, init) => {
+    receivedInit = init
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+  }
+
+  try {
+    await readJsonOrThrow<{ ok: boolean }>('/api/test', {
+      headers: { 'x-argus-test': '1' },
+      credentials: 'same-origin',
+    })
+
+    const headers = new Headers(receivedInit?.headers)
+    assert.equal(headers.get('accept'), 'application/json')
+    assert.equal(headers.get('x-argus-test'), '1')
+    assert.equal(receivedInit?.cache, 'no-store')
+    assert.equal(receivedInit?.credentials, 'same-origin')
   } finally {
     globalThis.fetch = previousFetch
   }

--- a/apps/argus/lib/fetch-json.ts
+++ b/apps/argus/lib/fetch-json.ts
@@ -13,7 +13,14 @@ export function buildAppPath(path: string): string {
 }
 
 export async function readJsonOrThrow<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
-  const response = await fetch(input, init)
+  const headers = new Headers(init?.headers)
+  headers.set('accept', 'application/json')
+
+  const response = await fetch(input, {
+    ...init,
+    cache: 'no-store',
+    headers,
+  })
   const contentType = response.headers.get('content-type')
   const text = await response.text()
 


### PR DESCRIPTION
## What changed
- force shared Argus JSON fetches to send `Accept: application/json`
- force those requests to use `cache: 'no-store'`
- add regression coverage for the fetch options in `fetch-json.test.ts`

## Why
Monitoring on `os.targonglobal.com/argus` could be poisoned by top-level navigation to raw monitoring API routes like `/argus/api/monitoring/bootstrap` or `/argus/api/monitoring/health` in the same tab. Returning to `/argus/monitoring` after that caused client fetches to see `text/html` and throw `Expected JSON response ...` errors.

## Impact
The shared monitoring JSON reader now forces fresh JSON-only requests so the Monitoring page stops reusing poisoned document-style responses in that tab state.

## Validation
- `pnpm exec tsx --test apps/argus/lib/fetch-json.test.ts apps/argus/app/'(app)'/monitoring/page.test.ts apps/argus/app/'(app)'/monitoring/detail-page.test.ts`
- `pnpm --filter @targon/argus lint`
- `pnpm --filter @targon/argus type-check`
