### PR TITLE
fix(xplan): preserve authz claim fallbacks

### DIFF
--- a/apps/xplan/lib/auth.ts
+++ b/apps/xplan/lib/auth.ts
@@ -20,7 +20,14 @@ function resolveAuthOptions(): NextAuthConfig {
   requireEnv('PORTAL_AUTH_URL');
   requireEnv('NEXT_PUBLIC_PORTAL_AUTH_URL');
 
-  const sharedSecret = process.env.PORTAL_AUTH_SECRET || process.env.NEXTAUTH_SECRET;
+  const portalAuthSecret = process.env.PORTAL_AUTH_SECRET;
+  const nextAuthSecret = process.env.NEXTAUTH_SECRET;
+  const sharedSecret =
+    typeof portalAuthSecret === 'string' && portalAuthSecret.trim() !== ''
+      ? portalAuthSecret
+      : typeof nextAuthSecret === 'string' && nextAuthSecret.trim() !== ''
+        ? nextAuthSecret
+        : undefined;
   if (!sharedSecret) {
     throw new Error(
       'PORTAL_AUTH_SECRET or NEXTAUTH_SECRET must be defined for X-Plan auth configuration.',
@@ -41,12 +48,27 @@ function resolveAuthOptions(): NextAuthConfig {
         return token;
       },
       async session({ session, token }) {
-        (session as { authz?: unknown }).authz = (token as { authz?: unknown }).authz;
-        (session as { roles?: unknown }).roles = (token as { roles?: unknown }).roles;
-        (session as { globalRoles?: unknown }).globalRoles = (token as { globalRoles?: unknown }).globalRoles;
+        const tokenClaims = token as {
+          authz?: {
+            apps?: unknown;
+            globalRoles?: unknown;
+            version?: unknown;
+          };
+          roles?: unknown;
+          globalRoles?: unknown;
+          authzVersion?: unknown;
+          sub?: unknown;
+        };
+
+        (session as { authz?: unknown }).authz = tokenClaims.authz;
+        (session as { roles?: unknown }).roles = tokenClaims.roles ?? tokenClaims.authz?.apps;
+        (session as { globalRoles?: unknown }).globalRoles =
+          tokenClaims.globalRoles ?? tokenClaims.authz?.globalRoles;
         (session as { authzVersion?: unknown }).authzVersion =
-          (token as { authzVersion?: unknown }).authzVersion;
-        session.user.id = (token.sub as string) || session.user.id;
+          tokenClaims.authzVersion ?? tokenClaims.authz?.version;
+        if (typeof tokenClaims.sub === 'string' && tokenClaims.sub.trim() !== '') {
+          session.user.id = tokenClaims.sub;
+        }
         return session;
       },
     },

--- a/apps/xplan/tests/unit/auth.test.ts
+++ b/apps/xplan/tests/unit/auth.test.ts
@@ -98,4 +98,66 @@ describe('xplan auth', () => {
     expect(nextAuthMock).toHaveBeenCalledTimes(1)
     expect(nextAuthAuthMock).toHaveBeenCalledTimes(1)
   })
+
+  it('maps authz apps into session roles when the token omits roles', async () => {
+    vi.stubEnv('COOKIE_DOMAIN', '.targonglobal.com')
+    vi.stubEnv('NEXTAUTH_URL', 'https://os.targonglobal.com/xplan')
+    vi.stubEnv('NEXT_PUBLIC_APP_URL', 'https://os.targonglobal.com/xplan')
+    vi.stubEnv('PORTAL_AUTH_URL', 'https://os.targonglobal.com')
+    vi.stubEnv('NEXT_PUBLIC_PORTAL_AUTH_URL', 'https://os.targonglobal.com')
+    vi.stubEnv('PORTAL_AUTH_SECRET', 'test-portal-auth-secret-000000000000')
+    vi.stubEnv('NEXTAUTH_SECRET', 'test-portal-auth-secret-000000000000')
+
+    const tokenAuthz = {
+      apps: {
+        xplan: {
+          departments: ['Admin'],
+          tenantMemberships: [],
+        },
+      },
+      globalRoles: ['platform_admin'],
+      version: 7,
+    }
+
+    getWorktreeDevSessionMock.mockResolvedValue(null)
+    withSharedAuthMock.mockImplementation((baseConfig) => baseConfig)
+    nextAuthAuthMock.mockResolvedValue(null)
+    nextAuthMock.mockReturnValue({
+      auth: nextAuthAuthMock,
+      handlers: {
+        GET: vi.fn(),
+        POST: vi.fn(),
+      },
+    })
+
+    const { auth } = await import('@/lib/auth')
+    await auth()
+
+    const baseConfig = withSharedAuthMock.mock.calls[0]?.[0]
+    expect(baseConfig).toBeDefined()
+
+    const sessionCallback = baseConfig.callbacks?.session
+    expect(sessionCallback).toBeTypeOf('function')
+
+    const session = await sessionCallback({
+      session: {
+        expires: '2026-04-22T00:00:00.000Z',
+        user: {
+          id: '',
+          email: 'planner@targonglobal.com',
+          name: 'Planner User',
+        },
+      },
+      token: {
+        sub: 'xplan-user-1',
+        authz: tokenAuthz,
+      },
+    })
+
+    expect(session.user.id).toBe('xplan-user-1')
+    expect((session as { authz?: unknown }).authz).toEqual(tokenAuthz)
+    expect((session as { roles?: unknown }).roles).toEqual(tokenAuthz.apps)
+    expect((session as { globalRoles?: unknown }).globalRoles).toEqual(tokenAuthz.globalRoles)
+    expect((session as { authzVersion?: unknown }).authzVersion).toBe(tokenAuthz.version)
+  })
 })


### PR DESCRIPTION
## Summary
- preserve xplan session claim fallbacks from authz when next-auth omits top-level roles data
- add a regression test that exercises the session callback with authz-only token claims
- keep the auth config on explicit non-empty secret resolution without || fallback logic

## Verification
- pnpm --filter @targon/xplan lint
- pnpm --filter @targon/xplan test
- pnpm --filter @targon/xplan type-check
- pnpm --filter @targon/xplan build