### PR TITLE
fix(talos): rename Amazon SKU tool label

### DIFF
--- a/apps/talos/next.config.js
+++ b/apps/talos/next.config.js
@@ -14,6 +14,10 @@ const basePath = hasDuplicatedBasePath
   ? `/${basePathSegments.slice(0, basePathHalfLen).join('/')}`
   : rawBasePathWithoutTrailingSlash
 const assetPrefix = basePath || ''
+const staticAssetCacheControl =
+  process.env.NODE_ENV === 'development'
+    ? 'no-store, no-cache, must-revalidate'
+    : 'public, max-age=31536000, immutable'
 
 if (!process.env.NEXT_PUBLIC_APP_URL) {
   throw new Error('NEXT_PUBLIC_APP_URL must be defined before loading the Talos Next.js config.')
@@ -125,7 +129,7 @@ const nextConfig = {
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=31536000, immutable'
+            value: staticAssetCacheControl
           }
         ]
       }

--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -30,6 +30,7 @@ import {
   Clock,
   DollarSign,
   Loader2,
+  Package,
   Search,
   XCircle,
 } from '@/lib/lucide-icons'
@@ -123,7 +124,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
       })
       if (!response.ok) {
         const payload = await response.json().catch(() => null)
-        throw new Error(payload?.error ?? 'Failed to load fee discrepancies')
+        throw new Error(payload?.error ?? 'Failed to load SKU info')
       }
 
       const payload = await response.json()
