### PR TITLE
feat(talos): improve dashboard inventory overview

### DIFF
--- a/apps/talos/src/app/api/dashboard/overview/route.ts
+++ b/apps/talos/src/app/api/dashboard/overview/route.ts
@@ -124,6 +124,27 @@ export const GET = withAuth(async (_request, session) => {
         currentPallets: balance.currentPallets,
         currentUnits: balance.currentUnits,
       })),
+      movements: transactions.map(
+        ({
+          purchaseOrder: _purchaseOrder,
+          fulfillmentOrder: _fulfillmentOrder,
+          ...transaction
+        }) => ({
+          id: transaction.id,
+          transactionType: transaction.transactionType,
+          transactionDate: transaction.transactionDate,
+          warehouseCode: transaction.warehouseCode,
+          warehouseName: transaction.warehouseName,
+          skuCode: transaction.skuCode,
+          skuDescription: transaction.skuDescription,
+          lotRef: transaction.lotRef,
+          cartonsIn: transaction.cartonsIn,
+          cartonsOut: transaction.cartonsOut,
+          storagePalletsIn: transaction.storagePalletsIn,
+          shippingPalletsOut: transaction.shippingPalletsOut,
+          unitsPerCarton: transaction.unitsPerCarton,
+        })
+      ),
     })
   )
 })

--- a/apps/talos/src/app/api/dashboard/overview/route.ts
+++ b/apps/talos/src/app/api/dashboard/overview/route.ts
@@ -133,6 +133,7 @@ export const GET = withAuth(async (_request, session) => {
           id: transaction.id,
           transactionType: transaction.transactionType,
           transactionDate: transaction.transactionDate,
+          createdAt: transaction.createdAt,
           warehouseCode: transaction.warehouseCode,
           warehouseName: transaction.warehouseName,
           skuCode: transaction.skuCode,

--- a/apps/talos/src/components/dashboard/dashboard-overview-board.tsx
+++ b/apps/talos/src/components/dashboard/dashboard-overview-board.tsx
@@ -1,9 +1,46 @@
-import type { DashboardOverviewSnapshot } from '@/lib/dashboard/dashboard-overview'
+'use client'
+
+import { useMemo, useState } from 'react'
+import Link from 'next/link'
+import type {
+  DashboardOverviewMovement,
+  DashboardOverviewSnapshot,
+} from '@/lib/dashboard/dashboard-overview'
+import { ArrowDown, ArrowUp } from '@/lib/lucide-icons'
+
+type InventoryMetric = 'cartons' | 'pallets' | 'units'
+
+type InventoryMetricRow = {
+  cartons: number
+  pallets: number
+  units: number
+  carriesPallets?: boolean
+}
 
 const numberFormatter = new Intl.NumberFormat('en-US')
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: '2-digit',
+})
+
+const metricOptions: Array<{ value: InventoryMetric; label: string }> = [
+  { value: 'cartons', label: 'Cartons' },
+  { value: 'pallets', label: 'Pallets' },
+  { value: 'units', label: 'Units' },
+]
+
+const metricLabels: Record<InventoryMetric, string> = {
+  cartons: 'Cartons',
+  pallets: 'Pallets',
+  units: 'Units',
+}
 
 function formatNumber(value: number) {
   return numberFormatter.format(value)
+}
+
+function formatDate(value: string) {
+  return dateFormatter.format(new Date(value))
 }
 
 function getShare(value: number, total: number) {
@@ -12,6 +49,54 @@ function getShare(value: number, total: number) {
   }
 
   return Math.round((value / total) * 100)
+}
+
+function getMetricValue(row: InventoryMetricRow, metric: InventoryMetric) {
+  return row[metric]
+}
+
+function formatMetricValue(row: InventoryMetricRow, metric: InventoryMetric) {
+  if (metric === 'pallets' && row.carriesPallets === false) {
+    return '—'
+  }
+
+  return formatNumber(getMetricValue(row, metric))
+}
+
+function MetricToggle({
+  selectedMetric,
+  setSelectedMetric,
+}: {
+  selectedMetric: InventoryMetric
+  setSelectedMetric: (metric: InventoryMetric) => void
+}) {
+  return (
+    <div
+      aria-label="Distribution metric"
+      className="inline-flex shrink-0 overflow-hidden rounded-md border border-slate-200 bg-slate-50 p-0.5 dark:border-slate-800 dark:bg-slate-950"
+      role="group"
+    >
+      {metricOptions.map(option => {
+        const selected = selectedMetric === option.value
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={selected}
+            onClick={() => setSelectedMetric(option.value)}
+            className={
+              selected
+                ? 'rounded-[5px] bg-slate-900 px-3 py-1.5 text-xs font-semibold text-slate-50 shadow-sm dark:bg-slate-100 dark:text-slate-950'
+                : 'rounded-[5px] px-3 py-1.5 text-xs font-semibold text-slate-600 transition-colors hover:bg-white hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-900 dark:hover:text-slate-100'
+            }
+          >
+            {option.label}
+          </button>
+        )
+      })}
+    </div>
+  )
 }
 
 function StageTable({ snapshot }: { snapshot: DashboardOverviewSnapshot }) {
@@ -92,8 +177,17 @@ function StageTable({ snapshot }: { snapshot: DashboardOverviewSnapshot }) {
   )
 }
 
