### PR TITLE
fix(argus): compact listings labels and port config

### DIFF
--- a/apps/archived/argus-v1/package.json
+++ b/apps/archived/argus-v1/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js argus -- next dev -p 3216",
+    "dev": "node ../../../scripts/run-dev-with-logs.js argus -- node ../../../scripts/run-next-port.js dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint app",

--- a/apps/argus/app/(app)/listings/page.tsx
+++ b/apps/argus/app/(app)/listings/page.tsx
@@ -1,14 +1,6 @@
-import Link from 'next/link'
-import {
-  Box,
-  Card,
-  Chip,
-  Stack,
-  Typography,
-} from '@mui/material'
-import ListAltIcon from '@mui/icons-material/ListAlt'
-import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
 import prisma from '@/lib/db'
+import { buildListingsViewModel } from '@/lib/listings/view-model'
+import { ListingsTable } from '@/components/listings/listings-table'
 
 export const dynamic = 'force-dynamic'
 
@@ -18,8 +10,17 @@ export default async function ListingsPage() {
     select: {
       id: true,
       asin: true,
+      marketplace: true,
       label: true,
       brandName: true,
+      enabled: true,
+      createdAt: true,
+      updatedAt: true,
+      titleRevisions: {
+        orderBy: { seq: 'desc' },
+        take: 1,
+        select: { title: true },
+      },
       _count: {
         select: {
           snapshots: true,
@@ -33,157 +34,7 @@ export default async function ListingsPage() {
     },
   })
 
-  const totalSnapshots = listings.reduce((sum, listing) => sum + listing._count.snapshots, 0)
-  const totalRevisions = listings.reduce(
-    (sum, listing) =>
-      sum +
-      listing._count.titleRevisions +
-      listing._count.bulletsRevisions +
-      listing._count.galleryRevisions +
-      listing._count.videoRevisions +
-      listing._count.ebcRevisions,
-    0,
-  )
+  const viewModel = buildListingsViewModel(listings)
 
-  return (
-    <Box
-      sx={{
-        mx: 'auto',
-        display: 'grid',
-        gap: 3,
-        gridTemplateColumns: '1fr',
-        alignItems: 'start',
-      }}
-    >
-      <Stack direction="row" spacing={3} sx={{ mb: 2 }}>
-        <Typography variant="body2" color="text.secondary">
-          <strong>{listings.length}</strong> tracked PDPs
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          <strong>{totalSnapshots}</strong> snapshots
-        </Typography>
-        <Typography variant="body2" color="text.secondary">
-          <strong>{totalRevisions}</strong> revisions
-        </Typography>
-      </Stack>
-
-      {listings.length > 0 ? (
-        <Stack spacing={1}>
-          {listings.map(
-            (listing: {
-              id: string
-              asin: string
-              label: string
-              brandName: string | null
-              _count: {
-                snapshots: number
-                titleRevisions: number
-                bulletsRevisions: number
-                galleryRevisions: number
-                videoRevisions: number
-                ebcRevisions: number
-              }
-            }) => (
-              <Link
-                key={listing.id}
-                href={`/listings/${listing.id}`}
-                style={{ textDecoration: 'none', color: 'inherit' }}
-              >
-                <Card
-                  sx={{
-                    p: { xs: 1.5, md: 1.75 },
-                    borderRadius: 2,
-                    transition: 'transform 0.16s ease, box-shadow 0.16s ease, border-color 0.16s ease',
-                    '&:hover': {
-                      transform: 'translateY(-1px)',
-                      boxShadow: '0 22px 40px -30px rgba(0, 44, 81, 0.45)',
-                      borderColor: 'rgba(0, 194, 185, 0.18)',
-                    },
-                  }}
-                >
-                  <Stack direction="row" spacing={2} alignItems="center">
-                    <Box
-                      sx={{
-                        width: 40,
-                        height: 40,
-                        bgcolor: 'action.hover',
-                        borderRadius: 2.5,
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        flexShrink: 0,
-                      }}
-                    >
-                      <ListAltIcon sx={{ color: 'text.secondary', fontSize: 22 }} />
-                    </Box>
-                    <Box sx={{ flex: 1, minWidth: 0 }}>
-                      <Typography variant="h6" sx={{ fontWeight: 700, letterSpacing: '-0.03em' }}>
-                        {listing.label !== listing.asin ? listing.label : listing.asin}
-                      </Typography>
-                      <Typography variant="body2" color="text.secondary" sx={{ mt: 0.45 }}>
-                        {listing.label !== listing.asin ? `(${listing.asin})` : ''}
-                        {listing.brandName && ` · ${listing.brandName}`}
-                      </Typography>
-                      <Stack direction="row" spacing={0.5} mt={1.2} flexWrap="wrap" useFlexGap>
-                        <Chip
-                          label={`${listing._count.snapshots} snapshot${listing._count.snapshots !== 1 ? 's' : ''}`}
-                          size="small"
-                          color="primary"
-                          variant="outlined"
-                          sx={{ height: 22, fontSize: '0.675rem' }}
-                        />
-                        {listing._count.titleRevisions > 0 && (
-                          <Chip
-                            label={`Title ×${listing._count.titleRevisions}`}
-                            size="small"
-                            sx={{ height: 22, fontSize: '0.675rem' }}
-                          />
-                        )}
-                        {listing._count.bulletsRevisions > 0 && (
-                          <Chip
-                            label={`Bullets ×${listing._count.bulletsRevisions}`}
-                            size="small"
-                            sx={{ height: 22, fontSize: '0.675rem' }}
-                          />
-                        )}
-                        {listing._count.galleryRevisions > 0 && (
-                          <Chip
-                            label={`Gallery ×${listing._count.galleryRevisions}`}
-                            size="small"
-                            sx={{ height: 22, fontSize: '0.675rem' }}
-                          />
-                        )}
-                        {listing._count.videoRevisions > 0 && (
-                          <Chip
-                            label={`Video ×${listing._count.videoRevisions}`}
-                            size="small"
-                            sx={{ height: 22, fontSize: '0.675rem' }}
-                          />
-                        )}
-                        {listing._count.ebcRevisions > 0 && (
-                          <Chip
-                            label={`A+ ×${listing._count.ebcRevisions}`}
-                            size="small"
-                            sx={{ height: 22, fontSize: '0.675rem' }}
-                          />
-                        )}
-                      </Stack>
-                    </Box>
-                    <ArrowOutwardIcon sx={{ color: 'text.secondary', fontSize: 20, flexShrink: 0 }} />
-                  </Stack>
-                </Card>
-              </Link>
-            )
-          )}
-        </Stack>
-      ) : (
-        <Card sx={{ p: 6, textAlign: 'center', borderRadius: 4 }}>
-          <ListAltIcon sx={{ fontSize: 48, color: 'divider', mb: 1 }} />
-          <Typography color="text.secondary" variant="body2">
-            No listings yet
-          </Typography>
-        </Card>
-      )}
-    </Box>
-  )
+  return <ListingsTable viewModel={viewModel} />
 }

--- a/apps/argus/app/api/listings/metadata/route.ts
+++ b/apps/argus/app/api/listings/metadata/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from 'next/server'
+import { RevisionOrigin } from '@targon/prisma-argus'
+import prisma from '@/lib/db'
+import { getCatalogItemWithRanks } from '@/lib/sp-api'
+import { buildListingMetadataUpdate } from '@/lib/listings/metadata'
+
+function clean(value: string | null): string {
+  if (value === null) return ''
+  return value.trim()
+}
+
+export async function POST() {
+  const listings = await prisma.listing.findMany({
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      asin: true,
+      label: true,
+      brandName: true,
+      titleRevisions: {
+        orderBy: { seq: 'desc' },
+        take: 1,
+        select: { seq: true, title: true },
+      },
+    },
+  })
+
+  let refreshed = 0
+
+  for (const listing of listings) {
+    const catalog = await getCatalogItemWithRanks(listing.asin)
+    const data = buildListingMetadataUpdate(listing, catalog)
+    const catalogTitle = clean(catalog.title)
+    const latestTitle = listing.titleRevisions[0]
+    let titleRevisionId: string | null = null
+
+    if (catalogTitle.length > 0) {
+      let shouldCreateTitleRevision = false
+      if (latestTitle === undefined) {
+        shouldCreateTitleRevision = true
+      } else if (latestTitle.title !== catalogTitle) {
+        shouldCreateTitleRevision = true
+      }
+
+      if (shouldCreateTitleRevision) {
+        const seq = latestTitle === undefined ? 1 : latestTitle.seq + 1
+        const titleRevision = await prisma.titleRevision.create({
+          data: {
+            listingId: listing.id,
+            seq,
+            title: catalogTitle,
+            origin: RevisionOrigin.CAPTURED_SNAPSHOT,
+            note: 'Catalog metadata refresh',
+          },
+          select: { id: true },
+        })
+        titleRevisionId = titleRevision.id
+      }
+    }
+
+    if (titleRevisionId !== null) {
+      data.activeTitleId = titleRevisionId
+    }
+
+    const keys = Object.keys(data)
+    if (keys.length === 0) continue
+
+    await prisma.listing.update({ where: { id: listing.id }, data })
+    refreshed += 1
+  }
+
+  return NextResponse.json({ refreshed, total: listings.length })
+}

