### PR TITLE
chore(release): sync dev back to main

### DIFF
--- a/apps/argus/lib/fetch-json.test.ts
+++ b/apps/argus/lib/fetch-json.test.ts
@@ -15,15 +15,49 @@ test('buildAppPath uses the normalized public base path', () => {
 
 test('readJsonOrThrow parses a successful JSON response', async () => {
   const previousFetch = globalThis.fetch
-  globalThis.fetch = async () =>
-    new Response(JSON.stringify({ ok: true }), {
+  let receivedInit: RequestInit | undefined
+  globalThis.fetch = async (_input, init) => {
+    receivedInit = init
+
+    return new Response(JSON.stringify({ ok: true }), {
       status: 200,
       headers: { 'content-type': 'application/json; charset=utf-8' },
     })
+  }
 
   try {
     const payload = await readJsonOrThrow<{ ok: boolean }>('/api/test')
     assert.deepEqual(payload, { ok: true })
+    assert.equal(receivedInit?.cache, 'no-store')
+    assert.equal(new Headers(receivedInit?.headers).get('accept'), 'application/json')
+  } finally {
+    globalThis.fetch = previousFetch
+  }
+})
+
+test('readJsonOrThrow preserves caller headers while forcing JSON no-store requests', async () => {
+  const previousFetch = globalThis.fetch
+  let receivedInit: RequestInit | undefined
+  globalThis.fetch = async (_input, init) => {
+    receivedInit = init
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json; charset=utf-8' },
+    })
+  }
+
+  try {
+    await readJsonOrThrow<{ ok: boolean }>('/api/test', {
+      headers: { 'x-argus-test': '1' },
+      credentials: 'same-origin',
+    })
+
+    const headers = new Headers(receivedInit?.headers)
+    assert.equal(headers.get('accept'), 'application/json')
+    assert.equal(headers.get('x-argus-test'), '1')
+    assert.equal(receivedInit?.cache, 'no-store')
+    assert.equal(receivedInit?.credentials, 'same-origin')
   } finally {
     globalThis.fetch = previousFetch
   }

--- a/apps/argus/lib/fetch-json.ts
+++ b/apps/argus/lib/fetch-json.ts
@@ -13,7 +13,14 @@ export function buildAppPath(path: string): string {
 }
 
 export async function readJsonOrThrow<T>(input: RequestInfo | URL, init?: RequestInit): Promise<T> {
-  const response = await fetch(input, init)
+  const headers = new Headers(init?.headers)
+  headers.set('accept', 'application/json')
+
+  const response = await fetch(input, {
+    ...init,
+    cache: 'no-store',
+    headers,
+  })
   const contentType = response.headers.get('content-type')
   const text = await response.text()
 


### PR DESCRIPTION
## Summary
- promote the current green `dev` head to `main`
- carry forward the post-release Argus merge from PR #5162 so `main` catches up to the actual `dev` branch
- preserve the already released portal auth stabilization while bringing the branches back into sync safely

## Validation On Dev
- `CI` push run succeeded on `b72fd62f2b9fa45df927452f3a976daee53c2aea`
- `CD` push run succeeded on `b72fd62f2b9fa45df927452f3a976daee53c2aea`