-function WarehouseTable({ warehouses }: { warehouses: DashboardOverviewSnapshot['warehouses'] }) {
-  const totalCartons = warehouses.reduce((sum, row) => sum + row.cartons, 0)
+function WarehouseTable({
+  warehouses,
+  selectedMetric,
+}: {
+  warehouses: DashboardOverviewSnapshot['warehouses']
+  selectedMetric: InventoryMetric
+}) {
+  const totalSelected = warehouses.reduce(
+    (sum, row) => sum + getMetricValue(row, selectedMetric),
+    0
+  )
 
   return (
     <section className="min-w-0">
@@ -127,7 +221,8 @@ function WarehouseTable({ warehouses }: { warehouses: DashboardOverviewSnapshot[
               </tr>
             ) : null}
             {warehouses.map(row => {
-              const share = getShare(row.cartons, totalCartons)
+              const selectedValue = getMetricValue(row, selectedMetric)
+              const share = getShare(selectedValue, totalSelected)
 
               return (
                 <tr
@@ -142,15 +237,21 @@ function WarehouseTable({ warehouses }: { warehouses: DashboardOverviewSnapshot[
                       {row.warehouseCode}
                     </div>
                   </td>
-                  <td className="px-4 py-4 text-right text-base font-semibold tabular-nums text-slate-900 dark:text-slate-100">
-                    {formatNumber(row.cartons)}
-                  </td>
-                  <td className="px-4 py-4 text-right tabular-nums text-slate-600 dark:text-slate-300">
-                    {formatNumber(row.pallets)}
-                  </td>
-                  <td className="px-4 py-4 text-right tabular-nums text-slate-600 dark:text-slate-300">
-                    {formatNumber(row.units)}
-                  </td>
+                  {metricOptions.map(option => {
+                    const selected = selectedMetric === option.value
+                    return (
+                      <td
+                        key={option.value}
+                        className={
+                          selected
+                            ? 'px-4 py-4 text-right text-base font-semibold tabular-nums text-slate-900 dark:text-slate-100'
+                            : 'px-4 py-4 text-right tabular-nums text-slate-600 dark:text-slate-300'
+                        }
+                      >
+                        {formatMetricValue(row, option.value)}
+                      </td>
+                    )
+                  })}
                   <td className="px-4 py-4 text-right tabular-nums text-slate-600 dark:text-slate-300">
                     {formatNumber(row.skuCount)}
                   </td>
@@ -167,20 +268,31 @@ function WarehouseTable({ warehouses }: { warehouses: DashboardOverviewSnapshot[
   )
 }
 
-function WarehouseChart({ warehouses }: { warehouses: DashboardOverviewSnapshot['warehouses'] }) {
+function WarehouseChart({
+  warehouses,
+  selectedMetric,
+  setSelectedMetric,
+}: {
+  warehouses: DashboardOverviewSnapshot['warehouses']
+  selectedMetric: InventoryMetric
+  setSelectedMetric: (metric: InventoryMetric) => void
+}) {
   const chartData = warehouses.map(row => ({
     name: row.warehouseCode,
-    cartons: row.cartons,
+    value: getMetricValue(row, selectedMetric),
+    carriesPallets: row.carriesPallets,
   }))
-  const maxCartons = chartData.reduce((max, row) => Math.max(max, row.cartons, 0), 0)
-  const scaleMax = maxCartons === 0 ? 1 : maxCartons
+  const maxValue = chartData.reduce((max, row) => Math.max(max, row.value, 0), 0)
+  const scaleMax = maxValue === 0 ? 1 : maxValue
+  const metricLabel = metricLabels[selectedMetric].toLowerCase()
 
   return (
     <section className="min-w-0">
-      <div className="mb-3 flex items-end justify-between gap-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
           Distribution
         </h2>
+        <MetricToggle selectedMetric={selectedMetric} setSelectedMetric={setSelectedMetric} />
       </div>
 
       <div className="border-y border-slate-200 py-4 dark:border-slate-800">
@@ -191,7 +303,15 @@ function WarehouseChart({ warehouses }: { warehouses: DashboardOverviewSnapshot[
         ) : (
           <div className="space-y-4">
             {chartData.map(row => {
-              const width = Math.round((Math.max(row.cartons, 0) / scaleMax) * 100)
+              const width = Math.round((Math.max(row.value, 0) / scaleMax) * 100)
+              const displayValue =
+                selectedMetric === 'pallets' && row.carriesPallets === false
+                  ? '—'
+                  : formatNumber(row.value)
+              const title =
+                selectedMetric === 'pallets' && row.carriesPallets === false
+                  ? `${row.name}: FBA does not carry pallets`
+                  : `${row.name}: ${formatNumber(row.value)} ${metricLabel}`
 
               return (
                 <div
@@ -205,11 +325,11 @@ function WarehouseChart({ warehouses }: { warehouses: DashboardOverviewSnapshot[
                     <div
                       className="h-full bg-teal-700/80"
                       style={{ width: `${width}%` }}
-                      title={`${row.name}: ${formatNumber(row.cartons)} cartons`}
+                      title={title}
                     />
                   </div>
                   <div className="text-right text-sm font-semibold tabular-nums text-slate-900 dark:text-slate-100">
-                    {formatNumber(row.cartons)}
+                    {displayValue}
                   </div>
                 </div>
               )
@@ -221,16 +341,115 @@ function WarehouseChart({ warehouses }: { warehouses: DashboardOverviewSnapshot[
   )
 }
 
+function MovementQuantity({ movement }: { movement: DashboardOverviewMovement }) {
+  return (
+    <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+      <span>{formatNumber(movement.cartons)} cartons</span>
+      <span>{formatNumber(movement.units)} units</span>
+      <span>
+        {movement.carriesPallets ? `${formatNumber(movement.pallets)} pallets` : 'No pallets'}
+      </span>
+    </div>
+  )
+}
+
+function RecentMovementSection({
+  title,
+  movements,
+  direction,
+}: {
+  title: string
+  movements: DashboardOverviewMovement[]
+  direction: 'in' | 'out'
+}) {
+  const Icon = direction === 'in' ? ArrowDown : ArrowUp
+  const iconClass =
+    direction === 'in'
+      ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+      : 'bg-cyan-50 text-cyan-700 dark:bg-cyan-950/40 dark:text-cyan-300'
+
+  return (
+    <section className="min-w-0">
+      <div className="mb-3 flex items-center justify-between gap-4">
+        <h2 className="text-sm font-semibold uppercase tracking-[0.12em] text-slate-500 dark:text-slate-400">
+          {title}
+        </h2>
+        <Link
+          href="/operations/transactions"
+          className="text-xs font-semibold text-teal-700 hover:text-teal-900 dark:text-teal-300 dark:hover:text-teal-100"
+        >
+          Ledger
+        </Link>
+      </div>
+
+      <div className="border-y border-slate-200 dark:border-slate-800">
+        {movements.length === 0 ? (
+          <div className="flex h-32 items-center justify-center text-sm text-slate-500 dark:text-slate-500">
+            No recent movements.
+          </div>
+        ) : (
+          <div className="divide-y divide-slate-200 dark:divide-slate-800">
+            {movements.map(movement => (
+              <div
+                key={movement.id}
+                className="grid grid-cols-[2rem_minmax(0,1fr)_4rem] gap-3 py-3"
+              >
+                <div className={`flex h-8 w-8 items-center justify-center rounded-md ${iconClass}`}>
+                  <Icon className="h-4 w-4" aria-hidden="true" />
+                </div>
+                <div className="min-w-0">
+                  <div className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                      {movement.skuCode}
+                    </span>
+                    <span className="text-xs font-medium text-slate-500 dark:text-slate-500">
+                      {movement.lotRef}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 truncate text-xs text-slate-500 dark:text-slate-400">
+                    {movement.warehouseName} · {movement.transactionType}
+                  </div>
+                  <MovementQuantity movement={movement} />
+                </div>
+                <div className="pt-0.5 text-right text-xs font-semibold tabular-nums text-slate-500 dark:text-slate-500">
+                  {formatDate(movement.transactionDate)}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  )
+}
+
 export function DashboardOverviewBoard({ snapshot }: { snapshot: DashboardOverviewSnapshot }) {
-  const warehouses = [...snapshot.warehouses].sort((left, right) => right.cartons - left.cartons)
+  const [selectedMetric, setSelectedMetric] = useState<InventoryMetric>('cartons')
+  const warehouses = useMemo(
+    () =>
+      [...snapshot.warehouses].sort(
+        (left, right) =>
+          getMetricValue(right, selectedMetric) - getMetricValue(left, selectedMetric)
+      ),
+    [selectedMetric, snapshot.warehouses]
+  )
 
   return (
     <div className="space-y-7 text-slate-700 dark:text-slate-200">
       <StageTable snapshot={snapshot} />
 
       <div className="grid gap-8 xl:grid-cols-[minmax(0,1.35fr)_minmax(24rem,0.65fr)]">
-        <WarehouseTable warehouses={warehouses} />
-        <WarehouseChart warehouses={warehouses} />
+        <WarehouseTable warehouses={warehouses} selectedMetric={selectedMetric} />
+        <WarehouseChart
+          warehouses={warehouses}
+          selectedMetric={selectedMetric}
+          setSelectedMetric={setSelectedMetric}
+        />
+      </div>
+
+      <div className="grid gap-8 lg:grid-cols-2">
+        <RecentMovementSection title="Recent In" movements={snapshot.recentIn} direction="in" />
+        <RecentMovementSection title="Recent Out" movements={snapshot.recentOut} direction="out" />
       </div>
     </div>
   )

--- a/apps/talos/src/components/dashboard/dashboard-overview-board.tsx
+++ b/apps/talos/src/components/dashboard/dashboard-overview-board.tsx
@@ -21,6 +21,7 @@ const numberFormatter = new Intl.NumberFormat('en-US')
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: '2-digit',
+  timeZone: 'UTC',
 })
 
 const metricOptions: Array<{ value: InventoryMetric; label: string }> = [

--- a/apps/talos/src/lib/dashboard/dashboard-overview.test.ts
+++ b/apps/talos/src/lib/dashboard/dashboard-overview.test.ts
@@ -16,7 +16,7 @@ process.env.COOKIE_DOMAIN ??= 'localhost'
 process.env.PORTAL_AUTH_SECRET ??= 'test-secret'
 
 let resolveDashboardOverviewWarehouseCodeFilter:
-  | typeof import('../../app/api/dashboard/overview/route')['resolveDashboardOverviewWarehouseCodeFilter']
+  | (typeof import('../../app/api/dashboard/overview/route'))['resolveDashboardOverviewWarehouseCodeFilter']
   | undefined
 
 const loadResolveDashboardOverviewWarehouseCodeFilter = async () => {
@@ -81,7 +81,7 @@ test('buildDashboardOverviewSnapshot snapshot for factory, transit, and warehous
     },
   ]
 
-  const snapshot = buildDashboardOverviewSnapshot({ purchaseOrders, balances })
+  const snapshot = buildDashboardOverviewSnapshot({ purchaseOrders, balances, movements: [] })
 
   const expectedSnapshot: DashboardOverviewSnapshot = {
     summary: {
@@ -112,6 +112,7 @@ test('buildDashboardOverviewSnapshot snapshot for factory, transit, and warehous
         pallets: 17,
         units: 2800,
         skuCount: 2,
+        carriesPallets: true,
       },
       {
         warehouseCode: 'TCL-CHINO',
@@ -120,8 +121,11 @@ test('buildDashboardOverviewSnapshot snapshot for factory, transit, and warehous
         pallets: 20,
         units: 2400,
         skuCount: 1,
+        carriesPallets: true,
       },
     ],
+    recentIn: [],
+    recentOut: [],
   }
 
   assert.deepEqual(snapshot, expectedSnapshot)
@@ -130,6 +134,7 @@ test('buildDashboardOverviewSnapshot snapshot for factory, transit, and warehous
 test('buildDashboardOverviewSnapshot sorts warehouses by cartons descending', () => {
   const snapshot = buildDashboardOverviewSnapshot({
     purchaseOrders: [],
+    movements: [],
     balances: [
       {
         warehouseCode: 'B',
@@ -150,12 +155,16 @@ test('buildDashboardOverviewSnapshot sorts warehouses by cartons descending', ()
     ],
   })
 
-  assert.deepEqual(snapshot.warehouses.map(row => row.warehouseCode), ['A', 'B'])
+  assert.deepEqual(
+    snapshot.warehouses.map(row => row.warehouseCode),
+    ['A', 'B']
+  )
 })
 
 test('buildDashboardOverviewSnapshot skips zero-value warehouse balances', () => {
   const snapshot = buildDashboardOverviewSnapshot({
     purchaseOrders: [],
+    movements: [],
     balances: [
       {
         warehouseCode: 'A',
@@ -176,7 +185,10 @@ test('buildDashboardOverviewSnapshot skips zero-value warehouse balances', () =>
     ],
   })
 
-  assert.deepEqual(snapshot.warehouses.map(row => row.warehouseCode), ['B'])
+  assert.deepEqual(
+    snapshot.warehouses.map(row => row.warehouseCode),
+    ['B']
+  )
   assert.deepEqual(snapshot.summary.warehouses, {
     cartons: 5,
     pallets: 0,
@@ -188,6 +200,7 @@ test('buildDashboardOverviewSnapshot skips zero-value warehouse balances', () =>
 test('buildDashboardOverviewSnapshot keeps negative warehouse balances visible', () => {
   const snapshot = buildDashboardOverviewSnapshot({
     purchaseOrders: [],
+    movements: [],
     balances: [
       {
         warehouseCode: 'NEG',
@@ -208,7 +221,10 @@ test('buildDashboardOverviewSnapshot keeps negative warehouse balances visible',
     ],
   })
 
-  assert.deepEqual(snapshot.warehouses.map(row => row.warehouseCode), ['NEG'])
+  assert.deepEqual(
+    snapshot.warehouses.map(row => row.warehouseCode),
+    ['NEG']
+  )
   assert.deepEqual(snapshot.summary.warehouses, {
     cartons: -3,
     pallets: -1,
@@ -217,9 +233,132 @@ test('buildDashboardOverviewSnapshot keeps negative warehouse balances visible',
   })
 })
 
+test('buildDashboardOverviewSnapshot excludes Amazon FBA pallets from warehouse totals', () => {
+  const snapshot = buildDashboardOverviewSnapshot({
+    purchaseOrders: [],
+    movements: [],
+    balances: [
+      {
+        warehouseCode: 'AMZN-US',
+        warehouseName: 'Amazon FBA US',
+        skuCode: 'SKU-FBA',
+        currentCartons: 120,
+        currentPallets: 12,
+        currentUnits: 1200,
+      },
+      {
+        warehouseCode: 'TCL-CHINO',
+        warehouseName: 'Tactical Warehouse Solutions',
+        skuCode: 'SKU-3PL',
+        currentCartons: 80,
+        currentPallets: 5,
+        currentUnits: 800,
+      },
+    ],
+  })
+
+  assert.deepEqual(snapshot.summary.warehouses, {
+    cartons: 200,
+    pallets: 5,
+    units: 2000,
+    warehouseCount: 2,
+  })
+  assert.deepEqual(
+    snapshot.warehouses.map(row => ({
+      warehouseCode: row.warehouseCode,
+      pallets: row.pallets,
+      carriesPallets: row.carriesPallets,
+    })),
+    [
+      { warehouseCode: 'AMZN-US', pallets: 0, carriesPallets: false },
+      { warehouseCode: 'TCL-CHINO', pallets: 5, carriesPallets: true },
+    ]
+  )
+})
+
+test('buildDashboardOverviewSnapshot returns recent inbound and outbound movements', () => {
+  const snapshot = buildDashboardOverviewSnapshot({
+    purchaseOrders: [],
+    balances: [],
+    movements: [
+      {
+        id: 'old-receive',
+        transactionType: 'RECEIVE',
+        transactionDate: new Date('2026-04-10T12:00:00.000Z'),
+        warehouseCode: 'TCL-CHINO',
+        warehouseName: 'Tactical Warehouse Solutions',
+        skuCode: 'SKU-OLD',
+        skuDescription: 'Older item',
+        lotRef: 'LOT-OLD',
+        cartonsIn: 3,
+        cartonsOut: 0,
+        storagePalletsIn: 1,
+        shippingPalletsOut: 0,
+        unitsPerCarton: 10,
+      },
+      {
+        id: 'recent-receive',
+        transactionType: 'RECEIVE',
+        transactionDate: new Date('2026-04-13T12:00:00.000Z'),
+        warehouseCode: 'TCL-CHINO',
+        warehouseName: 'Tactical Warehouse Solutions',
+        skuCode: 'SKU-IN',
+        skuDescription: 'Inbound item',
+        lotRef: 'LOT-IN',
+        cartonsIn: 7,
+        cartonsOut: 0,
+        storagePalletsIn: 2,
+        shippingPalletsOut: 0,
+        unitsPerCarton: 12,
+      },
+      {
+        id: 'recent-ship',
+        transactionType: 'SHIP',
+        transactionDate: new Date('2026-04-14T12:00:00.000Z'),
+        warehouseCode: 'AMZN-US',
+        warehouseName: 'Amazon FBA US',
+        skuCode: 'SKU-OUT',
+        skuDescription: 'Outbound item',
+        lotRef: 'LOT-OUT',
+        cartonsIn: 0,
+        cartonsOut: 4,
+        storagePalletsIn: 0,
+        shippingPalletsOut: 3,
+        unitsPerCarton: 6,
+      },
+    ],
+  })
+
+  assert.deepEqual(
+    snapshot.recentIn.map(row => row.id),
+    ['recent-receive', 'old-receive']
+  )
+  assert.deepEqual(
+    snapshot.recentOut.map(row => row.id),
+    ['recent-ship']
+  )
+  assert.deepEqual(snapshot.recentIn[0], {
+    id: 'recent-receive',
+    transactionType: 'RECEIVE',
+    transactionDate: '2026-04-13T12:00:00.000Z',
+    warehouseCode: 'TCL-CHINO',
+    warehouseName: 'Tactical Warehouse Solutions',
+    skuCode: 'SKU-IN',
+    skuDescription: 'Inbound item',
+    lotRef: 'LOT-IN',
+    cartons: 7,
+    pallets: 2,
+    units: 84,
+    carriesPallets: true,
+  })
+  assert.equal(snapshot.recentOut[0].pallets, 0)
+  assert.equal(snapshot.recentOut[0].carriesPallets, false)
+})
+
 test('buildDashboardOverviewSnapshot normalizes warehouse codes to the trimmed grouping key', () => {
   const snapshot = buildDashboardOverviewSnapshot({
     purchaseOrders: [],
+    movements: [],
     balances: [
       {
         warehouseCode: '  FMC-UK  ',
@@ -248,6 +387,7 @@ test('buildDashboardOverviewSnapshot normalizes warehouse codes to the trimmed g
       pallets: 3,
       units: 250,
       skuCount: 2,
+      carriesPallets: true,
     },
   ])
 })
@@ -292,6 +432,7 @@ test('buildDashboardOverviewSnapshot throws when warehouseCode is blank even on 
     () =>
       buildDashboardOverviewSnapshot({
         purchaseOrders: [],
+        movements: [],
         balances: [
           {
             warehouseCode: '   ',
@@ -311,6 +452,7 @@ test('buildDashboardOverviewSnapshot throws when pallet data is missing', () => 
   assert.throws(
     () =>
       buildDashboardOverviewSnapshot({
+        movements: [],
         purchaseOrders: [
           {
             id: 'po-null-pallets',

--- a/apps/talos/src/lib/dashboard/dashboard-overview.test.ts
+++ b/apps/talos/src/lib/dashboard/dashboard-overview.test.ts
@@ -285,6 +285,7 @@ test('buildDashboardOverviewSnapshot returns recent inbound and outbound movemen
         id: 'old-receive',
         transactionType: 'RECEIVE',
         transactionDate: new Date('2026-04-10T12:00:00.000Z'),
+        createdAt: new Date('2026-04-10T12:01:00.000Z'),
         warehouseCode: 'TCL-CHINO',
         warehouseName: 'Tactical Warehouse Solutions',
         skuCode: 'SKU-OLD',
@@ -300,6 +301,7 @@ test('buildDashboardOverviewSnapshot returns recent inbound and outbound movemen
         id: 'recent-receive',
         transactionType: 'RECEIVE',
         transactionDate: new Date('2026-04-13T12:00:00.000Z'),
+        createdAt: new Date('2026-04-13T12:01:00.000Z'),
         warehouseCode: 'TCL-CHINO',
         warehouseName: 'Tactical Warehouse Solutions',
         skuCode: 'SKU-IN',
@@ -315,6 +317,7 @@ test('buildDashboardOverviewSnapshot returns recent inbound and outbound movemen
         id: 'recent-ship',
         transactionType: 'SHIP',
         transactionDate: new Date('2026-04-14T12:00:00.000Z'),
+        createdAt: new Date('2026-04-14T12:01:00.000Z'),
         warehouseCode: 'AMZN-US',
         warehouseName: 'Amazon FBA US',
         skuCode: 'SKU-OUT',
@@ -353,6 +356,36 @@ test('buildDashboardOverviewSnapshot returns recent inbound and outbound movemen
   })
   assert.equal(snapshot.recentOut[0].pallets, 0)
   assert.equal(snapshot.recentOut[0].carriesPallets, false)
+})
+
+test('buildDashboardOverviewSnapshot uses createdAt to rank same-day recent movements', () => {
+  const movements = Array.from({ length: 6 }, (_, index) => ({
+    id: `same-day-${index + 1}`,
+    transactionType: 'RECEIVE',
+    transactionDate: new Date('2026-04-15T00:00:00.000Z'),
+    createdAt: new Date(`2026-04-15T00:0${index}:00.000Z`),
+    warehouseCode: 'TCL-CHINO',
+    warehouseName: 'Tactical Warehouse Solutions',
+    skuCode: `SKU-${index + 1}`,
+    skuDescription: `Same day item ${index + 1}`,
+    lotRef: `LOT-${index + 1}`,
+    cartonsIn: 1,
+    cartonsOut: 0,
+    storagePalletsIn: 1,
+    shippingPalletsOut: 0,
+    unitsPerCarton: 10,
+  }))
+
+  const snapshot = buildDashboardOverviewSnapshot({
+    purchaseOrders: [],
+    balances: [],
+    movements,
+  })
+
+  assert.deepEqual(
+    snapshot.recentIn.map(row => row.id),
+    ['same-day-6', 'same-day-5', 'same-day-4', 'same-day-3', 'same-day-2']
+  )
 })
 
 test('buildDashboardOverviewSnapshot normalizes warehouse codes to the trimmed grouping key', () => {

--- a/apps/talos/src/lib/dashboard/dashboard-overview.ts
+++ b/apps/talos/src/lib/dashboard/dashboard-overview.ts
@@ -1,3 +1,5 @@
+import { isAmazonWarehouseCode } from '@/lib/warehouses/amazon-warehouse'
+
 export interface DashboardOverviewPurchaseOrderInput {
   id: string
   orderNumber: string
@@ -31,6 +33,37 @@ export interface DashboardOverviewBalanceInput {
   currentUnits: number
 }
 
+export interface DashboardOverviewMovementInput {
+  id: string
+  transactionType: string
+  transactionDate: Date
+  warehouseCode: string
+  warehouseName: string
+  skuCode: string
+  skuDescription: string
+  lotRef: string
+  cartonsIn: number
+  cartonsOut: number
+  storagePalletsIn: number
+  shippingPalletsOut: number
+  unitsPerCarton: number
+}
+
+export type DashboardOverviewMovement = {
+  id: string
+  transactionType: string
+  transactionDate: string
+  warehouseCode: string
+  warehouseName: string
+  skuCode: string
+  skuDescription: string
+  lotRef: string
+  cartons: number
+  pallets: number
+  units: number
+  carriesPallets: boolean
+}
+
 export interface DashboardOverviewSnapshot {
   summary: {
     factory: { cartons: number; pallets: number; units: number; poCount: number }
@@ -44,8 +77,13 @@ export interface DashboardOverviewSnapshot {
     pallets: number
     units: number
     skuCount: number
+    carriesPallets: boolean
   }>
+  recentIn: DashboardOverviewMovement[]
+  recentOut: DashboardOverviewMovement[]
 }
+
+const RECENT_MOVEMENT_LIMIT = 5
 
 function hasOnHandInventory(balance: DashboardOverviewBalanceInput) {
   return !(
@@ -83,6 +121,50 @@ function parseDashboardOverviewStatus(
   throw new Error(`Unsupported purchase order status: ${status}`)
 }
 
+function warehouseCarriesPallets(warehouseCode: string) {
+  return !isAmazonWarehouseCode(warehouseCode)
+}
+
+function mapDashboardMovement(
+  movement: DashboardOverviewMovementInput,
+  direction: 'in' | 'out'
+): DashboardOverviewMovement {
+  const warehouseCode = movement.warehouseCode.trim()
+  if (warehouseCode.length === 0) {
+    throw new Error('warehouseCode is required')
+  }
+
+  const carriesPallets = warehouseCarriesPallets(warehouseCode)
+  const cartons = direction === 'in' ? movement.cartonsIn : movement.cartonsOut
+  const pallets = direction === 'in' ? movement.storagePalletsIn : movement.shippingPalletsOut
+
+  return {
+    id: movement.id,
+    transactionType: movement.transactionType,
+    transactionDate: movement.transactionDate.toISOString(),
+    warehouseCode,
+    warehouseName: movement.warehouseName,
+    skuCode: movement.skuCode,
+    skuDescription: movement.skuDescription,
+    lotRef: movement.lotRef,
+    cartons,
+    pallets: carriesPallets ? pallets : 0,
+    units: cartons * movement.unitsPerCarton,
+    carriesPallets,
+  }
+}
+
+function buildRecentMovements(
+  movements: DashboardOverviewMovementInput[],
+  direction: 'in' | 'out'
+) {
+  return movements
+    .filter(movement => (direction === 'in' ? movement.cartonsIn > 0 : movement.cartonsOut > 0))
+    .sort((left, right) => right.transactionDate.getTime() - left.transactionDate.getTime())
+    .slice(0, RECENT_MOVEMENT_LIMIT)
+    .map(movement => mapDashboardMovement(movement, direction))
+}
+
 export function mapPurchaseOrderToDashboardOverviewInput(
   order: DashboardOverviewPurchaseOrderRow
 ): DashboardOverviewPurchaseOrderInput {
@@ -102,9 +184,11 @@ export function mapPurchaseOrderToDashboardOverviewInput(
 export function buildDashboardOverviewSnapshot({
   purchaseOrders,
   balances,
+  movements,
 }: {
   purchaseOrders: DashboardOverviewPurchaseOrderInput[]
   balances: DashboardOverviewBalanceInput[]
+  movements: DashboardOverviewMovementInput[]
 }): DashboardOverviewSnapshot {
   const factoryOrders = purchaseOrders.filter(order => order.status === 'MANUFACTURING')
   const transitOrders = purchaseOrders.filter(order => order.status === 'OCEAN')
@@ -125,22 +209,25 @@ export function buildDashboardOverviewSnapshot({
     }
 
     const existing = warehouseMap.get(key)
+    const carriesPallets = warehouseCarriesPallets(key)
+    const currentPallets = carriesPallets ? balance.currentPallets : 0
 
     if (existing === undefined) {
       warehouseMap.set(key, {
         warehouseCode: key,
         warehouseName: balance.warehouseName,
         cartons: balance.currentCartons,
-        pallets: balance.currentPallets,
+        pallets: currentPallets,
         units: balance.currentUnits,
         skuCount: 1,
+        carriesPallets,
         skuCodes: new Set([balance.skuCode]),
       })
       continue
     }
 
     existing.cartons += balance.currentCartons
-    existing.pallets += balance.currentPallets
+    existing.pallets += currentPallets
     existing.units += balance.currentUnits
     existing.skuCodes.add(balance.skuCode)
     existing.skuCount = existing.skuCodes.size
@@ -172,5 +259,7 @@ export function buildDashboardOverviewSnapshot({
       },
     },
     warehouses,
+    recentIn: buildRecentMovements(movements, 'in'),
+    recentOut: buildRecentMovements(movements, 'out'),
   }
 }

--- a/apps/talos/src/lib/dashboard/dashboard-overview.ts
+++ b/apps/talos/src/lib/dashboard/dashboard-overview.ts
@@ -37,6 +37,7 @@ export interface DashboardOverviewMovementInput {
   id: string
   transactionType: string
   transactionDate: Date
+  createdAt: Date
   warehouseCode: string
   warehouseName: string
   skuCode: string
@@ -160,7 +161,19 @@ function buildRecentMovements(
 ) {
   return movements
     .filter(movement => (direction === 'in' ? movement.cartonsIn > 0 : movement.cartonsOut > 0))
-    .sort((left, right) => right.transactionDate.getTime() - left.transactionDate.getTime())
+    .sort((left, right) => {
+      const transactionDateDelta = right.transactionDate.getTime() - left.transactionDate.getTime()
+      if (transactionDateDelta !== 0) {
+        return transactionDateDelta
+      }
+
+      const createdAtDelta = right.createdAt.getTime() - left.createdAt.getTime()
+      if (createdAtDelta !== 0) {
+        return createdAtDelta
+      }
+
+      return right.id.localeCompare(left.id)
+    })
     .slice(0, RECENT_MOVEMENT_LIMIT)
     .map(movement => mapDashboardMovement(movement, direction))
 }


### PR DESCRIPTION
## Summary
- add dashboard metric switching for cartons, pallets, and units
- exclude FBA warehouses from pallet carrying totals and display pallet-unavailable state
- add recent inbound and outbound inventory movement sections

## Verification
- pnpm --filter @targon/talos exec tsx src/lib/dashboard/dashboard-overview.test.ts
- pnpm --filter @targon/talos exec eslint src/lib/dashboard/dashboard-overview.ts src/lib/dashboard/dashboard-overview.test.ts src/components/dashboard/dashboard-overview-board.tsx src/app/api/dashboard/overview/route.ts
- pnpm --filter @targon/talos type-check:app
- git diff --check ce5dba19^ ce5dba19