### PR TITLE
fix(talos): restrict fulfillment source warehouses

### DIFF
--- a/apps/talos/src/app/api/warehouses/route.ts
+++ b/apps/talos/src/app/api/warehouses/route.ts
@@ -4,9 +4,9 @@ import { Prisma, WarehouseKind } from '@targon/prisma-talos'
 import { sanitizeForDisplay, validateAlphanumeric } from '@/lib/security/input-sanitization'
 import {
   canRegionUseWarehouseCode,
-  isAmazonWarehouseCode,
   type TalosRegion,
 } from '@/lib/warehouses/amazon-warehouse'
+import { isAmazonVirtualWarehouse } from '@/lib/services/fulfillment-source-warehouse'
 import { warehouseListSelect } from './list-query'
 export const dynamic = 'force-dynamic'
 
@@ -130,7 +130,7 @@ export const GET = withAuth(async (req, session) => {
   })
 
   const regionScopedWarehouses = warehouses.filter(warehouse => {
-    if (!isAmazonWarehouseCode(warehouse.code)) {
+    if (!isAmazonVirtualWarehouse(warehouse)) {
       return true
     }
 

--- a/apps/talos/src/app/operations/fulfillment-orders/new/components/amazon-shipment-picker.tsx
+++ b/apps/talos/src/app/operations/fulfillment-orders/new/components/amazon-shipment-picker.tsx
@@ -91,26 +91,6 @@ export function AmazonShipmentPicker({
     })
   }, [shipments, searchTerm])
 
-  // Try to find a warehouse matching the FC code
-  const findWarehouseForFC = useCallback(
-    (fcCode: string) => {
-      // Try exact match first, then partial match
-      const exactMatch = warehouses.find(
-        w => w.code.toUpperCase() === fcCode.toUpperCase()
-      )
-      if (exactMatch) return exactMatch
-
-      // Try partial match (FC code might be part of warehouse code or name)
-      const partialMatch = warehouses.find(
-        w =>
-          w.code.toUpperCase().includes(fcCode.toUpperCase()) ||
-          w.name.toUpperCase().includes(fcCode.toUpperCase())
-      )
-      return partialMatch
-    },
-    [warehouses]
-  )
-
   const handleImport = async (shipmentId: string) => {
     if (!shipmentId.trim()) {
       toast.error('Amazon shipment ID is required')
@@ -179,13 +159,9 @@ export function AmazonShipmentPicker({
 
       const destinationAddress = shipToAddress ? formatAmazonAddress(shipToAddress) : ''
 
-      // Try to auto-select warehouse based on FC code
-      const matchedWarehouse = findWarehouseForFC(destinationFC)
-
       setFormData(prev => ({
         ...prev,
         destinationType: 'AMAZON_FBA',
-        warehouseCode: matchedWarehouse?.code ?? prev.warehouseCode,
         destinationName: destinationFC || prev.destinationName,
         destinationAddress: destinationAddress || prev.destinationAddress,
         externalReference: resolvedShipmentId || prev.externalReference,

--- a/apps/talos/src/app/operations/fulfillment-orders/new/page.tsx
+++ b/apps/talos/src/app/operations/fulfillment-orders/new/page.tsx
@@ -200,7 +200,7 @@ export default function NewFulfillmentOrderPage() {
       try {
 	        setLoading(true)
 	        const [warehousesRes, skusRes] = await Promise.all([
-	          fetch(withBasePath('/api/warehouses?includeAmazon=true'), { credentials: 'include' }),
+	          fetch(withBasePath('/api/warehouses'), { credentials: 'include' }),
 	          fetch(withBasePath('/api/skus'), { credentials: 'include' }),
 	        ])
 
@@ -227,7 +227,7 @@ export default function NewFulfillmentOrderPage() {
             ? (skusPayload as SkuMasterOption[])
             : []
 
-        setWarehouses(warehousesData)
+        setWarehouses(warehousesData.filter(warehouse => warehouse.kind !== 'AMAZON_FBA'))
         setSkus(skusData)
       } catch (error) {
         toast.error(error instanceof Error ? error.message : 'Failed to load data')

--- a/apps/talos/src/lib/services/fulfillment-order-service.ts
+++ b/apps/talos/src/lib/services/fulfillment-order-service.ts
@@ -1,6 +1,7 @@
 import { getTenantPrisma } from '@/lib/tenant/server'
 import { sanitizeForDisplay } from '@/lib/security/input-sanitization'
 import { ValidationError, NotFoundError, ConflictError } from '@/lib/api'
+import { assertValidFulfillmentSourceWarehouse } from '@/lib/services/fulfillment-source-warehouse'
 import {
   FulfillmentDestinationType,
   FulfillmentOrderLineStatus,
@@ -169,12 +170,14 @@ export async function createFulfillmentOrder(
 
   const warehouse = await prisma.warehouse.findFirst({
     where: { code: sanitizeForDisplay(input.warehouseCode.trim()) },
-    select: { code: true, name: true, address: true },
+    select: { code: true, name: true, address: true, kind: true },
   })
 
   if (!warehouse) {
     throw new ValidationError(`Warehouse not found: ${input.warehouseCode}`)
   }
+
+  assertValidFulfillmentSourceWarehouse(warehouse)
 
   const skuCodes = Array.from(new Set(normalizedLines.map(line => line.skuCode)))
   const skus = await prisma.sku.findMany({

--- a/apps/talos/src/lib/services/fulfillment-source-warehouse.ts
+++ b/apps/talos/src/lib/services/fulfillment-source-warehouse.ts
@@ -1,0 +1,29 @@
+import { ValidationError } from '@/lib/api/errors'
+import { WarehouseKind } from '@targon/prisma-talos'
+import { isAmazonWarehouseCode } from '@/lib/warehouses/amazon-warehouse'
+
+export function isAmazonVirtualWarehouse(warehouse: {
+  code: string
+  kind: WarehouseKind
+}) {
+  if (warehouse.kind === WarehouseKind.AMAZON_FBA) {
+    return true
+  }
+
+  if (isAmazonWarehouseCode(warehouse.code)) {
+    return true
+  }
+
+  return false
+}
+
+export function assertValidFulfillmentSourceWarehouse(warehouse: {
+  code: string
+  kind: WarehouseKind
+}) {
+  if (isAmazonVirtualWarehouse(warehouse)) {
+    throw new ValidationError(
+      `Warehouse ${warehouse.code} is an Amazon virtual warehouse and cannot be used as a fulfillment source`
+    )
+  }
+}

--- a/apps/talos/tests/unit/fulfillment-order-source-warehouse.test.ts
+++ b/apps/talos/tests/unit/fulfillment-order-source-warehouse.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { WarehouseKind } from '@targon/prisma-talos'
+
+import { ValidationError } from '../../src/lib/api/errors'
+import { assertValidFulfillmentSourceWarehouse } from '../../src/lib/services/fulfillment-source-warehouse'
+
+test('rejects Amazon virtual warehouses as fulfillment sources', () => {
+  assert.throws(
+    () =>
+      assertValidFulfillmentSourceWarehouse({
+        code: 'AMZN-UK',
+        kind: WarehouseKind.AMAZON_FBA,
+      }),
+    ValidationError
+  )
+})
+
+test('rejects legacy Amazon warehouse codes even when kind is wrong', () => {
+  assert.throws(
+    () =>
+      assertValidFulfillmentSourceWarehouse({
+        code: 'AMZN-UK',
+        kind: WarehouseKind.THIRD_PARTY,
+      }),
+    ValidationError
+  )
+})
+
+test('allows physical warehouses as fulfillment sources', () => {
+  assert.doesNotThrow(() =>
+    assertValidFulfillmentSourceWarehouse({
+      code: 'FMC',
+      kind: WarehouseKind.THIRD_PARTY,
+    })
+  )
+})


### PR DESCRIPTION
## Summary
- block Amazon virtual warehouses from being used as fulfillment source warehouses
- stop the Amazon shipment import flow from auto-selecting a source warehouse
- only show configured non-Amazon warehouses in the fulfillment source picker

## Verification
- pnpm --filter @targon/talos exec tsx --test tests/unit/fulfillment-order-source-warehouse.test.ts
- pnpm --filter @targon/talos exec eslint src/lib/services/fulfillment-source-warehouse.ts src/lib/services/fulfillment-order-service.ts src/app/operations/fulfillment-orders/new/page.tsx src/app/operations/fulfillment-orders/new/components/amazon-shipment-picker.tsx src/app/api/warehouses/route.ts tests/unit/fulfillment-order-source-warehouse.test.ts
- pnpm --filter @targon/talos type-check