--- a/apps/argus/components/listings/listings-table.tsx
+++ b/apps/argus/components/listings/listings-table.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  IconButton,
+  LinearProgress,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward'
+import RefreshIcon from '@mui/icons-material/Refresh'
+import { getPublicBasePath } from '@/lib/base-path'
+import type { ListingsViewModel, ListingTableRow } from '@/lib/listings/view-model'
+
+const basePath = getPublicBasePath()
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function HeaderCell({ label, align = 'left' }: { label: string; align?: 'left' | 'right' | 'center' }) {
+  return (
+    <TableCell
+      align={align}
+      sx={{
+        px: 1.25,
+        py: 0.45,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        bgcolor: 'background.paper',
+        color: 'text.secondary',
+        fontSize: '0.58rem',
+        fontWeight: 800,
+        letterSpacing: '0.08em',
+        textTransform: 'uppercase',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </TableCell>
+  )
+}
+
+function BodyCell({
+  children,
+  align = 'left',
+  mono = false,
+}: {
+  children: React.ReactNode
+  align?: 'left' | 'right' | 'center'
+  mono?: boolean
+}) {
+  return (
+    <TableCell
+      align={align}
+      sx={{
+        px: 1,
+        py: 0.5,
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        fontFamily: mono ? 'var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace' : 'inherit',
+        fontSize: '0.74rem',
+        lineHeight: 1.2,
+        verticalAlign: 'middle',
+      }}
+    >
+      {children}
+    </TableCell>
+  )
+}
+
+function CountCell({ value }: { value: number }) {
+  return (
+    <Typography
+      component="span"
+      sx={{
+        display: 'inline-flex',
+        minWidth: 24,
+        justifyContent: 'flex-end',
+        fontFamily: 'var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+        fontSize: '0.72rem',
+        fontWeight: 700,
+      }}
+    >
+      {value}
+    </Typography>
+  )
+}
+
+function ProductCell({ row }: { row: ListingTableRow }) {
+  return (
+    <Stack spacing={0.1} sx={{ minWidth: 0 }}>
+      <Stack direction="row" spacing={0.5} alignItems="center" sx={{ minWidth: 0 }}>
+        <Typography
+          component={Link}
+          href={`/listings/${row.id}`}
+          sx={{
+            color: 'text.primary',
+            display: 'block',
+            fontSize: '0.8rem',
+            fontWeight: 800,
+            maxWidth: 520,
+            overflow: 'hidden',
+            textDecoration: 'none',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {row.displayName}
+        </Typography>
+        {row.needsMetadataRefresh ? (
+          <Chip
+            label="Needs metadata"
+            size="small"
+            variant="outlined"
+            sx={{ height: 18, borderRadius: 1, fontSize: '0.6rem', fontWeight: 700 }}
+          />
+        ) : null}
+      </Stack>
+      <Stack direction="row" spacing={0.75} alignItems="center">
+        <Typography
+          variant="caption"
+          sx={{
+            color: 'text.secondary',
+            fontFamily: 'var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace',
+            fontSize: '0.65rem',
+            fontWeight: 700,
+          }}
+        >
+          {row.asin}
+        </Typography>
+        <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+          {row.marketplace}
+        </Typography>
+        {row.brandName ? (
+          <Typography variant="caption" color="text.secondary" sx={{ fontSize: '0.65rem' }}>
+            {row.brandName}
+          </Typography>
+        ) : null}
+      </Stack>
+    </Stack>
+  )
+}
+
+export function ListingsTable({ viewModel }: { viewModel: ListingsViewModel }) {
+  const router = useRouter()
+  const [refreshingMetadata, setRefreshingMetadata] = useState(false)
+  const [metadataMessage, setMetadataMessage] = useState<string | null>(null)
+  const [metadataError, setMetadataError] = useState<string | null>(null)
+
+  async function refreshMetadata() {
+    setRefreshingMetadata(true)
+    setMetadataMessage(null)
+    setMetadataError(null)
+
+    try {
+      const response = await fetch(`${basePath}/api/listings/metadata`, { method: 'POST' })
+      const text = await response.text()
+      if (!response.ok) {
+        throw new Error(text)
+      }
+
+      const payload = JSON.parse(text) as { refreshed: number; total: number }
+      setMetadataMessage(`Updated ${payload.refreshed} of ${payload.total} listings.`)
+      router.refresh()
+    } catch (error) {
+      setMetadataError(error instanceof Error ? error.message : String(error))
+    } finally {
+      setRefreshingMetadata(false)
+    }
+  }
+
+  return (
+    <Box sx={{ display: 'grid', gap: 1 }}>
+      <Stack
+        direction={{ xs: 'column', md: 'row' }}
+        spacing={1}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', md: 'center' }}
+      >
+        <Stack direction="row" spacing={2.5} flexWrap="wrap" useFlexGap>
+          <Typography variant="caption" color="text.secondary">
+            <strong>{viewModel.totalListings}</strong> listings
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            <strong>{viewModel.totalSnapshots}</strong> snapshots
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            <strong>{viewModel.totalRevisions}</strong> revisions
+          </Typography>
+          <Typography variant="caption" color="text.secondary">
+            <strong>{viewModel.metadataRefreshCount}</strong> need metadata
+          </Typography>
+        </Stack>
+
+        <Button
+          type="button"
+          size="small"
+          variant="outlined"
+          startIcon={<RefreshIcon sx={{ fontSize: 16 }} />}
+          onClick={refreshMetadata}
+          disabled={refreshingMetadata ? true : viewModel.totalListings === 0}
+          sx={{ alignSelf: { xs: 'flex-start', md: 'center' }, minHeight: 28, py: 0.25 }}
+        >
+          {refreshingMetadata ? 'Fetching...' : 'Fetch metadata'}
+        </Button>
+      </Stack>
+
+      {metadataMessage ? <Alert severity="success">{metadataMessage}</Alert> : null}
+      {metadataError ? <Alert severity="error">{metadataError}</Alert> : null}
+      {refreshingMetadata ? <LinearProgress /> : null}
+
+      <TableContainer
+        sx={{
+          border: '1px solid',
+          borderColor: 'divider',
+          borderRadius: 1,
+          bgcolor: 'background.paper',
+          overflowX: 'auto',
+        }}
+      >
+        <Table stickyHeader size="small" sx={{ minWidth: 940, tableLayout: 'fixed' }}>
+          <colgroup>
+            <col style={{ width: '42%' }} />
+            <col style={{ width: '8%' }} />
+            <col style={{ width: '7%' }} />
+            <col style={{ width: '7%' }} />
+            <col style={{ width: '7%' }} />
+            <col style={{ width: '7%' }} />
+            <col style={{ width: '7%' }} />
+            <col style={{ width: '11%' }} />
+            <col style={{ width: '4%' }} />
+          </colgroup>
+          <TableHead>
+            <TableRow>
+              <HeaderCell label="Product" />
+              <HeaderCell label="Snapshots" align="right" />
+              <HeaderCell label="Title" align="right" />
+              <HeaderCell label="Bullets" align="right" />
+              <HeaderCell label="Images" align="right" />
+              <HeaderCell label="Video" align="right" />
+              <HeaderCell label="A+" align="right" />
+              <HeaderCell label="Updated" />
+              <HeaderCell label="Open" align="right" />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {viewModel.rows.length === 0 ? (
+              <TableRow>
+                <BodyCell>
+                  <Typography variant="body2" color="text.secondary">
+                    No listings yet
+                  </Typography>
+                </BodyCell>
+                <BodyCell align="right">—</BodyCell>
+                <BodyCell align="right">—</BodyCell>
+                <BodyCell align="right">—</BodyCell>
+                <BodyCell align="right">—</BodyCell>
+                <BodyCell align="right">—</BodyCell>
+                <BodyCell align="right">—</BodyCell>
+                <BodyCell>—</BodyCell>
+                <BodyCell align="right">—</BodyCell>
+              </TableRow>
+            ) : (
+              viewModel.rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  hover
+                  sx={{
+                    '&:last-child td': { borderBottom: 0 },
+                  }}
+                >
+                  <BodyCell>
+                    <ProductCell row={row} />
+                  </BodyCell>
+                  <BodyCell align="right"><CountCell value={row.counts.snapshots} /></BodyCell>
+                  <BodyCell align="right"><CountCell value={row.counts.titleRevisions} /></BodyCell>
+                  <BodyCell align="right"><CountCell value={row.counts.bulletsRevisions} /></BodyCell>
+                  <BodyCell align="right"><CountCell value={row.counts.galleryRevisions} /></BodyCell>
+                  <BodyCell align="right"><CountCell value={row.counts.videoRevisions} /></BodyCell>
+                  <BodyCell align="right"><CountCell value={row.counts.ebcRevisions} /></BodyCell>
+                  <BodyCell>{formatDate(row.updatedAt)}</BodyCell>
+                  <BodyCell align="right">
+                    <Tooltip title="Open listing">
+                      <IconButton component={Link} href={`/listings/${row.id}`} size="small" aria-label="Open listing">
+                        <ArrowOutwardIcon sx={{ fontSize: 15 }} />
+                      </IconButton>
+                    </Tooltip>
+                  </BodyCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  )
+}

--- a/apps/argus/lib/listings/metadata.test.ts
+++ b/apps/argus/lib/listings/metadata.test.ts
@@ -1,0 +1,53 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildListingMetadataUpdate } from './metadata'
+
+test('buildListingMetadataUpdate replaces ASIN labels with catalog identity', () => {
+  assert.deepEqual(
+    buildListingMetadataUpdate(
+      { asin: 'B09HXC3NL8', label: 'B09HXC3NL8', brandName: null },
+      { asin: 'B09HXC3NL8', brand: 'HomeNest', title: 'Portable greenhouse kit' },
+    ),
+    { label: 'Portable greenhouse kit', brandName: 'HomeNest' },
+  )
+})
+
+test('buildListingMetadataUpdate preserves curated labels', () => {
+  assert.deepEqual(
+    buildListingMetadataUpdate(
+      { asin: 'B09HXC3NL8', label: 'Greenhouse 12 x 9', brandName: null },
+      { asin: 'B09HXC3NL8', brand: 'HomeNest', title: 'Portable greenhouse kit' },
+    ),
+    { brandName: 'HomeNest' },
+  )
+})
+
+test('buildListingMetadataUpdate replaces generic brand labels with title labels', () => {
+  assert.deepEqual(
+    buildListingMetadataUpdate(
+      { asin: 'B09HXC3NL8', label: 'HomeNest', brandName: 'HomeNest' },
+      { asin: 'B09HXC3NL8', brand: 'HomeNest', title: 'HomeNest Portable greenhouse kit with reinforced frame' },
+    ),
+    { label: 'Portable greenhouse kit with reinforced frame' },
+  )
+})
+
+test('buildListingMetadataUpdate replaces old brand-prefixed generated labels', () => {
+  assert.deepEqual(
+    buildListingMetadataUpdate(
+      { asin: 'B09HXC3NL8', label: 'HomeNest Portable greenhouse kit with reinforced frame', brandName: 'HomeNest' },
+      { asin: 'B09HXC3NL8', brand: 'HomeNest', title: 'HomeNest Portable greenhouse kit with reinforced frame' },
+    ),
+    { label: 'Portable greenhouse kit with reinforced frame' },
+  )
+})
+
+test('buildListingMetadataUpdate returns no update when catalog has no usable identity', () => {
+  assert.deepEqual(
+    buildListingMetadataUpdate(
+      { asin: 'B09HXC3NL8', label: 'B09HXC3NL8', brandName: null },
+      { asin: 'B09HXC3NL8', brand: null, title: null },
+    ),
+    {},
+  )
+})

--- a/apps/argus/lib/listings/metadata.ts
+++ b/apps/argus/lib/listings/metadata.ts
@@ -1,0 +1,56 @@
+import { formatAmazonTitleLabel } from '@/lib/product-labels'
+
+export interface ListingMetadataSource {
+  asin: string
+  label: string
+  brandName: string | null
+}
+
+export interface CatalogIdentitySource {
+  asin: string
+  brand: string | null
+  title: string | null
+}
+
+export interface ListingMetadataUpdate {
+  label?: string
+  brandName?: string
+  activeTitleId?: string
+}
+
+function clean(value: string | null): string {
+  if (value === null) return ''
+  return value.trim()
+}
+
+function shouldReplaceLabel(currentLabel: string, asin: string, brandName: string, nextLabel: string): boolean {
+  if (currentLabel.toUpperCase() === asin) return true
+  if (brandName.length === 0) return false
+  if (currentLabel.toLowerCase() === `${brandName} ${nextLabel}`.toLowerCase()) return true
+  return currentLabel.toLowerCase() === brandName.toLowerCase()
+}
+
+export function buildListingMetadataUpdate(
+  listing: ListingMetadataSource,
+  catalog: CatalogIdentitySource,
+): ListingMetadataUpdate {
+  const data: ListingMetadataUpdate = {}
+  const asin = listing.asin.trim().toUpperCase()
+  const currentLabel = listing.label.trim()
+  const nextLabel = formatAmazonTitleLabel({
+    asin,
+    brand: catalog.brand,
+    title: catalog.title,
+  })
+  const nextBrandName = clean(catalog.brand)
+
+  if (shouldReplaceLabel(currentLabel, asin, nextBrandName, nextLabel) && nextLabel !== asin) {
+    data.label = nextLabel
+  }
+
+  if (clean(listing.brandName).length === 0 && nextBrandName.length > 0) {
+    data.brandName = nextBrandName
+  }
+
+  return data
+}

--- a/apps/argus/lib/listings/view-model.test.ts
+++ b/apps/argus/lib/listings/view-model.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { buildListingsViewModel } from './view-model'
+
+const baseListing = {
+  id: 'listing-1',
+  asin: 'B09HXC3NL8',
+  marketplace: 'US',
+  label: 'B09HXC3NL8',
+  brandName: null,
+  enabled: true,
+  createdAt: new Date('2026-04-20T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-21T10:00:00.000Z'),
+  titleRevisions: [],
+  _count: {
+    snapshots: 0,
+    titleRevisions: 0,
+    bulletsRevisions: 0,
+    galleryRevisions: 0,
+    videoRevisions: 0,
+    ebcRevisions: 0,
+  },
+}
+
+test('buildListingsViewModel summarizes listings for the table', () => {
+  const viewModel = buildListingsViewModel([
+    {
+      ...baseListing,
+      label: 'Greenhouse 12 x 9',
+      _count: {
+        snapshots: 2,
+        titleRevisions: 1,
+        bulletsRevisions: 1,
+        galleryRevisions: 1,
+        videoRevisions: 0,
+        ebcRevisions: 1,
+      },
+    },
+  ])
+
+  assert.equal(viewModel.totalListings, 1)
+  assert.equal(viewModel.totalSnapshots, 2)
+  assert.equal(viewModel.totalRevisions, 4)
+  assert.equal(viewModel.metadataRefreshCount, 0)
+  assert.equal(viewModel.rows[0].displayName, 'Greenhouse 12 x 9')
+  assert.equal(viewModel.rows[0].revisionTotal, 4)
+})
+
+test('buildListingsViewModel marks ASIN-only rows for metadata refresh', () => {
+  const viewModel = buildListingsViewModel([baseListing])
+
+  assert.equal(viewModel.metadataRefreshCount, 1)
+  assert.equal(viewModel.rows[0].displayName, 'B09HXC3NL8')
+  assert.equal(viewModel.rows[0].needsMetadataRefresh, true)
+})
+
+test('buildListingsViewModel uses latest title for generic brand labels', () => {
+  const viewModel = buildListingsViewModel([
+    {
+      ...baseListing,
+      label: 'HomeNest',
+      brandName: 'HomeNest',
+      titleRevisions: [{ title: 'HomeNest Portable greenhouse kit with reinforced frame and shelves' }],
+      _count: {
+        snapshots: 0,
+        titleRevisions: 1,
+        bulletsRevisions: 0,
+        galleryRevisions: 0,
+        videoRevisions: 0,
+        ebcRevisions: 0,
+      },
+    },
+  ])
+
+  assert.equal(viewModel.metadataRefreshCount, 0)
+  assert.equal(viewModel.rows[0].displayName, 'Portable greenhouse kit with reinforced frame')
+  assert.equal(viewModel.rows[0].needsMetadataRefresh, false)
+})

--- a/apps/argus/lib/listings/view-model.ts
+++ b/apps/argus/lib/listings/view-model.ts
@@ -1,0 +1,139 @@
+import { formatAmazonTitleLabel, formatProductLabel } from '@/lib/product-labels'
+
+interface ListingRevisionCounts {
+  snapshots: number
+  titleRevisions: number
+  bulletsRevisions: number
+  galleryRevisions: number
+  videoRevisions: number
+  ebcRevisions: number
+}
+
+export interface ListingTableSource {
+  id: string
+  asin: string
+  marketplace: string
+  label: string
+  brandName: string | null
+  enabled: boolean
+  createdAt: Date
+  updatedAt: Date
+  titleRevisions: Array<{ title: string }>
+  _count: ListingRevisionCounts
+}
+
+export interface ListingTableRow {
+  id: string
+  asin: string
+  marketplace: string
+  displayName: string
+  brandName: string | null
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+  needsMetadataRefresh: boolean
+  revisionTotal: number
+  counts: ListingRevisionCounts
+}
+
+export interface ListingsViewModel {
+  rows: ListingTableRow[]
+  totalListings: number
+  totalSnapshots: number
+  totalRevisions: number
+  metadataRefreshCount: number
+}
+
+function revisionTotal(counts: ListingRevisionCounts): number {
+  return counts.titleRevisions + counts.bulletsRevisions + counts.galleryRevisions + counts.videoRevisions + counts.ebcRevisions
+}
+
+function latestTitle(listing: ListingTableSource): string | null {
+  const revision = listing.titleRevisions[0]
+  if (revision === undefined) return null
+  return revision.title
+}
+
+function clean(value: string | null): string {
+  if (value === null) return ''
+  return value.trim()
+}
+
+function labelIsGeneric(label: string, asin: string, brandName: string): boolean {
+  if (label.length === 0) return true
+  if (label.toUpperCase() === asin) return true
+  if (brandName.length === 0) return false
+  return label.toLowerCase() === brandName.toLowerCase()
+}
+
+function formatListingDisplayName(listing: ListingTableSource): string {
+  const asin = listing.asin.trim().toUpperCase()
+  const label = listing.label.trim()
+  const brandName = clean(listing.brandName)
+  const title = latestTitle(listing)
+
+  if (!labelIsGeneric(label, asin, brandName)) return label
+
+  if (title !== null && title.trim().length > 0) {
+    return formatAmazonTitleLabel({
+      asin,
+      brandName,
+      title,
+    })
+  }
+
+  return formatProductLabel({
+    asin,
+    label,
+    brandName,
+  })
+}
+
+function needsMetadataRefresh(listing: ListingTableSource, displayName: string): boolean {
+  const asin = listing.asin.trim().toUpperCase()
+  if (displayName === asin) return true
+  const brandName = clean(listing.brandName)
+  if (brandName.length === 0) return false
+  const title = latestTitle(listing)
+  if (title !== null && title.trim().length > 0) return false
+  return displayName.toLowerCase() === brandName.toLowerCase()
+}
+
+export function buildListingsViewModel(listings: ListingTableSource[]): ListingsViewModel {
+  let totalSnapshots = 0
+  let totalRevisions = 0
+  let metadataRefreshCount = 0
+
+  const rows = listings.map((listing) => {
+    const counts = listing._count
+    const nextRevisionTotal = revisionTotal(counts)
+    const displayName = formatListingDisplayName(listing)
+    const nextNeedsMetadataRefresh = needsMetadataRefresh(listing, displayName)
+
+    totalSnapshots += counts.snapshots
+    totalRevisions += nextRevisionTotal
+    if (nextNeedsMetadataRefresh) metadataRefreshCount += 1
+
+    return {
+      id: listing.id,
+      asin: listing.asin.trim().toUpperCase(),
+      marketplace: listing.marketplace,
+      displayName,
+      brandName: listing.brandName,
+      enabled: listing.enabled,
+      createdAt: listing.createdAt.toISOString(),
+      updatedAt: listing.updatedAt.toISOString(),
+      needsMetadataRefresh: nextNeedsMetadataRefresh,
+      revisionTotal: nextRevisionTotal,
+      counts,
+    }
+  })
+
+  return {
+    rows,
+    totalListings: listings.length,
+    totalSnapshots,
+    totalRevisions,
+    metadataRefreshCount,
+  }
+}

--- a/apps/argus/lib/monitoring/labels.test.ts
+++ b/apps/argus/lib/monitoring/labels.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { formatMonitoringLabel } from './labels'
+
+test('formatMonitoringLabel includes variant size with brand', () => {
+  assert.equal(
+    formatMonitoringLabel({
+      asin: 'B09HXC3NL8',
+      brand: 'Caelum star',
+      size: '6 PK - Light',
+      title: 'Caelum Star 6 Pack 12x9 ft Extra Large Plastic Drop Cloth',
+    }),
+    'Caelum star - 6 PK - Light',
+  )
+})
+
+test('formatMonitoringLabel uses title identity before brand when size is missing', () => {
+  assert.equal(
+    formatMonitoringLabel({
+      asin: 'B09HXC3NL8',
+      brand: 'Caelum star',
+      title: 'Caelum Star 6 Pack 12x9 ft Extra Large Plastic Drop Cloth',
+    }),
+    '6 Pack 12x9 ft Extra Large',
+  )
+})

--- a/apps/argus/lib/monitoring/labels.ts
+++ b/apps/argus/lib/monitoring/labels.ts
@@ -1,19 +1,10 @@
 import type { MonitoringStateRecord } from './types'
+import { formatProductLabel } from '@/lib/product-labels'
 
 export type MonitoringLabelSource =
   | Pick<MonitoringStateRecord, 'asin' | 'brand' | 'size' | 'title'>
   | { asin: string; brand?: string | null; size?: string | null; title?: string | null }
 
 export function formatMonitoringLabel(source: MonitoringLabelSource): string {
-  const asin = source.asin.trim().toUpperCase()
-  const brand = (source.brand ?? '').trim()
-  const size = (source.size ?? '').trim()
-  const title = (source.title ?? '').trim()
-
-  if (brand && size) return `${brand} - ${size}`
-  if (brand) return brand
-  if (size) return size
-  if (title) return title
-
-  return asin
+  return formatProductLabel(source)
 }

--- a/apps/argus/lib/monitoring/reader.ts
+++ b/apps/argus/lib/monitoring/reader.ts
@@ -919,26 +919,21 @@ function normalizeChangeEvent(
           currentSnapshot,
           baselineSnapshot,
         })
-  const displayName = label ?? row.event_label ?? asin
-  const headline =
-    didFilterBsrChanges
-      ? buildHeadline({
-          asin: displayName,
-          owner,
-          primaryCategory,
-          currentSnapshot,
-          baselineSnapshot,
-          changedFields,
-        })
-      : readString(row.event_headline) ??
-        buildHeadline({
-          asin: displayName,
-          owner,
-          primaryCategory,
-          currentSnapshot,
-          baselineSnapshot,
-          changedFields,
-        })
+  const displaySource =
+    currentSnapshot !== null
+      ? currentSnapshot
+      : baselineSnapshot !== null
+        ? baselineSnapshot
+        : { asin }
+  const displayName = label !== null ? label : formatMonitoringLabel(displaySource)
+  const headline = buildHeadline({
+    asin: displayName,
+    owner,
+    primaryCategory,
+    currentSnapshot,
+    baselineSnapshot,
+    changedFields,
+  })
   const summary =
     didFilterBsrChanges
       ? buildSummary({
@@ -960,7 +955,7 @@ function normalizeChangeEvent(
   return {
     id: `${asin}-${row.snapshot_timestamp_utc}-${index}`,
     asin,
-    label: label ?? row.event_label ?? null,
+    label: displayName,
     owner,
     timestamp: row.snapshot_timestamp_utc,
     baselineTimestamp: readString(row.baseline_timestamp_utc),

--- a/apps/argus/lib/product-labels.test.ts
+++ b/apps/argus/lib/product-labels.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { formatAmazonTitleLabel, formatProductLabel } from './product-labels'
+
+test('formatProductLabel prefers a curated non-ASIN label', () => {
+  assert.equal(
+    formatProductLabel({
+      asin: 'B09HXC3NL8',
+      label: 'White Greenhouse',
+      brand: 'Targon',
+      size: '12 x 9',
+      title: 'Long Amazon title',
+    }),
+    'White Greenhouse',
+  )
+})
+
+test('formatProductLabel ignores labels that are just the ASIN', () => {
+  assert.equal(
+    formatProductLabel({
+      asin: 'B09HXC3NL8',
+      label: 'b09hxc3nl8',
+      brand: 'HomeNest',
+      size: '12 x 9',
+      title: 'Long Amazon title',
+    }),
+    'HomeNest - 12 x 9',
+  )
+})
+
+test('formatProductLabel falls through to brand, size, title, then ASIN', () => {
+  assert.equal(formatProductLabel({ asin: 'B0CR1GSBQ9', size: '10 x 8' }), '10 x 8')
+  assert.equal(formatProductLabel({ asin: 'B0CR1GSBQ9', title: 'Portable greenhouse kit' }), 'Portable greenhouse kit')
+  assert.equal(formatProductLabel({ asin: 'B0CR1GSBQ9', brand: 'HomeNest' }), 'HomeNest')
+  assert.equal(formatProductLabel({ asin: 'b0cr1gsbq9' }), 'B0CR1GSBQ9')
+})
+
+test('formatAmazonTitleLabel creates a short title label', () => {
+  assert.equal(
+    formatAmazonTitleLabel({
+      asin: 'B0CR1GSBQ9',
+      brand: 'HomeNest',
+      title: 'HomeNest Portable greenhouse kit with reinforced cover, shelves, and stakes',
+    }),
+    'Portable greenhouse kit with reinforced cover',
+  )
+})

--- a/apps/argus/lib/product-labels.ts
+++ b/apps/argus/lib/product-labels.ts
@@ -1,0 +1,80 @@
+export interface ProductLabelSource {
+  asin: string
+  label?: string | null
+  brand?: string | null
+  brandName?: string | null
+  size?: string | null
+  title?: string | null
+}
+
+export interface AmazonTitleLabelSource {
+  asin: string
+  brand?: string | null
+  brandName?: string | null
+  title?: string | null
+}
+
+function clean(value: string | null | undefined): string {
+  if (value === null) return ''
+  if (value === undefined) return ''
+  return value.trim()
+}
+
+function firstText(values: Array<string | null | undefined>): string {
+  for (const value of values) {
+    const text = clean(value)
+    if (text.length > 0) return text
+  }
+
+  return ''
+}
+
+function removeBrandPrefix(title: string, brand: string): string {
+  if (brand.length === 0) return title
+  if (!title.toLowerCase().startsWith(brand.toLowerCase())) return title
+
+  const withoutBrand = title.slice(brand.length).trim()
+  return withoutBrand.replace(/^[\s:-]+/, '').trim()
+}
+
+function firstTitleSegment(title: string): string {
+  const segments = title.split(/[|,;(\[]/)
+  const segment = clean(segments[0])
+  if (segment.length > 0) return segment
+  return title
+}
+
+function limitWords(text: string, maxWords: number): string {
+  const words = text.split(/\s+/).filter((word) => word.length > 0)
+  if (words.length <= maxWords) return words.join(' ')
+  return words.slice(0, maxWords).join(' ')
+}
+
+export function formatProductLabel(source: ProductLabelSource): string {
+  const asin = source.asin.trim().toUpperCase()
+  const label = clean(source.label)
+  if (label.length > 0 && label.toUpperCase() !== asin) return label
+
+  const brand = firstText([source.brand, source.brandName])
+  const size = clean(source.size)
+  const title = clean(source.title)
+
+  if (brand.length > 0 && size.length > 0) return `${brand} - ${size}`
+  if (size.length > 0) return size
+  if (title.length > 0) return formatAmazonTitleLabel({ asin, brand, title })
+  if (brand.length > 0) return brand
+
+  return asin
+}
+
+export function formatAmazonTitleLabel(source: AmazonTitleLabelSource): string {
+  const asin = source.asin.trim().toUpperCase()
+  const title = clean(source.title)
+  if (title.length === 0) return asin
+
+  const brand = firstText([source.brand, source.brandName])
+  const titleWithoutBrand = removeBrandPrefix(firstTitleSegment(title), brand)
+  const titleLabel = limitWords(titleWithoutBrand, 6)
+  if (titleLabel.length === 0) return brand
+  return titleLabel
+}

--- a/apps/argus/package.json
+++ b/apps/argus/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js argus -- node ../../scripts/run-next-port.js dev 3216",
+    "dev": "node ../../scripts/run-dev-with-logs.js argus -- node ../../scripts/run-next-port.js dev",
     "build": "next build",
-    "start": "node ../../scripts/run-next-port.js start 3216",
+    "start": "node ../../scripts/run-next-port.js start",
     "lint": "eslint app components lib middleware.ts",
     "type-check": "prisma generate --schema prisma/schema.prisma && tsc --noEmit --skipLibCheck"
   },

--- a/apps/atlas/package.json
+++ b/apps/atlas/package.json
@@ -3,9 +3,9 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js atlas -- node ../../scripts/run-next-port.js dev 3206 --webpack",
+    "dev": "node ../../scripts/run-dev-with-logs.js atlas -- node ../../scripts/run-next-port.js dev --webpack",
     "build": "node -e \"require('fs').rmSync('.next/dev', { recursive: true, force: true }); require('fs').rmSync('.next/types', { recursive: true, force: true })\" && next build --webpack",
-    "start": "node ../../scripts/run-next-port.js start 3206",
+    "start": "node ../../scripts/run-next-port.js start",
     "type-check": "node -e \"require('fs').rmSync('.next/dev', { recursive: true, force: true }); require('fs').rmSync('.next/types', { recursive: true, force: true })\" && DATABASE_URL=${DATABASE_URL:-postgresql://localhost:5432/atlas} prisma generate --schema prisma/schema.prisma && pnpm exec tsc -p tsconfig.typecheck.json --noEmit --skipLibCheck",
     "test": "cd tests && playwright test",
     "test:unit": "node --import tsx --test tests/unit/*.test.ts",

--- a/apps/hermes/package.json
+++ b/apps/hermes/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node ../../scripts/run-next-port.js dev 3214",
+    "dev": "node ../../scripts/run-next-port.js dev",
     "build": "next build",
-    "start": "node ../../scripts/run-next-port.js start 3214",
+    "start": "node ../../scripts/run-next-port.js start",
     "worker:request-review": "tsx src/server/jobs/request-review-dispatcher.ts",
     "worker:buyer-message": "tsx src/server/jobs/buyer-message-dispatcher.ts",
     "lint": "next lint",

--- a/apps/kairos/package.json
+++ b/apps/kairos/package.json
@@ -3,10 +3,10 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-next-port.js dev 3210",
+    "dev": "node ../../scripts/run-next-port.js dev",
     "clean": "rm -rf .next out dist",
     "build": "next build",
-    "start": "node ../../scripts/run-next-port.js start 3210",
+    "start": "node ../../scripts/run-next-port.js start",
     "lint": "eslint app components lib",
     "type-check": "prisma generate --schema prisma/schema.prisma && tsc --noEmit",
     "format": "prettier --check \"{app,components,lib,styles}/**/*.{ts,tsx,mdx}\"",

--- a/apps/plutus/package.json
+++ b/apps/plutus/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "description": "Plutus – finance workspace for custom financials from QuickBooks Online",
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js plutus -- node ../../scripts/run-next-port.js dev 3212",
+    "dev": "node ../../scripts/run-dev-with-logs.js plutus -- node ../../scripts/run-next-port.js dev",
     "clean": "rm -rf .next out dist",
     "build": "prisma generate --schema prisma/schema.prisma && next build",
-    "start": "node ../../scripts/run-next-port.js start 3212",
+    "start": "node ../../scripts/run-next-port.js start",
     "lint": "eslint app components lib",
     "test": "tsx tests/run.ts",
     "type-check": "prisma generate --schema prisma/schema.prisma && tsc --noEmit",

--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -3,10 +3,10 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js sso -- node ../../scripts/run-next-port.js dev 3200",
+    "dev": "node ../../scripts/run-dev-with-logs.js sso -- node ../../scripts/run-next-port.js dev",
     "clean": "rm -rf .next out dist",
     "build": "next build",
-    "start": "node ../../scripts/run-next-port.js start 3200",
+    "start": "node ../../scripts/run-next-port.js start",
     "type-check": "tsc --noEmit",
     "test:auth-contracts": "tsx --test lib/auth-logger.test.ts lib/auth-route-recovery.test.ts tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts scripts/ensure-hosted-smoke-user-lib.test.ts",
     "test:auth-smoke": "pnpm run test:auth-contracts && playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",

--- a/apps/talos/package.json
+++ b/apps/talos/package.json
@@ -3,10 +3,10 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js talos -- node ../../scripts/run-next-port.js dev 3201",
+    "dev": "node ../../scripts/run-dev-with-logs.js talos -- node ../../scripts/run-next-port.js dev",
     "dev:30001": "next dev -p 30001",
     "dev:turbo": "next dev --turbo",
-    "dev:port": "PORT=3201 next dev",
+    "dev:port": "node ../../scripts/run-next-port.js dev",
     "dev:logged": "node server.js",
     "build": "pnpm db:generate && next build",
     "build:prod": "NODE_ENV=production npm run clean && npm run build && npm run post-build",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "description": "Targon – Company site and product catalog",
   "scripts": {
-    "dev": "node ../../scripts/run-dev-with-logs.js website -- node ../../scripts/run-next-port.js dev 3205",
+    "dev": "node ../../scripts/run-dev-with-logs.js website -- node ../../scripts/run-next-port.js dev",
     "clean": "rm -rf .next out dist",
     "build": "next build",
-    "start": "node ../../scripts/run-next-port.js start 3205",
+    "start": "node ../../scripts/run-next-port.js start",
     "lint": "next lint",
     "type-check": "node -e \"require('fs').rmSync('.next/types', { recursive: true, force: true })\" && tsc --noEmit --skipLibCheck",
     "format": "prettier --write \"src/**/*.{ts,tsx}\""

--- a/apps/xplan/package.json
+++ b/apps/xplan/package.json
@@ -3,10 +3,10 @@
   "version": "1.1.0",
   "private": true,
   "scripts": {
-    "dev": "node ../../scripts/run-next-port.js dev 3208",
+    "dev": "node ../../scripts/run-next-port.js dev",
     "clean": "rm -rf .next out dist",
     "build": "prisma generate --schema ../talos/prisma/schema.prisma && prisma generate --schema prisma/schema.prisma && next build",
-    "start": "node ../../scripts/run-next-port.js start 3208",
+    "start": "node ../../scripts/run-next-port.js start",
     "lint": "eslint app components lib ",
     "type-check": "prisma generate --schema ../talos/prisma/schema.prisma && prisma generate --schema prisma/schema.prisma && tsc --noEmit",
     "format": "prettier --check \"{app,components,lib,styles}/**/*.{ts,tsx,mdx}\"",

--- a/scripts/run-next-port.js
+++ b/scripts/run-next-port.js
@@ -30,7 +30,7 @@ function parsePortFromEnvText(text) {
   return null
 }
 
-function resolvePortFromAppEnv(appDir, fallbackPort) {
+function resolvePortFromAppEnv(appDir) {
   for (const candidate of ENV_FILE_CANDIDATES) {
     const envPath = path.join(appDir, candidate)
     if (!fs.existsSync(envPath)) {
@@ -43,7 +43,7 @@ function resolvePortFromAppEnv(appDir, fallbackPort) {
     }
   }
 
-  return fallbackPort
+  throw new Error('PORT must be defined in an app env file.')
 }
 
 function resolveNextCommand() {
@@ -56,24 +56,25 @@ function resolveNextCommand() {
 
 function runCli() {
   const args = process.argv.slice(2)
-  if (args.length < 2) {
-    console.error('Usage: run-next-port <dev|start> <fallback-port> [next args...]')
+  if (args.length < 1) {
+    console.error('Usage: run-next-port <dev|start> [next args...]')
     process.exit(1)
   }
 
-  const [mode, fallbackPortRaw, ...nextArgs] = args
+  const [mode, ...nextArgs] = args
   if (mode !== 'dev' && mode !== 'start') {
     console.error(`Unsupported Next mode "${mode}". Expected "dev" or "start".`)
     process.exit(1)
   }
 
-  if (!/^\d+$/.test(fallbackPortRaw)) {
-    console.error(`Fallback port must be numeric. Received "${fallbackPortRaw}".`)
+  let port
+  try {
+    port = resolvePortFromAppEnv(process.cwd())
+  } catch (error) {
+    console.error(`[run-next-port] ${error.message}`)
     process.exit(1)
   }
 
-  const fallbackPort = Number(fallbackPortRaw)
-  const port = resolvePortFromAppEnv(process.cwd(), fallbackPort)
   const child = spawn(resolveNextCommand(), [mode, '-p', String(port), ...nextArgs], {
     cwd: process.cwd(),
     env: process.env,

--- a/scripts/run-next-port.test.cjs
+++ b/scripts/run-next-port.test.cjs
@@ -14,14 +14,17 @@ test('parsePortFromEnvText ignores comments and blank lines', () => {
   assert.equal(parsePortFromEnvText('\n# comment\nPORT=41210\n'), 41210)
 })
 
-test('resolvePortFromAppEnv prefers the app env file over the fallback port', () => {
+test('resolvePortFromAppEnv returns the app env port', () => {
   const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-next-port-'))
   fs.writeFileSync(path.join(appDir, '.env.local'), 'PORT=41216\n', 'utf8')
 
-  assert.equal(resolvePortFromAppEnv(appDir, 3216), 41216)
+  assert.equal(resolvePortFromAppEnv(appDir), 41216)
 })
 
-test('resolvePortFromAppEnv returns the fallback port when no env file exists', () => {
+test('resolvePortFromAppEnv fails when no app env port exists', () => {
   const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-next-port-'))
-  assert.equal(resolvePortFromAppEnv(appDir, 3214), 3214)
+  assert.throws(
+    () => resolvePortFromAppEnv(appDir),
+    /PORT must be defined in an app env file/,
+  )
 })


### PR DESCRIPTION
## Summary
- Replace the Argus listings card stack with a compact tabular listings grid.
- Add shared product-label helpers so Listings and Monitoring stop showing ASINs or generic brand-only names as the primary identity.
- Add a Listings metadata refresh endpoint that pulls SP-API catalog identity and records title revisions.
- Remove 32xx fallback ports from Next app scripts so apps require their env-defined PORT.

## Root Cause
Listings only had ASIN-backed labels and no title revisions, while Monitoring had better ASIN-specific size/title data but sometimes trusted stale CSV event labels/headlines. The shared label path also let generic brand names outrank useful product identity.

## Validation
- `pnpm --filter @targon/argus exec node --import tsx --test lib/product-labels.test.ts lib/monitoring/labels.test.ts lib/listings/view-model.test.ts lib/listings/metadata.test.ts`
- `pnpm --filter @targon/argus type-check`
- `pnpm --filter @targon/argus lint`
- `node --test scripts/run-next-port.test.cjs`
- Browser smoke checks for `/argus/listings` and `/argus/monitoring`