@@ -131,7 +132,7 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
       setSkus(Array.isArray(payload?.skus) ? payload.skus : [])
       setTotalRows(typeof payload?.total === 'number' ? payload.total : 0)
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to load fee discrepancies')
+      toast.error(error instanceof Error ? error.message : 'Failed to load SKU info')
       setSkus([])
       setTotalRows(0)
     } finally {
@@ -196,9 +197,9 @@ export default function AmazonFbaFeeDiscrepanciesPage() {
   return (
     <PageContainer>
       <PageHeaderSection
-        title="FBA Fee Discrepancies"
+        title="SKU Info"
         description="Amazon"
-        icon={DollarSign}
+        icon={Package}
         backHref="/dashboard"
         backLabel="Dashboard"
         metadata={<AmazonWorkspaceSwitcher currentHref="/amazon/fba-fee-discrepancies" />}

--- a/apps/talos/src/components/ui/breadcrumb.tsx
+++ b/apps/talos/src/components/ui/breadcrumb.tsx
@@ -5,14 +5,46 @@ import { usePathname } from 'next/navigation'
 import { ChevronRight, Home } from '@/lib/lucide-icons'
 import { withoutBasePath } from '@/lib/utils/base-path'
 
-export function Breadcrumb() {
- const pathname = usePathname()
- const normalizedPathname = withoutBasePath(pathname)
- 
- // Don't show breadcrumbs on home or login pages
- if (normalizedPathname === '/' || normalizedPathname === '/auth/login') {
- return null
+type BreadcrumbItem = {
+ href: string
+ label: string
+ skip: boolean
+}
+
+const ROUTE_LABELS = new Map<string, string>([
+ ['/amazon/fba-fee-discrepancies', 'SKU Info'],
+])
+
+function formatSegmentLabel(segment: string): string {
+ switch (segment) {
+ case 'operations':
+ return 'Operations'
+ case 'finance':
+ return 'Ledgers'
+ case 'config':
+ return 'Configuration'
+ case 'integrations':
+ return 'Integrations'
+ case 'transactions':
+ return 'Transactions'
+ case 'inventory':
+ return 'Inventory'
+ default:
+ // For IDs and other segments, format them nicely
+ if (segment.match(/^[a-f0-9-]+$/i) && segment.length > 20) {
+ // Looks like an ID, truncate it
+ return segment.substring(0, 8) + '...'
  }
+
+ return segment
+ .split('-')
+ .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+ .join(' ')
+ }
+}
+
+export function buildBreadcrumbItems(pathname: string): BreadcrumbItem[] {
+ const normalizedPathname = withoutBasePath(pathname, pathname)
 
  // Parse the pathname into segments
  const segments = normalizedPathname.split('/').filter(Boolean)
@@ -28,42 +60,25 @@ export function Breadcrumb() {
  const isWarehouseId = previousSegment === 'warehouses' && nextSegment !== null && ['edit', 'rates'].includes(nextSegment)
  const isOperationsRoot = segment === 'operations'
 
- // Handle special cases for better labels
- let label = segment
- switch (segment) {
- case 'operations':
- label = 'Operations'
- break
- case 'finance':
- label = 'Ledgers'
- break
- case 'config':
- label = 'Configuration'
- break
- case 'integrations':
- label = 'Integrations'
- break
- case 'transactions':
- label = 'Transactions'
- break
- case 'inventory':
- label = 'Inventory'
- break
- default:
- // For IDs and other segments, format them nicely
- if (segment.match(/^[a-f0-9-]+$/i) && segment.length > 20) {
- // Looks like an ID, truncate it
- label = segment.substring(0, 8) + '...'
- } else {
- label = segment
- .split('-')
- .map(word => word.charAt(0).toUpperCase() + word.slice(1))
- .join(' ')
- }
- }
+ const routeLabel = ROUTE_LABELS.get(href)
+ const label = typeof routeLabel === 'string' ? routeLabel : formatSegmentLabel(segment)
 
  return { href, label, skip: isWarehouseId || isOperationsRoot }
  }).filter(item => !item.skip)
+
+ return breadcrumbs
+}
+
+export function Breadcrumb() {
+ const pathname = usePathname()
+ const normalizedPathname = withoutBasePath(pathname, pathname)
+
+ // Don't show breadcrumbs on home or login pages
+ if (normalizedPathname === '/' || normalizedPathname === '/auth/login') {
+ return null
+ }
+
+ const breadcrumbs = buildBreadcrumbItems(normalizedPathname)
 
  const homeLink = '/dashboard'
 

--- a/apps/talos/src/lib/amazon/workspace.ts
+++ b/apps/talos/src/lib/amazon/workspace.ts
@@ -1,6 +1,6 @@
 import type { LucideIcon } from 'lucide-react'
 import {
-  Activity,
+  Package,
 } from '@/lib/lucide-icons'
 
 export type NavigationMatchMode = 'prefix' | 'exact'
@@ -16,11 +16,11 @@ export type AmazonWorkspaceTool = {
 
 export const AMAZON_WORKSPACE_TOOLS: AmazonWorkspaceTool[] = [
   {
-    name: 'FBA Fee Discrepancies',
+    name: 'SKU Info',
     href: '/amazon/fba-fee-discrepancies',
-    description: 'Compare reference packaging against Amazon fee inputs and isolate mismatches fast.',
-    note: 'Audit',
-    icon: Activity,
+    description: 'Review SKU packaging, Amazon dimensions, fees, and listing inputs.',
+    note: 'Catalog',
+    icon: Package,
     matchMode: 'prefix',
   },
 ] as const

--- a/apps/talos/tests/unit/breadcrumb.test.ts
+++ b/apps/talos/tests/unit/breadcrumb.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { buildBreadcrumbItems } from '../../src/components/ui/breadcrumb'
+
+test('breadcrumb uses the current SKU info label for the Amazon SKU page', () => {
+  const labels = buildBreadcrumbItems('/talos/amazon/fba-fee-discrepancies').map(
+    (item) => item.label
+  )
+
+  assert.deepEqual(labels, ['Amazon', 'SKU Info'])
+  assert.equal(labels.includes('Fba Fee Discrepancies'), false)
+})

--- a/apps/talos/tests/unit/navigation.test.ts
+++ b/apps/talos/tests/unit/navigation.test.ts
@@ -11,6 +11,10 @@ test('amazon workspace exposes the live tool surfaces in Talos', () => {
     AMAZON_WORKSPACE_TOOLS.map((tool) => tool.href),
     ['/amazon/fba-fee-discrepancies']
   )
+  assert.deepEqual(
+    AMAZON_WORKSPACE_TOOLS.map((tool) => tool.name),
+    ['SKU Info']
+  )
 
   assert.equal(AMAZON_WORKSPACE_TOOLS.some((tool) => tool.href === '/amazon'), false)
   assert.equal(AMAZON_WORKSPACE_TOOLS.some((tool) => tool.href === '/market/shipment-planning'), false)
@@ -26,6 +30,10 @@ test('main navigation surfaces live Talos pages and keeps super-admin routes gat
   assert.deepEqual(
     amazonSection.items.map((item) => item.href),
     ['/amazon/fba-fee-discrepancies']
+  )
+  assert.deepEqual(
+    amazonSection.items.map((item) => item.name),
+    ['SKU Info']
   )
 
   const operationsSection = staffNavigation.find((section) => section.title === 'Operations')
@@ -90,4 +98,15 @@ test('talos no longer ships the FBA fee tables page or SKU link', () => {
     false,
     'SKU panel should not link to the removed FBA fee tables page'
   )
+})
+
+test('amazon SKU info page uses the current product label', () => {
+  const talosRoot = path.resolve(__dirname, '..', '..')
+  const pageSource = readFileSync(
+    path.join(talosRoot, 'src/app/amazon/fba-fee-discrepancies/page.tsx'),
+    'utf8'
+  )
+
+  assert.equal(pageSource.includes('title="SKU Info"'), true)
+  assert.equal(pageSource.includes('title="FBA Fee Discrepancies"'), false)
 })

--- a/apps/talos/tests/unit/next-config-cache.test.ts
+++ b/apps/talos/tests/unit/next-config-cache.test.ts
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import test from 'node:test'
+
+const requireFromTest = createRequire(import.meta.url)
+const configPath = path.resolve(__dirname, '..', '..', 'next.config.js')
+const resolvedConfigPath = requireFromTest.resolve(configPath)
+
+function setEnv(name: string, value: string): void {
+  Reflect.set(process.env, name, value)
+}
+
+function deleteEnv(name: string): void {
+  Reflect.deleteProperty(process.env, name)
+}
+
+async function readStaticAssetCacheControl(nodeEnv: string): Promise<string> {
+  const previousNodeEnv = process.env.NODE_ENV
+  const previousAppUrl = process.env.NEXT_PUBLIC_APP_URL
+
+  setEnv('NODE_ENV', nodeEnv)
+  setEnv('NEXT_PUBLIC_APP_URL', 'http://127.0.0.1:41101/talos')
+  delete requireFromTest.cache[resolvedConfigPath]
+
+  try {
+    const config = requireFromTest(configPath)
+    const headers = await config.headers()
+    const staticRoute = headers.find((entry: { source: string }) => entry.source === '/_next/static/:path*')
+
+    assert.ok(staticRoute)
+
+    const cacheHeader = staticRoute.headers.find(
+      (header: { key: string }) => header.key === 'Cache-Control'
+    )
+
+    assert.ok(cacheHeader)
+
+    return cacheHeader.value
+  } finally {
+    delete requireFromTest.cache[resolvedConfigPath]
+
+    if (typeof previousNodeEnv === 'string') {
+      setEnv('NODE_ENV', previousNodeEnv)
+    } else {
+      deleteEnv('NODE_ENV')
+    }
+
+    if (typeof previousAppUrl === 'string') {
+      setEnv('NEXT_PUBLIC_APP_URL', previousAppUrl)
+    } else {
+      deleteEnv('NEXT_PUBLIC_APP_URL')
+    }
+  }
+}
+
+test('development static chunks are not cached immutably', async () => {
+  assert.equal(
+    await readStaticAssetCacheControl('development'),
+    'no-store, no-cache, must-revalidate'
+  )
+})
+
+test('production static chunks keep immutable caching', async () => {
+  assert.equal(
+    await readStaticAssetCacheControl('production'),
+    'public, max-age=31536000, immutable'
+  )
+})


### PR DESCRIPTION
## Summary
- Rename the Amazon workspace/page label from FBA Fee Discrepancies to SKU Info.
- Add a route-label override so breadcrumbs stop deriving the old label from the legacy URL slug.
- Disable immutable caching for Talos dev static chunks while keeping production immutable caching.

## Root cause
The source label had not been updated everywhere, and local `_next/static` chunks were being served with one-year immutable cache headers in development. That let the in-app browser keep rendering the old nav label after the source had changed.

## Validation
- `pnpm --filter @targon/talos exec tsx tests/unit/navigation.test.ts`
- `pnpm --filter @targon/talos exec tsx tests/unit/breadcrumb.test.ts`
- `pnpm --filter @targon/talos exec tsx tests/unit/next-config-cache.test.ts`
- `pnpm --filter @targon/talos exec eslint src/lib/amazon/workspace.ts src/app/amazon/fba-fee-discrepancies/page.tsx src/components/ui/breadcrumb.tsx tests/unit/navigation.test.ts tests/unit/breadcrumb.test.ts tests/unit/next-config-cache.test.ts`
- Browser DOM on local Talos showed `SKU Info` and no visible `FBA Fee Discrepancies` / `Fba Fee Discrepancies`.
