### PR TITLE
feat(argus): add UK WPR and monitoring market support

### DIFF
--- a/apps/argus/.env.dev.ci
+++ b/apps/argus/.env.dev.ci
@@ -10,4 +10,8 @@ NEXT_PUBLIC_PORTAL_AUTH_URL=https://dev-os.targonglobal.com
 PORTAL_AUTH_SECRET=ci-portal-auth-secret
 CSRF_ALLOWED_ORIGINS=https://dev-os.targonglobal.com
 DATABASE_URL=postgresql://user:password@localhost:5432/portal_db?schema=argus_dev
+ARGUS_SALES_ROOT_US=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales
+ARGUS_SALES_ROOT_UK=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - UK/Sales
+WPR_DATA_DIR_US=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/WPR/wpr-workspace/output
+WPR_DATA_DIR_UK=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - UK/Sales/WPR/wpr-workspace/output
 WPR_DATA_DIR=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/WPR/wpr-workspace/output

--- a/apps/argus/app/(app)/monitoring/[id]/page.tsx
+++ b/apps/argus/app/(app)/monitoring/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
-import { useParams } from 'next/navigation'
+import { useParams, useSearchParams } from 'next/navigation'
 import {
   Alert,
   Box,
@@ -45,11 +45,14 @@ import {
   formatMoney,
   humanizeFieldName,
 } from '@/components/monitoring/ui'
+import { appendMarketParam, parseArgusMarket } from '@/lib/argus-market'
 
 type RangeValue = '24h' | '7d' | '30d' | 'all'
 
 export default function TrackingDetailPage() {
   const params = useParams()
+  const searchParams = useSearchParams()
+  const market = parseArgusMarket(searchParams.get('market'))
   const asin = String(params.id ?? '').trim().toUpperCase()
   const [detail, setDetail] = useState<MonitoringAsinDetail | null>(null)
   const [loading, setLoading] = useState(true)
@@ -63,7 +66,9 @@ export default function TrackingDetailPage() {
       try {
         setLoading(true)
         setError(null)
-        const payload = await readAppJsonOrThrow<MonitoringAsinDetail>(`/api/monitoring/asins/${asin}`)
+        const payload = await readAppJsonOrThrow<MonitoringAsinDetail>(
+          appendMarketParam(`/api/monitoring/asins/${asin}`, market),
+        )
         if (!cancelled) {
           setDetail(payload)
           setLoading(false)
@@ -83,7 +88,7 @@ export default function TrackingDetailPage() {
     return () => {
       cancelled = true
     }
-  }, [asin])
+  }, [asin, market])
 
   const filteredSnapshots = useMemo(
     () => filterSnapshots(detail?.snapshots ?? [], range),
@@ -126,9 +131,9 @@ export default function TrackingDetailPage() {
   return (
     <Box sx={{ maxWidth: 1480, mx: 'auto', pb: 4 }}>
       <Stack spacing={3}>
-        <Button
-          component={Link}
-          href="/monitoring"
+          <Button
+            component={Link}
+            href={appendMarketParam('/monitoring', market)}
           startIcon={<ArrowBackIcon />}
           sx={{ alignSelf: 'flex-start' }}
         >

--- a/apps/argus/app/(app)/monitoring/page.tsx
+++ b/apps/argus/app/(app)/monitoring/page.tsx
@@ -33,6 +33,12 @@ import { formatDateTime } from '@/components/monitoring/ui'
 import FeedRail from '@/components/monitoring/FeedRail'
 import ChangeDetail from '@/components/monitoring/ChangeDetail'
 import SourceHealthGrid from '@/components/monitoring/SourceHealthGrid'
+import {
+  ARGUS_MARKETS,
+  appendMarketParam,
+  parseArgusMarket,
+  type ArgusMarket,
+} from '@/lib/argus-market'
 
 type OwnerFilter = 'ALL' | 'OURS' | 'COMPETITOR'
 
@@ -49,6 +55,7 @@ function TrackingDashboardContent() {
   const pathname = usePathname()
   const router = useRouter()
   const searchParams = useSearchParams()
+  const market = parseArgusMarket(searchParams.get('market'))
   const [activeTab, setActiveTab] = useState<'changes' | 'sources'>('changes')
   const [overview, setOverview] = useState<MonitoringOverview | null>(null)
   const [changes, setChanges] = useState<MonitoringChangeEvent[]>([])
@@ -75,6 +82,7 @@ function TrackingDashboardContent() {
   const changeRequestQuery = useMemo(
     () =>
       buildUrlSearchParams({
+        market,
         windowValue,
         owner,
         category,
@@ -82,14 +90,12 @@ function TrackingDashboardContent() {
         query: deferredQuery,
         snapshotTimestamp,
       }).toString(),
-    [category, deferredQuery, owner, severity, snapshotTimestamp, windowValue],
+    [category, deferredQuery, market, owner, severity, snapshotTimestamp, windowValue],
   )
-  const [initialChangeRequestQuery] = useState(changeRequestQuery)
-  const [loadedChangeRequestQuery, setLoadedChangeRequestQuery] = useState<string | null>(null)
   const [selectedEventId, setSelectedEventId] = useState<string | null>(null)
   const [readIds, setReadIds] = useState<Set<string>>(() => {
     try {
-      const stored = localStorage.getItem('argus:read-events')
+      const stored = localStorage.getItem(readEventsStorageKey(market))
       return stored ? new Set(JSON.parse(stored) as string[]) : new Set()
     } catch {
       return new Set()
@@ -114,6 +120,7 @@ function TrackingDashboardContent() {
 
   useEffect(() => {
     const nextSearchParams = buildUrlSearchParams({
+      market,
       windowValue,
       owner,
       category,
@@ -131,6 +138,7 @@ function TrackingDashboardContent() {
     })
   }, [
     category,
+    market,
     owner,
     pathname,
     query,
@@ -149,14 +157,13 @@ function TrackingDashboardContent() {
         setLoading(true)
         setError(null)
         const requestPath =
-          initialChangeRequestQuery === ''
+          changeRequestQuery === ''
             ? '/api/monitoring/bootstrap'
-            : `/api/monitoring/bootstrap?${initialChangeRequestQuery}`
+            : `/api/monitoring/bootstrap?${changeRequestQuery}`
         const bootstrap = await readAppJsonOrThrow<MonitoringBootstrap>(requestPath)
         if (!cancelled) {
           setOverview(bootstrap.overview)
           setChanges(bootstrap.changes)
-          setLoadedChangeRequestQuery(initialChangeRequestQuery)
           setLoading(false)
         }
       } catch (loadError) {
@@ -171,42 +178,7 @@ function TrackingDashboardContent() {
     return () => {
       cancelled = true
     }
-  }, [initialChangeRequestQuery])
-
-  useEffect(() => {
-    if (loadedChangeRequestQuery === null) return
-    if (loadedChangeRequestQuery === changeRequestQuery) return
-
-    let cancelled = false
-
-    async function loadChanges() {
-      try {
-        setLoading(true)
-        setError(null)
-        const requestPath =
-          changeRequestQuery === ''
-            ? '/api/monitoring/changes'
-            : `/api/monitoring/changes?${changeRequestQuery}`
-        const payload = await readAppJsonOrThrow<MonitoringChangeEvent[]>(requestPath)
-
-        if (!cancelled) {
-          setChanges(payload)
-          setLoadedChangeRequestQuery(changeRequestQuery)
-          setLoading(false)
-        }
-      } catch (loadError) {
-        if (!cancelled) {
-          setError(loadError instanceof Error ? loadError.message : 'Failed to load monitoring changes.')
-          setLoading(false)
-        }
-      }
-    }
-
-    void loadChanges()
-    return () => {
-      cancelled = true
-    }
-  }, [changeRequestQuery, loadedChangeRequestQuery])
+  }, [changeRequestQuery])
 
   useEffect(() => {
     if (activeTab !== 'sources') return
@@ -215,7 +187,9 @@ function TrackingDashboardContent() {
     async function loadHealth() {
       try {
         setHealthError(null)
-        const payload = await readAppJsonOrThrow<MonitoringHealthReport>('/api/monitoring/health')
+        const payload = await readAppJsonOrThrow<MonitoringHealthReport>(
+          appendMarketParam('/api/monitoring/health', market),
+        )
         if (!cancelled) {
           setHealth(payload)
         }
@@ -230,7 +204,16 @@ function TrackingDashboardContent() {
     return () => {
       cancelled = true
     }
-  }, [activeTab])
+  }, [activeTab, market])
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(readEventsStorageKey(market))
+      setReadIds(stored ? new Set(JSON.parse(stored) as string[]) : new Set())
+    } catch {
+      setReadIds(new Set())
+    }
+  }, [market])
 
   useEffect(() => {
     if (changes.length === 0) {
@@ -262,7 +245,7 @@ function TrackingDashboardContent() {
     setReadIds((prev) => {
       const next = new Set(prev)
       next.add(id)
-      try { localStorage.setItem('argus:read-events', JSON.stringify([...next])) } catch {}
+      try { localStorage.setItem(readEventsStorageKey(market), JSON.stringify([...next])) } catch {}
       return next
     })
   }
@@ -284,10 +267,11 @@ function TrackingDashboardContent() {
       const bootstrap = await readAppJsonOrThrow<MonitoringBootstrap>(bootstrapPath)
       setOverview(bootstrap.overview)
       setChanges(bootstrap.changes)
-      setLoadedChangeRequestQuery(changeRequestQuery)
 
       if (activeTab === 'sources') {
-        const healthPayload = await readAppJsonOrThrow<MonitoringHealthReport>('/api/monitoring/health')
+        const healthPayload = await readAppJsonOrThrow<MonitoringHealthReport>(
+          appendMarketParam('/api/monitoring/health', market),
+        )
         setHealth(healthPayload)
       }
     } catch (refreshError) {
@@ -295,6 +279,23 @@ function TrackingDashboardContent() {
     } finally {
       setRefreshing(false)
     }
+  }
+
+  function handleSelectMarket(nextMarket: ArgusMarket) {
+    const nextSearchParams = buildUrlSearchParams({
+      market: nextMarket,
+      windowValue,
+      owner,
+      category,
+      severity,
+      query,
+      snapshotTimestamp,
+    })
+    const nextQueryString = nextSearchParams.toString()
+    const nextUrl = nextQueryString === '' ? pathname : `${pathname}?${nextQueryString}`
+    startTransition(() => {
+      router.replace(nextUrl, { scroll: false })
+    })
   }
 
   return (
@@ -364,6 +365,19 @@ function TrackingDashboardContent() {
             </Tabs>
 
             <Stack direction="row" spacing={1} alignItems="center">
+              <Stack direction="row" spacing={0.5} alignItems="center">
+                {ARGUS_MARKETS.map((option) => (
+                  <Button
+                    key={option.slug}
+                    size="small"
+                    variant={market === option.slug ? 'contained' : 'outlined'}
+                    onClick={() => handleSelectMarket(option.slug)}
+                    sx={{ minWidth: 38, px: 1.1, py: 0.35, fontWeight: 800 }}
+                  >
+                    {option.label}
+                  </Button>
+                ))}
+              </Stack>
               <Button
                 variant="outlined"
                 size="small"
@@ -376,7 +390,7 @@ function TrackingDashboardContent() {
               {selectedEvent ? (
                 <Button
                   component={Link}
-                  href={`/monitoring/${selectedEvent.asin}`}
+                  href={appendMarketParam(`/monitoring/${selectedEvent.asin}`, market)}
                   variant="outlined"
                   size="small"
                   startIcon={<ArrowOutwardIcon sx={{ fontSize: 14 }} />}
@@ -502,6 +516,7 @@ function readSnapshotParam(value: string | null): string | null {
 }
 
 function buildUrlSearchParams(input: {
+  market: ArgusMarket
   windowValue: '24h' | '7d' | '30d' | 'all'
   owner: OwnerFilter
   category: MonitoringCategory | 'ALL'
@@ -510,6 +525,7 @@ function buildUrlSearchParams(input: {
   snapshotTimestamp: string | null
 }): URLSearchParams {
   const searchParams = new URLSearchParams()
+  if (input.market !== 'us') searchParams.set('market', input.market)
   if (input.windowValue !== '7d') searchParams.set('window', input.windowValue)
   if (input.owner !== 'ALL') searchParams.set('owner', input.owner)
   if (input.category !== 'ALL') searchParams.set('category', input.category)
@@ -517,4 +533,8 @@ function buildUrlSearchParams(input: {
   if (input.query.trim() !== '') searchParams.set('query', input.query.trim())
   if (input.snapshotTimestamp) searchParams.set('snapshot', input.snapshotTimestamp)
   return searchParams
+}
+
+function readEventsStorageKey(market: ArgusMarket): string {
+  return `argus:${market}:read-events`
 }

--- a/apps/argus/app/api/monitoring/asins/[asin]/route.ts
+++ b/apps/argus/app/api/monitoring/asins/[asin]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { parseArgusMarket } from '@/lib/argus-market'
 import { getMonitoringAsinDetail } from '@/lib/monitoring/reader'
 
 type Params = { params: Promise<{ asin: string }> }
@@ -8,7 +9,9 @@ export const dynamic = 'force-dynamic'
 export async function GET(_request: NextRequest, { params }: Params) {
   try {
     const { asin } = await params
-    const detail = await getMonitoringAsinDetail(asin)
+    const { searchParams } = new URL(_request.url)
+    const market = parseArgusMarket(searchParams.get('market'))
+    const detail = await getMonitoringAsinDetail(asin, market)
 
     if (!detail.current) {
       return NextResponse.json({ error: 'ASIN not found in monitoring state.' }, { status: 404 })

--- a/apps/argus/app/api/monitoring/bootstrap/route.ts
+++ b/apps/argus/app/api/monitoring/bootstrap/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { parseArgusMarket } from '@/lib/argus-market'
 import { getMonitoringBootstrap } from '@/lib/monitoring/reader'
 import type {
   MonitoringCategory,
@@ -12,7 +13,9 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
+    const market = parseArgusMarket(searchParams.get('market'))
     const bootstrap = await getMonitoringBootstrap({
+      market,
       window: readWindow(searchParams.get('window')),
       owner: readOwner(searchParams.get('owner')),
       category: readCategory(searchParams.get('category')),

--- a/apps/argus/app/api/monitoring/changes/route.ts
+++ b/apps/argus/app/api/monitoring/changes/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { parseArgusMarket } from '@/lib/argus-market'
 import { getMonitoringChanges } from '@/lib/monitoring/reader'
 import type {
   MonitoringCategory,
@@ -12,7 +13,9 @@ export const dynamic = 'force-dynamic'
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
+    const market = parseArgusMarket(searchParams.get('market'))
     const changes = await getMonitoringChanges({
+      market,
       window: readWindow(searchParams.get('window')),
       owner: readOwner(searchParams.get('owner')),
       category: readCategory(searchParams.get('category')),

--- a/apps/argus/app/api/monitoring/health/[jobId]/runs/route.ts
+++ b/apps/argus/app/api/monitoring/health/[jobId]/runs/route.ts
@@ -1,27 +1,36 @@
 import { NextResponse } from 'next/server'
 import { promises as fs } from 'fs'
 import path from 'path'
+import { getArgusMarketConfig, parseArgusMarket, type ArgusMarket } from '@/lib/argus-market'
 
 export const dynamic = 'force-dynamic'
 
-const MONITORING_BASE =
-  '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring'
+const JOB_LOG_DIRS: Record<string, string> = {
+  'tracking-fetch': 'tracking-fetch',
+  'hourly-listing-attributes-api': 'hourly-listing-attributes-api',
+  'daily-account-health': 'daily-account-health',
+  'daily-visuals': 'daily-visuals',
+  'weekly-api-sources': 'weekly-api-sources',
+  'weekly-browser-sources': 'weekly-browser-sources',
+}
 
-const JOB_LOG_PATHS: Record<string, string> = {
-  'tracking-fetch': path.join(MONITORING_BASE, 'Logs/tracking-fetch/run-log.jsonl'),
-  'hourly-listing-attributes-api': path.join(MONITORING_BASE, 'Logs/hourly-listing-attributes-api/run-log.jsonl'),
-  'daily-account-health': path.join(MONITORING_BASE, 'Logs/daily-account-health/run-log.jsonl'),
-  'daily-visuals': path.join(MONITORING_BASE, 'Logs/daily-visuals/run-log.jsonl'),
-  'weekly-api-sources': path.join(MONITORING_BASE, 'Logs/weekly-api-sources/run-log.jsonl'),
-  'weekly-browser-sources': path.join(MONITORING_BASE, 'Logs/weekly-browser-sources/run-log.jsonl'),
+function resolveJobLogPath(jobId: string, market: ArgusMarket): string | null {
+  const logDir = JOB_LOG_DIRS[jobId]
+  if (logDir === undefined) {
+    return null
+  }
+
+  return path.join(getArgusMarketConfig(market).monitoringRoot, 'Logs', logDir, 'run-log.jsonl')
 }
 
 export async function GET(
-  _request: Request,
+  request: Request,
   { params }: { params: Promise<{ jobId: string }> },
 ) {
   const { jobId } = await params
-  const logPath = JOB_LOG_PATHS[jobId]
+  const { searchParams } = new URL(request.url)
+  const market = parseArgusMarket(searchParams.get('market'))
+  const logPath = resolveJobLogPath(jobId, market)
 
   if (!logPath) {
     return NextResponse.json([])

--- a/apps/argus/app/api/monitoring/health/route.ts
+++ b/apps/argus/app/api/monitoring/health/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from 'next/server'
+import { parseArgusMarket } from '@/lib/argus-market'
 import { getMonitoringHealth } from '@/lib/monitoring/reader'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const health = await getMonitoringHealth()
+    const { searchParams } = new URL(request.url)
+    const market = parseArgusMarket(searchParams.get('market'))
+    const health = await getMonitoringHealth(market)
     return NextResponse.json(health)
   } catch (error) {
     return NextResponse.json(

--- a/apps/argus/app/api/monitoring/overview/route.ts
+++ b/apps/argus/app/api/monitoring/overview/route.ts
@@ -1,11 +1,14 @@
 import { NextResponse } from 'next/server'
+import { parseArgusMarket } from '@/lib/argus-market'
 import { getMonitoringOverview } from '@/lib/monitoring/reader'
 
 export const dynamic = 'force-dynamic'
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const overview = await getMonitoringOverview()
+    const { searchParams } = new URL(request.url)
+    const market = parseArgusMarket(searchParams.get('market'))
+    const overview = await getMonitoringOverview(market)
     return NextResponse.json(overview)
   } catch (error) {
     return NextResponse.json(

--- a/apps/argus/app/api/monitoring/route-market.test.ts
+++ b/apps/argus/app/api/monitoring/route-market.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+const ROUTES = [
+  {
+    path: './bootstrap/route.ts',
+    readerCall: /getMonitoringBootstrap\(\{\s*market,/s,
+  },
+  {
+    path: './changes/route.ts',
+    readerCall: /getMonitoringChanges\(\{\s*market,/s,
+  },
+  {
+    path: './overview/route.ts',
+    readerCall: /getMonitoringOverview\(market\)/,
+  },
+  {
+    path: './health/route.ts',
+    readerCall: /getMonitoringHealth\(market\)/,
+  },
+  {
+    path: './asins/[asin]/route.ts',
+    readerCall: /getMonitoringAsinDetail\(asin,\s*market\)/,
+  },
+] as const
+
+test('monitoring routes parse and pass Argus market into reader calls', () => {
+  for (const route of ROUTES) {
+    const source = readFileSync(new URL(route.path, import.meta.url), 'utf8')
+    assert.match(source, /parseArgusMarket/)
+    assert.match(source, /searchParams\.get\('market'\)/)
+    assert.match(source, route.readerCall)
+  }
+})

--- a/apps/argus/app/api/wpr/changelog-week-route.test.ts
+++ b/apps/argus/app/api/wpr/changelog-week-route.test.ts
@@ -137,7 +137,8 @@ function buildPayload() {
 
 test('GET /api/wpr/changelog/[week] returns only the requested week entries', async () => {
   const dataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-changelog-week-route-'))
-  process.env.WPR_DATA_DIR = dataDir
+  process.env.ARGUS_SALES_ROOT_US = path.join(dataDir, '..', '..', '..')
+  process.env.WPR_DATA_DIR_US = dataDir
   writeFileSync(path.join(dataDir, 'wpr-data-latest.json'), JSON.stringify(buildPayload()))
 
   const mod = await import('./changelog/[week]/route')
@@ -166,7 +167,8 @@ test('GET /api/wpr/changelog/[week] returns only the requested week entries', as
 
 test('GET /api/wpr/changelog/[week] returns 404 for an unknown week', async () => {
   const dataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-changelog-week-route-'))
-  process.env.WPR_DATA_DIR = dataDir
+  process.env.ARGUS_SALES_ROOT_US = path.join(dataDir, '..', '..', '..')
+  process.env.WPR_DATA_DIR_US = dataDir
   writeFileSync(path.join(dataDir, 'wpr-data-latest.json'), JSON.stringify(buildPayload()))
 
   const mod = await import('./changelog/[week]/route')

--- a/apps/argus/app/api/wpr/changelog/[week]/route.ts
+++ b/apps/argus/app/api/wpr/changelog/[week]/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from 'next/server';
+import { parseArgusMarket } from '@/lib/argus-market';
 import { getWprChangeLogWeek } from '@/lib/wpr/reader';
 
 type RouteContext = {
   params: Promise<{ week: string }>;
 };
 
-export async function GET(_request: Request, context: RouteContext) {
+export async function GET(request: Request, context: RouteContext) {
   try {
     const { week } = await context.params;
-    const entries = await getWprChangeLogWeek(week);
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
+    const entries = await getWprChangeLogWeek(week, market);
     return NextResponse.json(entries);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load the requested WPR changelog week.';

--- a/apps/argus/app/api/wpr/changelog/route.ts
+++ b/apps/argus/app/api/wpr/changelog/route.ts
@@ -1,12 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { parseArgusMarket } from '@/lib/argus-market';
 import { getWprChangeLog } from '@/lib/wpr/reader';
 import { createWprChangeLogEntry } from '@/lib/wpr/change-log-write';
 
 export const runtime = 'nodejs';
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const changes = await getWprChangeLog();
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
+    const changes = await getWprChangeLog(market);
     return NextResponse.json(changes);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load the WPR changelog.';
@@ -51,6 +54,8 @@ function expectStringArray(value: unknown, fieldName: string): string[] {
 
 export async function POST(request: NextRequest) {
   try {
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
     const payload = (await request.json()) as ChangeLogRequestPayload;
     const result = await createWprChangeLogEntry({
       weekLabel: expectString(payload.weekLabel, 'weekLabel'),
@@ -62,7 +67,7 @@ export async function POST(request: NextRequest) {
       fieldLabels: expectStringArray(payload.fieldLabels, 'fieldLabels'),
       highlights: expectStringArray(payload.highlights, 'highlights'),
       statusLines: expectStringArray(payload.statusLines, 'statusLines'),
-    });
+    }, market);
 
     return NextResponse.json({ ok: true, filePath: result.filePath });
   } catch (error) {

--- a/apps/argus/app/api/wpr/payload/route.test.ts
+++ b/apps/argus/app/api/wpr/payload/route.test.ts
@@ -135,11 +135,12 @@ function buildPayload() {
 
 test('GET /api/wpr/payload returns the validated payload', async () => {
   const dataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-payload-route-'))
-  process.env.WPR_DATA_DIR = dataDir
+  process.env.ARGUS_SALES_ROOT_US = path.join(dataDir, '..', '..', '..')
+  process.env.WPR_DATA_DIR_US = dataDir
   writeFileSync(path.join(dataDir, 'wpr-data-latest.json'), JSON.stringify(buildPayload()))
 
   const mod = await import('./route')
-  const response = await mod.GET()
+  const response = await mod.GET(new Request('http://localhost/api/wpr/payload'))
   const payload = await response.json()
 
   assert.equal(response.status, 200)

--- a/apps/argus/app/api/wpr/payload/route.ts
+++ b/apps/argus/app/api/wpr/payload/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
+import { parseArgusMarket } from '@/lib/argus-market';
 import { getWprPayload } from '@/lib/wpr/reader';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const payload = await getWprPayload();
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
+    const payload = await getWprPayload(market);
     return NextResponse.json(payload);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load the WPR payload.';

--- a/apps/argus/app/api/wpr/sources/route.ts
+++ b/apps/argus/app/api/wpr/sources/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
+import { parseArgusMarket } from '@/lib/argus-market';
 import { getWprSources } from '@/lib/wpr/reader';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const overview = await getWprSources();
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
+    const overview = await getWprSources(market);
     return NextResponse.json(overview);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load WPR source coverage.';

--- a/apps/argus/app/api/wpr/weeks/[week]/route.ts
+++ b/apps/argus/app/api/wpr/weeks/[week]/route.ts
@@ -1,14 +1,17 @@
 import { NextResponse } from 'next/server';
+import { parseArgusMarket } from '@/lib/argus-market';
 import { getWprWeekBundle } from '@/lib/wpr/reader';
 
 type RouteContext = {
   params: Promise<{ week: string }>;
 };
 
-export async function GET(_request: Request, context: RouteContext) {
+export async function GET(request: Request, context: RouteContext) {
   try {
     const { week } = await context.params;
-    const bundle = await getWprWeekBundle(week);
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
+    const bundle = await getWprWeekBundle(week, market);
     return NextResponse.json(bundle);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load the requested WPR week.';

--- a/apps/argus/app/api/wpr/weeks/route.ts
+++ b/apps/argus/app/api/wpr/weeks/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
+import { parseArgusMarket } from '@/lib/argus-market';
 import { getWprWeekSummary } from '@/lib/wpr/reader';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const summary = await getWprWeekSummary();
+    const { searchParams } = new URL(request.url);
+    const market = parseArgusMarket(searchParams.get('market'));
+    const summary = await getWprWeekSummary(market);
     return NextResponse.json(summary);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to load WPR weeks.';

--- a/apps/argus/components/monitoring/SourceCard.tsx
+++ b/apps/argus/components/monitoring/SourceCard.tsx
@@ -10,6 +10,7 @@ import {
 } from '@mui/material'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import type { MonitoringHealthDataset, MonitoringSchedulerJob } from '@/lib/monitoring/types'
+import { appendMarketParam, type ArgusMarket } from '@/lib/argus-market'
 
 export type UnifiedSourceStatus = 'healthy' | 'stale' | 'failed'
 
@@ -42,11 +43,12 @@ const basePath = (process.env.NEXT_PUBLIC_BASE_PATH ?? '').replace(/\/$/, '')
 
 interface SourceCardProps {
   source: UnifiedSource
+  market: ArgusMarket
   expanded: boolean
   onToggle: () => void
 }
 
-export default function SourceCard({ source, expanded, onToggle }: SourceCardProps) {
+export default function SourceCard({ source, market, expanded, onToggle }: SourceCardProps) {
   const { job, primaryDataset, status } = source
   const [runs, setRuns] = useState<RunLogEntry[]>([])
   const [loadingRuns, setLoadingRuns] = useState(false)
@@ -56,7 +58,7 @@ export default function SourceCard({ source, expanded, onToggle }: SourceCardPro
     let cancelled = false
     setLoadingRuns(true)
 
-    fetch(`${basePath}/api/monitoring/health/${job.id}/runs`)
+    fetch(`${basePath}${appendMarketParam(`/api/monitoring/health/${job.id}/runs`, market)}`)
       .then((res) => (res.ok ? res.json() : []))
       .then((data: RunLogEntry[]) => {
         if (!cancelled) setRuns(data)
@@ -66,7 +68,7 @@ export default function SourceCard({ source, expanded, onToggle }: SourceCardPro
       })
 
     return () => { cancelled = true }
-  }, [expanded, job.id])
+  }, [expanded, job.id, market])
 
   const age = primaryDataset?.ageMinutes != null ? formatAge(primaryDataset.ageMinutes) : '—'
   const typeStyle = SOURCE_TYPE_STYLES[job.sourceType]

--- a/apps/argus/components/wpr/change-timeline.tsx
+++ b/apps/argus/components/wpr/change-timeline.tsx
@@ -16,6 +16,7 @@ import {
   Typography,
 } from '@mui/material';
 import { getPublicBasePath } from '@/lib/base-path';
+import { appendMarketParam, type ArgusMarket } from '@/lib/argus-market';
 import {
   formatWprChangeCategory,
   getWprChangeCategoryColor,
@@ -186,12 +187,14 @@ export default function ChangeTimeline({
   weeks,
   weekStartDates,
   onSelectWeek,
+  market,
 }: {
   entries: WprChangeLogEntry[];
   selectedWeek: WeekLabel;
   weeks: WeekLabel[];
   weekStartDates: Record<WeekLabel, string>;
   onSelectWeek: (week: WeekLabel) => void;
+  market: ArgusMarket;
 }) {
   const queryClient = useQueryClient();
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -223,7 +226,7 @@ export default function ChangeTimeline({
     setError(null);
 
     try {
-      const response = await fetch(`${basePath}/api/wpr/changelog`, {
+      const response = await fetch(`${basePath}${appendMarketParam('/api/wpr/changelog', market)}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -246,7 +249,7 @@ export default function ChangeTimeline({
         throw new Error(payload.error ?? 'Failed to create the WPR changelog entry.');
       }
 
-      await queryClient.invalidateQueries({ queryKey: ['wpr'] });
+      await queryClient.invalidateQueries({ queryKey: ['wpr', market] });
       setDialogOpen(false);
       resetDraft();
     } catch (submissionError) {

--- a/apps/argus/components/wpr/tabs/changelog-tab.tsx
+++ b/apps/argus/components/wpr/tabs/changelog-tab.tsx
@@ -1,4 +1,5 @@
 import ChangeTimeline from '@/components/wpr/change-timeline';
+import type { ArgusMarket } from '@/lib/argus-market';
 import type { WprChangeLogEntry, WeekLabel } from '@/lib/wpr/types';
 
 export default function ChangelogTab({
@@ -7,12 +8,14 @@ export default function ChangelogTab({
   weeks,
   weekStartDates,
   onSelectWeek,
+  market,
 }: {
   entries: WprChangeLogEntry[];
   selectedWeek: WeekLabel;
   weeks: WeekLabel[];
   weekStartDates: Record<WeekLabel, string>;
   onSelectWeek: (week: WeekLabel) => void;
+  market: ArgusMarket;
 }) {
   return (
     <ChangeTimeline
@@ -21,6 +24,7 @@ export default function ChangelogTab({
       weeks={weeks}
       weekStartDates={weekStartDates}
       onSelectWeek={onSelectWeek}
+      market={market}
     />
   );
 }

--- a/apps/argus/components/wpr/wpr-dashboard-shell.tsx
+++ b/apps/argus/components/wpr/wpr-dashboard-shell.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Alert, Box, CircularProgress } from '@mui/material';
+import { parseArgusMarket, type ArgusMarket } from '@/lib/argus-market';
 import {
   useWprChangeLogWeekQuery,
   useWprSourcesQuery,
@@ -31,14 +32,15 @@ export default function WprDashboardShell() {
   const selectedWeek = useWprStore((state) => state.selectedWeek);
   const setActiveTab = useWprStore((state) => state.setActiveTab);
   const setSelectedWeek = useWprStore((state) => state.setSelectedWeek);
-  const weeksQuery = useWprWeeksQuery();
+  const market = parseArgusMarket(searchParams.get('market'));
+  const weeksQuery = useWprWeeksQuery(market);
   const needsBundle = BUNDLE_TABS.has(activeTab);
   const needsChartChangeEntries = CHART_CHANGE_ENTRY_TABS.has(activeTab);
   const bundleWeek = weeksQuery.data?.defaultWeek ?? null;
-  const bundleQuery = useWprWeekBundleQuery(bundleWeek, needsBundle);
-  const chartChangeLogQuery = useWprChangeLogWeekQuery(bundleWeek, needsChartChangeEntries);
-  const changelogQuery = useWprChangeLogWeekQuery(selectedWeek, activeTab === 'changelog');
-  const sourcesQuery = useWprSourcesQuery(activeTab === 'sources');
+  const bundleQuery = useWprWeekBundleQuery(market, bundleWeek, needsBundle);
+  const chartChangeLogQuery = useWprChangeLogWeekQuery(market, bundleWeek, needsChartChangeEntries);
+  const changelogQuery = useWprChangeLogWeekQuery(market, selectedWeek, activeTab === 'changelog');
+  const sourcesQuery = useWprSourcesQuery(market, activeTab === 'sources');
 
   const tabFromQuery = getInitialWprTab(searchParams);
 
@@ -66,7 +68,26 @@ export default function WprDashboardShell() {
     }
 
     setActiveTab(tab);
-    router.replace(tab === 'sqp' ? '/wpr' : `/wpr?tab=${tab}`);
+    const params = new URLSearchParams(searchParams.toString());
+    if (tab === 'sqp') {
+      params.delete('tab');
+    } else {
+      params.set('tab', tab);
+    }
+    const query = params.toString();
+    router.replace(query === '' ? '/wpr' : `/wpr?${query}`);
+  };
+
+  const handleSelectMarket = (nextMarket: ArgusMarket) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextMarket === 'us') {
+      params.delete('market');
+    } else {
+      params.set('market', nextMarket);
+    }
+    const query = params.toString();
+    setSelectedWeek(null);
+    router.replace(query === '' ? '/wpr' : `/wpr?${query}`);
   };
 
   if (weeksQuery.error instanceof Error) {
@@ -136,7 +157,9 @@ export default function WprDashboardShell() {
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
       <WprTopBar
         activeTab={activeTab}
+        market={market}
         onSelectTab={handleSelectTab}
+        onSelectMarket={handleSelectMarket}
       />
       <Box sx={{ flex: 1, minHeight: 0, overflow: 'auto', px: 0, py: 1.5 }}>
         {activeTab === 'sqp' && bundle !== undefined && chartChangeEntries !== undefined ? <SqpTab bundle={bundle} changeEntries={chartChangeEntries} /> : null}
@@ -151,6 +174,7 @@ export default function WprDashboardShell() {
             weeks={weeksQuery.data.weeks}
             weekStartDates={weeksQuery.data.weekStartDates}
             onSelectWeek={setSelectedWeek}
+            market={market}
           />
         ) : null}
         {activeTab === 'compare' && bundle !== undefined && chartChangeEntries !== undefined ? <CompareTab bundle={bundle} changeEntries={chartChangeEntries} /> : null}

--- a/apps/argus/components/wpr/wpr-layout.tsx
+++ b/apps/argus/components/wpr/wpr-layout.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { useWprWeeksQuery } from '@/hooks/use-wpr';
 import { useWprStore } from '@/stores/wpr-store';
+import { DEFAULT_ARGUS_MARKET } from '@/lib/argus-market';
 
 const TAB_ITEMS = [
   { href: '/wpr', label: 'SQP' },
@@ -33,7 +34,7 @@ function resolveTabValue(pathname: string): string {
 
 export default function WprLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const { data, error } = useWprWeeksQuery();
+  const { data, error } = useWprWeeksQuery(DEFAULT_ARGUS_MARKET);
   const selectedWeek = useWprStore((state) => state.selectedWeek);
   const setSelectedWeek = useWprStore((state) => state.setSelectedWeek);
   const activeTab = resolveTabValue(pathname);

--- a/apps/argus/components/wpr/wpr-top-bar.tsx
+++ b/apps/argus/components/wpr/wpr-top-bar.tsx
@@ -1,15 +1,20 @@
 'use client';
 
 import { Box, Stack } from '@mui/material';
+import { ARGUS_MARKETS, type ArgusMarket } from '@/lib/argus-market';
 import { WPR_TABS, type WprTab } from '@/lib/wpr/dashboard-state';
 import { panelBgDarker, subtleBorder, teal, textPrimary, textSecondary } from '@/lib/wpr/panel-tokens';
 
 export default function WprTopBar({
   activeTab,
+  market,
   onSelectTab,
+  onSelectMarket,
 }: {
   activeTab: WprTab;
+  market: ArgusMarket;
   onSelectTab: (tab: WprTab) => void;
+  onSelectMarket: (market: ArgusMarket) => void;
 }) {
   return (
     <Stack
@@ -56,6 +61,37 @@ export default function WprTopBar({
               }}
             >
               {tab.label}
+            </Box>
+          );
+        })}
+      </Stack>
+      <Stack direction="row" spacing={0.5} alignItems="center" sx={{ flexShrink: 0, ml: 1.5 }}>
+        {ARGUS_MARKETS.map((option) => {
+          const selected = option.slug === market;
+          return (
+            <Box
+              key={option.slug}
+              component="button"
+              type="button"
+              onClick={() => onSelectMarket(option.slug)}
+              sx={{
+                width: 34,
+                height: 28,
+                border: '1px solid',
+                borderColor: selected ? 'rgba(0,194,185,0.55)' : 'rgba(255,255,255,0.08)',
+                bgcolor: selected ? 'rgba(0,194,185,0.16)' : 'transparent',
+                color: selected ? teal : textSecondary,
+                borderRadius: 1,
+                fontSize: '0.68rem',
+                fontWeight: 800,
+                cursor: 'pointer',
+                '&:hover': {
+                  color: selected ? teal : textPrimary,
+                  bgcolor: selected ? 'rgba(0,194,185,0.2)' : 'rgba(255,255,255,0.04)',
+                },
+              }}
+            >
+              {option.label}
             </Box>
           );
         })}

--- a/apps/argus/hooks/use-wpr.ts
+++ b/apps/argus/hooks/use-wpr.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { getPublicBasePath } from '@/lib/base-path';
+import { appendMarketParam, type ArgusMarket } from '@/lib/argus-market';
 import type {
   WprChangeLogEntry,
   WeekLabel,
@@ -25,40 +26,40 @@ async function getJson<T>(path: string): Promise<T> {
   return payload;
 }
 
-export function useWprWeeksQuery() {
+export function useWprWeeksQuery(market: ArgusMarket) {
   return useQuery({
-    queryKey: ['wpr', 'weeks'],
-    queryFn: () => getJson<WprWeekSummaryResponse>('/api/wpr/weeks'),
+    queryKey: ['wpr', market, 'weeks'],
+    queryFn: () => getJson<WprWeekSummaryResponse>(appendMarketParam('/api/wpr/weeks', market)),
   });
 }
 
-export function useWprWeekBundleQuery(week: WeekLabel | null, enabled = true) {
+export function useWprWeekBundleQuery(market: ArgusMarket, week: WeekLabel | null, enabled = true) {
   return useQuery({
-    queryKey: ['wpr', 'weeks', week],
+    queryKey: ['wpr', market, 'weeks', week],
     enabled: enabled && week !== null,
-    queryFn: () => getJson<WprWeekBundle>(`/api/wpr/weeks/${week}`),
+    queryFn: () => getJson<WprWeekBundle>(appendMarketParam(`/api/wpr/weeks/${week}`, market)),
   });
 }
 
-export function useWprSourcesQuery(enabled = true) {
+export function useWprSourcesQuery(market: ArgusMarket, enabled = true) {
   return useQuery({
-    queryKey: ['wpr', 'sources'],
+    queryKey: ['wpr', market, 'sources'],
     enabled,
-    queryFn: () => getJson<WprSourceOverview>('/api/wpr/sources'),
+    queryFn: () => getJson<WprSourceOverview>(appendMarketParam('/api/wpr/sources', market)),
   });
 }
 
-export function useWprChangeLogQuery() {
+export function useWprChangeLogQuery(market: ArgusMarket) {
   return useQuery({
-    queryKey: ['wpr', 'changelog'],
-    queryFn: () => getJson<Record<WeekLabel, WprChangeLogEntry[]>>('/api/wpr/changelog'),
+    queryKey: ['wpr', market, 'changelog'],
+    queryFn: () => getJson<Record<WeekLabel, WprChangeLogEntry[]>>(appendMarketParam('/api/wpr/changelog', market)),
   });
 }
 
-export function useWprChangeLogWeekQuery(week: WeekLabel | null, enabled = true) {
+export function useWprChangeLogWeekQuery(market: ArgusMarket, week: WeekLabel | null, enabled = true) {
   return useQuery({
-    queryKey: ['wpr', 'changelog', week],
+    queryKey: ['wpr', market, 'changelog', week],
     enabled: enabled && week !== null,
-    queryFn: () => getJson<WprChangeLogEntry[]>(`/api/wpr/changelog/${week}`),
+    queryFn: () => getJson<WprChangeLogEntry[]>(appendMarketParam(`/api/wpr/changelog/${week}`, market)),
   });
 }

--- a/apps/argus/lib/argus-market.test.ts
+++ b/apps/argus/lib/argus-market.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import {
+  ARGUS_MARKETS,
+  appendMarketParam,
+  getArgusMarketConfig,
+  parseArgusMarket,
+} from './argus-market'
+
+test('parseArgusMarket defaults to US and accepts supported slugs', () => {
+  assert.equal(parseArgusMarket(null), 'us')
+  assert.equal(parseArgusMarket(''), 'us')
+  assert.equal(parseArgusMarket('us'), 'us')
+  assert.equal(parseArgusMarket('uk'), 'uk')
+  assert.deepEqual(ARGUS_MARKETS.map((market) => market.slug), ['us', 'uk'])
+})
+
+test('parseArgusMarket rejects unsupported slugs', () => {
+  assert.throws(
+    () => parseArgusMarket('eu'),
+    /Unsupported Argus market: eu/,
+  )
+})
+
+test('getArgusMarketConfig resolves market-specific sales and WPR paths from env', () => {
+  const root = mkdtempSync(path.join(tmpdir(), 'argus-market-config-'))
+  const usSalesRoot = path.join(root, 'Dust Sheets - US', 'Sales')
+  const ukSalesRoot = path.join(root, 'Dust Sheets - UK', 'Sales')
+  const usWprDataDir = path.join(usSalesRoot, 'WPR', 'wpr-workspace', 'output')
+  const ukWprDataDir = path.join(ukSalesRoot, 'WPR', 'wpr-workspace', 'output')
+
+  process.env.ARGUS_SALES_ROOT_US = usSalesRoot
+  process.env.ARGUS_SALES_ROOT_UK = ukSalesRoot
+  process.env.WPR_DATA_DIR_US = usWprDataDir
+  process.env.WPR_DATA_DIR_UK = ukWprDataDir
+
+  assert.deepEqual(getArgusMarketConfig('uk'), {
+    slug: 'uk',
+    label: 'UK',
+    salesRoot: ukSalesRoot,
+    monitoringRoot: path.join(ukSalesRoot, 'Monitoring'),
+    wprRoot: path.join(ukSalesRoot, 'WPR'),
+    wprDataDir: ukWprDataDir,
+  })
+})
+
+test('appendMarketParam preserves US default and appends UK explicitly', () => {
+  assert.equal(appendMarketParam('/api/wpr/weeks', 'us'), '/api/wpr/weeks')
+  assert.equal(appendMarketParam('/api/wpr/weeks', 'uk'), '/api/wpr/weeks?market=uk')
+  assert.equal(appendMarketParam('/api/monitoring/bootstrap?window=24h', 'uk'), '/api/monitoring/bootstrap?window=24h&market=uk')
+})

--- a/apps/argus/lib/argus-market.ts
+++ b/apps/argus/lib/argus-market.ts
@@ -1,0 +1,102 @@
+export type ArgusMarket = 'us' | 'uk'
+
+export type ArgusMarketOption = {
+  slug: ArgusMarket
+  label: string
+}
+
+export type ArgusMarketConfig = ArgusMarketOption & {
+  salesRoot: string
+  monitoringRoot: string
+  wprRoot: string
+  wprDataDir: string
+}
+
+export const DEFAULT_ARGUS_MARKET: ArgusMarket = 'us'
+
+export const ARGUS_MARKETS: ArgusMarketOption[] = [
+  { slug: 'us', label: 'US' },
+  { slug: 'uk', label: 'UK' },
+]
+
+export function parseArgusMarket(value: string | null | undefined): ArgusMarket {
+  if (value === undefined) {
+    return DEFAULT_ARGUS_MARKET
+  }
+
+  if (value === null) {
+    return DEFAULT_ARGUS_MARKET
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (normalized === '') {
+    return DEFAULT_ARGUS_MARKET
+  }
+
+  if (normalized === 'us') {
+    return 'us'
+  }
+
+  if (normalized === 'uk') {
+    return 'uk'
+  }
+
+  throw new Error(`Unsupported Argus market: ${value}`)
+}
+
+export function getArgusMarketOption(market: ArgusMarket): ArgusMarketOption {
+  const option = ARGUS_MARKETS.find((entry) => entry.slug === market)
+  if (option === undefined) {
+    throw new Error(`Unsupported Argus market: ${market}`)
+  }
+
+  return option
+}
+
+export function getArgusMarketConfig(market: ArgusMarket): ArgusMarketConfig {
+  const option = getArgusMarketOption(market)
+  const envSuffix = market.toUpperCase()
+  const salesRoot = requireEnv(`ARGUS_SALES_ROOT_${envSuffix}`)
+  const wprDataDir = requireEnv(`WPR_DATA_DIR_${envSuffix}`)
+  const normalizedSalesRoot = stripTrailingSlash(salesRoot)
+
+  return {
+    slug: option.slug,
+    label: option.label,
+    salesRoot: normalizedSalesRoot,
+    monitoringRoot: joinPath(normalizedSalesRoot, 'Monitoring'),
+    wprRoot: joinPath(normalizedSalesRoot, 'WPR'),
+    wprDataDir: stripTrailingSlash(wprDataDir),
+  }
+}
+
+export function appendMarketParam(path: string, market: ArgusMarket): string {
+  if (market === DEFAULT_ARGUS_MARKET) {
+    return path
+  }
+
+  const separator = path.includes('?') ? '&' : '?'
+  return `${path}${separator}market=${market}`
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]
+  if (value === undefined) {
+    throw new Error(`${name} is required for Argus.`)
+  }
+
+  const trimmed = value.trim()
+  if (trimmed === '') {
+    throw new Error(`${name} is required for Argus.`)
+  }
+
+  return trimmed
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/g, '')
+}
+
+function joinPath(root: string, child: string): string {
+  return `${stripTrailingSlash(root)}/${child}`
+}

--- a/apps/argus/lib/monitoring/reader.ts
+++ b/apps/argus/lib/monitoring/reader.ts
@@ -4,6 +4,7 @@ import { execFile } from 'child_process'
 import { promises as fs } from 'fs'
 import path from 'path'
 import { promisify } from 'util'
+import { DEFAULT_ARGUS_MARKET, getArgusMarketConfig, type ArgusMarket } from '@/lib/argus-market'
 import prisma from '@/lib/db'
 import { parseCsvRows } from './csv'
 import { formatMonitoringLabel } from './labels'
@@ -26,53 +27,100 @@ import type {
 } from './types'
 
 const execFileAsync = promisify(execFile)
-const HOME_DIR = process.env.HOME
+const HOME_DIR = requireHomeDir()
 
-if (!HOME_DIR) {
-  throw new Error('Missing HOME environment variable.')
+function requireHomeDir(): string {
+  const value = process.env.HOME
+  if (!value) {
+    throw new Error('Missing HOME environment variable.')
+  }
+  return value
 }
 
-const MONITORING_BASE =
-  '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring'
+interface MonitoringPaths {
+  monitoringBase: string
+  dailyBase: string
+  weeklyBase: string
+  listingAttributesBase: string
+  latestStatePath: string
+  changeHistoryPath: string
+  snapshotHistoryPath: string
+  dailyAccountHealthPath: string
+  dailyVisualsPath: string
+  dailyVocPath: string
+  weeklyBrandAnalyticsPath: string
+  weeklyBusinessReportsPath: string
+  weeklyDatadivePath: string
+  weeklySellerboardPath: string
+  weeklyCategoryInsightsPath: string
+  weeklyPoePath: string
+  weeklySponsoredProductsPath: string
+  weeklyBrandMetricsPath: string
+  weeklyScaleinsightsPath: string
+}
 
-const DAILY_BASE = path.join(MONITORING_BASE, 'Daily')
-const WEEKLY_BASE = path.join(MONITORING_BASE, 'Weekly')
-const LISTING_ATTRIBUTES_BASE = path.join(MONITORING_BASE, 'Hourly/Listing Attributes (API)')
-const LATEST_STATE_PATH = path.join(LISTING_ATTRIBUTES_BASE, 'latest_state.json')
-const CHANGE_HISTORY_PATH = path.join(LISTING_ATTRIBUTES_BASE, 'Listings-Changes-History.csv')
-const SNAPSHOT_HISTORY_PATH = path.join(LISTING_ATTRIBUTES_BASE, 'Listings-Snapshot-History.csv')
-const DAILY_ACCOUNT_HEALTH_PATH = path.join(DAILY_BASE, 'Account Health Dashboard (API)', 'account-health.csv')
-const DAILY_VISUALS_PATH = path.join(DAILY_BASE, 'Visuals (Browser)')
-const DAILY_VOC_PATH = path.join(DAILY_BASE, 'Voice of the Customer (Manual)')
-const WEEKLY_BRAND_ANALYTICS_PATH = path.join(WEEKLY_BASE, 'Brand Analytics (API)')
-const WEEKLY_BUSINESS_REPORTS_PATH = path.join(WEEKLY_BASE, 'Business Reports (API)')
-const WEEKLY_DATADIVE_PATH = path.join(WEEKLY_BASE, 'Datadive (API)')
-const WEEKLY_SELLERBOARD_PATH = path.join(WEEKLY_BASE, 'Sellerboard (API)')
-const WEEKLY_CATEGORY_INSIGHTS_PATH = path.join(WEEKLY_BASE, 'Category Insights (Browser)')
-const WEEKLY_POE_PATH = path.join(WEEKLY_BASE, 'Product Opportunity Explorer (Browser)')
-const WEEKLY_SPONSORED_PRODUCTS_PATH = path.join(
-  WEEKLY_BASE,
-  'Ad Console/SP - Sponsored Products (API)',
-)
-const WEEKLY_BRAND_METRICS_PATH = path.join(WEEKLY_BASE, 'Ad Console/Brand Metrics (Browser)')
-const WEEKLY_SCALEINSIGHTS_PATH = path.join(
-  WEEKLY_BASE,
-  'ScaleInsights/KeywordRanking (Browser)',
-)
+function buildMonitoringPaths(market: ArgusMarket): MonitoringPaths {
+  const monitoringBase = getArgusMarketConfig(market).monitoringRoot
+  const dailyBase = path.join(monitoringBase, 'Daily')
+  const weeklyBase = path.join(monitoringBase, 'Weekly')
+  const listingAttributesBase = path.join(monitoringBase, 'Hourly/Listing Attributes (API)')
+  return {
+    monitoringBase,
+    dailyBase,
+    weeklyBase,
+    listingAttributesBase,
+    latestStatePath: path.join(listingAttributesBase, 'latest_state.json'),
+    changeHistoryPath: path.join(listingAttributesBase, 'Listings-Changes-History.csv'),
+    snapshotHistoryPath: path.join(listingAttributesBase, 'Listings-Snapshot-History.csv'),
+    dailyAccountHealthPath: path.join(dailyBase, 'Account Health Dashboard (API)', 'account-health.csv'),
+    dailyVisualsPath: path.join(dailyBase, 'Visuals (Browser)'),
+    dailyVocPath: path.join(dailyBase, 'Voice of the Customer (Manual)'),
+    weeklyBrandAnalyticsPath: path.join(weeklyBase, 'Brand Analytics (API)'),
+    weeklyBusinessReportsPath: path.join(weeklyBase, 'Business Reports (API)'),
+    weeklyDatadivePath: path.join(weeklyBase, 'Datadive (API)'),
+    weeklySellerboardPath: path.join(weeklyBase, 'Sellerboard (API)'),
+    weeklyCategoryInsightsPath: path.join(weeklyBase, 'Category Insights (Browser)'),
+    weeklyPoePath: path.join(weeklyBase, 'Product Opportunity Explorer (Browser)'),
+    weeklySponsoredProductsPath: path.join(weeklyBase, 'Ad Console/SP - Sponsored Products (API)'),
+    weeklyBrandMetricsPath: path.join(weeklyBase, 'Ad Console/Brand Metrics (Browser)'),
+    weeklyScaleinsightsPath: path.join(weeklyBase, 'ScaleInsights/KeywordRanking (Browser)'),
+  }
+}
 
 const HOUR_IN_MINUTES = 60
 const DAY_IN_MINUTES = 24 * HOUR_IN_MINUTES
 
-const ARGUS_SCHEDULER_SPECS = [
+interface SchedulerSpec {
+  id: string
+  label: string
+  cadence: MonitoringHealthDataset['cadence']
+  sourceType: Exclude<MonitoringSourceType, 'MANUAL'>
+  schedule: string
+  launchdLabel: string
+  plistPath: string
+  runLogPath: string
+  outputs: string[]
+}
+
+function schedulerLaunchdLabel(market: ArgusMarket, baseLabel: string): string {
+  if (market === 'us') {
+    return baseLabel
+  }
+
+  return `${baseLabel}.${market}`
+}
+
+function buildArgusSchedulerSpecs(market: ArgusMarket, paths: MonitoringPaths): SchedulerSpec[] {
+  return [
   {
     id: 'tracking-fetch',
     label: 'Tracking fetch',
     cadence: 'hourly',
     sourceType: 'API',
     schedule: 'Every hour',
-    launchdLabel: 'com.targon.argus.tracking-fetch',
-    plistPath: path.join(HOME_DIR, 'Library/LaunchAgents/com.targon.argus.tracking-fetch.plist'),
-    runLogPath: path.join(MONITORING_BASE, 'Logs/tracking-fetch/run-log.jsonl'),
+    launchdLabel: schedulerLaunchdLabel(market, 'com.targon.argus.tracking-fetch'),
+    plistPath: path.join(HOME_DIR, `Library/LaunchAgents/${schedulerLaunchdLabel(market, 'com.targon.argus.tracking-fetch')}.plist`),
+    runLogPath: path.join(paths.monitoringBase, 'Logs/tracking-fetch/run-log.jsonl'),
     outputs: ['Argus tracking snapshots (DB)'],
   },
   {
@@ -81,9 +129,9 @@ const ARGUS_SCHEDULER_SPECS = [
     cadence: 'hourly',
     sourceType: 'API',
     schedule: 'Every hour',
-    launchdLabel: 'com.targon.hourly-listing-attributes-api',
-    plistPath: path.join(HOME_DIR, 'Library/LaunchAgents/com.targon.hourly-listing-attributes-api.plist'),
-    runLogPath: path.join(MONITORING_BASE, 'Logs/hourly-listing-attributes-api/run-log.jsonl'),
+    launchdLabel: schedulerLaunchdLabel(market, 'com.targon.hourly-listing-attributes-api'),
+    plistPath: path.join(HOME_DIR, `Library/LaunchAgents/${schedulerLaunchdLabel(market, 'com.targon.hourly-listing-attributes-api')}.plist`),
+    runLogPath: path.join(paths.monitoringBase, 'Logs/hourly-listing-attributes-api/run-log.jsonl'),
     outputs: ['Hourly latest state', 'Snapshot history', 'Change Feed -> Email'],
   },
   {
@@ -92,9 +140,9 @@ const ARGUS_SCHEDULER_SPECS = [
     cadence: 'daily',
     sourceType: 'API',
     schedule: 'Daily at 3:00 AM',
-    launchdLabel: 'com.targon.daily-account-health',
-    plistPath: path.join(HOME_DIR, 'Library/LaunchAgents/com.targon.daily-account-health.plist'),
-    runLogPath: path.join(MONITORING_BASE, 'Logs/daily-account-health/run-log.jsonl'),
+    launchdLabel: schedulerLaunchdLabel(market, 'com.targon.daily-account-health'),
+    plistPath: path.join(HOME_DIR, `Library/LaunchAgents/${schedulerLaunchdLabel(market, 'com.targon.daily-account-health')}.plist`),
+    runLogPath: path.join(paths.monitoringBase, 'Logs/daily-account-health/run-log.jsonl'),
     outputs: ['Account Health Dashboard (API)'],
   },
   {
@@ -103,9 +151,9 @@ const ARGUS_SCHEDULER_SPECS = [
     cadence: 'weekly',
     sourceType: 'API',
     schedule: 'Monday at 4:00 AM',
-    launchdLabel: 'com.targon.weekly-api-sources',
-    plistPath: path.join(HOME_DIR, 'Library/LaunchAgents/com.targon.weekly-api-sources.plist'),
-    runLogPath: path.join(MONITORING_BASE, 'Logs/weekly-api-sources/run-log.jsonl'),
+    launchdLabel: schedulerLaunchdLabel(market, 'com.targon.weekly-api-sources'),
+    plistPath: path.join(HOME_DIR, `Library/LaunchAgents/${schedulerLaunchdLabel(market, 'com.targon.weekly-api-sources')}.plist`),
+    runLogPath: path.join(paths.monitoringBase, 'Logs/weekly-api-sources/run-log.jsonl'),
     outputs: [
       'Brand Analytics (API)',
       'Business Reports (API)',
@@ -120,9 +168,9 @@ const ARGUS_SCHEDULER_SPECS = [
     cadence: 'daily',
     sourceType: 'BROWSER',
     schedule: 'Daily at 3:30 AM',
-    launchdLabel: 'com.targon.daily-visuals',
-    plistPath: path.join(HOME_DIR, 'Library/LaunchAgents/com.targon.daily-visuals.plist'),
-    runLogPath: path.join(MONITORING_BASE, 'Logs/daily-visuals/run-log.jsonl'),
+    launchdLabel: schedulerLaunchdLabel(market, 'com.targon.daily-visuals'),
+    plistPath: path.join(HOME_DIR, `Library/LaunchAgents/${schedulerLaunchdLabel(market, 'com.targon.daily-visuals')}.plist`),
+    runLogPath: path.join(paths.monitoringBase, 'Logs/daily-visuals/run-log.jsonl'),
     outputs: ['Visuals (Browser)'],
   },
   {
@@ -131,9 +179,9 @@ const ARGUS_SCHEDULER_SPECS = [
     cadence: 'weekly',
     sourceType: 'BROWSER',
     schedule: 'Monday at 3:00 AM',
-    launchdLabel: 'com.targon.weekly-browser-sources',
-    plistPath: path.join(HOME_DIR, 'Library/LaunchAgents/com.targon.weekly-browser-sources.plist'),
-    runLogPath: path.join(MONITORING_BASE, 'Logs/weekly-browser-sources/run-log.jsonl'),
+    launchdLabel: schedulerLaunchdLabel(market, 'com.targon.weekly-browser-sources'),
+    plistPath: path.join(HOME_DIR, `Library/LaunchAgents/${schedulerLaunchdLabel(market, 'com.targon.weekly-browser-sources')}.plist`),
+    runLogPath: path.join(paths.monitoringBase, 'Logs/weekly-browser-sources/run-log.jsonl'),
     outputs: [
       'Category Insights (Browser)',
       'Product Opportunity Explorer (Browser)',
@@ -141,7 +189,8 @@ const ARGUS_SCHEDULER_SPECS = [
       'Brand Metrics (Browser)',
     ],
   },
-] as const
+  ]
+}
 
 interface DatasetHealthSpec {
   id: string
@@ -156,188 +205,190 @@ interface DatasetHealthSpec {
   getUpdatedAt: () => Promise<string | null>
 }
 
-const DATASET_SPECS: DatasetHealthSpec[] = [
+function buildDatasetSpecs(paths: MonitoringPaths): DatasetHealthSpec[] {
+  return [
   {
     id: 'hourly-state',
     label: 'Hourly latest state',
     cadence: 'hourly',
     sourceType: 'API',
-    path: LATEST_STATE_PATH,
+    path: paths.latestStatePath,
     driveId: '1bp8zLczIxTqQDFACdlDg6hdZvCB9innQ',
     purpose: 'Latest listing baseline used to compute the next hourly diff run.',
     producedBy: 'Hourly listing attributes',
     consumers: ['Change detection'],
-    getUpdatedAt: async () => statIso(LATEST_STATE_PATH),
+    getUpdatedAt: async () => statIso(paths.latestStatePath),
   },
   {
     id: 'hourly-snapshots',
     label: 'Snapshot history',
     cadence: 'hourly',
     sourceType: 'API',
-    path: SNAPSHOT_HISTORY_PATH,
+    path: paths.snapshotHistoryPath,
     driveId: '1bp8zLczIxTqQDFACdlDg6hdZvCB9innQ',
     purpose: 'Historical snapshot archive behind per-ASIN timelines and comparisons.',
     producedBy: 'Hourly listing attributes',
     consumers: ['ASIN detail timelines', 'Baseline reconstruction'],
-    getUpdatedAt: async () => statIso(SNAPSHOT_HISTORY_PATH),
+    getUpdatedAt: async () => statIso(paths.snapshotHistoryPath),
   },
   {
     id: 'hourly-changes',
     label: 'Change Feed -> Email',
     cadence: 'hourly',
     sourceType: 'API',
-    path: CHANGE_HISTORY_PATH,
+    path: paths.changeHistoryPath,
     driveId: '1bp8zLczIxTqQDFACdlDg6hdZvCB9innQ',
     purpose: 'Canonical event stream consumed by the Change Feed and alert email digest.',
     producedBy: 'Hourly listing attributes',
     consumers: ['Change Feed', 'Alert email'],
-    getUpdatedAt: async () => statIso(CHANGE_HISTORY_PATH),
+    getUpdatedAt: async () => statIso(paths.changeHistoryPath),
   },
   {
     id: 'daily-account-health',
     label: 'Account Health Dashboard (API)',
     cadence: 'daily',
     sourceType: 'API',
-    path: DAILY_ACCOUNT_HEALTH_PATH,
+    path: paths.dailyAccountHealthPath,
     driveId: '10BC2vI2OqAoYegD1icqU_VvYaiA9Imxc',
     purpose: 'Daily account health report export.',
     producedBy: 'Daily account health',
     consumers: ['Source Health'],
-    getUpdatedAt: async () => statIso(DAILY_ACCOUNT_HEALTH_PATH),
+    getUpdatedAt: async () => statIso(paths.dailyAccountHealthPath),
   },
   {
     id: 'daily-visuals',
     label: 'Visuals (Browser)',
     cadence: 'daily',
     sourceType: 'BROWSER',
-    path: DAILY_VISUALS_PATH,
+    path: paths.dailyVisualsPath,
     driveId: '1z8u466gU3r1Q4_UPy3Dg_dzdI1Lj4ntN',
     purpose: 'Daily browser screenshots for monitored ASINs.',
     producedBy: 'Daily visuals',
     consumers: ['Daily monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(DAILY_VISUALS_PATH, 4),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.dailyVisualsPath, 4),
   },
   {
     id: 'daily-voc',
     label: 'Voice of the Customer (Manual)',
     cadence: 'daily',
     sourceType: 'MANUAL',
-    path: DAILY_VOC_PATH,
+    path: paths.dailyVocPath,
     driveId: '1iHqtjKY01veKSWNj8zZF76UMcyrDdXZe',
     purpose: 'Manual VOC files that support daily review.',
     producedBy: null,
     consumers: ['Daily monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(DAILY_VOC_PATH, 2),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.dailyVocPath, 2),
   },
   {
     id: 'weekly-brand-analytics',
     label: 'Brand Analytics (API)',
     cadence: 'weekly',
     sourceType: 'API',
-    path: WEEKLY_BRAND_ANALYTICS_PATH,
+    path: paths.weeklyBrandAnalyticsPath,
     driveId: '1OQ1_pvWGLzdIKBfwZmRSWYDEVoP9dHUi',
     purpose: 'Weekly Amazon Brand Analytics exports.',
     producedBy: 'Weekly API sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_BRAND_ANALYTICS_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyBrandAnalyticsPath, 3),
   },
   {
     id: 'weekly-business-reports',
     label: 'Business Reports (API)',
     cadence: 'weekly',
     sourceType: 'API',
-    path: WEEKLY_BUSINESS_REPORTS_PATH,
+    path: paths.weeklyBusinessReportsPath,
     driveId: '1jVUnicQEiNqTW3rEl-8hr79BZ_YjVG2j',
     purpose: 'Weekly Amazon business reports exports.',
     producedBy: 'Weekly API sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_BUSINESS_REPORTS_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyBusinessReportsPath, 3),
   },
   {
     id: 'weekly-datadive',
     label: 'Datadive (API)',
     cadence: 'weekly',
     sourceType: 'API',
-    path: WEEKLY_DATADIVE_PATH,
+    path: paths.weeklyDatadivePath,
     driveId: '1ZFiwse0eukOHJUPgokvHWRcWMri0klvY',
     purpose: 'Weekly Datadive keyword, competitor, and rank radar exports.',
     producedBy: 'Weekly API sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_DATADIVE_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyDatadivePath, 3),
   },
   {
     id: 'weekly-sellerboard',
     label: 'Sellerboard (API)',
     cadence: 'weekly',
     sourceType: 'API',
-    path: WEEKLY_SELLERBOARD_PATH,
+    path: paths.weeklySellerboardPath,
     driveId: '1lhg3lHwprusOZiOYV0oM5Ce5wqlBoH8w',
     purpose: 'Weekly Sellerboard dashboard and order exports.',
     producedBy: 'Weekly API sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_SELLERBOARD_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklySellerboardPath, 3),
   },
   {
     id: 'weekly-sponsored-products',
     label: 'SP - Sponsored Products (API)',
     cadence: 'weekly',
     sourceType: 'API',
-    path: WEEKLY_SPONSORED_PRODUCTS_PATH,
+    path: paths.weeklySponsoredProductsPath,
     driveId: '1pXOzQwXPcTYvw-feJhZB4muO0PD0tl9S',
     purpose: 'Weekly Sponsored Products console exports and manifest.',
     producedBy: 'Weekly API sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_SPONSORED_PRODUCTS_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklySponsoredProductsPath, 3),
   },
   {
     id: 'weekly-category-insights',
     label: 'Category Insights (Browser)',
     cadence: 'weekly',
     sourceType: 'BROWSER',
-    path: WEEKLY_CATEGORY_INSIGHTS_PATH,
+    path: paths.weeklyCategoryInsightsPath,
     driveId: '14SWSVb9w7e9m_Pd0U8eyKQZAsSVmFctI',
     purpose: 'Weekly browser capture of category insights.',
     producedBy: 'Weekly browser sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_CATEGORY_INSIGHTS_PATH, 2),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyCategoryInsightsPath, 2),
   },
   {
     id: 'weekly-poe',
     label: 'Product Opportunity Explorer (Browser)',
     cadence: 'weekly',
     sourceType: 'BROWSER',
-    path: WEEKLY_POE_PATH,
+    path: paths.weeklyPoePath,
     driveId: '1EB67PbUwcxFHJHigwwtCsfj0pAVWOWqo',
     purpose: 'Weekly browser export from Product Opportunity Explorer.',
     producedBy: 'Weekly browser sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_POE_PATH, 2),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyPoePath, 2),
   },
   {
     id: 'weekly-scaleinsights',
     label: 'KeywordRanking (Browser)',
     cadence: 'weekly',
     sourceType: 'BROWSER',
-    path: WEEKLY_SCALEINSIGHTS_PATH,
+    path: paths.weeklyScaleinsightsPath,
     driveId: '1TzCiN-ja4inCCK_s_-9wOgH0S0D5hq_Q',
     purpose: 'Weekly ScaleInsights keyword ranking workbook.',
     producedBy: 'Weekly browser sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_SCALEINSIGHTS_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyScaleinsightsPath, 3),
   },
   {
     id: 'weekly-brand-metrics',
     label: 'Brand Metrics (Browser)',
     cadence: 'weekly',
     sourceType: 'BROWSER',
-    path: WEEKLY_BRAND_METRICS_PATH,
+    path: paths.weeklyBrandMetricsPath,
     driveId: '1B-ohB3dGZU8c4gswpwRoYt034J_T8aqA',
     purpose: 'Weekly browser capture of Brand Metrics.',
     producedBy: 'Weekly browser sources',
     consumers: ['Weekly monitoring review'],
-    getUpdatedAt: async () => findLatestModifiedAt(WEEKLY_BRAND_METRICS_PATH, 3),
+    getUpdatedAt: async () => findLatestModifiedAt(paths.weeklyBrandMetricsPath, 3),
   },
-]
+  ]
+}
 
 interface LaunchAgentPlist {
   Label: string
@@ -501,6 +552,7 @@ interface ChangeHistoryRow {
 }
 
 export interface MonitoringChangeFilters {
+  market?: ArgusMarket
   window?: MonitoringWindow
   owner?: MonitoringOwner | 'ALL'
   category?: MonitoringCategory | 'ALL'
@@ -523,26 +575,27 @@ type CacheState = {
   model: MonitoringModel
 }
 
-let cacheState: CacheState | null = null
-let pendingCacheKey: string | null = null
-let pendingModelPromise: Promise<MonitoringModel> | null = null
+const cacheStateByMarket = new Map<ArgusMarket, CacheState>()
+const pendingModelByMarket = new Map<ArgusMarket, { key: string; promise: Promise<MonitoringModel> }>()
 
-export async function getMonitoringOverview(): Promise<MonitoringOverview> {
-  const model = await loadMonitoringModel()
+export async function getMonitoringOverview(market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<MonitoringOverview> {
+  const model = await loadMonitoringModel(market)
   return buildMonitoringOverview(model)
 }
 
 export async function getMonitoringChanges(
   filters: MonitoringChangeFilters = {},
 ): Promise<MonitoringChangeEvent[]> {
-  const model = await loadMonitoringModel()
+  const market = filters.market ?? DEFAULT_ARGUS_MARKET
+  const model = await loadMonitoringModel(market)
   return applyFilters(model.changes, filters)
 }
 
 export async function getMonitoringBootstrap(
   filters: MonitoringChangeFilters = {},
 ): Promise<MonitoringBootstrap> {
-  const model = await loadMonitoringModel()
+  const market = filters.market ?? DEFAULT_ARGUS_MARKET
+  const model = await loadMonitoringModel(market)
 
   return {
     overview: buildMonitoringOverview(model),
@@ -550,9 +603,12 @@ export async function getMonitoringBootstrap(
   }
 }
 
-export async function getMonitoringAsinDetail(asin: string): Promise<MonitoringAsinDetail> {
+export async function getMonitoringAsinDetail(
+  asin: string,
+  market: ArgusMarket = DEFAULT_ARGUS_MARKET,
+): Promise<MonitoringAsinDetail> {
   const normalizedAsin = asin.trim().toUpperCase()
-  const model = await loadMonitoringModel()
+  const model = await loadMonitoringModel(market)
   const current = model.currentByAsin.get(normalizedAsin) ?? null
   const snapshots = model.snapshotsByAsin.get(normalizedAsin) ?? []
   const changes = model.changes.filter((item) => item.asin === normalizedAsin)
@@ -572,10 +628,13 @@ export async function getMonitoringAsinDetail(asin: string): Promise<MonitoringA
   }
 }
 
-export async function getMonitoringHealth(): Promise<MonitoringHealthReport> {
+export async function getMonitoringHealth(market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<MonitoringHealthReport> {
+  const paths = buildMonitoringPaths(market)
+  const datasetSpecs = buildDatasetSpecs(paths)
+  const schedulerSpecs = buildArgusSchedulerSpecs(market, paths)
   const [datasets, jobs] = await Promise.all([
-    Promise.all(DATASET_SPECS.map((spec) => getDatasetHealth(spec))),
-    Promise.all(ARGUS_SCHEDULER_SPECS.map((spec) => getSchedulerHealth(spec))),
+    Promise.all(datasetSpecs.map((spec) => getDatasetHealth(spec))),
+    Promise.all(schedulerSpecs.map((spec) => getSchedulerHealth(spec))),
   ])
 
   return {
@@ -667,41 +726,44 @@ function buildMonitoringOverview(model: MonitoringModel): MonitoringOverview {
   }
 }
 
-async function loadMonitoringModel(): Promise<MonitoringModel> {
-  const cacheKey = await getMonitoringCacheKey()
+async function loadMonitoringModel(market: ArgusMarket): Promise<MonitoringModel> {
+  const paths = buildMonitoringPaths(market)
+  const cacheKey = await getMonitoringCacheKey(market, paths)
+  const cacheState = cacheStateByMarket.get(market)
 
-  if (cacheState !== null && cacheState.key === cacheKey) {
+  if (cacheState !== undefined && cacheState.key === cacheKey) {
     return cacheState.model
   }
 
-  if (pendingCacheKey === cacheKey && pendingModelPromise !== null) {
-    return pendingModelPromise
+  const pending = pendingModelByMarket.get(market)
+  if (pending !== undefined && pending.key === cacheKey) {
+    return pending.promise
   }
 
-  const modelPromise = buildMonitoringModel()
-  pendingCacheKey = cacheKey
-  pendingModelPromise = modelPromise
+  const modelPromise = buildMonitoringModel(paths)
+  pendingModelByMarket.set(market, { key: cacheKey, promise: modelPromise })
 
   try {
     const model = await modelPromise
-    if (pendingCacheKey === cacheKey && pendingModelPromise === modelPromise) {
-      cacheState = { key: cacheKey, model }
+    const latestPending = pendingModelByMarket.get(market)
+    if (latestPending !== undefined && latestPending.key === cacheKey && latestPending.promise === modelPromise) {
+      cacheStateByMarket.set(market, { key: cacheKey, model })
     }
     return model
   } finally {
-    if (pendingModelPromise === modelPromise) {
-      pendingCacheKey = null
-      pendingModelPromise = null
+    const latestPending = pendingModelByMarket.get(market)
+    if (latestPending !== undefined && latestPending.promise === modelPromise) {
+      pendingModelByMarket.delete(market)
     }
   }
 }
 
-async function getMonitoringCacheKey(): Promise<string> {
+async function getMonitoringCacheKey(market: ArgusMarket, paths: MonitoringPaths): Promise<string> {
   const [latestStateStats, changeHistoryStats, snapshotHistoryStats, trackedAsinCount, latestTrackedAsin] =
     await Promise.all([
-      fs.stat(LATEST_STATE_PATH),
-      fs.stat(CHANGE_HISTORY_PATH),
-      fs.stat(SNAPSHOT_HISTORY_PATH),
+      fs.stat(paths.latestStatePath),
+      fs.stat(paths.changeHistoryPath),
+      fs.stat(paths.snapshotHistoryPath),
       prisma.trackedAsin.count(),
       prisma.trackedAsin.findFirst({
         orderBy: { updatedAt: 'desc' },
@@ -710,6 +772,7 @@ async function getMonitoringCacheKey(): Promise<string> {
     ])
 
   return [
+    market,
     latestStateStats.mtimeMs.toString(),
     changeHistoryStats.mtimeMs.toString(),
     snapshotHistoryStats.mtimeMs.toString(),
@@ -718,11 +781,11 @@ async function getMonitoringCacheKey(): Promise<string> {
   ].join(':')
 }
 
-async function buildMonitoringModel(): Promise<MonitoringModel> {
-  const latestState = await readLatestState()
+async function buildMonitoringModel(paths: MonitoringPaths): Promise<MonitoringModel> {
+  const latestState = await readLatestState(paths)
   const [changeRows, snapshotRows, trackedAsins] = await Promise.all([
-    readChangeHistory(),
-    readSnapshotHistory(),
+    readChangeHistory(paths),
+    readSnapshotHistory(paths),
     prisma.trackedAsin.findMany({ select: { asin: true, label: true } }),
   ])
 
@@ -758,8 +821,8 @@ async function buildMonitoringModel(): Promise<MonitoringModel> {
   }
 }
 
-async function readLatestState(): Promise<LatestStateFile> {
-  const content = await fs.readFile(LATEST_STATE_PATH, 'utf8')
+async function readLatestState(paths: MonitoringPaths): Promise<LatestStateFile> {
+  const content = await fs.readFile(paths.latestStatePath, 'utf8')
   const parsed = JSON.parse(content) as LatestStateFile
 
   if (!parsed.by_asin || !parsed.timestamp_utc || !parsed.snapshot_file) {
@@ -769,8 +832,8 @@ async function readLatestState(): Promise<LatestStateFile> {
   return parsed
 }
 
-async function readChangeHistory(): Promise<ChangeHistoryRow[]> {
-  const content = await fs.readFile(CHANGE_HISTORY_PATH, 'utf8')
+async function readChangeHistory(paths: MonitoringPaths): Promise<ChangeHistoryRow[]> {
+  const content = await fs.readFile(paths.changeHistoryPath, 'utf8')
   const rows = parseCsvRows(content)
 
   return rows.map((row) => ({
@@ -791,8 +854,8 @@ async function readChangeHistory(): Promise<ChangeHistoryRow[]> {
   }))
 }
 
-async function readSnapshotHistory(): Promise<MonitoringSnapshotRecord[]> {
-  const content = await fs.readFile(SNAPSHOT_HISTORY_PATH, 'utf8')
+async function readSnapshotHistory(paths: MonitoringPaths): Promise<MonitoringSnapshotRecord[]> {
+  const content = await fs.readFile(paths.snapshotHistoryPath, 'utf8')
   const rows = parseCsvRows(content)
 
   return rows.map((row) =>
@@ -1468,7 +1531,7 @@ async function getDatasetHealth(spec: DatasetHealthSpec): Promise<MonitoringHeal
   }
 }
 
-async function getSchedulerHealth(spec: (typeof ARGUS_SCHEDULER_SPECS)[number]): Promise<MonitoringSchedulerJob> {
+async function getSchedulerHealth(spec: SchedulerSpec): Promise<MonitoringSchedulerJob> {
   const plist = await readLaunchAgentPlist(spec.plistPath)
   const target = resolveLaunchAgentTarget(plist)
   const stdoutPath = plist?.StandardOutPath ?? null

--- a/apps/argus/lib/wpr/change-log-write.test.ts
+++ b/apps/argus/lib/wpr/change-log-write.test.ts
@@ -14,8 +14,9 @@ function createWprWorkspaceRoot() {
 }
 
 test('createWprChangeLogEntry writes the canonical markdown log into the selected week folder', async () => {
-  const { wprRoot, dataDir } = createWprWorkspaceRoot()
-  process.env.WPR_DATA_DIR = dataDir
+  const { salesRoot, wprRoot, dataDir } = createWprWorkspaceRoot()
+  process.env.ARGUS_SALES_ROOT_US = salesRoot
+  process.env.WPR_DATA_DIR_US = dataDir
 
   const weekDir = path.join(wprRoot, 'Week 16 - 2026-04-12 (Sun)')
   await import('node:fs/promises').then(({ mkdir }) => mkdir(path.join(weekDir, 'output', 'Plans'), { recursive: true }))
@@ -33,6 +34,7 @@ test('createWprChangeLogEntry writes the canonical markdown log into the selecte
       highlights: ['Rewrote backend terms for root coverage.', 'Tightened bullet hierarchy for mobile.'],
       statusLines: ['Submitted in Seller Central.', 'Waiting for propagation.'],
     },
+    'us',
     async () => {
       rebuildCalls += 1
     },
@@ -57,8 +59,9 @@ test('createWprChangeLogEntry writes the canonical markdown log into the selecte
 })
 
 test('createWprChangeLogEntry fails when the target week folder does not exist', async () => {
-  const { dataDir } = createWprWorkspaceRoot()
-  process.env.WPR_DATA_DIR = dataDir
+  const { salesRoot, dataDir } = createWprWorkspaceRoot()
+  process.env.ARGUS_SALES_ROOT_US = salesRoot
+  process.env.WPR_DATA_DIR_US = dataDir
 
   await assert.rejects(
     () =>
@@ -74,6 +77,7 @@ test('createWprChangeLogEntry fails when the target week folder does not exist',
           highlights: ['Logged the change.'],
           statusLines: [],
         },
+        'us',
         async () => undefined,
       ),
     /Missing WPR week folder for W16/,
@@ -81,8 +85,9 @@ test('createWprChangeLogEntry fails when the target week folder does not exist',
 })
 
 test('createWprChangeLogEntry rejects the removed manual category for new entries', async () => {
-  const { wprRoot, dataDir } = createWprWorkspaceRoot()
-  process.env.WPR_DATA_DIR = dataDir
+  const { salesRoot, wprRoot, dataDir } = createWprWorkspaceRoot()
+  process.env.ARGUS_SALES_ROOT_US = salesRoot
+  process.env.WPR_DATA_DIR_US = dataDir
 
   const weekDir = path.join(wprRoot, 'Week 16 - 2026-04-12 (Sun)')
   await import('node:fs/promises').then(({ mkdir }) => mkdir(path.join(weekDir, 'output', 'Plans'), { recursive: true }))
@@ -101,6 +106,7 @@ test('createWprChangeLogEntry rejects the removed manual category for new entrie
           highlights: ['Logged the change.'],
           statusLines: ['Queued.'],
         },
+        'us',
         async () => undefined,
       ),
     /Invalid WPR change category: MANUAL/,

--- a/apps/argus/lib/wpr/change-log-write.ts
+++ b/apps/argus/lib/wpr/change-log-write.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { execFile as execFileCallback } from 'node:child_process'
+import { DEFAULT_ARGUS_MARKET, getArgusMarketConfig, type ArgusMarket } from '@/lib/argus-market'
 import { expectWritableWprChangeCategory } from './change-log-categories'
 
 const execFile = promisify(execFileCallback)
@@ -21,30 +22,13 @@ export type CreateWprChangeLogEntryInput = {
 }
 
 type WprPaths = {
-  dataDir: string
-  workspaceRoot: string
   wprRoot: string
+  wprDataDir: string
 }
 
-function resolveDataDir(): string {
-  const value = process.env.WPR_DATA_DIR
-  if (value === undefined) {
-    throw new Error('WPR_DATA_DIR is required for Argus.')
-  }
-
-  const trimmed = value.trim()
-  if (trimmed === '') {
-    throw new Error('WPR_DATA_DIR is required for Argus.')
-  }
-
-  return trimmed
-}
-
-function resolveWprPaths(): WprPaths {
-  const dataDir = resolveDataDir()
-  const workspaceRoot = join(dataDir, '..')
-  const wprRoot = join(workspaceRoot, '..')
-  return { dataDir, workspaceRoot, wprRoot }
+function resolveWprPaths(market: ArgusMarket): WprPaths {
+  const config = getArgusMarketConfig(market)
+  return { wprRoot: config.wprRoot, wprDataDir: config.wprDataDir }
 }
 
 function expectWeekLabel(value: string): string {
@@ -104,8 +88,8 @@ function resolveWeekFolderNumber(weekLabel: string): number {
   return Number.parseInt(weekLabel.slice(1), 10)
 }
 
-async function resolveWeekFolderPath(weekLabel: string): Promise<string> {
-  const { wprRoot } = resolveWprPaths()
+async function resolveWeekFolderPath(weekLabel: string, market: ArgusMarket): Promise<string> {
+  const { wprRoot } = resolveWprPaths(market)
   try {
     await stat(wprRoot)
   } catch {
@@ -164,18 +148,25 @@ function buildMarkdown(input: CreateWprChangeLogEntryInput): string {
   ].join('\n')
 }
 
-async function defaultRebuildRunner(): Promise<void> {
+async function defaultRebuildRunner(market: ArgusMarket): Promise<void> {
   const rebuildScript = join(process.cwd(), 'apps/argus/scripts/wpr/rebuild_wpr.py')
   const buildScript = join(process.cwd(), 'apps/argus/scripts/wpr/build_intent_cluster_dashboard.py')
+  const { wprDataDir } = resolveWprPaths(market)
   await stat(rebuildScript)
   await stat(buildScript)
-  await execFile('python3', [rebuildScript], { env: process.env, cwd: process.cwd(), maxBuffer: 1024 * 1024 * 16 })
-  await execFile('python3', [buildScript], { env: process.env, cwd: process.cwd(), maxBuffer: 1024 * 1024 * 16 })
+  const env = {
+    ...process.env,
+    ARGUS_MARKET: market,
+    WPR_DATA_DIR: wprDataDir,
+  }
+  await execFile('python3', [rebuildScript], { env, cwd: process.cwd(), maxBuffer: 1024 * 1024 * 16 })
+  await execFile('python3', [buildScript], { env, cwd: process.cwd(), maxBuffer: 1024 * 1024 * 16 })
 }
 
 export async function createWprChangeLogEntry(
   input: CreateWprChangeLogEntryInput,
-  runRebuild: () => Promise<void> = defaultRebuildRunner,
+  market: ArgusMarket = DEFAULT_ARGUS_MARKET,
+  runRebuild: (market: ArgusMarket) => Promise<void> = defaultRebuildRunner,
 ): Promise<{ filePath: string }> {
   const weekLabel = expectWeekLabel(input.weekLabel)
   const entryDate = expectEntryDate(input.entryDate)
@@ -187,7 +178,7 @@ export async function createWprChangeLogEntry(
   const highlights = expectLineItems(input.highlights, 'What changed')
   const statusLines = expectLineItems(input.statusLines, 'Status')
 
-  const weekFolderPath = await resolveWeekFolderPath(weekLabel)
+  const weekFolderPath = await resolveWeekFolderPath(weekLabel, market)
   const plansDir = join(weekFolderPath, 'output', 'Plans')
   await mkdir(plansDir, { recursive: true })
 
@@ -206,6 +197,6 @@ export async function createWprChangeLogEntry(
   })
 
   await writeFile(filePath, markdown, { encoding: 'utf8', flag: 'wx' })
-  await runRebuild()
+  await runRebuild(market)
   return { filePath }
 }

--- a/apps/argus/lib/wpr/reader-market.test.ts
+++ b/apps/argus/lib/wpr/reader-market.test.ts
@@ -1,0 +1,154 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { getWprWeekSummary } from './reader'
+
+function buildScpMetrics() {
+  return {
+    asin_count: 0,
+    impressions: 0,
+    clicks: 0,
+    cart_adds: 0,
+    purchases: 0,
+    sales: 0,
+    ctr: 0,
+    atc_rate: 0,
+    purchase_rate: 0,
+    cvr: 0,
+  }
+}
+
+function buildWeekBundle(anchorWeek: string) {
+  return {
+    meta: {
+      anchorWeek,
+      competitorBrand: 'Competitor',
+      competitorAsin: 'B000000002',
+      benchmarkPolicy: 'policy',
+      competitor: {
+        brand: 'Competitor',
+        asin: 'B000000002',
+        config_source: 'config',
+      },
+      recentWindow: [anchorWeek],
+      baselineWindow: [anchorWeek],
+      policy: {
+        primary_window: 'recent_4w',
+        baseline_window: 'baseline_13w',
+        term_truth_set: 'tst',
+        dashboard_policy: 'dashboard',
+        benchmark_policy: 'benchmark',
+      },
+    },
+    weeks: [anchorWeek],
+    clusters: [],
+    scatterClusterIds: [],
+    lineClusterIds: [],
+    shareClusterIds: [],
+    ppcClusterIds: [],
+    defaultClusterIds: [],
+    sqpTerms: [],
+    sqpClusterTerms: {},
+    sqpGlobalTermIds: [],
+    regression: {
+      slope: 0,
+      intercept: 0,
+    },
+    brandMetricsWindow: {},
+    brandMetrics: {},
+    competitorWeekly: [],
+    scp: {
+      meta: {
+        targetAsin: 'B000000001',
+        recentWindow: [anchorWeek],
+        baselineWindow: [anchorWeek],
+      },
+      current_week: buildScpMetrics(),
+      recent_4w: buildScpMetrics(),
+      baseline_to_anchor: buildScpMetrics(),
+      weekly: [],
+      asins: [],
+    },
+    businessReports: {
+      meta: {
+        targetAsin: 'B000000001',
+        selectedWeek: anchorWeek,
+        availableWeeks: [anchorWeek],
+      },
+      current_week: {
+        asin_count: 0,
+        sessions: 0,
+        page_views: 0,
+        order_items: 0,
+        units_ordered: 0,
+        sales: 0,
+        order_item_session_percentage: 0,
+        unit_session_percentage: 0,
+        buy_box_percentage: 0,
+      },
+      baseline_to_anchor: {
+        asin_count: 0,
+        sessions: 0,
+        page_views: 0,
+        order_items: 0,
+        units_ordered: 0,
+        sales: 0,
+        order_item_session_percentage: 0,
+        unit_session_percentage: 0,
+        buy_box_percentage: 0,
+      },
+      weekly: [],
+      dailyByWeek: {},
+      asins: [],
+    },
+  }
+}
+
+function writePayload(dataDir: string, week: string) {
+  const bundle = buildWeekBundle(week)
+  writeFileSync(
+    path.join(dataDir, 'wpr-data-latest.json'),
+    JSON.stringify({
+      ...bundle,
+      defaultWeek: week,
+      weekStartDates: {
+        [week]: '2026-04-12',
+      },
+      sourceOverview: {
+        week_labels: [week],
+        latest_week: week,
+        weeks_with_data: 1,
+        source_completeness: 'ok',
+        critical_gaps: [],
+        matrix: [],
+      },
+      windowsByWeek: {
+        [week]: bundle,
+      },
+      changeLogByWeek: {
+        [week]: [],
+      },
+      audit: {},
+    }),
+  )
+}
+
+test('getWprWeekSummary caches payloads by market and path', async () => {
+  const usDataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-us-'))
+  const ukDataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-uk-'))
+  writePayload(usDataDir, 'W16')
+  writePayload(ukDataDir, 'W07')
+
+  process.env.ARGUS_SALES_ROOT_US = path.join(usDataDir, '..', '..')
+  process.env.ARGUS_SALES_ROOT_UK = path.join(ukDataDir, '..', '..')
+  process.env.WPR_DATA_DIR_US = usDataDir
+  process.env.WPR_DATA_DIR_UK = ukDataDir
+
+  const usSummary = await getWprWeekSummary('us')
+  const ukSummary = await getWprWeekSummary('uk')
+
+  assert.equal(usSummary.defaultWeek, 'W16')
+  assert.equal(ukSummary.defaultWeek, 'W07')
+})

--- a/apps/argus/lib/wpr/reader.ts
+++ b/apps/argus/lib/wpr/reader.ts
@@ -1,5 +1,6 @@
 import { stat, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { DEFAULT_ARGUS_MARKET, getArgusMarketConfig, type ArgusMarket } from '@/lib/argus-market';
 import { assertWprPayloadContract } from './payload-contract';
 import type {
   WeekLabel,
@@ -11,56 +12,45 @@ import type {
 } from './types';
 
 type CacheState = {
+  market: ArgusMarket;
   path: string;
   mtimeMs: number;
   payload: WprPayload;
 };
 
-let cacheState: CacheState | null = null;
+const cacheByMarket = new Map<ArgusMarket, CacheState>();
 
-function resolveDataDir(): string {
-  const value = process.env.WPR_DATA_DIR;
-  if (value === undefined) {
-    throw new Error('WPR_DATA_DIR is required for Argus.');
-  }
-
-  const trimmed = value.trim();
-  if (trimmed === '') {
-    throw new Error('WPR_DATA_DIR is required for Argus.');
-  }
-
-  return trimmed;
+function resolveLatestJsonPath(market: ArgusMarket): string {
+  return join(getArgusMarketConfig(market).wprDataDir, 'wpr-data-latest.json');
 }
 
-function resolveLatestJsonPath(): string {
-  return join(resolveDataDir(), 'wpr-data-latest.json');
-}
-
-async function loadPayload(): Promise<WprPayload> {
-  const path = resolveLatestJsonPath();
+async function loadPayload(market: ArgusMarket): Promise<WprPayload> {
+  const path = resolveLatestJsonPath(market);
   const fileStats = await stat(path);
+  const cacheState = cacheByMarket.get(market);
 
-  if (cacheState !== null && cacheState.path === path && cacheState.mtimeMs === fileStats.mtimeMs) {
+  if (cacheState !== undefined && cacheState.path === path && cacheState.mtimeMs === fileStats.mtimeMs) {
     return cacheState.payload;
   }
 
   const raw = await readFile(path, 'utf8');
   const payload = JSON.parse(raw) as unknown;
   assertWprPayloadContract(payload);
-  cacheState = {
+  cacheByMarket.set(market, {
+    market,
     path,
     mtimeMs: fileStats.mtimeMs,
     payload,
-  };
+  });
   return payload;
 }
 
-export async function getWprPayload(): Promise<WprPayload> {
-  return loadPayload();
+export async function getWprPayload(market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<WprPayload> {
+  return loadPayload(market);
 }
 
-export async function getWprWeekSummary(): Promise<WprWeekSummaryResponse> {
-  const payload = await loadPayload();
+export async function getWprWeekSummary(market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<WprWeekSummaryResponse> {
+  const payload = await loadPayload(market);
   return {
     defaultWeek: payload.defaultWeek,
     weeks: payload.weeks,
@@ -68,8 +58,8 @@ export async function getWprWeekSummary(): Promise<WprWeekSummaryResponse> {
   };
 }
 
-export async function getWprWeekBundle(week: WeekLabel): Promise<WprWeekBundle> {
-  const payload = await loadPayload();
+export async function getWprWeekBundle(week: WeekLabel, market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<WprWeekBundle> {
+  const payload = await loadPayload(market);
   const bundle = payload.windowsByWeek[week];
   if (bundle === undefined) {
     throw new Error(`Unknown WPR week: ${week}`);
@@ -78,18 +68,18 @@ export async function getWprWeekBundle(week: WeekLabel): Promise<WprWeekBundle> 
   return bundle;
 }
 
-export async function getWprSources(): Promise<WprSourceOverview> {
-  const payload = await loadPayload();
+export async function getWprSources(market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<WprSourceOverview> {
+  const payload = await loadPayload(market);
   return payload.sourceOverview;
 }
 
-export async function getWprChangeLog(): Promise<Record<WeekLabel, WprChangeLogEntry[]>> {
-  const payload = await loadPayload();
+export async function getWprChangeLog(market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<Record<WeekLabel, WprChangeLogEntry[]>> {
+  const payload = await loadPayload(market);
   return payload.changeLogByWeek;
 }
 
-export async function getWprChangeLogWeek(week: WeekLabel): Promise<WprChangeLogEntry[]> {
-  const payload = await loadPayload();
+export async function getWprChangeLogWeek(week: WeekLabel, market: ArgusMarket = DEFAULT_ARGUS_MARKET): Promise<WprChangeLogEntry[]> {
+  const payload = await loadPayload(market);
   const entries = payload.changeLogByWeek[week];
   if (entries === undefined) {
     throw new Error(`Unknown WPR week: ${week}`);

--- a/apps/argus/scripts/api/daily-account-health/collect.mjs
+++ b/apps/argus/scripts/api/daily-account-health/collect.mjs
@@ -6,9 +6,11 @@ import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import {
   REPO_ROOT,
+  ARGUS_MARKET,
   MONITORING_BASE,
   ensureDir,
   loadMonitoringEnv,
+  marketEnvSuffix,
   requireEnv,
   writeCsv,
 } from '../weekly-sources/lib/common.mjs'
@@ -109,10 +111,11 @@ function createClient() {
 
   const requireFromTalos = createRequire(TALOS_PACKAGE_JSON)
   const SellingPartnerAPI = requireFromTalos('amazon-sp-api')
+  const envSuffix = marketEnvSuffix(ARGUS_MARKET)
 
   return new SellingPartnerAPI({
-    region: requireEnv('AMAZON_SP_API_REGION_US'),
-    refresh_token: requireEnv('AMAZON_REFRESH_TOKEN_US'),
+    region: requireEnv(`AMAZON_SP_API_REGION_${envSuffix}`),
+    refresh_token: requireEnv(`AMAZON_REFRESH_TOKEN_${envSuffix}`),
     credentials: {
       SELLING_PARTNER_APP_CLIENT_ID: requireEnv('AMAZON_SP_APP_CLIENT_ID'),
       SELLING_PARTNER_APP_CLIENT_SECRET: requireEnv('AMAZON_SP_APP_CLIENT_SECRET'),
@@ -363,7 +366,7 @@ function upsertRow(file, row) {
 
 async function main() {
   const client = createClient()
-  const marketplaceId = requireEnv('AMAZON_MARKETPLACE_ID_US')
+  const marketplaceId = requireEnv(`AMAZON_MARKETPLACE_ID_${marketEnvSuffix(ARGUS_MARKET)}`)
 
   const reusableReportId = await findReusableReport(client, marketplaceId)
   const reportId = reusableReportId ?? await createReport(client, marketplaceId)

--- a/apps/argus/scripts/api/daily-account-health/collect.sh
+++ b/apps/argus/scripts/api/daily-account-health/collect.sh
@@ -6,6 +6,35 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG="/tmp/daily-account-health.log"
 RUN_LOG_WRITER="$SCRIPT_DIR/../../lib/write-monitoring-run-log.mjs"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+MARKET="us"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --market)
+      if [ "$#" -lt 2 ]; then
+        echo "--market requires us or uk." >&2
+        exit 1
+      fi
+      MARKET="$2"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+case "$MARKET" in
+  us|uk)
+    export ARGUS_MARKET="$MARKET"
+    ;;
+  *)
+    echo "Unsupported market: $MARKET" >&2
+    exit 1
+    ;;
+esac
 
 if ! NODE_BIN="$(command -v node)"; then
   echo "$(date '+%Y-%m-%d %H:%M:%S') — Collection FAILED (node not found in PATH=$PATH)" >> "$LOG"
@@ -18,9 +47,9 @@ RUN_STATUS="ok"
 RUN_SUMMARY="Daily account health completed successfully."
 RUN_ERROR_MESSAGE=""
 
-echo "$(date '+%Y-%m-%d %H:%M:%S') — Starting account health API collection" >> "$LOG"
+echo "$(date '+%Y-%m-%d %H:%M:%S') — Starting account health API collection (market=$MARKET)" >> "$LOG"
 
-if "$NODE_BIN" "$SCRIPT_DIR/collect.mjs" >> "$LOG" 2>&1; then
+if "$NODE_BIN" "$SCRIPT_DIR/collect.mjs" --market "$MARKET" >> "$LOG" 2>&1; then
   echo "$(date '+%Y-%m-%d %H:%M:%S') — Collection OK" >> "$LOG"
 else
   echo "$(date '+%Y-%m-%d %H:%M:%S') — Collection FAILED" >> "$LOG"
@@ -34,6 +63,7 @@ RUN_FINISHED_AT_ISO="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 DURATION_MS=$((RUN_FINISHED_AT_MS - RUN_STARTED_AT_MS))
 RUN_LOG_ARGS=(
   --job-id "daily-account-health"
+  --market "$MARKET"
   --status "$RUN_STATUS"
   --summary "$RUN_SUMMARY"
   --duration-ms "$DURATION_MS"

--- a/apps/argus/scripts/api/hourly-listing-attributes/collect.mjs
+++ b/apps/argus/scripts/api/hourly-listing-attributes/collect.mjs
@@ -12,7 +12,7 @@ const REPO_ROOT = path.resolve(__dirname, '../../../../../')
 const ARGUS_PACKAGE_JSON = path.join(REPO_ROOT, 'apps/argus/package.json')
 const TALOS_PACKAGE_JSON = path.join(REPO_ROOT, 'apps/talos/package.json')
 
-const MONITORING_HOURLY_LISTINGS_DIR = '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Hourly/Listing Attributes (API)'
+let MONITORING_HOURLY_LISTINGS_DIR = ''
 const SNAPSHOT_HISTORY_FILE_NAME = 'Listings-Snapshot-History.csv'
 const CHANGES_HISTORY_FILE_NAME = 'Listings-Changes-History.csv'
 
@@ -66,6 +66,30 @@ function requiredEnv(name) {
     throw new Error(`Missing required env var: ${name}`)
   }
   return value.trim()
+}
+
+function readMarketArg() {
+  const argv = process.argv.slice(2)
+  const index = argv.indexOf('--market')
+  if (index < 0) {
+    return process.env.ARGUS_MARKET
+  }
+  return argv[index + 1]
+}
+
+function resolveArgusMarket() {
+  const raw = readMarketArg()
+  if (raw === undefined) return 'us'
+  const value = String(raw).trim().toLowerCase()
+  if (value === '') return 'us'
+  if (value === 'us') return 'us'
+  if (value === 'uk') return 'uk'
+  throw new Error(`Unsupported Argus market: ${raw}`)
+}
+
+function monitoringHourlyListingsDir(market) {
+  const salesRoot = requiredEnv(`ARGUS_SALES_ROOT_${market.toUpperCase()}`)
+  return path.join(salesRoot, 'Monitoring', 'Hourly', 'Listing Attributes (API)')
 }
 
 function parseAsinList(value) {
@@ -1799,22 +1823,24 @@ ${overflowRow}
 }
 
 async function main() {
-  ensureDir(MONITORING_HOURLY_LISTINGS_DIR)
-
   loadEnvFile(path.join(REPO_ROOT, 'apps/argus/.env.local'))
   loadEnvFile(path.join(REPO_ROOT, 'apps/talos/.env.local'))
   loadEnvFile(path.join(REPO_ROOT, 'apps/xplan/.env.local'))
   loadEnvFile(path.join(REPO_ROOT, '.env.local'))
+  const market = resolveArgusMarket()
+  const envSuffix = market.toUpperCase()
+  MONITORING_HOURLY_LISTINGS_DIR = monitoringHourlyListingsDir(market)
+  ensureDir(MONITORING_HOURLY_LISTINGS_DIR)
 
   const competitorMainAsins = getCompetitorMainAsins()
   const heroBsrAsins = getHeroBsrAsins()
 
   const appClientId = requiredEnv('AMAZON_SP_APP_CLIENT_ID')
   const appClientSecret = requiredEnv('AMAZON_SP_APP_CLIENT_SECRET')
-  const refreshToken = requiredEnv('AMAZON_REFRESH_TOKEN_US')
-  const region = requiredEnv('AMAZON_SP_API_REGION_US')
-  const marketplaceId = requiredEnv('AMAZON_MARKETPLACE_ID_US')
-  const sellerId = requiredEnv('AMAZON_SELLER_ID_US')
+  const refreshToken = requiredEnv(`AMAZON_REFRESH_TOKEN_${envSuffix}`)
+  const region = requiredEnv(`AMAZON_SP_API_REGION_${envSuffix}`)
+  const marketplaceId = requiredEnv(`AMAZON_MARKETPLACE_ID_${envSuffix}`)
+  const sellerId = requiredEnv(`AMAZON_SELLER_ID_${envSuffix}`)
   const trackedAsinMarketplace = resolveTrackedAsinMarketplace(marketplaceId)
   const trackedLabelsByAsin = await loadTrackedAsinLabels(trackedAsinMarketplace)
 

--- a/apps/argus/scripts/api/hourly-listing-attributes/collect.sh
+++ b/apps/argus/scripts/api/hourly-listing-attributes/collect.sh
@@ -5,17 +5,43 @@
 #   - Listings-Changes-History.csv
 #   - latest_state.json
 #
-# Destination:
-# /Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Hourly/Listing Attributes (API)
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOG="/tmp/hourly-listing-attributes-api.log"
 RUN_LOG_WRITER="$SCRIPT_DIR/../../lib/write-monitoring-run-log.mjs"
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+MARKET="us"
 
-echo "$(date '+%Y-%m-%d %H:%M:%S') — Starting hourly listing attributes collection" >> "$LOG"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --market)
+      if [ "$#" -lt 2 ]; then
+        echo "--market requires us or uk." >&2
+        exit 1
+      fi
+      MARKET="$2"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+case "$MARKET" in
+  us|uk)
+    export ARGUS_MARKET="$MARKET"
+    ;;
+  *)
+    echo "Unsupported market: $MARKET" >&2
+    exit 1
+    ;;
+esac
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') — Starting hourly listing attributes collection (market=$MARKET)" >> "$LOG"
 
 if ! NODE_BIN="$(command -v node)"; then
   echo "$(date '+%Y-%m-%d %H:%M:%S') — Node.js not found in PATH=$PATH" >> "$LOG"
@@ -29,7 +55,7 @@ RUN_STATUS="ok"
 RUN_SUMMARY="Hourly listing attributes completed successfully."
 RUN_ERROR_MESSAGE=""
 
-if "$NODE_BIN" "$SCRIPT_DIR/collect.mjs" >> "$LOG" 2>&1; then
+if "$NODE_BIN" "$SCRIPT_DIR/collect.mjs" --market "$MARKET" >> "$LOG" 2>&1; then
   echo "$(date '+%Y-%m-%d %H:%M:%S') — Collection OK" >> "$LOG"
 else
   echo "$(date '+%Y-%m-%d %H:%M:%S') — Collection FAILED" >> "$LOG"
@@ -43,6 +69,7 @@ RUN_FINISHED_AT_ISO="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
 DURATION_MS=$((RUN_FINISHED_AT_MS - RUN_STARTED_AT_MS))
 RUN_LOG_ARGS=(
   --job-id "hourly-listing-attributes-api"
+  --market "$MARKET"
   --status "$RUN_STATUS"
   --summary "$RUN_SUMMARY"
   --duration-ms "$DURATION_MS"

--- a/apps/argus/scripts/api/weekly-sources/collect-sellerboard.mjs
+++ b/apps/argus/scripts/api/weekly-sources/collect-sellerboard.mjs
@@ -3,10 +3,12 @@
 import path from 'node:path'
 import fs from 'node:fs'
 import {
+  ARGUS_MARKET,
   MONITORING_BASE,
   ensureDir,
   latestCompleteWeek,
   loadMonitoringEnv,
+  marketEnvSuffix,
   orderHeaders,
   requireEnv,
   weekContextForRange,
@@ -78,6 +80,10 @@ function parseArgs() {
     const arg = argv[index]
     if (arg === '--dry-run') {
       dryRun = true
+      continue
+    }
+    if (arg === '--market') {
+      index += 1
       continue
     }
     if (arg === '--start-date') {
@@ -284,8 +290,9 @@ async function main() {
 
   loadMonitoringEnv()
 
-  const dashboardUrl = requireEnv('SELLERBOARD_US_DASHBOARD_REPORT_URL')
-  const ordersUrl = requireEnv('SELLERBOARD_US_ORDERS_REPORT_URL')
+  const envSuffix = marketEnvSuffix(ARGUS_MARKET)
+  const dashboardUrl = requireEnv(`SELLERBOARD_${envSuffix}_DASHBOARD_REPORT_URL`)
+  const ordersUrl = requireEnv(`SELLERBOARD_${envSuffix}_ORDERS_REPORT_URL`)
 
   const dashboardCsvRaw = await downloadCsv(dashboardUrl)
   const ordersCsvRaw = await downloadCsv(ordersUrl)

--- a/apps/argus/scripts/api/weekly-sources/collect-sp-ads.py
+++ b/apps/argus/scripts/api/weekly-sources/collect-sp-ads.py
@@ -16,8 +16,8 @@ from pathlib import Path
 ARGUS_APP_ROOT = Path(__file__).resolve().parents[3]
 ENV_PATH = ARGUS_APP_ROOT / '.env.local'
 
-DEST_ROOT = Path('/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Weekly/Ad Console/SP - Sponsored Products (API)')
-MANIFEST_ROOT = DEST_ROOT
+DEST_ROOT = None
+MANIFEST_ROOT = None
 
 POLL_INTERVAL_SEC = 15
 MAX_WAIT_SECONDS = 40 * 60
@@ -58,6 +58,21 @@ def load_env(path: Path):
                 value = value[:-1]
             env[key.strip()] = value
     return env
+
+
+def parse_market(raw):
+    value = (raw or 'us').strip().lower()
+    if value in ('us', 'uk'):
+        return value
+    raise RuntimeError(f'Unsupported Argus market: {raw}')
+
+
+def monitoring_base_for_market(env, market):
+    key = f'ARGUS_SALES_ROOT_{market.upper()}'
+    value = env.get(key)
+    if not value:
+        raise RuntimeError(f'Missing env var: {key}')
+    return Path(value) / 'Monitoring'
 
 
 def latest_complete_week():
@@ -566,15 +581,21 @@ def run_week(base_url, headers, week):
 
 
 def main():
+    global DEST_ROOT, MANIFEST_ROOT
     parser = argparse.ArgumentParser()
     parser.add_argument('--dry-run', action='store_true')
     parser.add_argument('--start-date')
     parser.add_argument('--end-date')
+    parser.add_argument('--market', default=os.environ.get('ARGUS_MARKET', 'us'))
     args = parser.parse_args()
 
     if bool(args.start_date) != bool(args.end_date):
         raise RuntimeError('Both --start-date and --end-date are required together.')
 
+    env = load_env(ENV_PATH)
+    market = parse_market(args.market)
+    DEST_ROOT = monitoring_base_for_market(env, market) / 'Weekly' / 'Ad Console' / 'SP - Sponsored Products (API)'
+    MANIFEST_ROOT = DEST_ROOT
     week = week_context_for_range(args.start_date, args.end_date) if args.start_date else latest_complete_week()
     dry_run = args.dry_run
 
@@ -586,7 +607,6 @@ def main():
             print(f'[SP-Ads][dry-run] {DEST_ROOT / subdir / file_name}')
         return
 
-    env = load_env(ENV_PATH)
     required = [
         'AMAZON_ADS_API_BASE_URL',
         'AMAZON_ADS_CLIENT_ID',

--- a/apps/argus/scripts/api/weekly-sources/collect-spapi.mjs
+++ b/apps/argus/scripts/api/weekly-sources/collect-spapi.mjs
@@ -8,11 +8,13 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { spawnSync } from 'node:child_process'
 import {
   REPO_ROOT,
+  ARGUS_MARKET,
   MONITORING_BASE,
   ensureDir,
   flattenRows,
   latestCompleteWeek,
   loadMonitoringEnv,
+  marketEnvSuffix,
   orderHeaders,
   requireEnv,
   weekContextForRange,
@@ -229,6 +231,10 @@ function parseArgs() {
     const arg = argv[index]
     if (arg === '--dry-run') {
       dryRun = true
+      continue
+    }
+    if (arg === '--market') {
+      index += 1
       continue
     }
     if (arg === '--start-date') {
@@ -590,9 +596,10 @@ async function main() {
 
   const appClientId = requireEnv('AMAZON_SP_APP_CLIENT_ID')
   const appClientSecret = requireEnv('AMAZON_SP_APP_CLIENT_SECRET')
-  const refreshToken = requireEnv('AMAZON_REFRESH_TOKEN_US')
-  const region = requireEnv('AMAZON_SP_API_REGION_US')
-  const marketplaceId = requireEnv('AMAZON_MARKETPLACE_ID_US')
+  const envSuffix = marketEnvSuffix(ARGUS_MARKET)
+  const refreshToken = requireEnv(`AMAZON_REFRESH_TOKEN_${envSuffix}`)
+  const region = requireEnv(`AMAZON_SP_API_REGION_${envSuffix}`)
+  const marketplaceId = requireEnv(`AMAZON_MARKETPLACE_ID_${envSuffix}`)
 
   const requireFromTalos = createRequire(TALOS_PACKAGE_JSON)
   const SellingPartnerAPI = requireFromTalos('amazon-sp-api')

--- a/apps/argus/scripts/api/weekly-sources/lib/common.mjs
+++ b/apps/argus/scripts/api/weekly-sources/lib/common.mjs
@@ -6,7 +6,6 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 export const REPO_ROOT = path.resolve(__dirname, '../../../../../../')
-export const MONITORING_BASE = '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring'
 
 const MILLIS_PER_DAY = 24 * 60 * 60 * 1000
 const BASE_WEEK_START_UTC = Date.UTC(2025, 11, 28)
@@ -56,6 +55,40 @@ export function requireEnv(name) {
   }
   return value.trim()
 }
+
+function readMarketArg(argv) {
+  const index = argv.indexOf('--market')
+  if (index < 0) return undefined
+  return argv[index + 1]
+}
+
+export function resolveArgusMarket(raw = readMarketArg(process.argv.slice(2)) ?? process.env.ARGUS_MARKET) {
+  if (raw === undefined) return 'us'
+  if (raw === null) return 'us'
+
+  const value = String(raw).trim().toLowerCase()
+  if (value === '') return 'us'
+  if (value === 'us') return 'us'
+  if (value === 'uk') return 'uk'
+  throw new Error(`Unsupported Argus market: ${raw}`)
+}
+
+export function marketEnvSuffix(market = resolveArgusMarket()) {
+  return market.toUpperCase()
+}
+
+export function salesRootForMarket(market = resolveArgusMarket()) {
+  return requireEnv(`ARGUS_SALES_ROOT_${marketEnvSuffix(market)}`)
+}
+
+export function monitoringBaseForMarket(market = resolveArgusMarket()) {
+  return path.join(salesRootForMarket(market), 'Monitoring')
+}
+
+loadMonitoringEnv()
+
+export const ARGUS_MARKET = resolveArgusMarket()
+export const MONITORING_BASE = monitoringBaseForMarket(ARGUS_MARKET)
 
 export function formatDate(date) {
   const year = date.getFullYear()

--- a/apps/argus/scripts/api/weekly-sources/repair-weekly-format-consistency.py
+++ b/apps/argus/scripts/api/weekly-sources/repair-weekly-format-consistency.py
@@ -3,18 +3,13 @@
 import argparse
 import csv
 import json
+import os
 import re
 from datetime import date, timedelta
 from pathlib import Path
 
-MONITORING_BASE = Path(
-    '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring'
-)
-WEEKLY_BASE = MONITORING_BASE / 'Weekly'
-
-SP_ADS_BASE = WEEKLY_BASE / 'Ad Console' / 'SP - Sponsored Products (API)'
-BRAND_ANALYTICS_BASE = WEEKLY_BASE / 'Brand Analytics (API)'
-BUSINESS_REPORTS_BASE = WEEKLY_BASE / 'Business Reports (API)' / 'Sales & Traffic (API)'
+ARGUS_APP_ROOT = Path(__file__).resolve().parents[3]
+ENV_PATH = ARGUS_APP_ROOT / '.env.local'
 
 SP_ADS_SCHEMAS = {
     'SP - Search Term Report (API)': [
@@ -375,7 +370,39 @@ SQP_ASIN_RE = re.compile(r'ASIN or Product=\["([^"]+)"\]')
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--dry-run', action='store_true')
+    parser.add_argument('--market', default=os.environ.get('ARGUS_MARKET', 'us'))
     return parser.parse_args()
+
+
+def load_env(path: Path):
+    env = {}
+    for raw_line in path.read_text().splitlines():
+        for line in re.split(r'\\\\n|\\n', raw_line):
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                value = value[1:-1]
+            env[key.strip()] = value
+    return env
+
+
+def parse_market(raw):
+    value = (raw or 'us').strip().lower()
+    if value in ('us', 'uk'):
+        return value
+    raise RuntimeError(f'Unsupported Argus market: {raw}')
+
+
+def monitoring_base_for_market(market):
+    env = load_env(ENV_PATH)
+    key = f'ARGUS_SALES_ROOT_{market.upper()}'
+    value = env.get(key)
+    if not value:
+        raise RuntimeError(f'Missing env var: {key}')
+    return Path(value) / 'Monitoring'
 
 
 def week_bounds_from_name(path: Path):
@@ -546,17 +573,21 @@ def rewrite_sqp(path: Path, dry_run):
 
 def main():
     args = parse_args()
+    weekly_base = monitoring_base_for_market(parse_market(args.market)) / 'Weekly'
+    sp_ads_base = weekly_base / 'Ad Console' / 'SP - Sponsored Products (API)'
+    brand_analytics_base = weekly_base / 'Brand Analytics (API)'
+    business_reports_base = weekly_base / 'Business Reports (API)' / 'Sales & Traffic (API)'
 
     for subdir, headers in SP_ADS_SCHEMAS.items():
-        for path in sorted((SP_ADS_BASE / subdir).glob('W*_*.csv')):
+        for path in sorted((sp_ads_base / subdir).glob('W*_*.csv')):
             rewrite_projected_csv(path, headers, args.dry_run)
 
-    for path in sorted(SP_ADS_BASE.glob('W*_SP-Manifest.json')):
+    for path in sorted(sp_ads_base.glob('W*_SP-Manifest.json')):
         if not WEEK_FILE_RE.match(path.name):
             continue
         rewrite_sp_ads_manifest(path, args.dry_run)
 
-    for path in sorted((BUSINESS_REPORTS_BASE).glob('W*_SalesTraffic-ByDate.csv')):
+    for path in sorted((business_reports_base).glob('W*_SalesTraffic-ByDate.csv')):
         rewrite_sales_traffic(
             path,
             SALES_BY_DATE_HEADERS,
@@ -564,7 +595,7 @@ def main():
             args.dry_run,
         )
 
-    for path in sorted((BUSINESS_REPORTS_BASE).glob('W*_SalesTraffic-ByAsin.csv')):
+    for path in sorted((business_reports_base).glob('W*_SalesTraffic-ByAsin.csv')):
         rewrite_sales_traffic(
             path,
             SALES_BY_ASIN_HEADERS,
@@ -572,13 +603,13 @@ def main():
             args.dry_run,
         )
 
-    for path in sorted((BRAND_ANALYTICS_BASE / 'TST - Top Search Terms (API)').glob('W*_TST.csv')):
+    for path in sorted((brand_analytics_base / 'TST - Top Search Terms (API)').glob('W*_TST.csv')):
         rewrite_tst(path, args.dry_run)
 
-    for path in sorted((BRAND_ANALYTICS_BASE / 'SCP - Search Catalog Performance (API)').glob('W*_SCP.csv')):
+    for path in sorted((brand_analytics_base / 'SCP - Search Catalog Performance (API)').glob('W*_SCP.csv')):
         rewrite_scp(path, args.dry_run)
 
-    for path in sorted((BRAND_ANALYTICS_BASE / 'SQP - Search Query Performance (API)').glob('W*_SQP.csv')):
+    for path in sorted((brand_analytics_base / 'SQP - Search Query Performance (API)').glob('W*_SQP.csv')):
         rewrite_sqp(path, args.dry_run)
 
 

--- a/apps/argus/scripts/api/weekly-sources/run.sh
+++ b/apps/argus/scripts/api/weekly-sources/run.sh
@@ -21,11 +21,20 @@ export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 DRY_FLAG=""
 START_DATE=""
 END_DATE=""
+MARKET="us"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --dry-run)
       DRY_FLAG="--dry-run"
+      ;;
+    --market)
+      if [ "$#" -lt 2 ]; then
+        echo "--market requires us or uk." >&2
+        exit 1
+      fi
+      MARKET="$2"
+      shift
       ;;
     --start-date)
       START_DATE="${2:-}"
@@ -43,6 +52,16 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
+case "$MARKET" in
+  us|uk)
+    export ARGUS_MARKET="$MARKET"
+    ;;
+  *)
+    echo "Unsupported market: $MARKET" >&2
+    exit 1
+    ;;
+esac
+
 if [ -n "$START_DATE" ] && [ -z "$END_DATE" ] || [ -z "$START_DATE" ] && [ -n "$END_DATE" ]; then
   echo "Both --start-date and --end-date are required together." >&2
   exit 1
@@ -52,10 +71,11 @@ DATE_FLAGS=""
 if [ -n "$START_DATE" ]; then
   DATE_FLAGS="--start-date $START_DATE --end-date $END_DATE"
 fi
+MARKET_FLAG="--market $MARKET"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') — $1" >> "$LOG"; }
 
-log "=== Weekly API Sources run starting ${DRY_FLAG:-live} ==="
+log "=== Weekly API Sources run starting market=$MARKET mode=${DRY_FLAG:-live} ==="
 
 if ! NODE_BIN="$(command -v node)"; then
   log "FAILED: Node.js not found in PATH=$PATH"
@@ -105,15 +125,15 @@ run_optional_step() {
   fi
 }
 
-run_step "SP-API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-spapi.mjs\" $DRY_FLAG $DATE_FLAGS"
-run_optional_step "SP Ads API" "python3 \"$SCRIPT_DIR/collect-sp-ads.py\" $DRY_FLAG $DATE_FLAGS"
-run_optional_step "Datadive API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-datadive.mjs\" $DRY_FLAG"
-run_optional_step "Datadive format repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-datadive-formats.mjs\" $DRY_FLAG"
-run_step "Sellerboard API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-sellerboard.mjs\" $DRY_FLAG $DATE_FLAGS"
-run_step "Weekly label repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-week-labels.mjs\" $DRY_FLAG"
+run_step "SP-API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-spapi.mjs\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
+run_optional_step "SP Ads API" "python3 \"$SCRIPT_DIR/collect-sp-ads.py\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
+run_optional_step "Datadive API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-datadive.mjs\" $MARKET_FLAG $DRY_FLAG"
+run_optional_step "Datadive format repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-datadive-formats.mjs\" $MARKET_FLAG $DRY_FLAG"
+run_step "Sellerboard API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-sellerboard.mjs\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
+run_step "Weekly label repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-week-labels.mjs\" $MARKET_FLAG $DRY_FLAG"
 
 if [ -z "$DRY_FLAG" ] && [ "$FAILED" -eq 0 ]; then
-  run_step "WPR workspace sync" "bash \"$WPR_SYNC_SCRIPT\" --trigger weekly-api-sources"
+  run_step "WPR workspace sync" "bash \"$WPR_SYNC_SCRIPT\" --market \"$MARKET\" --trigger weekly-api-sources"
 fi
 
 log "=== Weekly API Sources run done (failures=$FAILED) ==="
@@ -142,6 +162,7 @@ fi
 
 RUN_LOG_ARGS=(
   --job-id "weekly-api-sources"
+  --market "$MARKET"
   --status "$RUN_STATUS"
   --summary "$RUN_SUMMARY"
   --duration-ms "$DURATION_MS"

--- a/apps/argus/scripts/browser/common.sh
+++ b/apps/argus/scripts/browser/common.sh
@@ -352,6 +352,38 @@ require_env() {
   printf '%s' "$value"
 }
 
+argus_market() {
+  local value="${ARGUS_MARKET:-us}"
+  case "$value" in
+    us|uk)
+      printf '%s' "$value"
+      ;;
+    *)
+      echo "Unsupported market: $value" >&2
+      exit 1
+      ;;
+  esac
+}
+
+argus_sales_root() {
+  local market
+  local env_name
+  market="$(argus_market)"
+  case "$market" in
+    us)
+      env_name="ARGUS_SALES_ROOT_US"
+      ;;
+    uk)
+      env_name="ARGUS_SALES_ROOT_UK"
+      ;;
+  esac
+  require_env "$env_name"
+}
+
+argus_monitoring_root() {
+  printf '%s/Monitoring' "$(argus_sales_root)"
+}
+
 js_string_literal() {
   "$PYTHON_BIN" - "$1" <<'PY'
 import json

--- a/apps/argus/scripts/browser/daily-account-health/collect.sh
+++ b/apps/argus/scripts/browser/daily-account-health/collect.sh
@@ -12,8 +12,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
-DEST_AH="/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Daily/Account Health Dashboard (API)"
-DEST_VOC="/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Daily/Voice of the Customer (Manual)"
+load_monitoring_env
+DEST_AH="$(argus_monitoring_root)/Daily/Account Health Dashboard (API)"
+DEST_VOC="$(argus_monitoring_root)/Daily/Voice of the Customer (Manual)"
 CSV="$DEST_AH/account-health.csv"
 LOG="/tmp/daily-account-health.log"
 TODAY=$(date '+%Y-%m-%d')

--- a/apps/argus/scripts/browser/daily-visuals/collect.mjs
+++ b/apps/argus/scripts/browser/daily-visuals/collect.mjs
@@ -6,19 +6,68 @@ import path from 'node:path'
 import { execFileSync } from 'node:child_process'
 import { sendArgusAlertEmail } from '../../lib/alert-email.mjs'
 
-const DEST =
-  '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Daily/Visuals (Browser)'
 const LOG = '/tmp/daily-visuals.log'
 const TODAY = new Date().toLocaleDateString('en-CA', { timeZone: 'America/Chicago' })
 const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname)
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../../../../..')
 const NODE_BIN = process.execPath
 const RUN_LOG_WRITER = path.join(SCRIPT_DIR, '../../lib/write-monitoring-run-log.mjs')
+const MARKET = parseMarket(readMarketArg())
+const DEST = path.join(monitoringRootForMarket(MARKET), 'Daily', 'Visuals (Browser)')
 const CAPTURE_CHILD_TIMEOUT_MS = 210_000
 const MAX_CAPTURE_ATTEMPTS = 2
 const RUN_STARTED_AT = new Date()
 
 function log(message) {
   fs.appendFileSync(LOG, `${timestamp()} — ${message}\n`)
+}
+
+function readMarketArg() {
+  const argv = process.argv.slice(2)
+  const index = argv.indexOf('--market')
+  if (index < 0) return process.env.ARGUS_MARKET
+  return argv[index + 1]
+}
+
+function parseMarket(raw) {
+  if (raw === undefined) return 'us'
+  const value = String(raw).trim().toLowerCase()
+  if (value === '') return 'us'
+  if (value === 'us') return 'us'
+  if (value === 'uk') return 'uk'
+  throw new Error(`Unsupported Argus market: ${raw}`)
+}
+
+function loadEnvFile(file) {
+  if (!fs.existsSync(file)) return
+  const rawLines = fs.readFileSync(file, 'utf8').split(/\r?\n/)
+  for (const rawLine of rawLines) {
+    for (const line of rawLine.split(/\\\\n|\\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const separator = trimmed.indexOf('=')
+      if (separator < 0) continue
+      const key = trimmed.slice(0, separator).trim()
+      let value = trimmed.slice(separator + 1).trim()
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+      process.env[key] = process.env[key] ?? value
+    }
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required env var: ${name}`)
+  }
+  return value.trim()
+}
+
+function monitoringRootForMarket(market) {
+  loadEnvFile(path.join(REPO_ROOT, 'apps/argus/.env.local'))
+  return path.join(requireEnv(`ARGUS_SALES_ROOT_${market.toUpperCase()}`), 'Monitoring')
 }
 
 function timestamp() {
@@ -61,7 +110,7 @@ function appendErrorOutput(error) {
 
 function resolveAsins() {
   try {
-    const output = runFile(NODE_BIN, [path.join(SCRIPT_DIR, 'resolve-asins.mjs')])
+    const output = runFile(NODE_BIN, [path.join(SCRIPT_DIR, 'resolve-asins.mjs'), '--market', MARKET])
     const rows = output
       .split('\n')
       .map((line) => line.trim())
@@ -152,6 +201,8 @@ function writeRunLog({ status, summary, finishedAt, errorMessage }) {
     RUN_LOG_WRITER,
     '--job-id',
     'daily-visuals',
+    '--market',
+    MARKET,
     '--status',
     status,
     '--summary',

--- a/apps/argus/scripts/browser/daily-visuals/resolve-asins.mjs
+++ b/apps/argus/scripts/browser/daily-visuals/resolve-asins.mjs
@@ -1,8 +1,65 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs'
+import path from 'node:path'
 
-const STATE_PATH = '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Hourly/Listing Attributes (API)/latest_state.json'
+const SCRIPT_DIR = path.dirname(new URL(import.meta.url).pathname)
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '../../../../..')
+const MARKET = parseMarket(readMarketArg())
+const STATE_PATH = path.join(
+  monitoringRootForMarket(MARKET),
+  'Hourly',
+  'Listing Attributes (API)',
+  'latest_state.json',
+)
+
+function readMarketArg() {
+  const argv = process.argv.slice(2)
+  const index = argv.indexOf('--market')
+  if (index < 0) return process.env.ARGUS_MARKET
+  return argv[index + 1]
+}
+
+function parseMarket(raw) {
+  if (raw === undefined) return 'us'
+  const value = String(raw).trim().toLowerCase()
+  if (value === '') return 'us'
+  if (value === 'us') return 'us'
+  if (value === 'uk') return 'uk'
+  throw new Error(`Unsupported Argus market: ${raw}`)
+}
+
+function loadEnvFile(file) {
+  if (!fs.existsSync(file)) return
+  const rawLines = fs.readFileSync(file, 'utf8').split(/\r?\n/)
+  for (const rawLine of rawLines) {
+    for (const line of rawLine.split(/\\\\n|\\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+      const separator = trimmed.indexOf('=')
+      if (separator < 0) continue
+      const key = trimmed.slice(0, separator).trim()
+      let value = trimmed.slice(separator + 1).trim()
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+      process.env[key] = process.env[key] ?? value
+    }
+  }
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required env var: ${name}`)
+  }
+  return value.trim()
+}
+
+function monitoringRootForMarket(market) {
+  loadEnvFile(path.join(REPO_ROOT, 'apps/argus/.env.local'))
+  return path.join(requireEnv(`ARGUS_SALES_ROOT_${market.toUpperCase()}`), 'Monitoring')
+}
 
 function normalizeBrand(brandRaw) {
   const brand = String(brandRaw || '').trim()

--- a/apps/argus/scripts/browser/run-weekly.sh
+++ b/apps/argus/scripts/browser/run-weekly.sh
@@ -10,6 +10,35 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+MARKET="us"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --market)
+      if [ "$#" -lt 2 ]; then
+        echo "--market requires us or uk." >&2
+        exit 1
+      fi
+      MARKET="$2"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+case "$MARKET" in
+  us|uk)
+    export ARGUS_MARKET="$MARKET"
+    ;;
+  *)
+    echo "Unsupported market: $MARKET" >&2
+    exit 1
+    ;;
+esac
+
 LOG="/tmp/weekly-browser-sources.log"
 RUN_LOG_WRITER="$REPO_ROOT/apps/argus/scripts/lib/write-monitoring-run-log.mjs"
 WPR_SYNC_SCRIPT="$REPO_ROOT/apps/argus/scripts/lib/sync-wpr-workspace.sh"
@@ -43,7 +72,7 @@ append_detail_log_tail() {
   done < <(tail -10 "$detail_log")
 }
 
-log "=== Weekly Master Run Starting ==="
+log "=== Weekly Master Run Starting (market=$MARKET) ==="
 
 ensure_chrome_browser
 sleep 2
@@ -56,7 +85,7 @@ run_script() {
   local script="$2"
   local detail_log="$3"
   log "Running: $name"
-  if bash "$script"; then
+  if ARGUS_MARKET="$MARKET" bash "$script"; then
     log "OK: $name"
   else
     local exit_code=$?
@@ -76,7 +105,7 @@ run_script "Brand Metrics" "$SCRIPT_DIR/weekly-brand-metrics/collect.sh" "/tmp/w
 
 if [ "$FAILED" -eq 0 ]; then
   log "Running: WPR workspace sync"
-  if bash "$WPR_SYNC_SCRIPT" --trigger weekly-browser-sources >> "$LOG" 2>&1; then
+  if bash "$WPR_SYNC_SCRIPT" --market "$MARKET" --trigger weekly-browser-sources >> "$LOG" 2>&1; then
     log "OK: WPR workspace sync"
   else
     local_exit_code=$?
@@ -106,6 +135,7 @@ fi
 
 RUN_LOG_ARGS=(
   --job-id "weekly-browser-sources"
+  --market "$MARKET"
   --status "$RUN_STATUS"
   --summary "$RUN_SUMMARY"
   --duration-ms "$DURATION_MS"

--- a/apps/argus/scripts/browser/weekly-brand-metrics/collect.sh
+++ b/apps/argus/scripts/browser/weekly-brand-metrics/collect.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
+load_monitoring_env
 
-DEST="${ARGUS_BRAND_METRICS_DEST:-/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Weekly/Ad Console/Brand Metrics (Browser)}"
+DEST="${ARGUS_BRAND_METRICS_DEST:-$(argus_monitoring_root)/Weekly/Ad Console/Brand Metrics (Browser)}"
 DL="${ARGUS_BRAND_METRICS_DOWNLOAD_DIR:-$HOME/Downloads}"
 LOG="${ARGUS_BRAND_METRICS_LOG:-/tmp/weekly-brand-metrics.log}"
 TARGET_URL_BASE="https://advertising.amazon.com/bb/bm/overview?entityId=ENTITY2JBRT701DBI1P&brand=1113309&category=228899"

--- a/apps/argus/scripts/browser/weekly-category-insights/collect.sh
+++ b/apps/argus/scripts/browser/weekly-category-insights/collect.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
+load_monitoring_env
 
-DEST="${ARGUS_CATEGORY_INSIGHTS_DEST:-/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Weekly/Category Insights (Browser)}"
+DEST="${ARGUS_CATEGORY_INSIGHTS_DEST:-$(argus_monitoring_root)/Weekly/Category Insights (Browser)}"
 LOG="${ARGUS_CATEGORY_INSIGHTS_LOG:-/tmp/weekly-category-insights.log}"
 TARGET_URL="https://sellercentral.amazon.com/selection/category-insights"
 TARGET_MARKETPLACE_ID="ATVPDKIKX0DER"

--- a/apps/argus/scripts/browser/weekly-poe/collect.sh
+++ b/apps/argus/scripts/browser/weekly-poe/collect.sh
@@ -5,8 +5,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
+load_monitoring_env
 
-DEST="${ARGUS_POE_DEST:-/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Weekly/Product Opportunity Explorer (Browser)}"
+DEST="${ARGUS_POE_DEST:-$(argus_monitoring_root)/Weekly/Product Opportunity Explorer (Browser)}"
 LOG="${ARGUS_POE_LOG:-/tmp/weekly-poe.log}"
 TARGET_URL_BASE="https://sellercentral.amazon.com/opportunity-explorer/explore/niche/84dd9c9ba70c2b6df8c7bacb37f9a326"
 

--- a/apps/argus/scripts/browser/weekly-scaleinsights/collect.sh
+++ b/apps/argus/scripts/browser/weekly-scaleinsights/collect.sh
@@ -8,7 +8,7 @@ source "$SCRIPT_DIR/../common.sh"
 
 load_monitoring_env
 
-DEST="${ARGUS_SCALEINSIGHTS_DEST:-/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring/Weekly/ScaleInsights/KeywordRanking (Browser)}"
+DEST="${ARGUS_SCALEINSIGHTS_DEST:-$(argus_monitoring_root)/Weekly/ScaleInsights/KeywordRanking (Browser)}"
 DL="${ARGUS_SCALEINSIGHTS_DOWNLOAD_DIR:-$HOME/Downloads}"
 LOG="${ARGUS_SCALEINSIGHTS_LOG:-/tmp/weekly-scaleinsights.log}"
 TARGET_URL="https://portal.scaleinsights.com/KeywordRanking"

--- a/apps/argus/scripts/lib/scaffold-market-workspace.sh
+++ b/apps/argus/scripts/lib/scaffold-market-workspace.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+MARKET=""
+SALES_ROOT=""
+DRY_RUN="false"
+
+load_env_file() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    return 0
+  fi
+
+  local export_lines
+  export_lines="$(python3 - "$file" <<'PY'
+from pathlib import Path
+import shlex
+import sys
+
+path = Path(sys.argv[1])
+for raw_line in path.read_text().splitlines():
+    for line in raw_line.split('\\n'):
+        trimmed = line.strip()
+        if not trimmed or trimmed.startswith('#') or '=' not in trimmed:
+            continue
+        key, value = trimmed.split('=', 1)
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        print(f"export {key}={shlex.quote(value)}")
+PY
+)"
+
+  if [ -n "$export_lines" ]; then
+    eval "$export_lines"
+  fi
+}
+
+load_env_file "$REPO_ROOT/apps/argus/.env.local"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --market)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --market" >&2
+        exit 1
+      fi
+      MARKET="$2"
+      shift
+      ;;
+    --sales-root)
+      if [ "$#" -lt 2 ]; then
+        echo "Missing value for --sales-root" >&2
+        exit 1
+      fi
+      SALES_ROOT="$2"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [ "$MARKET" != "us" ] && [ "$MARKET" != "uk" ]; then
+  echo "Expected --market us or --market uk" >&2
+  exit 1
+fi
+
+if [ -z "$SALES_ROOT" ]; then
+  env_name="ARGUS_SALES_ROOT_$(printf '%s' "$MARKET" | tr '[:lower:]' '[:upper:]')"
+  if [ -z "${!env_name+x}" ]; then
+    echo "Missing --sales-root for market=$MARKET" >&2
+    exit 1
+  fi
+  SALES_ROOT="${!env_name}"
+fi
+
+if [ -z "$SALES_ROOT" ]; then
+  echo "Missing --sales-root for market=$MARKET" >&2
+  exit 1
+fi
+
+PATHS=(
+  "Monitoring/Hourly/Listing Attributes (API)"
+  "Monitoring/Daily/Account Health Dashboard (API)"
+  "Monitoring/Daily/Visuals (Browser)"
+  "Monitoring/Daily/Voice of the Customer (Manual)"
+  "Monitoring/Weekly/Amazon Inventory Ledger (API)"
+  "Monitoring/Weekly/Ad Console/SP - Sponsored Products (API)"
+  "Monitoring/Weekly/Ad Console/Brand Metrics (Browser)"
+  "Monitoring/Weekly/Brand Analytics (API)/SCP - Search Catalog Performance (API)"
+  "Monitoring/Weekly/Brand Analytics (API)/SQP - Search Query Performance (API)"
+  "Monitoring/Weekly/Brand Analytics (API)/TST - Top Search Terms (API)"
+  "Monitoring/Weekly/Business Reports (API)/Sales & Traffic (API)"
+  "Monitoring/Weekly/Category Insights (Browser)"
+  "Monitoring/Weekly/Datadive (API)/DD-Competitors - Datadive Competitors (API)"
+  "Monitoring/Weekly/Datadive (API)/DD-Keywords - Datadive Keywords (API)"
+  "Monitoring/Weekly/Datadive (API)/Rank Radar - Datadive Rank Radar (API)"
+  "Monitoring/Weekly/Product Opportunity Explorer (Browser)"
+  "Monitoring/Weekly/ScaleInsights/KeywordRanking (Browser)"
+  "Monitoring/Weekly/Sellerboard (API)/SB - Dashboard Report (API)"
+  "Monitoring/Weekly/Sellerboard (API)/SB - Orders Report (API)"
+  "Monitoring/Logs/tracking-fetch"
+  "Monitoring/Logs/hourly-listing-attributes-api"
+  "Monitoring/Logs/daily-account-health"
+  "Monitoring/Logs/daily-visuals"
+  "Monitoring/Logs/weekly-api-sources"
+  "Monitoring/Logs/weekly-browser-sources"
+  "Monitoring/Logs/sellerboard-sync"
+  "WPR/wpr-workspace/output"
+)
+
+echo "market=$MARKET"
+echo "sales_root=$SALES_ROOT"
+
+for relative_path in "${PATHS[@]}"; do
+  target="$SALES_ROOT/$relative_path"
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "mkdir -p $target"
+  else
+    mkdir -p "$target"
+    echo "created $relative_path"
+  fi
+done

--- a/apps/argus/scripts/lib/scaffold-market-workspace.test.mjs
+++ b/apps/argus/scripts/lib/scaffold-market-workspace.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+test('scaffold-market-workspace dry-run reports the UK Monitoring and WPR structure', () => {
+  const salesRoot = path.join(mkdtempSync(path.join(tmpdir(), 'argus-uk-sales-')), 'Sales')
+  const result = spawnSync(
+    'bash',
+    ['apps/argus/scripts/lib/scaffold-market-workspace.sh', '--market', 'uk', '--sales-root', salesRoot, '--dry-run'],
+    {
+      cwd: path.resolve(new URL('../../../..', import.meta.url).pathname),
+      encoding: 'utf8',
+    },
+  )
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /market=uk/)
+  assert.match(result.stdout, /Monitoring\/Hourly\/Listing Attributes \(API\)/)
+  assert.match(result.stdout, /Monitoring\/Weekly\/Brand Analytics \(API\)/)
+  assert.match(result.stdout, /Monitoring\/Logs\/weekly-api-sources/)
+  assert.match(result.stdout, /WPR\/wpr-workspace\/output/)
+})

--- a/apps/argus/scripts/lib/sync-wpr-workspace.sh
+++ b/apps/argus/scripts/lib/sync-wpr-workspace.sh
@@ -5,17 +5,34 @@ set -euo pipefail
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
 LOCK_FILE="/tmp/argus-wpr-workspace.lock"
 
-if [ "${1:-}" != "--locked" ]; then
+if [ "$#" -eq 0 ]; then
+  exec /usr/bin/lockf "$LOCK_FILE" /bin/bash "$SCRIPT_PATH" --locked
+fi
+
+if [ "$1" != "--locked" ]; then
   exec /usr/bin/lockf "$LOCK_FILE" /bin/bash "$SCRIPT_PATH" --locked "$@"
 fi
 shift
 
 TRIGGER="manual"
+MARKET="us"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --trigger)
-      TRIGGER="${2:-}"
+      if [ "$#" -lt 2 ]; then
+        echo "--trigger requires a value." >&2
+        exit 1
+      fi
+      TRIGGER="$2"
+      shift
+      ;;
+    --market)
+      if [ "$#" -lt 2 ]; then
+        echo "--market requires us or uk." >&2
+        exit 1
+      fi
+      MARKET="$2"
       shift
       ;;
     *)
@@ -32,7 +49,22 @@ export PYTHON_BIN
 source "$(cd "$(dirname "$0")/../browser" && pwd)/common.sh"
 load_monitoring_env
 
-WPR_DATA_DIR="$(require_env WPR_DATA_DIR)"
+case "$MARKET" in
+  us)
+    WPR_DATA_ENV_NAME="WPR_DATA_DIR_US"
+    ;;
+  uk)
+    WPR_DATA_ENV_NAME="WPR_DATA_DIR_UK"
+    ;;
+  *)
+    echo "Unsupported market: $MARKET" >&2
+    exit 1
+    ;;
+esac
+
+WPR_DATA_DIR="$(require_env "$WPR_DATA_ENV_NAME")"
+export WPR_DATA_DIR
+export ARGUS_MARKET="$MARKET"
 WPR_WORKSPACE="$(cd "$(dirname "$WPR_DATA_DIR")" && pwd)"
 REBUILD_SCRIPT="$REPO_ROOT/apps/argus/scripts/wpr/rebuild_wpr.py"
 BUILD_SCRIPT="$REPO_ROOT/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py"
@@ -47,7 +79,7 @@ if [ ! -f "$BUILD_SCRIPT" ]; then
   exit 1
 fi
 
-echo "$(date '+%Y-%m-%d %H:%M:%S') — WPR workspace sync starting (trigger=$TRIGGER)"
+echo "$(date '+%Y-%m-%d %H:%M:%S') — WPR workspace sync starting (market=$MARKET, trigger=$TRIGGER)"
 echo "$(date '+%Y-%m-%d %H:%M:%S') — WPR workspace: $WPR_WORKSPACE"
 
 "$PYTHON_BIN" "$REBUILD_SCRIPT"

--- a/apps/argus/scripts/lib/write-monitoring-run-log.mjs
+++ b/apps/argus/scripts/lib/write-monitoring-run-log.mjs
@@ -1,8 +1,36 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const MONITORING_BASE =
-  '/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/Monitoring'
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../../../../')
+
+function loadEnvFile(file) {
+  if (!fs.existsSync(file)) return
+
+  const rawLines = fs.readFileSync(file, 'utf8').split(/\r?\n/)
+  for (const rawLine of rawLines) {
+    for (const line of rawLine.split(/\\\\n|\\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) continue
+
+      const separator = trimmed.indexOf('=')
+      if (separator < 0) continue
+
+      const key = trimmed.slice(0, separator).trim()
+      let value = trimmed.slice(separator + 1).trim()
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1)
+      }
+      if (!process.env[key]) process.env[key] = value
+    }
+  }
+}
+
+function loadArgusEnv() {
+  loadEnvFile(path.join(REPO_ROOT, 'apps/argus/.env.local'))
+}
 
 function readFlag(argv, flag) {
   const index = argv.indexOf(flag)
@@ -16,6 +44,28 @@ function requireFlag(argv, flag) {
     throw new Error(`Missing required flag: ${flag}`)
   }
   return value.trim()
+}
+
+function parseMarket(raw) {
+  if (raw === null) return 'us'
+  const value = String(raw).trim().toLowerCase()
+  if (value === '') return 'us'
+  if (value === 'us') return 'us'
+  if (value === 'uk') return 'uk'
+  throw new Error(`Unsupported market: ${raw}`)
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value || !value.trim()) {
+    throw new Error(`Missing required env var: ${name}`)
+  }
+  return value.trim()
+}
+
+function monitoringRootForMarket(market) {
+  const salesRoot = requireEnv(`ARGUS_SALES_ROOT_${market.toUpperCase()}`)
+  return path.join(salesRoot, 'Monitoring')
 }
 
 function parseDurationMs(raw) {
@@ -54,7 +104,9 @@ function parseTimestamp(raw) {
 }
 
 async function main() {
+  loadArgusEnv()
   const argv = process.argv.slice(2)
+  const market = parseMarket(readFlag(argv, '--market'))
   const jobId = requireFlag(argv, '--job-id')
   const status = parseStatus(requireFlag(argv, '--status'))
   const summary = requireFlag(argv, '--summary')
@@ -82,7 +134,7 @@ async function main() {
     ...(warnSteps.length > 0 ? { warnSteps } : {}),
   }
 
-  const targetPath = path.join(MONITORING_BASE, 'Logs', jobId, 'run-log.jsonl')
+  const targetPath = path.join(monitoringRootForMarket(market), 'Logs', jobId, 'run-log.jsonl')
   await fs.promises.mkdir(path.dirname(targetPath), { recursive: true })
   await fs.promises.appendFile(targetPath, `${JSON.stringify(entry)}\n`, 'utf8')
 }

--- a/apps/argus/stores/wpr-store.ts
+++ b/apps/argus/stores/wpr-store.ts
@@ -23,7 +23,7 @@ import type { WeekLabel } from '@/lib/wpr/types';
 type WprStore = WprDashboardState & {
   replaceState: (nextState: Partial<WprDashboardState>) => void;
   setActiveTab: (activeTab: WprTab) => void;
-  setSelectedWeek: (selectedWeek: WeekLabel) => void;
+  setSelectedWeek: (selectedWeek: WeekLabel | null) => void;
   setSelectedClusterId: (selectedClusterId: string | null) => void;
   setSelectedSqpRootIds: (rootIds: string[]) => void;
   setSelectedSqpTermIds: (termIds: string[]) => void;


### PR DESCRIPTION
## Summary
- add explicit US/UK Argus market config for WPR and Monitoring paths
- wire WPR APIs, cache, changelog writes, UI query keys, and market selector through selected market
- wire Monitoring APIs, readers, health/run logs, ASIN detail, UI links, collectors, sync scripts, and UK shared-drive scaffold through selected market

## Verification
- python3 apps/argus/scripts/wpr/test_rebuild_wpr.py
- python3 apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
- pnpm --filter @targon/argus exec tsx --test lib/argus-market.test.ts lib/wpr/reader-market.test.ts lib/wpr/change-log-write.test.ts app/api/wpr/payload/route.test.ts app/api/wpr/changelog-week-route.test.ts app/api/monitoring/route-market.test.ts
- node --test apps/argus/scripts/lib/scaffold-market-workspace.test.mjs
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/argus type-check
- bash -n changed shell scripts
- node --check changed node scripts
- python3 -m py_compile changed python scripts
- rg check: no active hardcoded Dust Sheets - US/Sales/Monitoring paths in apps/argus