### PR TITLE
fix(sso): keep worktree dev auth strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,29 @@ LMB.zip
 .claude/
 .codex/generated/
 
+# Local agent/Codex runtime artifacts
+.superpowers/
+.codex/env-templates/
+.codex/environments/
+.codex/generated/
+.codex/runtime/
+.codex/worktree-overrides.txt
+.codex/scripts/assert-shared-sso-env.mjs
+.codex/scripts/resolve-shared-sso-env.mjs
+.codex/scripts/run-kairos-ml.sh
+.codex/scripts/run-shared-portal.sh
+.codex/scripts/run-worktree-app.sh
+.codex/scripts/show-worktree-ports.sh
+.codex/scripts/start-worktree-stack.sh
+.codex/scripts/worktree-ports.mjs
+.codex/scripts/worktree-ports.test.mjs
+docs/superpowers/plans/2026-04-16-*.md
+docs/superpowers/plans/2026-04-19-*.md
+apps/sso/public/brand/targon-once-in-a-lifetime.jpg
+apps/sso/public/brand/targon-wordmark-inverted.svg
+scripts/ensure-worktree-dev-user.mjs
+scripts/setup-codex-env.mjs
+scripts/worktree-dev-auth-config.mjs
+
 # Local git worktrees
 .worktrees/

--- a/apps/talos/src/lib/auth/super-admin.ts
+++ b/apps/talos/src/lib/auth/super-admin.ts
@@ -1,6 +1,10 @@
 function parseEmailSet(raw: string | undefined): Set<string> {
+  if (raw === undefined) {
+    return new Set()
+  }
+
   return new Set(
-    (raw ?? '')
+    raw
       .split(/[,\s]+/)
       .map((value) => value.trim().toLowerCase())
       .filter(Boolean),

--- a/packages/auth/dist/index.js
+++ b/packages/auth/dist/index.js
@@ -171,7 +171,10 @@ export function isWorktreeDevAuthEnabled() {
 }
 function requireWorktreeDevAuthEnv(name) {
     const value = process.env[name];
-    if (!value || value.trim() === '') {
+    if (!value) {
+        throw new Error(`${name} must be defined when TARGON_WORKTREE_DEV_AUTH is enabled.`);
+    }
+    if (value.trim() === '') {
         throw new Error(`${name} must be defined when TARGON_WORKTREE_DEV_AUTH is enabled.`);
     }
     return value.trim();
@@ -233,7 +236,19 @@ export async function getWorktreeDevSession(appId) {
         return null;
     }
     const authz = normalizeAuthzFromClaims(payload);
-    if (!authz || !payload.sub || !payload.email) {
+    if (!authz) {
+        throw new Error('Worktree dev auth payload is incomplete.');
+    }
+    if (!payload.sub) {
+        throw new Error('Worktree dev auth payload is incomplete.');
+    }
+    if (!payload.email) {
+        throw new Error('Worktree dev auth payload is incomplete.');
+    }
+    if (typeof payload.name !== 'string') {
+        throw new Error('Worktree dev auth payload is incomplete.');
+    }
+    if (payload.name.trim() === '') {
         throw new Error('Worktree dev auth payload is incomplete.');
     }
     return {
@@ -241,7 +256,7 @@ export async function getWorktreeDevSession(appId) {
         user: {
             id: payload.sub,
             email: payload.email,
-            name: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name : payload.email,
+            name: payload.name,
         },
         authz,
         roles: buildRolesClaimFromAuthz(authz),

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -243,7 +243,10 @@ export function isWorktreeDevAuthEnabled(): boolean {
 
 function requireWorktreeDevAuthEnv(name: string): string {
   const value = process.env[name];
-  if (!value || value.trim() === '') {
+  if (!value) {
+    throw new Error(`${name} must be defined when TARGON_WORKTREE_DEV_AUTH is enabled.`);
+  }
+  if (value.trim() === '') {
     throw new Error(`${name} must be defined when TARGON_WORKTREE_DEV_AUTH is enabled.`);
   }
   return value.trim();
@@ -316,7 +319,19 @@ export async function getWorktreeDevSession(appId?: string): Promise<WorktreeDev
   }
 
   const authz = normalizeAuthzFromClaims(payload);
-  if (!authz || !payload.sub || !payload.email) {
+  if (!authz) {
+    throw new Error('Worktree dev auth payload is incomplete.');
+  }
+  if (!payload.sub) {
+    throw new Error('Worktree dev auth payload is incomplete.');
+  }
+  if (!payload.email) {
+    throw new Error('Worktree dev auth payload is incomplete.');
+  }
+  if (typeof payload.name !== 'string') {
+    throw new Error('Worktree dev auth payload is incomplete.');
+  }
+  if (payload.name.trim() === '') {
     throw new Error('Worktree dev auth payload is incomplete.');
   }
 
@@ -325,7 +340,7 @@ export async function getWorktreeDevSession(appId?: string): Promise<WorktreeDev
     user: {
       id: payload.sub,
       email: payload.email,
-      name: typeof payload.name === 'string' && payload.name.trim() !== '' ? payload.name : payload.email,
+      name: payload.name,
     },
     authz,
     roles: buildRolesClaimFromAuthz(authz),


### PR DESCRIPTION
## Summary
- keeps worktree-dev auth configuration blocking by requiring complete dev-auth payload fields
- removes the dev-auth name/email fallback path
- lets Talos super-admin emails include env-configured local worktree users
- ignores local Codex/scratch/server-only artifacts so they do not leak into PRs

## Validation
- pnpm --filter @targon/auth test
- pnpm --filter @targon/auth type-check
- pnpm --filter @targon/talos exec tsx --test src/lib/auth/super-admin.test.ts
- pnpm --filter @targon/talos type-check
- git diff --check origin/dev...HEAD
