### PR TITLE
fix(xplan): polish setup workspace UI

### DIFF
--- a/apps/xplan/app/[sheet]/page.tsx
+++ b/apps/xplan/app/[sheet]/page.tsx
@@ -2301,11 +2301,7 @@ export default async function SheetPage({ params, searchParams }: SheetPageProps
         },
       })
     : null;
-  const activeStrategyName: string | null = activeStrategyRow
-    ? activeStrategyRow.strategyGroup?.name
-      ? `${activeStrategyRow.strategyGroup.name} · ${activeStrategyRow.name}`
-      : activeStrategyRow.name
-    : null;
+  const activeStrategyName: string | null = activeStrategyRow ? activeStrategyRow.name : null;
   const strategyRegion: StrategyRegion =
     strategyId && activeStrategyRow
       ? (() => {

--- a/apps/xplan/components/active-strategy-indicator.tsx
+++ b/apps/xplan/components/active-strategy-indicator.tsx
@@ -1,68 +1,65 @@
 'use client';
 
-import Chip from '@mui/material/Chip';
 import MuiTooltip from '@mui/material/Tooltip';
 import Box from '@mui/material/Box';
-import { keyframes } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
 
 interface ActiveStrategyIndicatorProps {
   strategyName: string;
   className?: string;
 }
 
-const pulse = keyframes`
-  0%, 100% { opacity: 0.4; transform: scale(1); }
-  50% { opacity: 0; transform: scale(2); }
-`;
-
 function GreenDot() {
   return (
-    <Box sx={{ position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', width: 8, height: 8, flexShrink: 0 }}>
-      <Box
-        sx={{
-          position: 'absolute',
-          width: '100%',
-          height: '100%',
-          borderRadius: '50%',
-          bgcolor: '#34d399',
-          animation: `${pulse} 2s cubic-bezier(0.4, 0, 0.6, 1) infinite`,
-        }}
-      />
-      <Box sx={{ position: 'relative', width: 8, height: 8, borderRadius: '50%', bgcolor: '#10b981' }} />
-    </Box>
+    <Box
+      sx={{
+        width: 8,
+        height: 8,
+        flexShrink: 0,
+        borderRadius: '50%',
+        bgcolor: '#10b981',
+        boxShadow: '0 0 0 3px rgba(16, 185, 129, 0.14)',
+      }}
+    />
   );
 }
 
 export function ActiveStrategyIndicator({ strategyName, className }: ActiveStrategyIndicatorProps) {
   return (
     <MuiTooltip title={strategyName} placement="bottom">
-      <Chip
-        icon={<GreenDot />}
-        label={strategyName}
-        size="small"
+      <Box
+        data-testid="active-strategy-indicator"
         className={className}
         sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 0.75,
           height: 28,
-          borderRadius: '9999px',
-          fontWeight: 700,
-          fontSize: '11px',
-          border: 1,
-          borderColor: 'rgba(16, 185, 129, 0.2)',
-          bgcolor: 'rgba(240, 253, 250, 0.86)',
+          maxWidth: { xs: 150, sm: 200, md: 240, lg: 270, xl: 300 },
+          minWidth: 0,
           color: '#064e3b',
-          boxShadow: '0 12px 24px -22px rgba(6, 78, 59, 0.42)',
           '.dark &': {
-            borderColor: 'rgba(16, 185, 129, 0.3)',
-            bgcolor: 'rgba(16, 185, 129, 0.12)',
             color: '#d1fae5',
           },
-          '& .MuiChip-label': {
-            whiteSpace: 'nowrap',
-            paddingLeft: 2,
-            paddingRight: 8,
-          },
         }}
-      />
+      >
+        <GreenDot />
+        <Typography
+          component="span"
+          sx={{
+            display: 'block',
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontSize: '11px',
+            fontWeight: 700,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {strategyName}
+        </Typography>
+      </Box>
     </MuiTooltip>
   );
 }

--- a/apps/xplan/components/sheets/setup-workspace.tsx
+++ b/apps/xplan/components/sheets/setup-workspace.tsx
@@ -107,97 +107,33 @@ export function SetupWorkspace({
   const [activeTab, setActiveTab] = useState<TabId>('strategies');
 
   const hasStrategy = Boolean(activeStrategyId);
-  const activeStrategy = strategies.find((strategy) => strategy.id === activeStrategyId) ?? null;
-  const regionCount = new Set(strategies.map((strategy) => strategy.region)).size;
-  const regionsLabel = regionCount === 2 ? 'US + UK' : strategies[0]?.region ?? 'None';
-  const summaryItems = [
-    {
-      label: 'Scenarios',
-      value: String(strategies.length),
-      detail: 'Strategy sets available',
-    },
-    {
-      label: 'Products',
-      value: String(products.length),
-      detail: hasStrategy ? 'Loaded in the active scenario' : 'Pick a scenario to continue',
-    },
-    {
-      label: 'Coverage',
-      value: regionsLabel,
-      detail: activeStrategy ? `${activeStrategy.region} focus` : 'No active scenario selected',
-    },
-  ];
   const tabHelperText =
     activeTab === 'strategies'
-      ? 'Pick the scenario the workbook should follow, then switch or edit it in place.'
-      : 'Tune defaults and product assumptions before moving into ops, sales, and finance sheets.';
+      ? `${strategies.length} scenarios`
+      : `${products.length} products`;
 
   return (
-    <div className="space-y-5">
-      <section className="rounded-[24px] border border-slate-200/80 bg-white/90 p-5 shadow-[0_20px_50px_-28px_rgba(15,23,42,0.25)] dark:border-[#153a54] dark:bg-[#081a2b]/88">
-        <div className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
-          <div className="space-y-3">
-            <div className="space-y-1.5">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-cyan-700 dark:text-[#5fd8d2]">
-                Planning Control
-              </p>
-              <div>
-                <h1 className="text-[2rem] font-semibold tracking-[-0.04em] text-slate-950 dark:text-white">
-                  Setup
-                </h1>
-                <p className="mt-1 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
-                  Strategies, defaults, and product configuration for the workbook before execution moves into ops, sales, and finance.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600 dark:text-slate-300">
-              <span className="rounded-full border border-cyan-200 bg-cyan-50 px-3 py-1 font-semibold text-cyan-900 dark:border-cyan-900/60 dark:bg-cyan-950/40 dark:text-cyan-100">
-                {activeStrategy ? `Active scenario: ${activeStrategy.name}` : 'No active scenario'}
-              </span>
-              <span className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 font-medium dark:border-slate-700 dark:bg-slate-900/60">
-                Workbook scope {regionsLabel}
-              </span>
-            </div>
-          </div>
-
-          <div className="grid gap-3 sm:grid-cols-3">
-            {summaryItems.map((item) => (
-              <div
-                key={item.label}
-                className="min-w-[148px] rounded-[18px] border border-slate-200/80 bg-slate-50/90 px-4 py-3 dark:border-slate-700/80 dark:bg-slate-900/55"
-              >
-                <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
-                  {item.label}
-                </p>
-                <p className="mt-2 text-xl font-semibold tracking-[-0.03em] text-slate-950 dark:text-white">
-                  {item.value}
-                </p>
-                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{item.detail}</p>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <div className="flex flex-col gap-3 rounded-[20px] border border-slate-200/80 bg-white/88 p-2.5 shadow-[0_20px_40px_-34px_rgba(15,23,42,0.34)] dark:border-[#153a54] dark:bg-[#081a2b]/84 lg:flex-row lg:items-center lg:justify-between">
-        <div className="inline-flex flex-wrap gap-1 rounded-[16px] bg-slate-100/90 p-1 dark:bg-slate-900/60">
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 rounded-[16px] border border-slate-200/80 bg-white/90 p-2 shadow-[0_16px_34px_-30px_rgba(15,23,42,0.34)] dark:border-slate-700/70 dark:bg-slate-950/50 lg:flex-row lg:items-center lg:justify-between">
+        <div className="inline-flex flex-wrap gap-1 rounded-[12px] bg-slate-100/90 p-1 dark:bg-slate-900/70">
           {TABS.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}
               className={cn(
-                'rounded-[12px] px-3.5 py-2 text-sm font-semibold transition-colors',
+                'rounded-[9px] px-3.5 py-2 text-sm font-semibold transition-colors',
                 activeTab === tab.id
                   ? 'bg-white text-slate-950 shadow-sm dark:bg-[#0d3048] dark:text-white'
-                  : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200',
+                  : 'text-slate-500 hover:text-slate-700 dark:text-slate-300 dark:hover:text-white',
               )}
             >
               {tab.label}
             </button>
           ))}
         </div>
-        <p className="px-1 text-sm text-slate-500 dark:text-slate-400">{tabHelperText}</p>
+        <p className="px-1 text-xs font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-300">
+          {tabHelperText}
+        </p>
       </div>
 
       {activeTab === 'strategies' && (

--- a/apps/xplan/components/sheets/strategy-table.tsx
+++ b/apps/xplan/components/sheets/strategy-table.tsx
@@ -175,18 +175,12 @@ export function StrategyTable({
       : strategies.filter((s) => s.region === regionFilter);
 
     return [...filtered].sort((a, b) => {
-      // Active first
-      if (a.id === selectedStrategyId && b.id !== selectedStrategyId) return -1;
-      if (b.id === selectedStrategyId && a.id !== selectedStrategyId) return 1;
-      // Then by group name
       const groupCmp = a.strategyGroup!.name.localeCompare(b.strategyGroup!.name);
       if (groupCmp !== 0) return groupCmp;
-      // Primary first within group
       if (a.isPrimary !== b.isPrimary) return a.isPrimary ? -1 : 1;
-      // Then by updated
       return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
     });
-  }, [strategies, regionFilter, selectedStrategyId]);
+  }, [strategies, regionFilter]);
 
   const strategyAssigneeIds = (strategy: Strategy) =>
     Array.isArray(strategy.strategyAssignees) && strategy.strategyAssignees.length > 0
@@ -365,32 +359,22 @@ export function StrategyTable({
   return (
     <>
       <div className="space-y-4">
-        <div className="flex flex-col gap-3 rounded-[20px] border border-slate-200/80 bg-white/88 p-3 shadow-[0_18px_35px_-30px_rgba(15,23,42,0.35)] dark:border-[#153a54] dark:bg-[#081a2b]/84 sm:flex-row sm:items-center sm:justify-between">
-          <div className="space-y-2">
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.14em] text-slate-500 dark:text-slate-400">
-                Scenario Roster
-              </p>
-              <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
-                Switch the workbook between active planning scenarios without leaving setup.
-              </p>
-            </div>
-            <div className="flex flex-wrap gap-1.5">
-              {REGION_TABS.map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => setRegionFilter(tab.id)}
-                  className={cn(
-                    'rounded-xl px-3 py-1.5 text-sm font-semibold transition-colors',
-                    regionFilter === tab.id
-                      ? 'bg-slate-950 text-white shadow-sm dark:bg-[#00C2B9] dark:text-slate-950'
-                      : 'border border-transparent bg-transparent text-slate-600 hover:border-slate-200 hover:bg-slate-50 dark:text-slate-400 dark:hover:border-slate-700 dark:hover:bg-slate-900/60',
-                  )}
-                >
-                  {tab.label}
-                </button>
-              ))}
-            </div>
+        <div className="flex flex-col gap-3 px-1 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex flex-wrap gap-1.5">
+            {REGION_TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setRegionFilter(tab.id)}
+                className={cn(
+                  'rounded-xl px-3 py-1.5 text-sm font-semibold transition-colors',
+                  regionFilter === tab.id
+                    ? 'bg-slate-950 text-white shadow-sm dark:bg-cyan-400 dark:text-slate-950'
+                    : 'border border-transparent bg-transparent text-slate-600 hover:border-slate-200 hover:bg-slate-50 dark:text-slate-300 dark:hover:border-slate-700 dark:hover:bg-slate-900/70',
+                )}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
 
           <div className="flex items-center justify-between gap-3 sm:justify-end">
@@ -402,7 +386,7 @@ export function StrategyTable({
                 size="sm"
                 variant="outline"
                 onClick={() => openCreateDialog(availableGroups[0].id)}
-                className="gap-1.5 rounded-xl border-slate-300 bg-white/90 px-3.5 text-slate-900 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:bg-slate-800"
+                className="gap-1.5 rounded-lg border-slate-300 bg-white/90 px-3.5 text-slate-900 shadow-sm hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900/70 dark:text-slate-100 dark:hover:bg-slate-800"
               >
                 <Plus className="h-3.5 w-3.5" />
                 New Scenario
@@ -411,10 +395,10 @@ export function StrategyTable({
           </div>
         </div>
 
-        <div className="overflow-hidden rounded-[22px] border border-slate-200/80 bg-white/92 shadow-[0_22px_48px_-34px_rgba(15,23,42,0.42)] dark:border-[#153a54] dark:bg-[#081a2b]/90">
+        <div className="overflow-hidden rounded-lg border border-slate-200/80 bg-white/90 shadow-[0_22px_48px_-34px_rgba(15,23,42,0.42)] dark:border-slate-700/70 dark:bg-slate-950/50">
           <Table>
-            <TableHeader className="bg-slate-50/90 dark:bg-[#0a2237]/92">
-              <TableRow className="border-slate-200/80 hover:bg-transparent dark:border-[#17364d]">
+            <TableHeader className="bg-slate-50/90 dark:bg-slate-900/90">
+              <TableRow className="border-slate-200/80 hover:bg-transparent dark:border-slate-700/70">
                 <TableHead className="h-11 w-[280px] px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Strategy</TableHead>
                 <TableHead className="px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Group</TableHead>
                 <TableHead className="w-[88px] px-4 text-[11px] font-semibold uppercase tracking-[0.14em]">Region</TableHead>
@@ -438,8 +422,8 @@ export function StrategyTable({
                       key={strategy.id}
                       onClick={() => handleRowClick(strategy)}
                       className={cn(
-                        'cursor-pointer border-slate-200/80 hover:bg-slate-50/80 dark:border-[#17364d] dark:hover:bg-[#0d2438]/88',
-                        isActive && 'bg-cyan-50/70 ring-1 ring-inset ring-cyan-200/70 dark:bg-[#082f3a]/70 dark:ring-cyan-900/50',
+                        'cursor-pointer border-slate-200/80 hover:bg-slate-50/80 dark:border-slate-700/70 dark:hover:bg-slate-900/70',
+                        isActive && 'bg-cyan-50/70 ring-1 ring-inset ring-cyan-200/70 dark:bg-cyan-950/40 dark:ring-cyan-500/30',
                       )}
                     >
                       <TableCell className="px-4 py-3.5 font-medium">
@@ -451,7 +435,7 @@ export function StrategyTable({
                             <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400 shrink-0" />
                           )}
                           {isActive && (
-                            <span className="rounded-full border border-cyan-200 bg-cyan-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-cyan-900 dark:border-cyan-900/50 dark:bg-cyan-950/50 dark:text-cyan-100">
+                            <span className="rounded-full border border-emerald-200/80 bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-emerald-800 dark:border-emerald-400/25 dark:bg-emerald-500/10 dark:text-emerald-200">
                               Live
                             </span>
                           )}
@@ -463,16 +447,9 @@ export function StrategyTable({
                         )}
                       </TableCell>
                       <TableCell className="px-4 py-3.5">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm text-slate-700 dark:text-slate-300">
-                            {strategy.strategyGroup?.name ?? '\u2014'}
-                          </span>
-                          {strategy.strategyGroup?.code && (
-                            <span className="rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] text-slate-500 dark:bg-slate-800 dark:text-slate-400">
-                              {strategy.strategyGroup.code}
-                            </span>
-                          )}
-                        </div>
+                        <span className="text-sm text-slate-700 dark:text-slate-300">
+                          {strategy.strategyGroup?.name ?? '\u2014'}
+                        </span>
                       </TableCell>
                       <TableCell className="px-4 py-3.5">
                         <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-1 text-[11px] font-semibold text-slate-600 dark:bg-slate-800 dark:text-slate-300">
@@ -489,7 +466,7 @@ export function StrategyTable({
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-8 w-8 rounded-xl p-0 text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+                          className="h-8 w-8 rounded-lg p-0 text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
                           onClick={(e) => {
                             e.stopPropagation();
                             openEditDialog(strategy);

--- a/apps/xplan/components/timezone-clocks.tsx
+++ b/apps/xplan/components/timezone-clocks.tsx
@@ -57,17 +57,17 @@ export function TimeZoneClocks({ reportTimeZone }: { reportTimeZone: string }) {
       placement="bottom"
     >
       <Box
-        className="hidden sm:flex"
         sx={{
-          display: 'flex',
+          display: { xs: 'none', md: 'flex' },
           alignItems: 'center',
-          gap: 1.1,
+          gap: 0.7,
+          flexShrink: 0,
           borderRadius: '9999px',
           border: 1,
           borderColor: 'divider',
           bgcolor: 'rgba(255,255,255,0.72)',
-          px: 1.15,
-          py: 0.6,
+          px: 0.8,
+          py: 0.45,
           fontSize: '10px',
           fontWeight: 600,
           color: 'text.secondary',
@@ -77,7 +77,7 @@ export function TimeZoneClocks({ reportTimeZone }: { reportTimeZone: string }) {
           },
         }}
       >
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.35 }}>
           <Box
             component="span"
             sx={{
@@ -95,7 +95,7 @@ export function TimeZoneClocks({ reportTimeZone }: { reportTimeZone: string }) {
         <Box component="span" sx={{ color: 'divider' }}>
           /
         </Box>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.35 }}>
           <Box
             component="span"
             sx={{

--- a/apps/xplan/components/workbook-layout.tsx
+++ b/apps/xplan/components/workbook-layout.tsx
@@ -545,8 +545,31 @@ export function WorkbookLayout({
                   />
                 </Box>
 
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexShrink: 0 }}>
-                  {ribbon}
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-end',
+                    gap: 0.75,
+                    flex: '0 1 auto',
+                    minWidth: 0,
+                    maxWidth: { xs: '100%', md: 430, lg: 470, xl: 500 },
+                    ml: 'auto',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {ribbon ? (
+                    <Box
+                      sx={{
+                        minWidth: 0,
+                        flex: '0 1 auto',
+                        maxWidth: { xs: 150, sm: 200, md: 240, lg: 270, xl: 300 },
+                        overflow: 'hidden',
+                      }}
+                    >
+                      {ribbon}
+                    </Box>
+                  ) : null}
 
                   {showLoadingIndicator && (
                     <Box
@@ -582,7 +605,9 @@ export function WorkbookLayout({
 
                   {reportTimeZone ? <TimeZoneClocks reportTimeZone={reportTimeZone} /> : null}
 
-                  <ThemeToggle />
+                  <Box sx={{ display: 'flex', flexShrink: 0 }}>
+                    <ThemeToggle />
+                  </Box>
                 </Box>
               </Toolbar>
 

--- a/apps/xplan/tests/ui/active-strategy-indicator.test.tsx
+++ b/apps/xplan/tests/ui/active-strategy-indicator.test.tsx
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ActiveStrategyIndicator } from '@/components/active-strategy-indicator'
+
+describe('ActiveStrategyIndicator', () => {
+  it('renders as compact header status text instead of a pill chip', () => {
+    const { container } = render(<ActiveStrategyIndicator strategyName="PDS - Old Import (MAIN)" />)
+
+    expect(screen.getByText('PDS - Old Import (MAIN)')).toBeVisible()
+    expect(container.querySelector('.MuiChip-root')).not.toBeInTheDocument()
+  })
+})

--- a/apps/xplan/tests/ui/strategy-table.test.tsx
+++ b/apps/xplan/tests/ui/strategy-table.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { StrategyTable } from '@/components/sheets/strategy-table'
+
+const pushMock = vi.fn()
+const refreshMock = vi.fn()
+let searchParamsInstance = new URLSearchParams()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+    refresh: refreshMock,
+  }),
+  useSearchParams: () => searchParamsInstance,
+}))
+
+const strategies = [
+  {
+    id: 'demo',
+    name: 'Demo Strategy',
+    description: 'Demo strategy for exploring X-Plan',
+    region: 'US',
+    isDefault: false,
+    isPrimary: true,
+    strategyGroupId: 'demo-group',
+    strategyGroup: {
+      id: 'demo-group',
+      code: 'demo-strategy',
+      name: 'Demo Strategy',
+      region: 'US',
+      createdById: null,
+      createdByEmail: null,
+      assigneeId: null,
+      assigneeEmail: null,
+      createdAt: '2026-02-01T00:00:00.000Z',
+      updatedAt: '2026-02-04T00:00:00.000Z',
+    },
+    createdAt: '2026-02-01T00:00:00.000Z',
+    updatedAt: '2026-02-04T00:00:00.000Z',
+    _count: {
+      products: 0,
+      purchaseOrders: 0,
+      salesWeeks: 0,
+    },
+  },
+] as const
+
+describe('StrategyTable', () => {
+  beforeEach(() => {
+    pushMock.mockReset()
+    refreshMock.mockReset()
+    searchParamsInstance = new URLSearchParams()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        new Response(JSON.stringify({ assignees: [], directoryConfigured: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      ),
+    )
+  })
+
+  it('renders compact scenario controls without explanatory roster copy', () => {
+    render(
+      <StrategyTable
+        strategies={[...strategies]}
+        activeStrategyId="demo"
+        viewer={{ id: null, email: null, isSuperAdmin: false }}
+        keyParametersByStrategyId={{}}
+      />,
+    )
+
+    expect(screen.queryByText('Scenario Roster')).not.toBeInTheDocument()
+    expect(
+      screen.queryByText('Switch the workbook between active planning scenarios without leaving setup.'),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText('demo-strategy')).not.toBeInTheDocument()
+    expect(screen.getByText('Live')).toHaveClass('dark:bg-emerald-500/10')
+    expect(screen.getByRole('button', { name: 'All' })).toBeVisible()
+    expect(screen.getByRole('button', { name: 'New Scenario' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary
- Remove the oversized setup summary card and redundant scenario roster explainer from xplan setup.
- Keep strategy table order stable while highlighting the active row without moving it.
- Tighten dark-mode setup styling, header status display, and table status badges; remove slug pills from the group column.

## Validation
- pnpm --filter @targon/xplan lint
- pnpm --filter @targon/xplan type-check
- pnpm --filter @targon/xplan test -- tests/ui/active-strategy-indicator.test.tsx tests/ui/strategy-table.test.tsx tests/ui/workbook-layout.test.tsx tests/ui/sheet-tabs.test.tsx
- Browser verification at http://localhost:41308/xplan/1-setup?year=2026
