### PR TITLE
fix(xplan): polish workbook shell and align auth

### DIFF
--- a/apps/xplan/components/active-strategy-indicator.tsx
+++ b/apps/xplan/components/active-strategy-indicator.tsx
@@ -42,21 +42,24 @@ export function ActiveStrategyIndicator({ strategyName, className }: ActiveStrat
         size="small"
         className={className}
         sx={{
-          height: 26,
+          height: 28,
           borderRadius: '9999px',
-          fontWeight: 600,
+          fontWeight: 700,
           fontSize: '11px',
           border: 1,
-          borderColor: '#a7f3d0',
-          bgcolor: 'rgba(236, 253, 245, 0.7)',
+          borderColor: 'rgba(16, 185, 129, 0.2)',
+          bgcolor: 'rgba(240, 253, 250, 0.86)',
           color: '#064e3b',
+          boxShadow: '0 12px 24px -22px rgba(6, 78, 59, 0.42)',
           '.dark &': {
             borderColor: 'rgba(16, 185, 129, 0.3)',
-            bgcolor: 'rgba(16, 185, 129, 0.1)',
+            bgcolor: 'rgba(16, 185, 129, 0.12)',
             color: '#d1fae5',
           },
           '& .MuiChip-label': {
             whiteSpace: 'nowrap',
+            paddingLeft: 2,
+            paddingRight: 8,
           },
         }}
       />

--- a/apps/xplan/components/sheet-tabs.tsx
+++ b/apps/xplan/components/sheet-tabs.tsx
@@ -43,7 +43,22 @@ export function SheetTabs({
   if (isStack) {
     return (
       <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%', gap: 1.5 }}>
-        <List disablePadding sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+        <List
+          disablePadding
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 0.75,
+            borderRadius: '20px',
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'rgba(255,255,255,0.72)',
+            p: 1,
+            '.dark &': {
+              bgcolor: 'rgba(10, 26, 42, 0.84)',
+            },
+          }}
+        >
           {sheets.map((sheet) => {
             const Icon = sheet.icon;
             const href = sheet.href ?? `/${sheet.slug}`;
@@ -57,30 +72,46 @@ export function SheetTabs({
                 onClick={onSheetSelect ? (event: React.MouseEvent) => handleClick(sheet.slug, event) : undefined}
                 selected={isActive}
                 sx={{
-                  borderRadius: '16px',
+                  borderRadius: '14px',
                   border: 1,
-                  borderColor: isActive ? 'secondary.main' : 'divider',
-                  py: 1.5,
-                  px: 2,
+                  borderColor: isActive ? 'rgba(0, 194, 185, 0.3)' : 'transparent',
+                  py: 1.25,
+                  px: 1.75,
                   minWidth: 160,
+                  color: 'text.secondary',
+                  '&:hover': {
+                    bgcolor: 'rgba(15, 23, 42, 0.04)',
+                  },
                   ...(isActive && {
-                    bgcolor: 'rgba(0, 194, 185, 0.15)',
-                    boxShadow: 2,
+                    bgcolor: 'rgba(239, 251, 250, 0.96)',
+                    color: 'text.primary',
+                    boxShadow: '0 16px 30px -24px rgba(15, 23, 42, 0.38)',
+                    '.dark &': {
+                      bgcolor: 'rgba(9, 35, 51, 0.92)',
+                    },
                     '&.Mui-selected': {
-                      bgcolor: 'rgba(0, 194, 185, 0.15)',
-                      '&:hover': { bgcolor: 'rgba(0, 194, 185, 0.2)' },
+                      bgcolor: 'rgba(239, 251, 250, 0.96)',
+                      '.dark &': {
+                        bgcolor: 'rgba(9, 35, 51, 0.92)',
+                      },
+                      '&:hover': { bgcolor: 'rgba(232, 248, 246, 1)' },
                     },
                   }),
                 }}
               >
                 {Icon && (
-                  <ListItemIcon sx={{ minWidth: 32 }}>
+                  <ListItemIcon
+                    sx={{
+                      minWidth: 32,
+                      color: isActive ? 'secondary.main' : 'text.secondary',
+                    }}
+                  >
                     <Icon size={16} />
                   </ListItemIcon>
                 )}
                 <ListItemText
                   primary={sheet.label}
-                  primaryTypographyProps={{ fontSize: '0.875rem', fontWeight: 500 }}
+                  primaryTypographyProps={{ fontSize: '0.875rem', fontWeight: 600 }}
                 />
               </ListItemButton>
             );
@@ -92,31 +123,56 @@ export function SheetTabs({
   }
 
   return (
-    <Box sx={{ display: 'flex', width: '100%', alignItems: 'center', justifyContent: 'space-between', gap: 1, py: 0.5 }}>
+    <Box
+      sx={{
+        display: 'flex',
+        width: '100%',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 1,
+        borderRadius: '18px',
+        border: 1,
+        borderColor: 'divider',
+        bgcolor: 'rgba(255,255,255,0.64)',
+        px: 0.75,
+        py: 0.75,
+        '.dark &': {
+          bgcolor: 'rgba(10, 26, 42, 0.8)',
+        },
+      }}
+    >
       <Tabs
         value={activeIndex >= 0 ? activeIndex : false}
         variant="scrollable"
         scrollButtons="auto"
         allowScrollButtonsMobile
         sx={{
-          minHeight: 36,
+          minHeight: 40,
+          '& .MuiTabs-flexContainer': {
+            gap: 0.75,
+          },
           '& .MuiTabs-indicator': {
-            bgcolor: 'secondary.main',
+            display: 'none',
           },
           '& .MuiTab-root': {
-            minHeight: 36,
-            px: 1.25,
-            py: 0.5,
+            minHeight: 40,
+            minWidth: 0,
+            px: 1.5,
+            py: 0.75,
             fontSize: '0.875rem',
             fontWeight: 600,
             color: 'text.secondary',
-            borderRadius: '6px',
-            transition: 'background-color 0.15s',
+            borderRadius: '12px',
+            transition: 'background-color 0.15s, color 0.15s, box-shadow 0.15s',
+            '&:hover': {
+              bgcolor: 'rgba(15, 23, 42, 0.04)',
+            },
             '&.Mui-selected': {
-              color: 'secondary.main',
-              bgcolor: 'rgba(0,194,185,0.12)',
+              color: 'text.primary',
+              bgcolor: 'rgba(239, 251, 250, 0.96)',
+              boxShadow: '0 14px 24px -22px rgba(15, 23, 42, 0.45)',
               '.dark &': {
-                bgcolor: 'rgba(0,194,185,0.18)',
+                bgcolor: 'rgba(9, 35, 51, 0.94)',
               },
             },
           },

--- a/apps/xplan/components/sheets/setup-workspace.tsx
+++ b/apps/xplan/components/sheets/setup-workspace.tsx
@@ -107,41 +107,99 @@ export function SetupWorkspace({
   const [activeTab, setActiveTab] = useState<TabId>('strategies');
 
   const hasStrategy = Boolean(activeStrategyId);
+  const activeStrategy = strategies.find((strategy) => strategy.id === activeStrategyId) ?? null;
+  const regionCount = new Set(strategies.map((strategy) => strategy.region)).size;
+  const regionsLabel = regionCount === 2 ? 'US + UK' : strategies[0]?.region ?? 'None';
+  const summaryItems = [
+    {
+      label: 'Scenarios',
+      value: String(strategies.length),
+      detail: 'Strategy sets available',
+    },
+    {
+      label: 'Products',
+      value: String(products.length),
+      detail: hasStrategy ? 'Loaded in the active scenario' : 'Pick a scenario to continue',
+    },
+    {
+      label: 'Coverage',
+      value: regionsLabel,
+      detail: activeStrategy ? `${activeStrategy.region} focus` : 'No active scenario selected',
+    },
+  ];
+  const tabHelperText =
+    activeTab === 'strategies'
+      ? 'Pick the scenario the workbook should follow, then switch or edit it in place.'
+      : 'Tune defaults and product assumptions before moving into ops, sales, and finance sheets.';
 
   return (
-    <div className="space-y-6">
-      {/* Heading */}
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">
-          Setup
-        </h1>
-        <p className="mt-0.5 text-sm text-muted-foreground">
-          Strategies, defaults, and product configuration
-        </p>
+    <div className="space-y-5">
+      <section className="rounded-[24px] border border-slate-200/80 bg-white/90 p-5 shadow-[0_20px_50px_-28px_rgba(15,23,42,0.25)] dark:border-[#153a54] dark:bg-[#081a2b]/88">
+        <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+          <div className="space-y-3">
+            <div className="space-y-1.5">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-[#5fd8d2]">
+                Planning Control
+              </p>
+              <div>
+                <h1 className="text-[2rem] font-semibold tracking-[-0.04em] text-slate-950 dark:text-white">
+                  Setup
+                </h1>
+                <p className="mt-1 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+                  Strategies, defaults, and product configuration for the workbook before execution moves into ops, sales, and finance.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
+              <span className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 font-semibold text-cyan-900 dark:border-cyan-900/60 dark:bg-cyan-950/40 dark:text-cyan-100">
+                {activeStrategy ? `Active scenario: ${activeStrategy.name}` : 'No active scenario'}
+              </span>
+              <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 font-medium dark:border-slate-700 dark:bg-slate-900/60">
+                Workbook scope {regionsLabel}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-3">
+            {summaryItems.map((item) => (
+              <div
+                key={item.label}
+                className="min-w-[148px] rounded-[18px] border border-slate-200/80 bg-slate-50/90 px-4 py-3 dark:border-slate-700/80 dark:bg-slate-900/55"
+              >
+                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                  {item.label}
+                </p>
+                <p className="mt-2 text-xl font-semibold tracking-[-0.03em] text-slate-950 dark:text-white">
+                  {item.value}
+                </p>
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.detail}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <div className="flex flex-col gap-3 rounded-[20px] border border-slate-200/80 bg-white/88 p-2.5 shadow-[0_20px_40px_-34px_rgba(15,23,42,0.34)] dark:border-[#153a54] dark:bg-[#081a2b]/84 lg:flex-row lg:items-center lg:justify-between">
+        <div className="inline-flex flex-wrap gap-1 rounded-[16px] bg-slate-100/90 p-1 dark:bg-slate-900/60">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={cn(
+                'rounded-[12px] px-3.5 py-2 text-sm font-semibold transition-colors',
+                activeTab === tab.id
+                  ? 'bg-white text-slate-950 shadow-sm dark:bg-[#0d3048] dark:text-white'
+                  : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200',
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <p className="px-1 text-sm text-slate-500 dark:text-slate-400">{tabHelperText}</p>
       </div>
 
-      {/* Sub-tabs */}
-      <div className="flex gap-6 border-b border-slate-200 dark:border-[#0b3a52]">
-        {TABS.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={cn(
-              'relative pb-2.5 text-sm font-semibold transition-colors',
-              activeTab === tab.id
-                ? 'text-cyan-700 dark:text-[#00C2B9]'
-                : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300',
-            )}
-          >
-            {tab.label}
-            {activeTab === tab.id && (
-              <span className="absolute inset-x-0 bottom-0 h-0.5 rounded-full bg-cyan-500 dark:bg-[#00C2B9]" />
-            )}
-          </button>
-        ))}
-      </div>
-
-      {/* Strategies tab — flat table */}
       {activeTab === 'strategies' && (
         <StrategyTable
           strategies={strategies}

--- a/apps/xplan/components/sheets/strategy-table.tsx
+++ b/apps/xplan/components/sheets/strategy-table.tsx
@@ -358,61 +358,72 @@ export function StrategyTable({
 
   /* ---- Render ---- */
 
+  const availableGroups = regionFilter === 'ALL'
+    ? groups
+    : groups.filter((group) => group.region === regionFilter);
+
   return (
     <>
       <div className="space-y-4">
-        {/* Toolbar: region tabs + new scenario */}
-        <div className="flex items-center justify-between">
-          <div className="flex gap-1">
-            {REGION_TABS.map((tab) => (
-              <button
-                key={tab.id}
-                onClick={() => setRegionFilter(tab.id)}
-                className={cn(
-                  'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
-                  regionFilter === tab.id
-                    ? 'bg-slate-900 text-white dark:bg-white dark:text-slate-900'
-                    : 'text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800',
-                )}
-              >
-                {tab.label}
-              </button>
-            ))}
+        <div className="flex flex-col gap-3 rounded-[20px] border border-slate-200/80 bg-white/88 p-3 shadow-[0_18px_35px_-30px_rgba(15,23,42,0.35)] dark:border-[#153a54] dark:bg-[#081a2b]/84 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-2">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
+                Scenario Roster
+              </p>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                Switch the workbook between active planning scenarios without leaving setup.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {REGION_TABS.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setRegionFilter(tab.id)}
+                  className={cn(
+                    'rounded-xl px-3 py-1.5 text-sm font-semibold transition-colors',
+                    regionFilter === tab.id
+                      ? 'bg-slate-950 text-white shadow-sm dark:bg-[#00C2B9] dark:text-slate-950'
+                      : 'border border-transparent bg-transparent text-slate-600 hover:border-slate-200 hover:bg-slate-50 dark:text-slate-400 dark:hover:border-slate-700 dark:hover:bg-slate-900/60',
+                  )}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
           </div>
 
-          {groups.length > 0 && (() => {
-            const filtered = regionFilter === 'ALL'
-              ? groups
-              : groups.filter((g) => g.region === regionFilter);
-            if (filtered.length === 0) return null;
-            return (
+          <div className="flex items-center justify-between gap-3 sm:justify-end">
+            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">
+              {filteredStrategies.length} scenario{filteredStrategies.length === 1 ? '' : 's'}
+            </span>
+            {availableGroups.length > 0 && (
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() => openCreateDialog(filtered[0].id)}
-                className="gap-1.5"
+                onClick={() => openCreateDialog(availableGroups[0].id)}
+                className="gap-1.5 rounded-xl border-slate-300 bg-white/90 px-3.5 text-slate-900 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:bg-slate-800"
               >
                 <Plus className="h-3.5 w-3.5" />
                 New Scenario
               </Button>
-            );
-          })()}
+            )}
+          </div>
         </div>
 
-        {/* Table */}
-        <div className="rounded-lg border border-slate-200 dark:border-[#0b3a52]">
+        <div className="overflow-hidden rounded-[22px] border border-slate-200/80 bg-white/92 shadow-[0_22px_48px_-34px_rgba(15,23,42,0.42)] dark:border-[#153a54] dark:bg-[#081a2b]/90">
           <Table>
-            <TableHeader>
-              <TableRow className="hover:bg-transparent">
-                <TableHead className="w-[280px]">Strategy</TableHead>
-                <TableHead>Group</TableHead>
-                <TableHead className="w-[60px]">Region</TableHead>
-                <TableHead className="w-[80px] text-right">Products</TableHead>
-                <TableHead className="w-[120px]">Updated</TableHead>
+            <TableHeader className="bg-slate-50/90 dark:bg-[#0a2237]/92">
+              <TableRow className="border-slate-200/80 hover:bg-transparent dark:border-[#17364d]">
+                <TableHead className="h-11 w-[280px] px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Strategy</TableHead>
+                <TableHead className="px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Group</TableHead>
+                <TableHead className="w-[88px] px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Region</TableHead>
+                <TableHead className="w-[90px] px-4 text-right text-[11px] font-semibold uppercase tracking-[0.14em]">Products</TableHead>
+                <TableHead className="w-[120px] px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Updated</TableHead>
                 <TableHead className="w-[60px]" />
               </TableRow>
             </TableHeader>
-            <TableBody>
+            <TableBody className="[&_tr:last-child]:border-b-0">
               {filteredStrategies.length === 0 ? (
                 <TableRow>
                   <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
@@ -427,58 +438,58 @@ export function StrategyTable({
                       key={strategy.id}
                       onClick={() => handleRowClick(strategy)}
                       className={cn(
-                        'cursor-pointer',
-                        isActive && 'bg-teal-50/60 dark:bg-teal-900/15 shadow-[inset_3px_0_0_#00C2B9]',
+                        'cursor-pointer border-slate-200/80 hover:bg-slate-50/80 dark:border-[#17364d] dark:hover:bg-[#0d2438]/88',
+                        isActive && 'bg-cyan-50/70 ring-1 ring-inset ring-cyan-200/70 dark:bg-[#082f3a]/70 dark:ring-cyan-900/50',
                       )}
                     >
-                      <TableCell className="font-medium">
+                      <TableCell className="px-4 py-3.5 font-medium">
                         <div className="flex items-center gap-2">
-                          <span className="text-slate-900 dark:text-white">
+                          <span className="text-[15px] font-semibold text-slate-900 dark:text-white">
                             {strategy.name}
                           </span>
                           {strategy.isPrimary && (
                             <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400 shrink-0" />
                           )}
                           {isActive && (
-                            <span className="rounded bg-cyan-500 px-1.5 py-0.5 text-[10px] font-semibold text-white dark:bg-[#00C2B9] dark:text-[#002430]">
-                              Active
+                            <span className="rounded-full border border-cyan-200 bg-cyan-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-cyan-900 dark:border-cyan-900/50 dark:bg-cyan-950/50 dark:text-cyan-100">
+                              Live
                             </span>
                           )}
                         </div>
                         {strategy.description && (
-                          <p className="mt-0.5 text-xs text-muted-foreground line-clamp-1">
+                          <p className="mt-1 max-w-[32rem] text-xs text-muted-foreground line-clamp-1">
                             {strategy.description}
                           </p>
                         )}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="px-4 py-3.5">
                         <div className="flex items-center gap-2">
                           <span className="text-sm text-slate-700 dark:text-slate-300">
                             {strategy.strategyGroup?.name ?? '\u2014'}
                           </span>
                           {strategy.strategyGroup?.code && (
-                            <span className="font-mono text-[10px] bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 px-1 py-0.5 rounded">
+                            <span className="rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] text-slate-500 dark:bg-slate-800 dark:text-slate-400">
                               {strategy.strategyGroup.code}
                             </span>
                           )}
                         </div>
                       </TableCell>
-                      <TableCell>
-                        <span className="text-xs text-muted-foreground">
+                      <TableCell className="px-4 py-3.5">
+                        <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
                           {strategy.region === 'US' ? '\u{1F1FA}\u{1F1F8}' : '\u{1F1EC}\u{1F1E7}'} {strategy.region}
                         </span>
                       </TableCell>
-                      <TableCell className="text-right font-mono text-sm tabular-nums">
+                      <TableCell className="px-4 py-3.5 text-right font-mono text-sm tabular-nums">
                         {strategy._count.products}
                       </TableCell>
-                      <TableCell className="text-xs text-muted-foreground">
+                      <TableCell className="px-4 py-3.5 text-xs font-medium text-muted-foreground">
                         {timeAgo(strategy.updatedAt)}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="px-4 py-3.5">
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-7 w-7 p-0"
+                          className="h-8 w-8 rounded-xl p-0 text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
                           onClick={(e) => {
                             e.stopPropagation();
                             openEditDialog(strategy);

--- a/apps/xplan/components/theme-toggle.tsx
+++ b/apps/xplan/components/theme-toggle.tsx
@@ -17,7 +17,7 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <div className="h-9 w-9 rounded-xl border border-slate-200 bg-white dark:border-slate-600 dark:bg-slate-800" />
+      <div className="h-10 w-10 rounded-[14px] border border-slate-200/80 bg-white/70 dark:border-[#163f59] dark:bg-[#0b2236]/80" />
     );
   }
 
@@ -30,16 +30,19 @@ export function ThemeToggle() {
         aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
         size="small"
         sx={{
-          width: 36,
-          height: 36,
-          borderRadius: '12px',
+          width: 40,
+          height: 40,
+          borderRadius: '14px',
           border: 1,
           borderColor: 'divider',
-          bgcolor: 'background.paper',
+          bgcolor: 'rgba(255,255,255,0.72)',
           color: 'text.secondary',
-          boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',
+          boxShadow: '0 14px 24px -22px rgba(15, 23, 42, 0.42)',
+          '.dark &': {
+            bgcolor: 'rgba(10, 26, 42, 0.84)',
+          },
           '&:hover': {
-            bgcolor: 'action.hover',
+            bgcolor: 'rgba(236, 242, 248, 0.96)',
             color: 'text.primary',
           },
         }}

--- a/apps/xplan/components/timezone-clocks.tsx
+++ b/apps/xplan/components/timezone-clocks.tsx
@@ -61,22 +61,55 @@ export function TimeZoneClocks({ reportTimeZone }: { reportTimeZone: string }) {
         sx={{
           display: 'flex',
           alignItems: 'center',
-          gap: 1,
-          borderRadius: '8px',
+          gap: 1.1,
+          borderRadius: '9999px',
           border: 1,
           borderColor: 'divider',
-          bgcolor: 'background.paper',
-          px: 1,
-          py: 0.5,
+          bgcolor: 'rgba(255,255,255,0.72)',
+          px: 1.15,
+          py: 0.6,
           fontSize: '10px',
-          fontWeight: 500,
+          fontWeight: 600,
           color: 'text.secondary',
-          boxShadow: '0 1px 2px 0 rgba(0,0,0,0.05)',
+          boxShadow: '0 14px 24px -22px rgba(15, 23, 42, 0.42)',
+          '.dark &': {
+            bgcolor: 'rgba(10, 26, 42, 0.84)',
+          },
         }}
       >
-        <span className="tabular-nums">{reportNow.split(' ').pop()}</span>
-        <Box component="span" sx={{ color: 'divider' }}>/</Box>
-        <span className="tabular-nums">{userNow.split(' ').pop()}</span>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box
+            component="span"
+            sx={{
+              fontSize: '0.625rem',
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'text.disabled',
+            }}
+          >
+            {reportLabel.slice(0, 3)}
+          </Box>
+          <span className="tabular-nums">{reportNow.split(' ').pop()}</span>
+        </Box>
+        <Box component="span" sx={{ color: 'divider' }}>
+          /
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          <Box
+            component="span"
+            sx={{
+              fontSize: '0.625rem',
+              fontWeight: 700,
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'text.disabled',
+            }}
+          >
+            {userLabel.slice(0, 3)}
+          </Box>
+          <span className="tabular-nums">{userNow.split(' ').pop()}</span>
+        </Box>
       </Box>
     </MuiTooltip>
   );

--- a/apps/xplan/components/workbook-layout.tsx
+++ b/apps/xplan/components/workbook-layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
+import Image from 'next/image';
 import { SheetTabs } from '@/components/sheet-tabs';
 import { getSheetConfig } from '@/lib/sheets';
 import type { YearSegment } from '@/lib/calculations/calendar';
@@ -26,14 +27,18 @@ const assetBasePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '';
 function TargonWordmark({ className }: { className?: string }) {
   return (
     <div className={className}>
-      <img
+      <Image
         src={`${assetBasePath}/brand/logo.svg`}
         alt="Targon"
+        width={112}
+        height={24}
         className="h-6 w-auto dark:hidden"
       />
-      <img
+      <Image
         src={`${assetBasePath}/brand/logo-inverted.svg`}
         alt="Targon"
+        width={112}
+        height={24}
         className="hidden h-6 w-auto dark:block"
       />
     </div>
@@ -441,8 +446,26 @@ export function WorkbookLayout({
   }, [meta]);
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh', bgcolor: 'background.default' }}>
-      <Box component="main" sx={{ display: 'flex', flex: 1, overflow: 'hidden' }} role="main" aria-label="Main content">
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '100vh',
+        bgcolor: 'background.default',
+        backgroundImage:
+          'linear-gradient(180deg, rgba(226, 244, 247, 0.38) 0%, rgba(244, 247, 251, 0) 260px)',
+        '.dark &': {
+          backgroundImage:
+            'linear-gradient(180deg, rgba(7, 42, 56, 0.42) 0%, rgba(7, 21, 36, 0) 280px)',
+        },
+      }}
+    >
+      <Box
+        component="main"
+        sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}
+        role="main"
+        aria-label="Main content"
+      >
         <Box component="section" sx={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
           <Box ref={scrollContainerRef} sx={{ flex: 1, minHeight: 0, overflow: 'auto' }}>
             <AppBar
@@ -454,61 +477,65 @@ export function WorkbookLayout({
                 zIndex: 10,
                 borderBottom: 1,
                 borderColor: 'divider',
-                bgcolor: 'rgba(255,255,255,0.95)',
+                bgcolor: 'rgba(248, 250, 252, 0.86)',
                 backdropFilter: 'blur(16px)',
-                boxShadow: '0 1px 3px rgba(0,0,0,0.06)',
+                boxShadow: '0 20px 40px -34px rgba(15, 23, 42, 0.38)',
                 '.dark &': {
-                  bgcolor: 'rgba(4,19,36,0.95)',
-                  borderColor: '#0b3a52',
-                  boxShadow: '0 1px 4px rgba(1,12,24,0.3)',
+                  bgcolor: 'rgba(7, 21, 36, 0.84)',
+                  borderColor: 'rgba(20, 63, 88, 0.9)',
+                  boxShadow: '0 20px 40px -34px rgba(0, 0, 0, 0.72)',
                 },
               }}
               role="banner"
             >
               <Toolbar
                 variant="dense"
-                sx={{ px: { xs: 1.5, sm: 2, lg: 2.5 }, py: 1, gap: 1, minHeight: 'auto' }}
+                sx={{ px: { xs: 1.5, sm: 2, lg: 2.5 }, py: 1.25, gap: 1.5, minHeight: 'auto' }}
               >
-                {/* App branding - LEFT */}
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    flexShrink: 0,
+                    pr: { sm: 1.5 },
+                    mr: { sm: 0.5 },
+                    borderRight: { sm: 1 },
+                    borderColor: { sm: 'divider' },
+                  }}
+                >
+                  <TargonWordmark className="shrink-0" />
                   <Box
                     sx={{
-                      display: 'flex',
-                      height: 36,
-                      width: 36,
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      borderRadius: '12px',
-                      bgcolor: '#002C51',
-                      boxShadow: 2,
+                      display: { xs: 'none', md: 'flex' },
+                      flexDirection: 'column',
+                      gap: 0.125,
                     }}
                   >
-                    <svg
-                      viewBox="0 0 24 24"
-                      width="20"
-                      height="20"
-                      fill="none"
-                      aria-hidden="true"
-                      style={{ color: 'white' }}
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        fontWeight: 700,
+                        letterSpacing: '0.14em',
+                        textTransform: 'uppercase',
+                        color: 'text.secondary',
+                      }}
                     >
-                      <path d="M7 7L17 17" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" />
-                      <path d="M17 7L7 17" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" />
-                    </svg>
+                      Planning Workspace
+                    </Typography>
+                    <Typography
+                      variant="subtitle2"
+                      sx={{
+                        fontWeight: 700,
+                        letterSpacing: '-0.02em',
+                        color: 'text.primary',
+                      }}
+                    >
+                      xplan
+                    </Typography>
                   </Box>
-                  <Typography
-                    variant="subtitle2"
-                    sx={{
-                      display: { xs: 'none', sm: 'block' },
-                      fontWeight: 600,
-                      letterSpacing: '-0.01em',
-                      color: 'text.primary',
-                    }}
-                  >
-                    xplan
-                  </Typography>
                 </Box>
 
-                {/* Sheet tabs - CENTER */}
                 <Box sx={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
                   <SheetTabs
                     sheets={sheetTabs}
@@ -518,16 +545,35 @@ export function WorkbookLayout({
                   />
                 </Box>
 
-                {/* Right controls */}
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexShrink: 0 }}>
                   {ribbon}
 
                   {showLoadingIndicator && (
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 0.75,
+                        borderRadius: '9999px',
+                        border: 1,
+                        borderColor: 'rgba(0, 194, 185, 0.22)',
+                        bgcolor: 'rgba(240, 253, 250, 0.86)',
+                        px: 1.1,
+                        py: 0.55,
+                        '.dark &': {
+                          bgcolor: 'rgba(8, 47, 58, 0.8)',
+                        },
+                      }}
+                    >
                       <CircularProgress size={14} sx={{ color: 'secondary.main' }} />
                       <Typography
                         variant="caption"
-                        sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'secondary.main' }}
+                        sx={{
+                          fontWeight: 700,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.08em',
+                          color: 'secondary.main',
+                        }}
                       >
                         Loading
                       </Typography>
@@ -537,8 +583,6 @@ export function WorkbookLayout({
                   {reportTimeZone ? <TimeZoneClocks reportTimeZone={reportTimeZone} /> : null}
 
                   <ThemeToggle />
-
-                  <TargonWordmark className="shrink-0" />
                 </Box>
               </Toolbar>
 
@@ -553,7 +597,11 @@ export function WorkbookLayout({
                     borderTop: 1,
                     borderColor: 'divider',
                     px: { xs: 1.5, sm: 2, lg: 2.5 },
-                    py: 0.75,
+                    py: 0.9,
+                    bgcolor: 'rgba(255,255,255,0.56)',
+                    '.dark &': {
+                      bgcolor: 'rgba(8, 20, 34, 0.56)',
+                    },
                   }}
                 >
                   {headerControls}
@@ -561,7 +609,7 @@ export function WorkbookLayout({
                 </Box>
               )}
             </AppBar>
-            <Box sx={{ px: { xs: 2, sm: 3, lg: 4 }, py: 2 }}>{children}</Box>
+            <Box sx={{ px: { xs: 2, sm: 3, lg: 4 }, py: { xs: 2, sm: 2.5, lg: 3 } }}>{children}</Box>
           </Box>
           {hasContextPane && (
             <Box
@@ -572,9 +620,12 @@ export function WorkbookLayout({
                 flexShrink: 0,
                 borderLeft: 1,
                 borderColor: 'divider',
-                bgcolor: 'background.paper',
-                backdropFilter: 'blur(4px)',
+                bgcolor: 'rgba(248, 250, 252, 0.8)',
+                backdropFilter: 'blur(10px)',
                 width: contextWidth,
+                '.dark &': {
+                  bgcolor: 'rgba(8, 20, 34, 0.86)',
+                },
               }}
             >
               <Box
@@ -588,9 +639,9 @@ export function WorkbookLayout({
                   height: '100%',
                   width: 6,
                   cursor: 'ew-resize',
-                  bgcolor: 'rgba(0,194,185,0.3)',
+                  bgcolor: 'rgba(0,194,185,0.22)',
                   transition: 'background-color 0.15s',
-                  '&:hover': { bgcolor: 'rgba(0,194,185,0.5)' },
+                  '&:hover': { bgcolor: 'rgba(0,194,185,0.4)' },
                 }}
               />
               <Box sx={{ height: '100%', overflow: 'auto', px: 2.5, py: 3 }}>{contextPane}</Box>
@@ -605,15 +656,15 @@ export function WorkbookLayout({
         sx={{
           borderTop: 1,
           borderColor: 'divider',
-          bgcolor: 'rgba(255,255,255,0.95)',
+          bgcolor: 'rgba(248, 250, 252, 0.88)',
           backdropFilter: 'blur(16px)',
           px: 1.5,
           py: 1.25,
-          boxShadow: '0 -1px 3px rgba(0,0,0,0.06)',
+          boxShadow: '0 -18px 36px -32px rgba(15, 23, 42, 0.45)',
           '.dark &': {
-            bgcolor: 'rgba(4,19,36,0.95)',
-            borderColor: '#0b3a52',
-            boxShadow: '0 -1px 4px rgba(1,12,24,0.3)',
+            bgcolor: 'rgba(7, 21, 36, 0.9)',
+            borderColor: 'rgba(20, 63, 88, 0.9)',
+            boxShadow: '0 -18px 36px -28px rgba(0, 0, 0, 0.75)',
           },
         }}
         role="navigation"

--- a/apps/xplan/lib/auth.ts
+++ b/apps/xplan/lib/auth.ts
@@ -1,59 +1,81 @@
-import { headers } from 'next/headers';
-import type { Session } from 'next-auth';
-import type { PortalConsumerSession } from '@targon/auth';
-import { readPortalConsumerSession } from '@targon/auth';
+import NextAuth from 'next-auth';
+import type { NextAuthConfig, Session } from 'next-auth';
+import type { NextRequest } from 'next/server';
+import { getWorktreeDevSession, withSharedAuth } from '@targon/auth';
 
-type XPlanSession = Session & {
-  authz?: unknown;
-  roles?: unknown;
-  globalRoles?: unknown;
-  authzVersion?: unknown;
-  activeTenant?: string | null;
-};
+type NextAuthResult = ReturnType<typeof NextAuth>;
 
-function requireSharedSecret(): string {
-  const value = process.env.PORTAL_AUTH_SECRET ?? process.env.NEXTAUTH_SECRET;
+function requireEnv(name: string): string {
+  const value = process.env[name];
   if (!value || value.trim() === '') {
-    throw new Error('PORTAL_AUTH_SECRET or NEXTAUTH_SECRET must be defined for X-Plan auth.');
+    throw new Error(`${name} must be defined for X-Plan auth configuration.`);
   }
   return value;
 }
 
-function buildSession(session: PortalConsumerSession): Session {
-  const result: XPlanSession = {
-    expires: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
-    user: {
-      name: typeof session.payload.name === 'string' ? session.payload.name : undefined,
-      email: typeof session.payload.email === 'string' ? session.payload.email : undefined,
+function resolveAuthOptions(): NextAuthConfig {
+  requireEnv('COOKIE_DOMAIN');
+  requireEnv('NEXTAUTH_URL');
+  requireEnv('NEXT_PUBLIC_APP_URL');
+  requireEnv('PORTAL_AUTH_URL');
+  requireEnv('NEXT_PUBLIC_PORTAL_AUTH_URL');
+
+  const sharedSecret = process.env.PORTAL_AUTH_SECRET || process.env.NEXTAUTH_SECRET;
+  if (!sharedSecret) {
+    throw new Error(
+      'PORTAL_AUTH_SECRET or NEXTAUTH_SECRET must be defined for X-Plan auth configuration.',
+    );
+  }
+  process.env.NEXTAUTH_SECRET = sharedSecret;
+
+  const baseAuthOptions: NextAuthConfig = {
+    trustHost: true,
+    providers: [],
+    session: { strategy: 'jwt' },
+    secret: sharedSecret,
+    callbacks: {
+      async jwt({ token, user }) {
+        if (user && (user as any).id) {
+          token.sub = (user as any).id;
+        }
+        return token;
+      },
+      async session({ session, token }) {
+        (session as { authz?: unknown }).authz = (token as { authz?: unknown }).authz;
+        (session as { roles?: unknown }).roles = (token as { roles?: unknown }).roles;
+        (session as { globalRoles?: unknown }).globalRoles = (token as { globalRoles?: unknown }).globalRoles;
+        (session as { authzVersion?: unknown }).authzVersion =
+          (token as { authzVersion?: unknown }).authzVersion;
+        session.user.id = (token.sub as string) || session.user.id;
+        return session;
+      },
     },
-    authz: session.authz,
-    roles: session.payload.roles ?? session.authz.apps,
-    globalRoles: session.payload.globalRoles ?? session.authz.globalRoles,
-    authzVersion:
-      typeof session.payload.authzVersion === 'number'
-        ? session.payload.authzVersion
-        : session.authz.version,
-    activeTenant: session.activeTenant,
   };
 
-  if (typeof session.payload.sub === 'string' && session.payload.sub.trim() !== '') {
-    (result.user as { id?: string }).id = session.payload.sub;
-  }
-
-  return result;
+  return withSharedAuth(baseAuthOptions, {
+    cookieDomain: requireEnv('COOKIE_DOMAIN'),
+    // Read portal cookie in dev
+    appId: 'targon',
+  });
 }
 
+let cached: NextAuthResult | null = null;
+
+function getNextAuth(): NextAuthResult {
+  if (cached) return cached;
+  cached = NextAuth(resolveAuthOptions());
+  return cached;
+}
+
+export const handlers = {
+  GET: (request: NextRequest) => getNextAuth().handlers.GET(request),
+  POST: (request: NextRequest) => getNextAuth().handlers.POST(request),
+} satisfies NextAuthResult['handlers'];
+
 export async function auth(): Promise<Session | null> {
-  const headerList = await headers();
-  const session = await readPortalConsumerSession({
-    request: { headers: headerList },
-    appId: 'xplan',
-    secret: requireSharedSecret(),
-  });
-
-  if (!session) {
-    return null;
+  const worktreeSession = await getWorktreeDevSession('xplan');
+  if (worktreeSession) {
+    return worktreeSession as unknown as Session;
   }
-
-  return buildSession(session);
+  return getNextAuth().auth() as Promise<Session | null>;
 }

--- a/apps/xplan/lib/mui-theme.ts
+++ b/apps/xplan/lib/mui-theme.ts
@@ -5,7 +5,7 @@ const shared = {
     fontFamily: 'var(--font-sans), Inter, system-ui, sans-serif',
   },
   shape: {
-    borderRadius: 8,
+    borderRadius: 12,
   },
   components: {
     MuiButton: {
@@ -15,8 +15,8 @@ const shared = {
       styleOverrides: {
         root: {
           textTransform: 'none' as const,
-          fontWeight: 500,
-          borderRadius: 8,
+          fontWeight: 600,
+          borderRadius: 12,
           whiteSpace: 'nowrap' as const,
           '&.Mui-disabled': { opacity: 0.4, pointerEvents: 'none' },
         },
@@ -40,7 +40,7 @@ const shared = {
     MuiIconButton: {
       styleOverrides: {
         root: {
-          borderRadius: 8,
+          borderRadius: 12,
         },
       },
     },
@@ -58,10 +58,10 @@ const shared = {
     MuiChip: {
       styleOverrides: {
         root: {
-          fontWeight: 500,
-          height: 22,
+          fontWeight: 700,
+          height: 24,
           fontSize: '0.6875rem',
-          borderRadius: '6px',
+          borderRadius: '9999px',
         },
       },
     },
@@ -90,9 +90,9 @@ const shared = {
       styleOverrides: {
         root: {
           textTransform: 'none' as const,
-          fontWeight: 600,
-          minHeight: 36,
-          padding: '6px 12px',
+          fontWeight: 700,
+          minHeight: 40,
+          padding: '8px 14px',
           fontSize: '0.875rem',
         },
       },
@@ -100,7 +100,7 @@ const shared = {
     MuiTabs: {
       styleOverrides: {
         root: {
-          minHeight: 36,
+          minHeight: 40,
         },
         indicator: {
           height: 3,
@@ -120,10 +120,10 @@ const shared = {
       styleOverrides: {
         root: {
           textTransform: 'none' as const,
-          fontWeight: 500,
+          fontWeight: 700,
           fontSize: '0.75rem',
-          padding: '4px 10px',
-          borderRadius: 6,
+          padding: '5px 12px',
+          borderRadius: 10,
         },
       },
     },
@@ -148,10 +148,10 @@ export const lightTheme = createTheme({
       main: '#00C2B9',
     },
     background: {
-      default: '#f8fafc',
+      default: '#f4f7fb',
       paper: '#FFFFFF',
     },
-    divider: 'rgba(0, 0, 0, 0.08)',
+    divider: 'rgba(15, 23, 42, 0.08)',
   },
 });
 
@@ -160,15 +160,15 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: '#00C2B9',
+      main: '#dbeafe',
     },
     secondary: {
-      main: '#002C51',
+      main: '#00C2B9',
     },
     background: {
-      default: '#041324',
-      paper: '#06182b',
+      default: '#071524',
+      paper: '#0b1d2d',
     },
-    divider: 'rgba(255, 255, 255, 0.08)',
+    divider: 'rgba(148, 163, 184, 0.16)',
   },
 });

--- a/apps/xplan/tests/unit/auth.test.ts
+++ b/apps/xplan/tests/unit/auth.test.ts
@@ -1,78 +1,101 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const headersMock = vi.fn()
-const readPortalConsumerSessionMock = vi.fn()
-
-vi.mock('next/headers', () => ({
-  headers: headersMock,
-}))
+const getWorktreeDevSessionMock = vi.fn()
+const withSharedAuthMock = vi.fn()
+const nextAuthMock = vi.fn()
+const nextAuthAuthMock = vi.fn()
 
 vi.mock('@targon/auth', () => ({
-  getWorktreeDevSession: vi.fn(),
-  readPortalConsumerSession: readPortalConsumerSessionMock,
-  withSharedAuth: vi.fn(),
+  getWorktreeDevSession: getWorktreeDevSessionMock,
+  withSharedAuth: withSharedAuthMock,
+}))
+
+vi.mock('next-auth', () => ({
+  default: nextAuthMock,
 }))
 
 describe('xplan auth', () => {
   afterEach(() => {
     vi.resetModules()
     vi.unstubAllEnvs()
-    headersMock.mockReset()
-    readPortalConsumerSessionMock.mockReset()
+    getWorktreeDevSessionMock.mockReset()
+    withSharedAuthMock.mockReset()
+    nextAuthMock.mockReset()
+    nextAuthAuthMock.mockReset()
   })
 
-  it('returns null when the portal cookie is missing', async () => {
-    vi.stubEnv('PORTAL_AUTH_SECRET', 'test-portal-auth-secret-000000000000')
-    vi.stubEnv('NEXTAUTH_SECRET', 'test-portal-auth-secret-000000000000')
-    headersMock.mockResolvedValue(new Headers())
-    readPortalConsumerSessionMock.mockResolvedValue(null)
-
-    const { auth } = await import('@/lib/auth')
-
-    await expect(auth()).resolves.toBeNull()
-  })
-
-  it('returns claims from the shared portal cookie', async () => {
-    vi.stubEnv('PORTAL_AUTH_SECRET', 'test-portal-auth-secret-000000000000')
-    vi.stubEnv('NEXTAUTH_SECRET', 'test-portal-auth-secret-000000000000')
-    headersMock.mockResolvedValue(new Headers({
-      cookie: '__Secure-next-auth.session-token=token-value',
-    }))
-    readPortalConsumerSessionMock.mockResolvedValue({
-      payload: {
-        sub: 'xplan-user-1',
+  it('returns the worktree dev session before initializing next-auth', async () => {
+    const worktreeSession = {
+      expires: '2026-04-22T00:00:00.000Z',
+      user: {
+        id: 'xplan-user-1',
         email: 'planner@targonglobal.com',
         name: 'Planner User',
+      },
+    }
+
+    getWorktreeDevSessionMock.mockResolvedValue(worktreeSession)
+
+    const { auth } = await import('@/lib/auth')
+    const session = await auth()
+
+    expect(session).toEqual(worktreeSession)
+    expect(getWorktreeDevSessionMock).toHaveBeenCalledWith('xplan')
+    expect(nextAuthMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to next-auth when no worktree dev session exists', async () => {
+    vi.stubEnv('COOKIE_DOMAIN', '.targonglobal.com')
+    vi.stubEnv('NEXTAUTH_URL', 'https://os.targonglobal.com/xplan')
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://os.targonglobal.com/xplan')
+    vi.stubEnv('PORTAL_AUTH_URL', 'https://os.targonglobal.com')
+    vi.stubEnv('NEXT_PUBLIC_PORTAL_AUTH_URL', 'https://os.targonglobal.com')
+    vi.stubEnv('PORTAL_AUTH_SECRET', 'test-portal-auth-secret-000000000000')
+    vi.stubEnv('NEXTAUTH_SECRET', 'test-portal-auth-secret-000000000000')
+
+    const nextAuthSession = {
+      expires: '2026-04-22T00:00:00.000Z',
+      user: {
+        id: 'xplan-user-2',
+        email: 'ops@targonglobal.com',
+        name: 'Ops User',
       },
       authz: {
         version: 1,
         globalRoles: ['platform_admin'],
-        apps: {
-          xplan: {
-            departments: ['Admin'],
-            tenantMemberships: [],
-          },
-        },
       },
       activeTenant: null,
+    }
+
+    getWorktreeDevSessionMock.mockResolvedValue(null)
+    withSharedAuthMock.mockImplementation((baseConfig) => baseConfig)
+    nextAuthAuthMock.mockResolvedValue(nextAuthSession)
+    nextAuthMock.mockReturnValue({
+      auth: nextAuthAuthMock,
+      handlers: {
+        GET: vi.fn(),
+        POST: vi.fn(),
+      },
     })
 
     const { auth } = await import('@/lib/auth')
     const session = await auth()
 
-    expect(session?.user?.id).toBe('xplan-user-1')
-    expect(session?.user?.email).toBe('planner@targonglobal.com')
-    expect((session as { authz?: unknown } | null)?.authz).toEqual({
-      version: 1,
-      globalRoles: ['platform_admin'],
-      apps: {
-        xplan: {
-          departments: ['Admin'],
-          tenantMemberships: [],
-        },
+    expect(session).toEqual(nextAuthSession)
+    expect(getWorktreeDevSessionMock).toHaveBeenCalledWith('xplan')
+    expect(withSharedAuthMock).toHaveBeenCalledTimes(1)
+    expect(withSharedAuthMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trustHost: true,
+        providers: [],
+        secret: 'test-portal-auth-secret-000000000000',
+      }),
+      {
+        cookieDomain: '.targonglobal.com',
+        appId: 'targon',
       },
-    })
-    expect((session as { activeTenant?: unknown } | null)?.activeTenant).toBeNull()
-    expect(readPortalConsumerSessionMock).toHaveBeenCalledTimes(1)
+    )
+    expect(nextAuthMock).toHaveBeenCalledTimes(1)
+    expect(nextAuthAuthMock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- polish the xplan workbook shell so the header, tabs, setup summary, and scenario table feel consistent and production-ready
- align xplan with the shared NextAuth path already in this worktree
- update the xplan auth unit tests to cover the current worktree-session and NextAuth fallback behavior

## Root Cause
- the xplan shell still looked like a stitched set of defaults instead of the denser Targon workbook frame used elsewhere
- xplan auth had moved to the shared NextAuth path, but the unit test still targeted the old direct portal-cookie reader, so the suite no longer matched the implementation

## Validation
- `pnpm --filter @targon/xplan lint`
- `pnpm --filter @targon/xplan test`
- `pnpm --filter @targon/xplan type-check`
- `pnpm --filter @targon/xplan build`
