### PR TITLE
fix(argus): streamline WPR report panels

### DIFF
--- a/apps/argus/components/wpr/tabs/brand-metrics-tab.test.ts
+++ b/apps/argus/components/wpr/tabs/brand-metrics-tab.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('brand metrics tab owns the brand metrics chart', () => {
+  const source = readFileSync(new URL('./brand-metrics-tab.tsx', import.meta.url), 'utf8')
+
+  assert.match(source, /title="Brand Metrics"/)
+  assert.match(source, /dataKey="awareness"/)
+  assert.match(source, /dataKey="consideration"/)
+  assert.match(source, /dataKey="purchase"/)
+  assert.match(source, /<Legend content=\{<CompareChartLegend \/>/)
+})
+
+test('brand metrics tab keeps weekly change markers in the chart tooltip', () => {
+  const source = readFileSync(new URL('./brand-metrics-tab.tsx', import.meta.url), 'utf8')
+
+  assert.match(source, /buildWeeklyChangeMarkers\(changeEntries\)/)
+  assert.match(source, /buildChangeMarkerLookup\(weeklyChangeMarkers\)/)
+  assert.match(source, /<WprChangeTooltipContent/)
+  assert.match(source, /<RechartsChangeMarkers markers=\{weeklyChangeMarkers\} \/>/)
+})

--- a/apps/argus/components/wpr/tabs/brand-metrics-tab.tsx
+++ b/apps/argus/components/wpr/tabs/brand-metrics-tab.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { Box, Stack, Typography } from '@mui/material'
+import { CartesianGrid, Legend, Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts'
+import {
+  buildChangeMarkerLookup,
+  buildWeeklyChangeMarkers,
+  RechartsChangeMarkers,
+  WprChangeTooltipContent,
+} from '@/components/wpr/chart-change-markers'
+import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
+import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
+import { createCompareViewModel } from '@/lib/wpr/compare-view-model'
+import { formatCompactNumber } from '@/lib/wpr/format'
+import {
+  panelBadgeSx,
+  panelHeadSx,
+  panelSx,
+  panelTitleSx,
+  textPrimary,
+  textSecondary,
+} from '@/lib/wpr/panel-tokens'
+import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
+import { buildBundleWeekStartDateLookup, formatTooltipWeekLabelFromLookup } from '@/lib/wpr/week-display'
+import { CompareChartLegend } from './compare-chart-legend'
+
+const brandTooltipProps = {
+  contentStyle: {
+    background: 'rgba(0,20,35,0.96)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: 8,
+  },
+  labelStyle: {
+    color: textPrimary,
+  },
+  itemStyle: {
+    color: textSecondary,
+  },
+}
+
+function PanelTitle({
+  title,
+  badge,
+}: {
+  title: string
+  badge: string
+}) {
+  return (
+    <Box sx={panelHeadSx}>
+      <Typography sx={panelTitleSx}>{title}</Typography>
+      <Typography sx={panelBadgeSx}>{badge}</Typography>
+    </Box>
+  )
+}
+
+export default function BrandMetricsTab({
+  bundle,
+  changeEntries,
+}: {
+  bundle: WprWeekBundle
+  changeEntries: WprChangeLogEntry[]
+}) {
+  const viewModel = createCompareViewModel(bundle)
+  const weekStartDates = buildBundleWeekStartDateLookup(bundle)
+  const weeklyChangeMarkers = buildWeeklyChangeMarkers(changeEntries)
+  const weeklyChangeMarkersByLabel = buildChangeMarkerLookup(weeklyChangeMarkers)
+
+  return (
+    <Box
+      sx={{
+        display: 'grid',
+        gridTemplateColumns: '1fr',
+        gap: 2,
+      }}
+    >
+      <Box sx={panelSx}>
+        <PanelTitle title="Brand Metrics" badge="Awareness / Consideration / Purchase" />
+        <Box sx={{ p: 1.5 }}>
+          {viewModel.brandRows.length === 0 ? (
+            <Box
+              sx={{
+                minHeight: 320,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: 'rgba(255,255,255,0.54)',
+                fontSize: '0.76rem',
+              }}
+            >
+              No brand metrics data.
+            </Box>
+          ) : (
+            <Stack spacing={1.25}>
+              <Box role="img" aria-label="Brand metrics trend over weeks showing awareness, consideration, and purchase">
+                <ResponsiveChartFrame height={WPR_CHART_HEIGHT}>
+                  <LineChart data={viewModel.brandRows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+                    <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
+                    <YAxis tickFormatter={(value) => formatCompactNumber(value)} tick={{ fontSize: 10 }} />
+                    <Tooltip
+                      {...brandTooltipProps}
+                      content={({ active, payload, label }) => (
+                        <WprChangeTooltipContent
+                          active={active}
+                          payload={payload}
+                          label={label}
+                          labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
+                          changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
+                          formatRow={(entry) => {
+                            const value = entry.value
+                            if (typeof value !== 'number') {
+                              throw new Error(`Invalid brand-metrics tooltip value for ${String(entry.dataKey)}`)
+                            }
+
+                            const color = entry.color
+                            if (color === undefined) {
+                              throw new Error(`Missing brand-metrics tooltip color for ${String(entry.dataKey)}`)
+                            }
+
+                            const name = entry.name
+                            if (name === undefined) {
+                              throw new Error(`Missing brand-metrics tooltip label for ${String(entry.dataKey)}`)
+                            }
+
+                            return {
+                              label: String(name),
+                              value: formatCompactNumber(value),
+                              color,
+                            }
+                          }}
+                        />
+                      )}
+                    />
+                    <RechartsChangeMarkers markers={weeklyChangeMarkers} />
+                    <Legend content={<CompareChartLegend />} />
+                    <Line type="monotone" dataKey="awareness" name="Awareness" stroke="#8fc7ff" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#8fc7ff' }} activeDot={{ r: 3.5 }} />
+                    <Line type="monotone" dataKey="consideration" name="Consideration" stroke="#77dfd0" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#77dfd0' }} activeDot={{ r: 3.5 }} />
+                    <Line type="monotone" dataKey="purchase" name="Purchase" stroke="#d5ff62" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#d5ff62' }} activeDot={{ r: 3.5 }} />
+                  </LineChart>
+                </ResponsiveChartFrame>
+              </Box>
+            </Stack>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -42,11 +42,6 @@ import BusinessReportsSelectionTable from './business-reports-selection-table'
 
 type BusinessReportsViewMode = 'weekly' | 'daily'
 
-type BusinessReportsHeroContent = {
-  name: string
-  meta: string[]
-}
-
 const businessReportsViewToggleGroupSx = {
   '& .MuiToggleButtonGroup-grouped': {
     minWidth: 76,
@@ -462,13 +457,6 @@ function BusinessReportsChart({
   )
 }
 
-function buildHeroContent(): BusinessReportsHeroContent {
-  return {
-    name: 'Business Reports',
-    meta: ['Retail detail-page metrics'],
-  }
-}
-
 export default function BusinessReportsTab({
   bundle,
   changeEntries,
@@ -549,7 +537,6 @@ export default function BusinessReportsTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const heroContent = buildHeroContent()
   const dailySeries = bundle.businessReports.dailyByWeek[bundle.meta.anchorWeek]
   let dailyChartSeries: WprBusinessDailyPoint[] = []
   if (dailySeries !== undefined) {
@@ -569,8 +556,6 @@ export default function BusinessReportsTab({
   return (
     <Stack spacing={2}>
       <WprAnalyticsPanel
-        title={heroContent.name}
-        meta={heroContent.meta}
         footer={<WprAnalyticsFooter items={footerItems} />}
       >
         <BusinessReportsChart

--- a/apps/argus/components/wpr/tabs/compare-tab.test.ts
+++ b/apps/argus/components/wpr/tabs/compare-tab.test.ts
@@ -7,8 +7,8 @@ test('compare tab uses custom legend content for chart legends', () => {
   const legendUsages = source.match(/<Legend\b[\s\S]*?\/>/g) ?? []
   const customLegendUsages = legendUsages.filter((usage) => usage.includes('content='))
 
-  assert.equal(legendUsages.length, 3)
-  assert.equal(customLegendUsages.length, 3)
+  assert.equal(legendUsages.length, 2)
+  assert.equal(customLegendUsages.length, 2)
 })
 
 test('compare tab uses shared change tooltips for weekly charts and shared dark styling for the rest', () => {
@@ -18,8 +18,17 @@ test('compare tab uses shared change tooltips for weekly charts and shared dark 
   const changeTooltipUsages = source.match(/<WprChangeTooltipContent\b/g) ?? []
 
   assert.match(source, /const compareTooltipProps = \{/)
-  assert.equal(tooltipUsages.length, 4)
+  assert.equal(tooltipUsages.length, 3)
   assert.equal(sharedTooltipUsages.length, 2)
-  assert.equal(changeTooltipUsages.length, 2)
-  assert.equal(source.match(/labelText=\{/g)?.length, 2)
+  assert.equal(changeTooltipUsages.length, 1)
+  assert.equal(source.match(/labelText=\{/g)?.length, 1)
+})
+
+test('compare tab no longer owns brand metrics', () => {
+  const source = readFileSync(new URL('./compare-tab.tsx', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(source, /Brand Metrics/)
+  assert.doesNotMatch(source, /dataKey="awareness"/)
+  assert.doesNotMatch(source, /dataKey="consideration"/)
+  assert.doesNotMatch(source, /dataKey="purchase"/)
 })

--- a/apps/argus/components/wpr/tabs/compare-tab.tsx
+++ b/apps/argus/components/wpr/tabs/compare-tab.tsx
@@ -23,7 +23,7 @@ import {
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
 import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
-import { WPR_CHART_HEIGHT, WPR_COMPACT_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
+import { WPR_CHART_HEIGHT } from '@/lib/wpr/chart-layout'
 import { createCompareViewModel } from '@/lib/wpr/compare-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { useWprStore } from '@/stores/wpr-store'
@@ -239,74 +239,6 @@ export default function CompareTab({
         gap: 2,
       }}
     >
-      <Box sx={{ ...panelSx, gridColumn: '1 / -1' }}>
-        <PanelTitle title="Brand Metrics" badge="Awareness / Consideration / Purchase" />
-        <Box sx={{ p: 1.5 }}>
-          {viewModel.brandRows.length === 0 ? (
-            <Box
-              sx={{
-                minHeight: 220,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                color: 'rgba(255,255,255,0.54)',
-                fontSize: '0.76rem',
-              }}
-            >
-              No brand metrics data.
-            </Box>
-          ) : (
-            <Box role="img" aria-label="Brand metrics trend over weeks showing awareness, consideration, and purchase">
-              <ResponsiveChartFrame height={WPR_COMPACT_CHART_HEIGHT}>
-                <LineChart data={viewModel.brandRows} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
-                  <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
-                  <YAxis tickFormatter={(value) => formatCompactNumber(value)} tick={{ fontSize: 10 }} />
-                  <Tooltip
-                    content={({ active, payload, label }) => (
-                      <WprChangeTooltipContent
-                        active={active}
-                        payload={payload}
-                        label={label}
-                        labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
-                        changeMarker={weeklyChangeMarkersByLabel.get(String(label))}
-                        formatRow={(entry) => {
-                          const value = entry.value
-                          if (typeof value !== 'number') {
-                            throw new Error(`Invalid Compare brand-metrics tooltip value for ${String(entry.dataKey)}`)
-                          }
-
-                          const color = entry.color
-                          if (color === undefined) {
-                            throw new Error(`Missing Compare brand-metrics tooltip color for ${String(entry.dataKey)}`)
-                          }
-
-                          const name = entry.name
-                          if (name === undefined) {
-                            throw new Error(`Missing Compare brand-metrics tooltip label for ${String(entry.dataKey)}`)
-                          }
-
-                          return {
-                            label: String(name),
-                            value: formatCompactNumber(value),
-                            color,
-                          }
-                        }}
-                      />
-                    )}
-                  />
-                  <RechartsChangeMarkers markers={weeklyChangeMarkers} />
-                  <Legend content={<CompareChartLegend />} />
-                  <Line type="monotone" dataKey="awareness" name="Awareness" stroke="#8fc7ff" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#8fc7ff' }} activeDot={{ r: 3.5 }} />
-                  <Line type="monotone" dataKey="consideration" name="Consideration" stroke="#77dfd0" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#77dfd0' }} activeDot={{ r: 3.5 }} />
-                  <Line type="monotone" dataKey="purchase" name="Purchase" stroke="#d5ff62" strokeWidth={2} dot={{ r: 2, strokeWidth: 0, fill: '#d5ff62' }} activeDot={{ r: 3.5 }} />
-                </LineChart>
-              </ResponsiveChartFrame>
-            </Box>
-          )}
-        </Box>
-      </Box>
-
       <Box sx={{ ...panelSx, gridColumn: '1 / -1' }}>
         <Box
           sx={{

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -34,11 +34,6 @@ import {
 import { useWprStore } from '@/stores/wpr-store'
 import ScpSelectionTable from './scp-selection-table'
 
-type ScpHeroContent = {
-  name: string
-  meta: string[]
-}
-
 function ScpWeeklyChart({
   weekly,
   weekStartDates,
@@ -201,13 +196,6 @@ function ScpWeeklyChart({
   )
 }
 
-function buildHeroContent(): ScpHeroContent {
-  return {
-    name: 'Search Catalog Performance',
-    meta: ['Catalog search funnel'],
-  }
-}
-
 export default function ScpTab({
   bundle,
   changeEntries,
@@ -287,7 +275,6 @@ export default function ScpTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const heroContent = buildHeroContent()
   const historyLabel = formatWeekWindowLabel(bundle.scp.meta.baselineWindow, weekStartDates)
   const footerItems = [
     `Source: SCP`,
@@ -300,8 +287,6 @@ export default function ScpTab({
   return (
     <Stack spacing={2}>
       <WprAnalyticsPanel
-        title={heroContent.name}
-        meta={heroContent.meta}
         footer={<WprAnalyticsFooter items={footerItems} />}
       >
         <ScpWeeklyChart

--- a/apps/argus/components/wpr/tabs/sqp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-tab.tsx
@@ -5,7 +5,6 @@ import { Box, Stack } from '@mui/material'
 import {
   createSqpSelectionViewModel,
   rootTermIds,
-  type SqpSelectionViewModel,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { buildBundleWeekStartDateLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
@@ -56,93 +55,6 @@ function allSelectableTermIds(bundle: WprWeekBundle): string[] {
   }
 
   return termIds
-}
-
-function buildHeroContent(
-  bundle: WprWeekBundle,
-  viewModel: SqpSelectionViewModel,
-): { name: string; meta: string[] } {
-  if (viewModel.scopeType === 'empty') {
-    return {
-      name: 'SQP Selection',
-      meta: ['0 roots selected'],
-    }
-  }
-
-  const selectedRootId = viewModel.selectedRootIds[0]
-  const selectedRootRow = viewModel.rootRows.find((row) => row.id === selectedRootId)
-  if (selectedRootRow === undefined && viewModel.selectedRootIds.length === 1) {
-    throw new Error(`Missing SQP root row ${selectedRootId}`)
-  }
-
-  if (viewModel.scopeType === 'term') {
-    const selectedTermId = viewModel.selectedTermIds[0]
-    const selectedTerm = bundle.sqpTerms.find((term) => term.id === selectedTermId)
-    if (selectedTerm === undefined) {
-      throw new Error(`Missing SQP term ${selectedTermId}`)
-    }
-
-    return {
-      name: selectedTerm.term,
-      meta: [
-        selectedTerm.cluster,
-        `1 / ${viewModel.allTermIds.length} SQP terms selected`,
-      ],
-    }
-  }
-
-  if (viewModel.scopeType === 'root' || viewModel.scopeType === 'multi') {
-    if (selectedRootRow === undefined) {
-      throw new Error('Missing SQP root row for single-root selection')
-    }
-
-    return {
-      name: selectedRootRow.label,
-      meta: [
-        selectedRootRow.family,
-        `${viewModel.selectedTermIds.length} / ${viewModel.allTermIds.length} SQP terms selected`,
-      ],
-    }
-  }
-
-  if (viewModel.scopeType === 'no-terms') {
-    if (viewModel.selectedRootIds.length === 1) {
-      if (selectedRootRow === undefined) {
-        throw new Error('Missing SQP root row for no-term selection')
-      }
-
-      return {
-        name: selectedRootRow.label,
-        meta: [
-          selectedRootRow.family,
-          `0 / ${viewModel.allTermIds.length} SQP terms selected`,
-        ],
-      }
-    }
-
-    const preview = viewModel.selectedRootLabels.slice(0, 3).join(', ')
-    return {
-      name: `${viewModel.selectedRootIds.length} Roots`,
-      meta: [
-        preview,
-        `0 / ${viewModel.allTermIds.length} SQP terms selected`,
-      ],
-    }
-  }
-
-  const previewLabels = viewModel.selectedRootLabels.slice(0, 3)
-  let preview = previewLabels.join(', ')
-  if (viewModel.selectedRootLabels.length > 3) {
-    preview = `${preview} +${viewModel.selectedRootLabels.length - 3}`
-  }
-
-  return {
-    name: `${viewModel.selectedRootIds.length} Roots`,
-    meta: [
-      preview,
-      `${viewModel.selectedTermIds.length} / ${viewModel.allTermIds.length} SQP terms selected`,
-    ],
-  }
 }
 
 export default function SqpTab({
@@ -285,7 +197,6 @@ export default function SqpTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const heroContent = buildHeroContent(bundle, viewModel)
   const historyLabel = formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
 
   const handleSetRootSelection = (rootId: string, shouldSelect: boolean) => {
@@ -396,7 +307,6 @@ export default function SqpTab({
   return (
     <Stack spacing={2}>
       <SqpWeeklyPanel
-        heroContent={heroContent}
         weekly={viewModel.weekly}
         changeEntries={changeEntries}
         wowVisible={sqpWowVisible}

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -24,11 +24,6 @@ import {
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry } from '@/lib/wpr/types'
 
-type SqpHeroContent = {
-  name: string
-  meta: string[]
-}
-
 type ChartPoint = {
   week_label: string
   start_date: string
@@ -661,7 +656,6 @@ function SqpWeeklyChart({
 }
 
 export default function SqpWeeklyPanel({
-  heroContent,
   weekly,
   changeEntries,
   wowVisible,
@@ -672,7 +666,6 @@ export default function SqpWeeklyPanel({
   totalTermCount,
   historyLabel,
 }: {
-  heroContent: SqpHeroContent
   weekly: SqpWeeklyPoint[]
   changeEntries: WprChangeLogEntry[]
   wowVisible: WprSqpWowVisible
@@ -693,8 +686,6 @@ export default function SqpWeeklyPanel({
 
   return (
     <WprAnalyticsPanel
-      title={heroContent.name}
-      meta={heroContent.meta}
       footer={<WprAnalyticsFooter items={footerItems} />}
     >
       <SqpWeeklyChart

--- a/apps/argus/components/wpr/tabs/tst-tab.tsx
+++ b/apps/argus/components/wpr/tabs/tst-tab.tsx
@@ -6,7 +6,6 @@ import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import {
   competitorRootTermIds,
   createTstViewModel,
-  type TstSelectionViewModel,
 } from '@/lib/wpr/tst-view-model'
 import { buildBundleWeekStartDateLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
@@ -15,34 +14,6 @@ import TstWeeklyPanel from './tst-weekly-panel'
 
 function filterIds(ids: Set<string>, allowedIds: Set<string>): string[] {
   return Array.from(ids).filter((id) => allowedIds.has(id))
-}
-
-function buildHeroContent(
-  viewModel: TstSelectionViewModel,
-): { name: string; meta: string[] } {
-  if (viewModel.scopeType === 'empty') {
-    return {
-      name: 'TST Selection',
-      meta: ['0 roots selected'],
-    }
-  }
-
-  let rootLabel = viewModel.rootLabels.slice(0, 3).join(', ')
-  if (viewModel.rootLabels.length > 3) {
-    rootLabel = `${rootLabel} +${viewModel.rootLabels.length - 3}`
-  }
-
-  if (viewModel.scopeType === 'no-terms') {
-    return {
-      name: viewModel.rootIds.length > 1 ? `${viewModel.rootIds.length} Roots` : viewModel.rootLabels[0],
-      meta: [rootLabel, '0 terms selected'],
-    }
-  }
-
-  return {
-    name: viewModel.rootIds.length > 1 ? `${viewModel.rootIds.length} Roots` : viewModel.rootLabels[0],
-    meta: [rootLabel],
-  }
 }
 
 export default function TstTab({
@@ -138,7 +109,6 @@ export default function TstTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const heroContent = buildHeroContent(viewModel)
   const historyLabel = formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
   const competitor = bundle.meta.competitor
 
@@ -214,7 +184,6 @@ export default function TstTab({
   return (
     <Stack spacing={2}>
       <TstWeeklyPanel
-        heroContent={heroContent}
         viewModel={viewModel}
         changeEntries={changeEntries}
         historyLabel={historyLabel}

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -32,11 +32,6 @@ import {
 } from '@/lib/wpr/panel-tokens'
 import { formatPercent } from '@/lib/wpr/format'
 
-type TstHeroContent = {
-  name: string
-  meta: string[]
-}
-
 function WeeklyGapChart({
   weekly,
   weekStartDates,
@@ -169,7 +164,6 @@ function WeeklyGapChart({
 }
 
 export default function TstWeeklyPanel({
-  heroContent,
   viewModel,
   changeEntries,
   historyLabel,
@@ -177,7 +171,6 @@ export default function TstWeeklyPanel({
   wowVisible,
   setWowVisible,
 }: {
-  heroContent: TstHeroContent
   viewModel: TstSelectionViewModel
   changeEntries: WprChangeLogEntry[]
   historyLabel: string
@@ -207,8 +200,6 @@ export default function TstWeeklyPanel({
 
   return (
     <WprAnalyticsPanel
-      title={heroContent.name}
-      meta={heroContent.meta}
       footer={<WprAnalyticsFooter items={footerItems} />}
     >
       <WeeklyGapChart

--- a/apps/argus/components/wpr/wpr-analytics-panel.tsx
+++ b/apps/argus/components/wpr/wpr-analytics-panel.tsx
@@ -1,50 +1,8 @@
 'use client'
 
 import type { ReactNode } from 'react'
-import { Box, Stack, Typography } from '@mui/material'
-import { panelSx, subtleBorder, textMuted, textSecondary } from '@/lib/wpr/panel-tokens'
-
-export function WprAnalyticsMetric({
-  label,
-  value,
-}: {
-  label: string
-  value: string
-}) {
-  return (
-    <Box
-      sx={{
-        minHeight: 48,
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-      }}
-    >
-      <Typography
-        sx={{
-          fontSize: '0.58rem',
-          fontWeight: 700,
-          textTransform: 'uppercase',
-          letterSpacing: '0.12em',
-          color: textMuted,
-          mb: 0.35,
-        }}
-      >
-        {label}
-      </Typography>
-      <Typography
-        sx={{
-          fontSize: '1.18rem',
-          fontWeight: 700,
-          letterSpacing: '-0.04em',
-          color: 'rgba(255,255,255,0.92)',
-        }}
-      >
-        {value}
-      </Typography>
-    </Box>
-  )
-}
+import { Box, Typography } from '@mui/material'
+import { panelSx, subtleBorder, textMuted } from '@/lib/wpr/panel-tokens'
 
 export function WprAnalyticsFooter({
   items,
@@ -81,40 +39,14 @@ export function WprAnalyticsFooter({
 }
 
 export function WprAnalyticsPanel({
-  title,
-  meta,
   children,
   footer,
 }: {
-  title: string
-  meta: string[]
   children: ReactNode
   footer: ReactNode
 }) {
   return (
     <Box sx={panelSx}>
-      <Box
-        sx={{
-          px: 2.5,
-          pt: 2,
-          pb: 1.25,
-          borderBottom: subtleBorder,
-          display: 'flex',
-          justifyContent: 'space-between',
-          gap: 2,
-          flexWrap: 'wrap',
-        }}
-      >
-        <Stack spacing={0.45}>
-          <Typography sx={{ fontSize: '1.2rem', fontWeight: 700, color: 'rgba(255,255,255,0.92)' }}>
-            {title}
-          </Typography>
-          <Typography sx={{ fontSize: '0.72rem', color: textSecondary }}>
-            {meta.join(' · ')}
-          </Typography>
-        </Stack>
-      </Box>
-
       <Box sx={{ p: 2.5 }}>{children}</Box>
 
       {footer}

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -7,6 +7,7 @@ test('dashboard shell passes change entries into all week-based WPR tabs', () =>
 
   assert.match(shellSource, /<ScpTab bundle=\{bundle\} changeEntries=\{chartChangeEntries\} \/>/)
   assert.match(shellSource, /<BusinessReportsTab bundle=\{bundle\} changeEntries=\{chartChangeEntries\} \/>/)
+  assert.match(shellSource, /<BrandMetricsTab bundle=\{bundle\} changeEntries=\{chartChangeEntries\} \/>/)
   assert.match(shellSource, /<CompareTab bundle=\{bundle\} changeEntries=\{chartChangeEntries\} \/>/)
 })
 
@@ -87,12 +88,14 @@ test('all week-based WPR charts use the shared change tooltip renderer', () => {
   const scpSource = readFileSync(new URL('./tabs/scp-tab.tsx', import.meta.url), 'utf8')
   const tstSource = readFileSync(new URL('./tabs/tst-weekly-panel.tsx', import.meta.url), 'utf8')
   const brSource = readFileSync(new URL('./tabs/business-reports-tab.tsx', import.meta.url), 'utf8')
+  const brandSource = readFileSync(new URL('./tabs/brand-metrics-tab.tsx', import.meta.url), 'utf8')
   const compareSource = readFileSync(new URL('./tabs/compare-tab.tsx', import.meta.url), 'utf8')
 
   assert.match(scpSource, /<WprChangeTooltipContent/)
   assert.match(tstSource, /<WprChangeTooltipContent/)
   assert.match(brSource, /<WprChangeTooltipContent/)
-  assert.equal(compareSource.match(/<WprChangeTooltipContent/g)?.length, 2)
+  assert.match(brandSource, /<WprChangeTooltipContent/)
+  assert.equal(compareSource.match(/<WprChangeTooltipContent/g)?.length, 1)
 })
 
 test('SQP, SCP, BR, and TST use one shared analytics panel shell', () => {
@@ -115,13 +118,29 @@ test('week-based analytics panels drop the summary metric strip above the charts
   const scpSource = readFileSync(new URL('./tabs/scp-tab.tsx', import.meta.url), 'utf8')
   const brSource = readFileSync(new URL('./tabs/business-reports-tab.tsx', import.meta.url), 'utf8')
   const tstSource = readFileSync(new URL('./tabs/tst-weekly-panel.tsx', import.meta.url), 'utf8')
+  const sqpTabSource = readFileSync(new URL('./tabs/sqp-tab.tsx', import.meta.url), 'utf8')
+  const tstTabSource = readFileSync(new URL('./tabs/tst-tab.tsx', import.meta.url), 'utf8')
 
   assert.doesNotMatch(analyticsPanelSource, /metricColumns/)
   assert.doesNotMatch(analyticsPanelSource, /metrics:/)
+  assert.doesNotMatch(analyticsPanelSource, /title:/)
+  assert.doesNotMatch(analyticsPanelSource, /meta:/)
+  assert.doesNotMatch(analyticsPanelSource, /<Stack/)
+  assert.doesNotMatch(analyticsPanelSource, /textSecondary/)
   assert.doesNotMatch(sqpSource, /metrics=\{/)
   assert.doesNotMatch(scpSource, /metrics=\{/)
   assert.doesNotMatch(brSource, /metrics=\{/)
   assert.doesNotMatch(tstSource, /metrics=\{/)
+  assert.doesNotMatch(sqpSource, /title=\{/)
+  assert.doesNotMatch(scpSource, /title=\{/)
+  assert.doesNotMatch(brSource, /title=\{/)
+  assert.doesNotMatch(tstSource, /title=\{/)
+  assert.doesNotMatch(sqpSource, /meta=\{/)
+  assert.doesNotMatch(scpSource, /meta=\{/)
+  assert.doesNotMatch(brSource, /meta=\{/)
+  assert.doesNotMatch(tstSource, /meta=\{/)
+  assert.doesNotMatch(sqpTabSource, /buildHeroContent/)
+  assert.doesNotMatch(tstTabSource, /buildHeroContent/)
 })
 
 test('SQP, SCP, BR, and TST use one shared selection panel shell', () => {

--- a/apps/argus/components/wpr/wpr-dashboard-shell.tsx
+++ b/apps/argus/components/wpr/wpr-dashboard-shell.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/hooks/use-wpr';
 import { getInitialWprTab } from '@/lib/wpr/dashboard-state';
 import { useWprStore } from '@/stores/wpr-store';
+import BrandMetricsTab from './tabs/brand-metrics-tab';
 import BusinessReportsTab from './tabs/business-reports-tab';
 import ChangelogTab from './tabs/changelog-tab';
 import CompareTab from './tabs/compare-tab';
@@ -20,6 +21,9 @@ import SqpTab from './tabs/sqp-tab';
 import TstTab from './tabs/tst-tab';
 import WprTopBar from './wpr-top-bar';
 
+const BUNDLE_TABS = new Set(['sqp', 'scp', 'br', 'tst', 'brand', 'compare']);
+const CHART_CHANGE_ENTRY_TABS = new Set(['sqp', 'scp', 'br', 'tst', 'brand', 'compare']);
+
 export default function WprDashboardShell() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -28,8 +32,8 @@ export default function WprDashboardShell() {
   const setActiveTab = useWprStore((state) => state.setActiveTab);
   const setSelectedWeek = useWprStore((state) => state.setSelectedWeek);
   const weeksQuery = useWprWeeksQuery();
-  const needsBundle = activeTab === 'sqp' || activeTab === 'scp' || activeTab === 'br' || activeTab === 'tst' || activeTab === 'compare';
-  const needsChartChangeEntries = activeTab === 'sqp' || activeTab === 'scp' || activeTab === 'br' || activeTab === 'tst' || activeTab === 'compare';
+  const needsBundle = BUNDLE_TABS.has(activeTab);
+  const needsChartChangeEntries = CHART_CHANGE_ENTRY_TABS.has(activeTab);
   const bundleWeek = weeksQuery.data?.defaultWeek ?? null;
   const bundleQuery = useWprWeekBundleQuery(bundleWeek, needsBundle);
   const chartChangeLogQuery = useWprChangeLogWeekQuery(bundleWeek, needsChartChangeEntries);
@@ -139,6 +143,7 @@ export default function WprDashboardShell() {
         {activeTab === 'scp' && bundle !== undefined && chartChangeEntries !== undefined ? <ScpTab bundle={bundle} changeEntries={chartChangeEntries} /> : null}
         {activeTab === 'br' && bundle !== undefined && chartChangeEntries !== undefined ? <BusinessReportsTab bundle={bundle} changeEntries={chartChangeEntries} /> : null}
         {activeTab === 'tst' && bundle !== undefined && chartChangeEntries !== undefined ? <TstTab bundle={bundle} changeEntries={chartChangeEntries} /> : null}
+        {activeTab === 'brand' && bundle !== undefined && chartChangeEntries !== undefined ? <BrandMetricsTab bundle={bundle} changeEntries={chartChangeEntries} /> : null}
         {activeTab === 'changelog' && changelogEntries !== undefined ? (
           <ChangelogTab
             entries={changelogEntries}

--- a/apps/argus/lib/wpr/dashboard-state.test.ts
+++ b/apps/argus/lib/wpr/dashboard-state.test.ts
@@ -8,6 +8,7 @@ import {
   getLegacyWprRedirect,
   switchDashboardWeek,
   toggleSetMember,
+  WPR_TABS,
   wprStateReviver,
   wprStateReplacer,
   type WprTab,
@@ -44,6 +45,14 @@ test('legacy competitor route maps to the TST tab', () => {
 
 test('missing query params default the shell to SQP', () => {
   assert.equal(getInitialWprTab(new URLSearchParams()), 'sqp')
+})
+
+test('brand query param opens the Brand WPR tab', () => {
+  assert.equal(getInitialWprTab(new URLSearchParams('tab=brand')), 'brand')
+})
+
+test('brand metrics tab is labeled BM in the WPR navigation', () => {
+  assert.deepEqual(WPR_TABS.find((tab) => tab.id === 'brand'), { id: 'brand', label: 'BM' })
 })
 
 test('switchDashboardWeek snapshots the current week and clears state for an uncached week', () => {

--- a/apps/argus/lib/wpr/dashboard-state.ts
+++ b/apps/argus/lib/wpr/dashboard-state.ts
@@ -1,6 +1,6 @@
 import type { WeekLabel } from './types'
 
-export type WprTab = 'sqp' | 'scp' | 'br' | 'tst' | 'changelog' | 'compare' | 'sources'
+export type WprTab = 'sqp' | 'scp' | 'br' | 'tst' | 'brand' | 'changelog' | 'compare' | 'sources'
 export type WprCompareOrganicMode = 'map' | 'trend'
 export type WprSortDirection = 'asc' | 'desc'
 
@@ -59,6 +59,7 @@ export const WPR_TABS = [
   { id: 'scp', label: 'SCP' },
   { id: 'br', label: 'BR' },
   { id: 'tst', label: 'TST' },
+  { id: 'brand', label: 'BM' },
   { id: 'changelog', label: 'Change Log' },
   { id: 'compare', label: 'Compare' },
   { id: 'sources', label: 'Sources' },


### PR DESCRIPTION
## What changed

- Split WPR brand metrics into the BM tab so Compare stays focused on comparison charts.
- Removed the redundant chart summary/header band from SQP, SCP, BR, and TST report panels.
- Kept week filters scoped to the tables/changelog instead of filtering the full report page.
- Added/updated WPR source tests covering the BM tab and removed report-panel summary props.

## Validation

- pnpm exec tsx --tsconfig tsconfig.json --test components/wpr/wpr-change-props.test.ts components/wpr/tabs/sqp-weekly-panel.test.tsx components/wpr/tabs/compare-tab.test.ts components/wpr/tabs/brand-metrics-tab.test.ts lib/wpr/dashboard-state.test.ts
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/argus type-check
