### PR TITLE
fix(argus): clarify SQP query volume charting

### DIFF
--- a/apps/argus/components/wpr/tabs/business-reports-tab.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-tab.tsx
@@ -1,11 +1,8 @@
 'use client'
 
 import { useEffect, useRef, useState, type JSX, type RefObject } from 'react'
-import { Box, Button, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
-import {
-  WprAnalyticsFooter,
-  WprAnalyticsPanel,
-} from '@/components/wpr/wpr-analytics-panel'
+import { Box, Stack, ToggleButton, ToggleButtonGroup } from '@mui/material'
+import { WprAnalyticsPanel } from '@/components/wpr/wpr-analytics-panel'
 import {
   Bar,
   CartesianGrid,
@@ -23,24 +20,34 @@ import {
   buildWeeklyChangeMarkers,
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
-import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprInlineChartLegend, type WprInlineChartLegendItem } from '@/components/wpr/wpr-inline-chart-legend'
 import type { WprBrWowVisible } from '@/lib/wpr/dashboard-state'
 import {
   createBusinessReportsSelectionViewModel,
   type BusinessReportsSelectionViewModel,
 } from '@/lib/wpr/business-reports-view-model'
 import { formatCount } from '@/lib/wpr/format'
-import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprBusinessDailyPoint, WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import {
   buildBundleWeekStartDateLookup,
   formatTooltipWeekLabelFromLookup,
-  formatWeekWindowLabel,
 } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import BusinessReportsSelectionTable from './business-reports-selection-table'
 
 type BusinessReportsViewMode = 'weekly' | 'daily'
+type BusinessReportsSeriesKey = keyof WprBrWowVisible
+
+const BUSINESS_REPORTS_WOW_SERIES: Array<{
+  key: BusinessReportsSeriesKey
+  label: string
+  color: string
+}> = [
+  { key: 'sessions', label: 'Sessions', color: '#8fc7ff' },
+  { key: 'order_items', label: 'Order Item %', color: '#f5a623' },
+  { key: 'unit_session', label: 'Unit Session %', color: '#d5ff62' },
+]
 
 const businessReportsViewToggleGroupSx = {
   '& .MuiToggleButtonGroup-grouped': {
@@ -69,20 +76,6 @@ const businessReportsViewToggleGroupSx = {
       bgcolor: 'rgba(255,255,255,0.07)',
     },
   },
-}
-
-function dailyWindowLabel(dailySeries: WprBusinessDailyPoint[]): string {
-  if (dailySeries.length === 0) {
-    return 'No daily business-report history'
-  }
-
-  const first = dailySeries[0]
-  const last = dailySeries[dailySeries.length - 1]
-  if (first === undefined || last === undefined) {
-    throw new Error('Missing Business Reports daily history')
-  }
-
-  return `${first.day_label} to ${last.day_label}`
 }
 
 type OverlayLayout = {
@@ -246,14 +239,17 @@ function BusinessReportsChart({
   setViewMode: (nextMode: BusinessReportsViewMode) => void
 }) {
   const chartRootRef = useRef<HTMLDivElement | null>(null)
-  const visibleSeries = [
-    wowVisible.sessions ? { key: 'sessions', label: 'Sessions', color: '#8fc7ff' } : null,
-    wowVisible.order_items ? { key: 'order_items', label: 'Order Item %', color: '#f5a623' } : null,
-    wowVisible.unit_session ? { key: 'unit_session', label: 'Unit Session %', color: '#d5ff62' } : null,
-  ].filter(
-    (value): value is { key: 'sessions' | 'order_items' | 'unit_session'; label: string; color: string } =>
-      value !== null,
-  )
+  const visibleSeries = BUSINESS_REPORTS_WOW_SERIES.filter((series) => wowVisible[series.key])
+  const legendItems: Array<WprInlineChartLegendItem<BusinessReportsSeriesKey>> = BUSINESS_REPORTS_WOW_SERIES.map((series) => ({
+    ...series,
+    active: wowVisible[series.key],
+  }))
+  const toggleSeries = (seriesKey: BusinessReportsSeriesKey) => {
+    setWowVisible({
+      ...wowVisible,
+      [seriesKey]: !wowVisible[seriesKey],
+    })
+  }
   const changeMarkers =
     viewMode === 'weekly'
       ? buildWeeklyChangeMarkers(changeEntries)
@@ -294,165 +290,135 @@ function BusinessReportsChart({
     }
 
     chartBody = (
-      <Box ref={chartRootRef} sx={{ position: 'relative', height: '100%' }}>
-        <ResponsiveContainer width="100%" height="100%">
-          <ComposedChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
-            <XAxis dataKey="label" tick={{ fontSize: 10 }} />
-            <YAxis yAxisId="counts" tick={{ fontSize: 10 }} />
-            <YAxis
-              yAxisId="rates"
-              orientation="right"
-              tick={{ fontSize: 10 }}
-              tickFormatter={(value: number) => `${value.toFixed(0)}%`}
-            />
-            <Tooltip
-              content={({ active, payload, label }) => (
-                <WprChangeTooltipContent
-                  active={active}
-                  payload={payload}
-                  label={label}
-                  labelText={viewMode === 'weekly' ? formatTooltipWeekLabelFromLookup(label, weekStartDates) : undefined}
-                  changeMarker={changeMarkersByLabel.get(String(label))}
-                  formatRow={(entry) => {
-                    const key = entry.dataKey
-                    if (key === undefined) {
-                      throw new Error('Missing Business Reports tooltip data key')
-                    }
-
-                    const value = entry.value
-                    if (typeof value !== 'number') {
-                      throw new Error(`Invalid Business Reports tooltip value for ${String(key)}`)
-                    }
-
-                    const color = entry.color
-                    if (color === undefined) {
-                      throw new Error(`Missing Business Reports tooltip color for ${String(key)}`)
-                    }
-
-                    if (key === 'sessions') {
-                      return {
-                        label: 'Sessions',
-                        value: formatCount(value),
-                        color,
+      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <Box ref={chartRootRef} sx={{ position: 'relative', flex: 1, minHeight: 0 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <ComposedChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+              <XAxis dataKey="label" tick={{ fontSize: 10 }} />
+              <YAxis yAxisId="counts" tick={{ fontSize: 10 }} />
+              <YAxis
+                yAxisId="rates"
+                orientation="right"
+                tick={{ fontSize: 10 }}
+                tickFormatter={(value: number) => `${value.toFixed(0)}%`}
+              />
+              <Tooltip
+                content={({ active, payload, label }) => (
+                  <WprChangeTooltipContent
+                    active={active}
+                    payload={payload}
+                    label={label}
+                    labelText={viewMode === 'weekly' ? formatTooltipWeekLabelFromLookup(label, weekStartDates) : undefined}
+                    changeMarker={changeMarkersByLabel.get(String(label))}
+                    formatRow={(entry) => {
+                      const key = entry.dataKey
+                      if (key === undefined) {
+                        throw new Error('Missing Business Reports tooltip data key')
                       }
-                    }
 
-                    if (key === 'order_items') {
+                      const value = entry.value
+                      if (typeof value !== 'number') {
+                        throw new Error(`Invalid Business Reports tooltip value for ${String(key)}`)
+                      }
+
+                      const color = entry.color
+                      if (color === undefined) {
+                        throw new Error(`Missing Business Reports tooltip color for ${String(key)}`)
+                      }
+
+                      if (key === 'sessions') {
+                        return {
+                          label: 'Sessions',
+                          value: formatCount(value),
+                          color,
+                        }
+                      }
+
+                      if (key === 'order_items') {
+                        return {
+                          label: 'Order Item %',
+                          value: `${value.toFixed(1)}%`,
+                          color,
+                        }
+                      }
+
                       return {
-                        label: 'Order Item %',
+                        label: 'Unit Session %',
                         value: `${value.toFixed(1)}%`,
                         color,
                       }
-                    }
-
-                    return {
-                      label: 'Unit Session %',
-                      value: `${value.toFixed(1)}%`,
-                      color,
-                    }
-                  }}
+                    }}
+                  />
+                )}
+              />
+              {wowVisible.sessions ? (
+                <Bar yAxisId="counts" dataKey="sessions" fill="rgba(143,199,255,0.34)" stroke="#8fc7ff" />
+              ) : null}
+              {wowVisible.order_items ? (
+                <Line
+                  yAxisId="rates"
+                  type="monotone"
+                  dataKey="order_items"
+                  stroke="#f5a623"
+                  strokeWidth={2.2}
+                  dot={{ r: 2.5, strokeWidth: 0, fill: '#f5a623' }}
+                  activeDot={{ r: 4 }}
                 />
-              )}
-            />
-            {wowVisible.sessions ? (
-              <Bar yAxisId="counts" dataKey="sessions" fill="rgba(143,199,255,0.34)" stroke="#8fc7ff" />
-            ) : null}
-            {wowVisible.order_items ? (
-              <Line
-                yAxisId="rates"
-                type="monotone"
-                dataKey="order_items"
-                stroke="#f5a623"
-                strokeWidth={2.2}
-                dot={{ r: 2.5, strokeWidth: 0, fill: '#f5a623' }}
-                activeDot={{ r: 4 }}
-              />
-            ) : null}
-            {wowVisible.unit_session ? (
-              <Line
-                yAxisId="rates"
-                type="monotone"
-                dataKey="unit_session"
-                stroke="#d5ff62"
-                strokeWidth={2.2}
-                dot={{ r: 2.5, strokeWidth: 0, fill: '#d5ff62' }}
-                activeDot={{ r: 4 }}
-              />
-            ) : null}
-          </ComposedChart>
-        </ResponsiveContainer>
-        <BusinessReportsChangeOverlay chartRootRef={chartRootRef} markers={changeMarkers} />
+              ) : null}
+              {wowVisible.unit_session ? (
+                <Line
+                  yAxisId="rates"
+                  type="monotone"
+                  dataKey="unit_session"
+                  stroke="#d5ff62"
+                  strokeWidth={2.2}
+                  dot={{ r: 2.5, strokeWidth: 0, fill: '#d5ff62' }}
+                  activeDot={{ r: 4 }}
+                />
+              ) : null}
+            </ComposedChart>
+          </ResponsiveContainer>
+          <BusinessReportsChangeOverlay chartRootRef={chartRootRef} markers={changeMarkers} />
+        </Box>
+        <WprInlineChartLegend chartId="br" items={legendItems} onToggle={toggleSeries} />
       </Box>
     )
   }
 
-  return (
-    <WprChartShell
-      primaryControls={
-        <WprChartControlGroup label="View">
-          <ToggleButtonGroup
-            value={viewMode}
-            exclusive
-            size="small"
-            aria-label="Business Reports view mode"
-            onChange={(_event, nextMode: BusinessReportsViewMode | null) => {
-              if (nextMode !== null) {
-                setViewMode(nextMode)
-              }
-            }}
-            sx={businessReportsViewToggleGroupSx}
-          >
-            <ToggleButton value="weekly">Weekly</ToggleButton>
-            <ToggleButton value="daily">Daily</ToggleButton>
-          </ToggleButtonGroup>
-        </WprChartControlGroup>
-      }
-      secondaryControls={
-        <WprChartControlGroup label="Metrics">
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                sessions: !wowVisible.sessions,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.sessions, '#8fc7ff')}
-          >
-            Sessions
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                order_items: !wowVisible.order_items,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.order_items, '#f5a623')}
-          >
-            Order Item %
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                unit_session: !wowVisible.unit_session,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.unit_session, '#d5ff62')}
-          >
-            Unit Session %
-          </Button>
-        </WprChartControlGroup>
-      }
+  const viewModeControl = (
+    <Box
+      sx={{
+        position: 'absolute',
+        top: 10,
+        right: 12,
+        zIndex: 2,
+      }}
     >
-      {chartBody}
+      <ToggleButtonGroup
+        value={viewMode}
+        exclusive
+        size="small"
+        aria-label="Business Reports view mode"
+        onChange={(_event, nextMode: BusinessReportsViewMode | null) => {
+          if (nextMode !== null) {
+            setViewMode(nextMode)
+          }
+        }}
+        sx={businessReportsViewToggleGroupSx}
+      >
+        <ToggleButton value="weekly">Weekly</ToggleButton>
+        <ToggleButton value="daily">Daily</ToggleButton>
+      </ToggleButtonGroup>
+    </Box>
+  )
+
+  return (
+    <WprChartShell>
+      <Box sx={{ position: 'relative', height: '100%' }}>
+        {viewModeControl}
+        {chartBody}
+      </Box>
     </WprChartShell>
   )
 }
@@ -542,21 +508,11 @@ export default function BusinessReportsTab({
   if (dailySeries !== undefined) {
     dailyChartSeries = dailySeries
   }
-  const chartWindowLabel = viewMode === 'daily'
-    ? dailyWindowLabel(dailyChartSeries)
-    : formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
-  const footerItems = [
-    `Source: Business Reports`,
-    `Scope: detail page retail`,
-    `ASINs: ${viewModel.selectedIds.length} / ${viewModel.allIds.length}`,
-    `Target ASIN: ${bundle.businessReports.meta.targetAsin}`,
-    `Chart window: ${chartWindowLabel}`,
-  ]
 
   return (
     <Stack spacing={2}>
       <WprAnalyticsPanel
-        footer={<WprAnalyticsFooter items={footerItems} />}
+        footer={null}
       >
         <BusinessReportsChart
           viewMode={viewMode}

--- a/apps/argus/components/wpr/tabs/scp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/scp-tab.tsx
@@ -1,11 +1,8 @@
 'use client'
 
 import { useEffect, type JSX } from 'react'
-import { Box, Button, Stack } from '@mui/material'
-import {
-  WprAnalyticsFooter,
-  WprAnalyticsPanel,
-} from '@/components/wpr/wpr-analytics-panel'
+import { Box, Stack } from '@mui/material'
+import { WprAnalyticsPanel } from '@/components/wpr/wpr-analytics-panel'
 import {
   CartesianGrid,
   Line,
@@ -21,18 +18,30 @@ import {
   RechartsChangeMarkers,
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
-import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprInlineChartLegend, type WprInlineChartLegendItem } from '@/components/wpr/wpr-inline-chart-legend'
 import type { WprScpWowVisible } from '@/lib/wpr/dashboard-state'
 import { createScpSelectionViewModel, type ScpSelectionViewModel } from '@/lib/wpr/scp-view-model'
-import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import {
   buildBundleWeekStartDateLookup,
   formatTooltipWeekLabelFromLookup,
-  formatWeekWindowLabel,
 } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import ScpSelectionTable from './scp-selection-table'
+
+type ScpSeriesKey = keyof WprScpWowVisible
+
+const SCP_WOW_SERIES: Array<{
+  key: ScpSeriesKey
+  label: string
+  color: string
+}> = [
+  { key: 'ctr', label: 'CTR', color: '#8fc7ff' },
+  { key: 'atc', label: 'ATC Rate', color: '#f5a623' },
+  { key: 'purch', label: 'Purch Rate', color: '#77dfd0' },
+  { key: 'cvr', label: 'CVR', color: '#d5ff62' },
+]
 
 function ScpWeeklyChart({
   weekly,
@@ -47,12 +56,17 @@ function ScpWeeklyChart({
   wowVisible: WprScpWowVisible
   setWowVisible: (nextState: WprScpWowVisible) => void
 }) {
-  const visibleSeries = [
-    wowVisible.ctr ? { key: 'ctr', label: 'CTR', color: '#8fc7ff' } : null,
-    wowVisible.atc ? { key: 'atc', label: 'ATC Rate', color: '#f5a623' } : null,
-    wowVisible.purch ? { key: 'purch', label: 'Purch Rate', color: '#77dfd0' } : null,
-    wowVisible.cvr ? { key: 'cvr', label: 'CVR', color: '#d5ff62' } : null,
-  ].filter((value): value is { key: 'ctr' | 'atc' | 'purch' | 'cvr'; label: string; color: string } => value !== null)
+  const visibleSeries = SCP_WOW_SERIES.filter((series) => wowVisible[series.key])
+  const legendItems: Array<WprInlineChartLegendItem<ScpSeriesKey>> = SCP_WOW_SERIES.map((series) => ({
+    ...series,
+    active: wowVisible[series.key],
+  }))
+  const toggleSeries = (seriesKey: ScpSeriesKey) => {
+    setWowVisible({
+      ...wowVisible,
+      [seriesKey]: !wowVisible[seriesKey],
+    })
+  }
   const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
   let chartBody: JSX.Element
   if (weekly.length === 0) {
@@ -70,127 +84,73 @@ function ScpWeeklyChart({
     }))
 
     chartBody = (
-      <Box sx={{ height: '100%' }}>
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
-            <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
-            <YAxis tick={{ fontSize: 10 }} tickFormatter={(value: number) => `${value.toFixed(0)}%`} />
-            <Tooltip
-              content={({ active, payload, label }) => (
-                <WprChangeTooltipContent
-                  active={active}
-                  payload={payload}
-                  label={label}
-                  labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
-                  changeMarker={changeMarkersByLabel.get(String(label))}
-                  formatRow={(entry) => {
-                    const key = entry.dataKey
-                    if (key === undefined) {
-                      throw new Error('Missing SCP tooltip data key')
-                    }
+      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+              <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
+              <YAxis tick={{ fontSize: 10 }} tickFormatter={(value: number) => `${value.toFixed(0)}%`} />
+              <Tooltip
+                content={({ active, payload, label }) => (
+                  <WprChangeTooltipContent
+                    active={active}
+                    payload={payload}
+                    label={label}
+                    labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
+                    changeMarker={changeMarkersByLabel.get(String(label))}
+                    formatRow={(entry) => {
+                      const key = entry.dataKey
+                      if (key === undefined) {
+                        throw new Error('Missing SCP tooltip data key')
+                      }
 
-                    const value = entry.value
-                    if (typeof value !== 'number') {
-                      throw new Error(`Invalid SCP tooltip value for ${String(key)}`)
-                    }
+                      const value = entry.value
+                      if (typeof value !== 'number') {
+                        throw new Error(`Invalid SCP tooltip value for ${String(key)}`)
+                      }
 
-                    const color = entry.color
-                    if (color === undefined) {
-                      throw new Error(`Missing SCP tooltip color for ${String(key)}`)
-                    }
+                      const color = entry.color
+                      if (color === undefined) {
+                        throw new Error(`Missing SCP tooltip color for ${String(key)}`)
+                      }
 
-                    let rowLabel = 'CVR'
-                    if (key === 'ctr') rowLabel = 'CTR'
-                    if (key === 'atc') rowLabel = 'ATC Rate'
-                    if (key === 'purch') rowLabel = 'Purch Rate'
+                      let rowLabel = 'CVR'
+                      if (key === 'ctr') rowLabel = 'CTR'
+                      if (key === 'atc') rowLabel = 'ATC Rate'
+                      if (key === 'purch') rowLabel = 'Purch Rate'
 
-                    return {
-                      label: rowLabel,
-                      value: `${value.toFixed(1)}%`,
-                      color,
-                    }
-                  }}
-                />
-              )}
-            />
-            <RechartsChangeMarkers markers={changeMarkers} />
-            {visibleSeries.map((series) => (
-              <Line
-                key={series.key}
-                type="monotone"
-                dataKey={series.key}
-                stroke={series.color}
-                strokeWidth={2.2}
-                dot={{ r: 2.5, strokeWidth: 0, fill: series.color }}
-                activeDot={{ r: 4 }}
+                      return {
+                        label: rowLabel,
+                        value: `${value.toFixed(1)}%`,
+                        color,
+                      }
+                    }}
+                  />
+                )}
               />
-            ))}
-          </LineChart>
-        </ResponsiveContainer>
+              <RechartsChangeMarkers markers={changeMarkers} />
+              {visibleSeries.map((series) => (
+                <Line
+                  key={series.key}
+                  type="monotone"
+                  dataKey={series.key}
+                  stroke={series.color}
+                  strokeWidth={2.2}
+                  dot={{ r: 2.5, strokeWidth: 0, fill: series.color }}
+                  activeDot={{ r: 4 }}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </Box>
+        <WprInlineChartLegend chartId="scp" items={legendItems} onToggle={toggleSeries} />
       </Box>
     )
   }
 
   return (
-    <WprChartShell
-      secondaryControls={
-        <WprChartControlGroup label="Metrics">
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                ctr: !wowVisible.ctr,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.ctr, '#8fc7ff')}
-          >
-            CTR
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                atc: !wowVisible.atc,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.atc, '#f5a623')}
-          >
-            ATC Rate
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                purch: !wowVisible.purch,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.purch, '#77dfd0')}
-          >
-            Purch Rate
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                cvr: !wowVisible.cvr,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.cvr, '#d5ff62')}
-          >
-            CVR
-          </Button>
-        </WprChartControlGroup>
-      }
-    >
+    <WprChartShell>
       {chartBody}
     </WprChartShell>
   )
@@ -275,19 +235,11 @@ export default function ScpTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const historyLabel = formatWeekWindowLabel(bundle.scp.meta.baselineWindow, weekStartDates)
-  const footerItems = [
-    `Source: SCP`,
-    `Scope: catalog search`,
-    `ASINs: ${viewModel.selectedIds.length} / ${viewModel.allIds.length}`,
-    `Target ASIN: ${bundle.scp.meta.targetAsin}`,
-    `Chart history: ${historyLabel}`,
-  ]
 
   return (
     <Stack spacing={2}>
       <WprAnalyticsPanel
-        footer={<WprAnalyticsFooter items={footerItems} />}
+        footer={null}
       >
         <ScpWeeklyChart
           weekly={viewModel.weekly}

--- a/apps/argus/components/wpr/tabs/sqp-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-selection-table.tsx
@@ -4,6 +4,7 @@ import { Fragment, type ReactNode } from 'react'
 import {
   Box,
   Checkbox,
+  IconButton,
   Stack,
   Table,
   TableBody,
@@ -13,12 +14,12 @@ import {
   TableSortLabel,
   Typography,
 } from '@mui/material'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import {
   WprSelectionPanel,
   wprSelectionHeaderCellSx,
   wprSelectionMetricCellSx,
 } from '@/components/wpr/wpr-selection-panel'
-import WprWeekSelect from '@/components/wpr/wpr-week-select'
 import type { WprSortState } from '@/lib/wpr/dashboard-state'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import {
@@ -31,6 +32,7 @@ import {
 } from '@/lib/wpr/sqp-view-model'
 import type { WprSortDirection } from '@/lib/wpr/dashboard-state'
 import type { WeekLabel } from '@/lib/wpr/types'
+import { formatWeekLabelFromLookup } from '@/lib/wpr/week-display'
 
 const SQP_COLUMNS: Array<{ key: SqpSortKey; label: string }> = [
   { key: 'term', label: 'Term' },
@@ -98,6 +100,65 @@ function formatRatio(value: number): string {
   return `${value.toFixed(2)}x`
 }
 
+function formatSqpSelectionSummary(viewModel: SqpSelectionViewModel): string {
+  const baseSummary = `${viewModel.selectedRootIds.length} roots · ${viewModel.selectedTermIds.length} selected`
+  const selectedQueryVolume = selectedSqpQueryVolume(viewModel)
+  const activeTermCount = activeSqpTermCount(viewModel)
+  if (selectedQueryVolume === null) {
+    return baseSummary
+  }
+
+  return `${baseSummary} · ${activeTermCount} active · Total SV ${formatCount(selectedQueryVolume)}`
+}
+
+function selectedSqpQueryVolume(viewModel: SqpSelectionViewModel): number | null {
+  if (viewModel.selectedTermIds.length === 0) {
+    if (viewModel.metrics === null) {
+      return null
+    }
+
+    return viewModel.metrics.query_volume
+  }
+
+  const countedTermIds = new Set<string>()
+  let queryVolume = 0
+  for (const rows of Object.values(viewModel.termRowsByRoot)) {
+    for (const row of rows) {
+      if (!row.checked) {
+        continue
+      }
+
+      if (countedTermIds.has(row.id)) {
+        continue
+      }
+
+      countedTermIds.add(row.id)
+      queryVolume += row.current.query_volume
+    }
+  }
+
+  return queryVolume
+}
+
+function activeSqpTermCount(viewModel: SqpSelectionViewModel): number {
+  const countedTermIds = new Set<string>()
+  for (const rows of Object.values(viewModel.termRowsByRoot)) {
+    for (const row of rows) {
+      if (!row.checked) {
+        continue
+      }
+
+      if (row.current.query_volume <= 0) {
+        continue
+      }
+
+      countedTermIds.add(row.id)
+    }
+  }
+
+  return countedTermIds.size
+}
+
 function MetricCell({
   children,
   align,
@@ -127,6 +188,109 @@ function nextSortDirection(current: WprSortState, key: SqpSortKey): WprSortDirec
   }
 
   return 'desc'
+}
+
+function SqpWeekStepper({
+  selectedWeek,
+  weeks,
+  weekStartDates,
+  onSelectWeek,
+}: {
+  selectedWeek: WeekLabel
+  weeks: WeekLabel[]
+  weekStartDates: Record<WeekLabel, string>
+  onSelectWeek: (week: WeekLabel) => void
+}) {
+  const selectedIndex = weeks.indexOf(selectedWeek)
+  if (selectedIndex < 0) {
+    throw new Error(`Selected SQP table week is not available: ${selectedWeek}`)
+  }
+
+  const previousWeek = selectedIndex > 0 ? weeks[selectedIndex - 1] : undefined
+  const nextWeek = selectedIndex < weeks.length - 1 ? weeks[selectedIndex + 1] : undefined
+  const selectedWeekLabel = formatWeekLabelFromLookup(selectedWeek, weekStartDates)
+
+  const handlePreviousWeek = () => {
+    if (previousWeek === undefined) {
+      throw new Error(`Missing previous SQP table week before ${selectedWeek}`)
+    }
+
+    onSelectWeek(previousWeek)
+  }
+
+  const handleNextWeek = () => {
+    if (nextWeek === undefined) {
+      throw new Error(`Missing next SQP table week after ${selectedWeek}`)
+    }
+
+    onSelectWeek(nextWeek)
+  }
+
+  const arrowButtonSx = {
+    width: 30,
+    height: 30,
+    border: '1px solid rgba(255,255,255,0.08)',
+    color: 'rgba(255,255,255,0.78)',
+    bgcolor: 'rgba(255,255,255,0.035)',
+    '&:hover': {
+      bgcolor: 'rgba(0,194,185,0.12)',
+      borderColor: 'rgba(0,194,185,0.32)',
+      color: 'rgba(255,255,255,0.94)',
+    },
+    '&.Mui-disabled': {
+      color: 'rgba(255,255,255,0.22)',
+      borderColor: 'rgba(255,255,255,0.04)',
+      bgcolor: 'rgba(255,255,255,0.02)',
+    },
+  }
+
+  return (
+    <Stack
+      direction="row"
+      alignItems="center"
+      spacing={0.75}
+      aria-label="SQP table week controls"
+      sx={{
+        px: 0.75,
+        py: 0.45,
+        border: '1px solid rgba(255,255,255,0.08)',
+        borderRadius: '10px',
+        bgcolor: 'rgba(255,255,255,0.03)',
+      }}
+    >
+      <IconButton
+        size="small"
+        aria-label="Previous table week"
+        disabled={previousWeek === undefined}
+        onClick={handlePreviousWeek}
+        sx={arrowButtonSx}
+      >
+        <ChevronLeft size={15} strokeWidth={2.4} />
+      </IconButton>
+      <Box
+        sx={{
+          minWidth: 166,
+          textAlign: 'center',
+          fontSize: '0.77rem',
+          lineHeight: 1.2,
+          fontWeight: 700,
+          color: 'rgba(255,255,255,0.9)',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {selectedWeekLabel}
+      </Box>
+      <IconButton
+        size="small"
+        aria-label="Next table week"
+        disabled={nextWeek === undefined}
+        onClick={handleNextWeek}
+        sx={arrowButtonSx}
+      >
+        <ChevronRight size={15} strokeWidth={2.4} />
+      </IconButton>
+    </Stack>
+  )
 }
 
 export default function SqpSelectionTable({
@@ -163,14 +327,27 @@ export default function SqpSelectionTable({
   const allTermsChecked = viewModel.isAllSelected && viewModel.allTermIds.length > 0
   const allTermsIndeterminate = viewModel.selectedTermIds.length > 0 && !viewModel.isAllSelected
   const sortKey = toSqpSortKey(sortState.key)
+  const groupRowsByFamily = sortKey === 'term'
+  const rootRowSections = groupRowsByFamily
+    ? familyOrder.map((family) => ({
+      family,
+      rows: sortSqpRootRows(
+        viewModel.rootRows.filter((row) => row.family === family),
+        sortKey,
+        sortState.dir,
+      ),
+    }))
+    : [{
+      family: null,
+      rows: sortSqpRootRows(viewModel.rootRows, sortKey, sortState.dir),
+    }]
 
   return (
     <WprSelectionPanel
       title="SQP Selection"
-      summary={`${viewModel.selectedRootIds.length} roots · ${viewModel.selectedTermIds.length} terms`}
+      summary={formatSqpSelectionSummary(viewModel)}
       toolbar={(
-        <WprWeekSelect
-          label="Table week"
+        <SqpWeekStepper
           selectedWeek={selectedWeek}
           weeks={weeks}
           weekStartDates={weekStartDates}
@@ -229,33 +406,33 @@ export default function SqpSelectionTable({
           </TableHead>
 
           <TableBody>
-            {familyOrder.map((family) => {
-              const familyRows = viewModel.rootRows.filter((row) => row.family === family)
-              const sortedFamilyRows = sortSqpRootRows(familyRows, sortKey, sortState.dir)
-              if (sortedFamilyRows.length === 0) {
+            {rootRowSections.map((section) => {
+              if (section.rows.length === 0) {
                 return null
               }
 
               return (
-                <Fragment key={family}>
-                  <TableRow>
-                    <TableCell
-                      colSpan={SQP_COLUMNS.length + 1}
-                      sx={{
-                        bgcolor: 'rgba(0,194,185,0.05)',
-                        color: '#00C2B9',
-                        fontSize: '0.62rem',
-                        fontWeight: 800,
-                        textTransform: 'uppercase',
-                        letterSpacing: '0.14em',
-                        borderBottom: '1px solid rgba(0,194,185,0.12)',
-                      }}
-                    >
-                      {family}
-                    </TableCell>
-                  </TableRow>
+                <Fragment key={section.family ?? 'all-roots'}>
+                  {section.family !== null ? (
+                    <TableRow>
+                      <TableCell
+                        colSpan={SQP_COLUMNS.length + 1}
+                        sx={{
+                          bgcolor: 'rgba(0,194,185,0.05)',
+                          color: '#00C2B9',
+                          fontSize: '0.62rem',
+                          fontWeight: 800,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.14em',
+                          borderBottom: '1px solid rgba(0,194,185,0.12)',
+                        }}
+                      >
+                        {section.family}
+                      </TableCell>
+                    </TableRow>
+                  ) : null}
 
-                  {sortedFamilyRows.map((row) => {
+                  {section.rows.map((row) => {
                     const rowIsExpanded = expandedRootIds.has(row.id)
                     const termRows = viewModel.termRowsByRoot[row.id]
                     if (termRows === undefined) {
@@ -323,7 +500,9 @@ export default function SqpSelectionTable({
                                   {row.label}
                                 </Typography>
                                 <Typography sx={{ fontSize: '0.66rem', color: 'rgba(255,255,255,0.58)' }}>
-                                  {`${row.selectedCount} / ${row.totalCount} terms selected`}
+                                  {groupRowsByFamily
+                                    ? `${row.selectedCount} / ${row.totalCount} terms selected`
+                                    : `${row.family} · ${row.selectedCount} / ${row.totalCount} terms selected`}
                                 </Typography>
                               </Stack>
                             </Box>

--- a/apps/argus/components/wpr/tabs/sqp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-tab.tsx
@@ -7,7 +7,7 @@ import {
   rootTermIds,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
-import { buildBundleWeekStartDateLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
+import { buildBundleWeekStartDateLookup } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import SqpSelectionTable from './sqp-selection-table'
 import SqpWeeklyPanel from './sqp-weekly-panel'
@@ -197,7 +197,6 @@ export default function SqpTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const historyLabel = formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
 
   const handleSetRootSelection = (rootId: string, shouldSelect: boolean) => {
     const nextRootIds = new Set(selectedSqpRootIds)
@@ -311,11 +310,6 @@ export default function SqpTab({
         changeEntries={changeEntries}
         wowVisible={sqpWowVisible}
         setWowVisible={setSqpWowVisible}
-        scopeType={viewModel.scopeType}
-        selectedRootCount={viewModel.selectedRootIds.length}
-        selectedTermCount={viewModel.selectedTermIds.length}
-        totalTermCount={viewModel.allTermIds.length}
-        historyLabel={historyLabel}
       />
 
       <SqpSelectionTable

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.test.tsx
@@ -20,6 +20,7 @@ const weekly: SqpWeeklyPoint[] = [
     week_number: 1,
     start_date: '2026-01-01',
     metrics: buildMetrics({
+      query_volume: 1000,
       impression_share: 0.08,
       asin_ctr: 0.12,
       market_ctr: 0.1,
@@ -34,6 +35,7 @@ const weekly: SqpWeeklyPoint[] = [
     week_number: 2,
     start_date: '2026-01-08',
     metrics: buildMetrics({
+      query_volume: 1300,
       impression_share: 0.12,
       asin_ctr: 0.15,
       market_ctr: 0.1,
@@ -76,16 +78,27 @@ const changeEntries: WprChangeLogEntry[] = [
   },
 ]
 
+const allSeriesVisible = {
+  impr: true,
+  ctr: true,
+  atc: true,
+  cvr: true,
+}
+
 test('SQP weekly chart renders hover tooltip content for the active week', () => {
   const markup = renderToStaticMarkup(
     <SqpWeeklySvg
       weekly={weekly}
       changeEntries={changeEntries}
       visibleSeries={SQP_WOW_SERIES}
+      seriesVisibility={allSeriesVisible}
+      qVolVisible={true}
       width={800}
       height={320}
       hoveredIndex={1}
       onHoverIndexChange={() => {}}
+      onToggleQVol={() => {}}
+      onToggleSeries={() => {}}
     />,
   )
 
@@ -101,6 +114,10 @@ test('SQP weekly chart renders hover tooltip content for the active week', () =>
   assert.match(markup, /Impr Share/)
   assert.match(markup, /CTR x/)
   assert.match(markup, /1\.50x/)
+  assert.match(markup, /Q Vol/)
+  assert.doesNotMatch(markup, /Q Vol WoW/)
+  assert.doesNotMatch(markup, /300 \/ \+30\.0%/)
+  assert.doesNotMatch(markup, /Q Vol Trend/)
 })
 
 test('SQP weekly chart omits hover tooltip markup when no week is active', () => {
@@ -109,24 +126,59 @@ test('SQP weekly chart omits hover tooltip markup when no week is active', () =>
       weekly={weekly}
       changeEntries={changeEntries}
       visibleSeries={SQP_WOW_SERIES}
+      seriesVisibility={allSeriesVisible}
+      qVolVisible={true}
       width={800}
       height={320}
       hoveredIndex={null}
       onHoverIndexChange={() => {}}
+      onToggleQVol={() => {}}
+      onToggleSeries={() => {}}
     />,
   )
 
   assert.doesNotMatch(markup, /data-hover-tooltip=\"sqp\"/)
   assert.doesNotMatch(markup, /W02 · 08 Jan - 14 Jan 26 · 2 changes/)
-  assert.doesNotMatch(markup, /Impr Share/)
+  assert.match(markup, /data-chart-legend=\"sqp\"/)
 })
 
-test('SQP weekly chart uses the shared shell with grouped metric controls only', () => {
+test('SQP weekly chart renders query volume as normalized line only', () => {
+  const markup = renderToStaticMarkup(
+    <SqpWeeklySvg
+      weekly={weekly}
+      changeEntries={changeEntries}
+      visibleSeries={SQP_WOW_SERIES}
+      seriesVisibility={allSeriesVisible}
+      qVolVisible={true}
+      width={800}
+      height={320}
+      hoveredIndex={null}
+      onHoverIndexChange={() => {}}
+      onToggleQVol={() => {}}
+      onToggleSeries={() => {}}
+    />,
+  )
+
+  assert.match(markup, /data-series=\"query-volume-line\"/)
+  assert.doesNotMatch(markup, /data-series=\"query-volume-bars\"/)
+  assert.doesNotMatch(markup, /data-qvol-summary=\"true\"/)
+  assert.doesNotMatch(markup, /Q Vol 1\.0k to 1\.3k \(\+30\.0%\)/)
+  assert.match(markup, /SQP normalized query volume line/)
+  assert.match(markup, /data-chart-legend=\"sqp\"/)
+  assert.match(markup, /data-legend-item=\"qvol\"/)
+  assert.match(markup, /data-active=\"true\"/)
+  assert.doesNotMatch(markup, /tabindex=/)
+  assert.doesNotMatch(markup, /aria-pressed=/)
+})
+
+test('SQP weekly chart keeps controls in the centered legend instead of separate metric buttons', () => {
   const source = readFileSync(new URL('./sqp-weekly-panel.tsx', import.meta.url), 'utf8')
 
   assert.match(source, /<WprChartShell/)
   assert.doesNotMatch(source, /<WprChartShell[^>]*title=/)
   assert.doesNotMatch(source, /<WprChartShell[^>]*description=/)
   assert.doesNotMatch(source, /<WprChartShell[^>]*changeSummary=/)
-  assert.match(source, /<WprChartControlGroup label="Metrics">/)
+  assert.doesNotMatch(source, /<WprChartControlGroup/)
+  assert.doesNotMatch(source, /<Button/)
+  assert.match(source, /data-chart-legend="sqp"/)
 })

--- a/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-weekly-panel.tsx
@@ -1,25 +1,19 @@
 'use client'
 
 import React, { useState, type JSX } from 'react'
-import { Button } from '@mui/material'
 import ResponsiveChartFrame from '@/components/charts/responsive-chart-frame'
-import {
-  WprAnalyticsFooter,
-  WprAnalyticsPanel,
-} from '@/components/wpr/wpr-analytics-panel'
+import { WprAnalyticsPanel } from '@/components/wpr/wpr-analytics-panel'
 import {
   buildChangeMarkerLabelParts,
   buildChangeMarkerLookup,
   buildWeeklyChangeMarkers,
 } from '@/components/wpr/chart-change-markers'
-import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
 import type { WprSqpWowVisible } from '@/lib/wpr/dashboard-state'
-import { chartToggleButtonSx } from '@/lib/wpr/panel-tokens'
 import { formatWprChangeCategory, getWprChangeCategoryColor } from '@/lib/wpr/change-log-categories'
 import { formatWeekLabelWithDateRange } from '@/lib/wpr/week-display'
 import {
   rateRatio,
-  type SqpSelectionScope,
   type SqpWeeklyPoint,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry } from '@/lib/wpr/types'
@@ -27,6 +21,7 @@ import type { WprChangeLogEntry } from '@/lib/wpr/types'
 type ChartPoint = {
   week_label: string
   start_date: string
+  query_volume: number
   impr_points: number
   ctr_adv: number
   atc_adv: number
@@ -44,6 +39,8 @@ type ChartSeriesMeta = {
   valueField: keyof Pick<ChartPoint, 'impr_points' | 'ctr_adv' | 'atc_adv' | 'cvr_adv'>
   ratioField?: keyof Pick<ChartPoint, 'ctr_ratio' | 'atc_ratio' | 'cvr_ratio'>
 }
+
+type SqpLegendKey = 'qvol' | ChartSeriesMeta['key']
 
 export const SQP_WOW_SERIES: ChartSeriesMeta[] = [
   { key: 'impr', label: 'Impr Share', color: '#8fc7ff', kind: 'points', valueField: 'impr_points' },
@@ -68,28 +65,16 @@ function formatPoints(value: number): string {
   return `${value.toFixed(1)} pts`
 }
 
-function buildFooterItems({
-  scopeType,
-  rootCount,
-  termCount,
-  totalTermCount,
-  historyLabel,
-}: {
-  scopeType: SqpSelectionScope
-  rootCount: number
-  termCount: number
-  totalTermCount: number
-  historyLabel: string
-}) {
-  const footerItems = [
-    `Source: SQP`,
-    `Scope: ${scopeType}`,
-    `Roots: ${rootCount}`,
-    `SQP terms: ${termCount} / ${totalTermCount}`,
-    `Chart history: ${historyLabel}`,
-  ]
+function formatCompactCount(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '–'
+  }
 
-  return footerItems
+  if (Math.abs(value) >= 1000) {
+    return `${(value / 1000).toFixed(1)}k`
+  }
+
+  return new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 }).format(value)
 }
 
 function buildRatioFillPolygons(
@@ -106,8 +91,11 @@ function buildRatioFillPolygons(
   for (let index = 0; index < points.length - 1; index += 1) {
     const current = points[index]
     const next = points[index + 1]
-    if (current === undefined || next === undefined) {
-      throw new Error(`Missing SQP weekly chart points for index ${index}`)
+    if (current === undefined) {
+      throw new Error(`Missing SQP weekly chart current point for index ${index}`)
+    }
+    if (next === undefined) {
+      throw new Error(`Missing SQP weekly chart next point for index ${index}`)
     }
 
     const currentValue = current[series.valueField]
@@ -169,21 +157,32 @@ export function SqpWeeklySvg({
   weekly,
   changeEntries,
   visibleSeries,
+  seriesVisibility,
+  qVolVisible,
   width,
   height,
   hoveredIndex,
   onHoverIndexChange,
+  onToggleQVol,
+  onToggleSeries,
 }: {
   weekly: SqpWeeklyPoint[]
   changeEntries: WprChangeLogEntry[]
   visibleSeries: ChartSeriesMeta[]
+  seriesVisibility: WprSqpWowVisible
+  qVolVisible: boolean
   width?: number
   height?: number
   hoveredIndex: number | null
   onHoverIndexChange: (index: number | null) => void
+  onToggleQVol: () => void
+  onToggleSeries: (seriesKey: keyof WprSqpWowVisible) => void
 }) {
-  if (width === undefined || height === undefined) {
-    throw new Error('Missing SQP weekly chart frame size')
+  if (width === undefined) {
+    throw new Error('Missing SQP weekly chart frame width')
+  }
+  if (height === undefined) {
+    throw new Error('Missing SQP weekly chart frame height')
   }
 
   const compactLayout = width < 640
@@ -191,14 +190,18 @@ export function SqpWeeklySvg({
   const margin = {
     top: 18,
     right: crampedLayout ? 44 : compactLayout ? 56 : 72,
-    bottom: 24,
+    bottom: crampedLayout ? 40 : 42,
     left: crampedLayout ? 20 : compactLayout ? 28 : 38,
   }
   const plotWidth = width - margin.left - margin.right
   const plotHeight = height - margin.top - margin.bottom
-  if (plotWidth <= 0 || plotHeight <= 0) {
-    throw new Error(`Invalid SQP weekly chart frame dimensions ${width}x${height}`)
+  if (plotWidth <= 0) {
+    throw new Error(`Invalid SQP weekly chart frame width ${width}`)
   }
+  if (plotHeight <= 0) {
+    throw new Error(`Invalid SQP weekly chart frame height ${height}`)
+  }
+  const plotBottomY = height - margin.bottom
 
   const changeMarkers = buildChangeMarkerLookup(buildWeeklyChangeMarkers(changeEntries))
   const points: ChartPoint[] = weekly.map((week) => {
@@ -209,6 +212,7 @@ export function SqpWeeklySvg({
     return {
       week_label: week.week_label,
       start_date: week.start_date,
+      query_volume: week.metrics.query_volume,
       impr_points: week.metrics.impression_share * 100,
       ctr_ratio: ctrRatio,
       atc_ratio: atcRatio,
@@ -252,10 +256,56 @@ export function SqpWeeklySvg({
     return margin.top + plotHeight - progress * plotHeight
   }
 
+  const minQueryVolume = Math.min(...points.map((point) => point.query_volume))
+  const maxQueryVolume = Math.max(...points.map((point) => point.query_volume))
+  const queryVolumeRange = maxQueryVolume - minQueryVolume
+  const queryVolumeYPosition = (value: number) => {
+    if (queryVolumeRange === 0) {
+      return margin.top + plotHeight / 2
+    }
+
+    const progress = (value - minQueryVolume) / queryVolumeRange
+    return margin.top + plotHeight - progress * plotHeight
+  }
+
   const markerFontSize = crampedLayout ? 7 : 8
   const valueFontSize = crampedLayout ? 8 : 9
   const weekFontSize = crampedLayout ? 8 : 9
+  const legendFontSize = crampedLayout ? 7 : 8
+  const legendY = height - (crampedLayout ? 6 : 7)
+  const weekLabelY = height - (crampedLayout ? 22 : 24)
+  const legendGap = crampedLayout ? 55 : compactLayout ? 70 : 86
+  const legendItemWidth = crampedLayout ? 47 : compactLayout ? 58 : 70
   const valueLabelX = width - margin.right + (crampedLayout ? 4 : 8)
+  const legendItems: Array<{
+    key: SqpLegendKey
+    label: string
+    color: string
+    dash: boolean
+    active: boolean
+  }> = [
+    { key: 'qvol', label: 'Q Vol', color: '#00c2b9', dash: true, active: qVolVisible },
+    ...SQP_WOW_SERIES.map((series) => ({
+      key: series.key,
+      label: series.label,
+      color: series.color,
+      dash: false,
+      active: seriesVisibility[series.key],
+    })),
+  ]
+  const legendTotalWidth = (legendItems.length - 1) * legendGap + legendItemWidth
+  let legendStartX = margin.left + (plotWidth - legendTotalWidth) / 2
+  if (legendStartX < margin.left) {
+    legendStartX = margin.left
+  }
+  const toggleLegendItem = (key: SqpLegendKey) => {
+    if (key === 'qvol') {
+      onToggleQVol()
+      return
+    }
+
+    onToggleSeries(key)
+  }
   let activeHoverIndex: number | null = null
   if (hoveredIndex !== null && hoveredIndex >= 0 && hoveredIndex < points.length) {
     activeHoverIndex = hoveredIndex
@@ -269,12 +319,27 @@ export function SqpWeeklySvg({
     }
 
     const hoveredMarker = changeMarkers.get(hoveredPoint.week_label)
-    const tooltipRows = visibleSeries.map((series) => ({
+    const tooltipRows: Array<{
+      key: string
+      label: string
+      color: string
+      value: string
+    }> = visibleSeries.map((series) => ({
       key: series.key,
       label: series.label,
       color: series.color,
       value: formatSeriesTooltipValue(hoveredPoint, series),
     }))
+    if (qVolVisible) {
+      tooltipRows.unshift(
+        {
+          key: 'query-volume',
+          label: 'Q Vol',
+          color: '#00c2b9',
+          value: formatCompactCount(hoveredPoint.query_volume),
+        },
+      )
+    }
     const tooltipLabelParts = buildChangeMarkerLabelParts(
       formatWeekLabelWithDateRange(hoveredPoint.week_label, hoveredPoint.start_date),
       hoveredMarker,
@@ -325,8 +390,8 @@ export function SqpWeeklySvg({
           x1={activeX}
           x2={activeX}
           y1={margin.top}
-          y2={height - margin.bottom}
-          stroke="rgba(255,255,255,0.22)"
+          y2={plotBottomY}
+          stroke="rgba(255,255,255,0.2)"
           strokeWidth="1.2"
           strokeDasharray="4 4"
         />
@@ -440,6 +505,16 @@ export function SqpWeeklySvg({
             strokeWidth="1.8"
           />
         ))}
+        {qVolVisible ? (
+          <circle
+            cx={activeX}
+            cy={queryVolumeYPosition(hoveredPoint.query_volume)}
+            r={4.2}
+            fill="#00c2b9"
+            stroke="#09100f"
+            strokeWidth="1.8"
+          />
+        ) : null}
       </g>
     )
   }
@@ -469,8 +544,8 @@ export function SqpWeeklySvg({
       <line
         x1={margin.left}
         x2={width - margin.right}
-        y1={height - margin.bottom}
-        y2={height - margin.bottom}
+        y1={plotBottomY}
+        y2={plotBottomY}
         stroke="rgba(255,255,255,0.08)"
         strokeWidth="1"
       />
@@ -489,8 +564,8 @@ export function SqpWeeklySvg({
               x1={xPosition(index)}
               x2={xPosition(index)}
               y1={margin.top}
-              y2={height - margin.bottom}
-              stroke="rgba(241,235,222,0.34)"
+              y2={plotBottomY}
+              stroke="rgba(241,235,222,0.24)"
               strokeWidth="1.2"
               strokeDasharray="3 5"
             />
@@ -553,13 +628,40 @@ export function SqpWeeklySvg({
         )
       })}
 
+      {qVolVisible ? (
+        <g data-series="query-volume-line" aria-label="SQP normalized query volume line">
+          <path
+            d={points
+              .map((point, index) => `${index === 0 ? 'M' : 'L'} ${xPosition(index).toFixed(1)} ${queryVolumeYPosition(point.query_volume).toFixed(1)}`)
+              .join(' ')}
+            fill="none"
+            stroke="#00c2b9"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeDasharray="6 5"
+          />
+          {points.map((point, index) => (
+            <circle
+              key={`qvol-line-${point.week_label}`}
+              cx={xPosition(index)}
+              cy={queryVolumeYPosition(point.query_volume)}
+              r={2.5}
+              fill="#00c2b9"
+              stroke="#09100f"
+              strokeWidth="1"
+            />
+          ))}
+        </g>
+      ) : null}
+
       {hoverTooltip}
 
       {weekly.map((week, index) => (
         <text
           key={week.week_label}
           x={xPosition(index)}
-          y={height - 6}
+          y={weekLabelY}
           fill={activeHoverIndex === index ? 'rgba(255,255,255,0.86)' : '#93a399'}
           fontSize={weekFontSize}
           fontWeight={activeHoverIndex === index ? '700' : '500'}
@@ -568,6 +670,49 @@ export function SqpWeeklySvg({
           {week.week_label}
         </text>
       ))}
+
+      <g data-chart-legend="sqp" aria-label="SQP chart legend">
+        {legendItems.map((item, index) => {
+          const x = legendStartX + index * legendGap
+          return (
+            <g
+              key={item.key}
+              transform={`translate(${x}, ${legendY})`}
+              aria-label={`${item.label} series`}
+              data-legend-item={item.key}
+              data-active={item.active ? 'true' : 'false'}
+              onMouseDown={(event) => {
+                event.preventDefault()
+              }}
+              onClick={() => {
+                toggleLegendItem(item.key)
+              }}
+              style={{ cursor: 'pointer' }}
+            >
+              <line
+                x1="0"
+                x2="15"
+                y1="-4"
+                y2="-4"
+                stroke={item.color}
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeDasharray={item.dash ? '5 4' : undefined}
+                opacity={item.active ? 1 : 0.28}
+              />
+              <text
+                x="20"
+                y="0"
+                fill={item.active ? 'rgba(255,255,255,0.68)' : 'rgba(255,255,255,0.34)'}
+                fontSize={legendFontSize}
+                fontWeight="600"
+              >
+                {item.label}
+              </text>
+            </g>
+          )
+        })}
+      </g>
 
       {points.map((point, index) => {
         const currentX = xPosition(index)
@@ -607,11 +752,12 @@ function SqpWeeklyChart({
   setWowVisible: (nextState: WprSqpWowVisible) => void
 }) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
+  const [qVolVisible, setQVolVisible] = useState(true)
   const visibleSeries = SQP_WOW_SERIES.filter((series) => wowVisible[series.key])
   let chartBody: JSX.Element
   if (weekly.length === 0) {
     chartBody = <WprChartEmptyState>No weekly SQP history for this selection.</WprChartEmptyState>
-  } else if (visibleSeries.length === 0) {
+  } else if (visibleSeries.length === 0 && !qVolVisible) {
     chartBody = <WprChartEmptyState>Turn on at least one series to view the SQP history chart.</WprChartEmptyState>
   } else {
     chartBody = (
@@ -620,36 +766,26 @@ function SqpWeeklyChart({
           weekly={weekly}
           changeEntries={changeEntries}
           visibleSeries={visibleSeries}
+          seriesVisibility={wowVisible}
+          qVolVisible={qVolVisible}
           hoveredIndex={hoveredIndex}
           onHoverIndexChange={setHoveredIndex}
+          onToggleQVol={() => {
+            setQVolVisible(!qVolVisible)
+          }}
+          onToggleSeries={(seriesKey) => {
+            setWowVisible({
+              ...wowVisible,
+              [seriesKey]: !wowVisible[seriesKey],
+            })
+          }}
         />
       </ResponsiveChartFrame>
     )
   }
 
   return (
-    <WprChartShell
-      secondaryControls={
-        <WprChartControlGroup label="Metrics">
-          {SQP_WOW_SERIES.map((series) => (
-            <Button
-              key={series.key}
-              size="small"
-              variant="outlined"
-              onClick={() => {
-                setWowVisible({
-                  ...wowVisible,
-                  [series.key]: !wowVisible[series.key],
-                })
-              }}
-              sx={chartToggleButtonSx(wowVisible[series.key], series.color)}
-            >
-              {series.label}
-            </Button>
-          ))}
-        </WprChartControlGroup>
-      }
-    >
+    <WprChartShell>
       {chartBody}
     </WprChartShell>
   )
@@ -660,33 +796,15 @@ export default function SqpWeeklyPanel({
   changeEntries,
   wowVisible,
   setWowVisible,
-  scopeType,
-  selectedRootCount,
-  selectedTermCount,
-  totalTermCount,
-  historyLabel,
 }: {
   weekly: SqpWeeklyPoint[]
   changeEntries: WprChangeLogEntry[]
   wowVisible: WprSqpWowVisible
   setWowVisible: (nextState: WprSqpWowVisible) => void
-  scopeType: SqpSelectionScope
-  selectedRootCount: number
-  selectedTermCount: number
-  totalTermCount: number
-  historyLabel: string
 }) {
-  const footerItems = buildFooterItems({
-    scopeType,
-    rootCount: selectedRootCount,
-    termCount: selectedTermCount,
-    totalTermCount,
-    historyLabel,
-  })
-
   return (
     <WprAnalyticsPanel
-      footer={<WprAnalyticsFooter items={footerItems} />}
+      footer={null}
     >
       <SqpWeeklyChart
         weekly={weekly}

--- a/apps/argus/components/wpr/tabs/tst-tab.tsx
+++ b/apps/argus/components/wpr/tabs/tst-tab.tsx
@@ -7,7 +7,7 @@ import {
   competitorRootTermIds,
   createTstViewModel,
 } from '@/lib/wpr/tst-view-model'
-import { buildBundleWeekStartDateLookup, formatWeekWindowLabel } from '@/lib/wpr/week-display'
+import { buildBundleWeekStartDateLookup } from '@/lib/wpr/week-display'
 import { useWprStore } from '@/stores/wpr-store'
 import TstSelectionTable from './tst-selection-table'
 import TstWeeklyPanel from './tst-weekly-panel'
@@ -109,7 +109,6 @@ export default function TstTab({
   }
 
   const weekStartDates = buildBundleWeekStartDateLookup(bundle)
-  const historyLabel = formatWeekWindowLabel(bundle.meta.baselineWindow, weekStartDates)
   const competitor = bundle.meta.competitor
 
   const handleSetRootSelection = (rootId: string, shouldSelect: boolean) => {
@@ -186,7 +185,6 @@ export default function TstTab({
       <TstWeeklyPanel
         viewModel={viewModel}
         changeEntries={changeEntries}
-        historyLabel={historyLabel}
         weekStartDates={weekStartDates}
         wowVisible={compWowVisible}
         setWowVisible={setCompWowVisible}

--- a/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
+++ b/apps/argus/components/wpr/tabs/tst-weekly-panel.tsx
@@ -1,11 +1,8 @@
 'use client'
 
 import type { JSX } from 'react'
-import { Box, Button } from '@mui/material'
-import {
-  WprAnalyticsFooter,
-  WprAnalyticsPanel,
-} from '@/components/wpr/wpr-analytics-panel'
+import { Box } from '@mui/material'
+import { WprAnalyticsPanel } from '@/components/wpr/wpr-analytics-panel'
 import {
   CartesianGrid,
   Line,
@@ -22,15 +19,23 @@ import {
   RechartsChangeMarkers,
   WprChangeTooltipContent,
 } from '@/components/wpr/chart-change-markers'
-import { WprChartControlGroup, WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprChartEmptyState, WprChartShell } from '@/components/wpr/wpr-chart-shell'
+import { WprInlineChartLegend, type WprInlineChartLegendItem } from '@/components/wpr/wpr-inline-chart-legend'
 import type { WprCompWowVisible } from '@/lib/wpr/dashboard-state'
 import type { TstSelectionViewModel } from '@/lib/wpr/tst-view-model'
 import type { WprChangeLogEntry } from '@/lib/wpr/types'
 import { formatTooltipWeekLabelFromLookup } from '@/lib/wpr/week-display'
-import {
-  chartToggleButtonSx,
-} from '@/lib/wpr/panel-tokens'
-import { formatPercent } from '@/lib/wpr/format'
+
+type TstSeriesKey = keyof WprCompWowVisible
+
+const TST_WOW_SERIES: Array<{
+  key: TstSeriesKey
+  label: string
+  color: string
+}> = [
+  { key: 'click', label: 'Click Gap', color: '#77dfd0' },
+  { key: 'purch', label: 'Purch Gap', color: '#d5ff62' },
+]
 
 function WeeklyGapChart({
   weekly,
@@ -49,6 +54,16 @@ function WeeklyGapChart({
     wowVisible.click ? { key: 'clickGap', label: 'Click Gap', color: '#77dfd0' } : null,
     wowVisible.purch ? { key: 'purchaseGap', label: 'Purch Gap', color: '#d5ff62' } : null,
   ].filter((value): value is { key: 'clickGap' | 'purchaseGap'; label: string; color: string } => value !== null)
+  const legendItems: Array<WprInlineChartLegendItem<TstSeriesKey>> = TST_WOW_SERIES.map((series) => ({
+    ...series,
+    active: wowVisible[series.key],
+  }))
+  const toggleSeries = (seriesKey: TstSeriesKey) => {
+    setWowVisible({
+      ...wowVisible,
+      [seriesKey]: !wowVisible[seriesKey],
+    })
+  }
   const changeMarkers = buildWeeklyChangeMarkers(changeEntries)
   let chartBody: JSX.Element
   if (weekly.length === 0) {
@@ -64,100 +79,72 @@ function WeeklyGapChart({
     }))
 
     chartBody = (
-      <Box sx={{ height: '100%' }}>
-        <ResponsiveContainer width="100%" height="100%">
-          <LineChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
-            <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
-            <YAxis
-              tick={{ fontSize: 10 }}
-              tickFormatter={(value: number) => `${value.toFixed(0)} pts`}
-            />
-            <ReferenceLine y={0} stroke="rgba(255,255,255,0.18)" strokeDasharray="4 4" />
-            <Tooltip
-              content={({ active, payload, label }) => (
-                <WprChangeTooltipContent
-                  active={active}
-                  payload={payload}
-                  label={label}
-                  labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
-                  changeMarker={changeMarkersByLabel.get(String(label))}
-                  formatRow={(entry) => {
-                    const key = entry.dataKey
-                    if (key === undefined) {
-                      throw new Error('Missing TST tooltip data key')
-                    }
-
-                    const value = entry.value
-                    if (typeof value !== 'number') {
-                      throw new Error(`Invalid TST tooltip value for ${String(key)}`)
-                    }
-
-                    const color = entry.color
-                    if (color === undefined) {
-                      throw new Error(`Missing TST tooltip color for ${String(key)}`)
-                    }
-
-                    return {
-                      label: key === 'clickGap' ? 'Click Gap' : 'Purch Gap',
-                      value: `${value.toFixed(1)} pts`,
-                      color,
-                    }
-                  }}
-                />
-              )}
-            />
-            <RechartsChangeMarkers markers={changeMarkers} />
-            {visibleSeries.map((series) => (
-              <Line
-                key={series.key}
-                type="monotone"
-                dataKey={series.key}
-                stroke={series.color}
-                strokeWidth={2.2}
-                dot={{ r: 2.5, strokeWidth: 0, fill: series.color }}
-                activeDot={{ r: 4 }}
+      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        <Box sx={{ flex: 1, minHeight: 0 }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={chartRows} margin={{ top: 12, right: 16, bottom: 0, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+              <XAxis dataKey="weekLabel" tick={{ fontSize: 10 }} />
+              <YAxis
+                tick={{ fontSize: 10 }}
+                tickFormatter={(value: number) => `${value.toFixed(0)} pts`}
               />
-            ))}
-          </LineChart>
-        </ResponsiveContainer>
+              <ReferenceLine y={0} stroke="rgba(255,255,255,0.18)" strokeDasharray="4 4" />
+              <Tooltip
+                content={({ active, payload, label }) => (
+                  <WprChangeTooltipContent
+                    active={active}
+                    payload={payload}
+                    label={label}
+                    labelText={formatTooltipWeekLabelFromLookup(label, weekStartDates)}
+                    changeMarker={changeMarkersByLabel.get(String(label))}
+                    formatRow={(entry) => {
+                      const key = entry.dataKey
+                      if (key === undefined) {
+                        throw new Error('Missing TST tooltip data key')
+                      }
+
+                      const value = entry.value
+                      if (typeof value !== 'number') {
+                        throw new Error(`Invalid TST tooltip value for ${String(key)}`)
+                      }
+
+                      const color = entry.color
+                      if (color === undefined) {
+                        throw new Error(`Missing TST tooltip color for ${String(key)}`)
+                      }
+
+                      return {
+                        label: key === 'clickGap' ? 'Click Gap' : 'Purch Gap',
+                        value: `${value.toFixed(1)} pts`,
+                        color,
+                      }
+                    }}
+                  />
+                )}
+              />
+              <RechartsChangeMarkers markers={changeMarkers} />
+              {visibleSeries.map((series) => (
+                <Line
+                  key={series.key}
+                  type="monotone"
+                  dataKey={series.key}
+                  stroke={series.color}
+                  strokeWidth={2.2}
+                  dot={{ r: 2.5, strokeWidth: 0, fill: series.color }}
+                  activeDot={{ r: 4 }}
+                />
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </Box>
+        <WprInlineChartLegend chartId="tst" items={legendItems} onToggle={toggleSeries} />
       </Box>
     )
   }
 
   return (
-    <WprChartShell
-      secondaryControls={
-        <WprChartControlGroup label="Metrics">
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                click: !wowVisible.click,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.click, '#77dfd0')}
-          >
-            Click Gap
-          </Button>
-          <Button
-            size="small"
-            variant="outlined"
-            onClick={() => {
-              setWowVisible({
-                ...wowVisible,
-                purch: !wowVisible.purch,
-              })
-            }}
-            sx={chartToggleButtonSx(wowVisible.purch, '#d5ff62')}
-          >
-            Purch Gap
-          </Button>
-        </WprChartControlGroup>
-      }
-    >
+    <WprChartShell>
       {chartBody}
     </WprChartShell>
   )
@@ -166,41 +153,19 @@ function WeeklyGapChart({
 export default function TstWeeklyPanel({
   viewModel,
   changeEntries,
-  historyLabel,
   weekStartDates,
   wowVisible,
   setWowVisible,
 }: {
   viewModel: TstSelectionViewModel
   changeEntries: WprChangeLogEntry[]
-  historyLabel: string
   weekStartDates: Record<string, string>
   wowVisible: WprCompWowVisible
   setWowVisible: (nextState: WprCompWowVisible) => void
 }) {
-  const current = viewModel.current
-
-  let footerItems = [
-    `Source: TST`,
-    `Scope: ${viewModel.scopeType}`,
-    `Roots: ${viewModel.rootIds.length}`,
-    `TST terms: ${viewModel.selectedTermIds.length} / ${viewModel.allTermIds.length}`,
-    `Chart history: ${historyLabel}`,
-  ]
-
-  if (current !== null && viewModel.scopeType !== 'empty' && viewModel.scopeType !== 'no-terms') {
-    footerItems = [
-      `Covered terms: ${current.coverage.terms_covered} / ${viewModel.allTermIds.length}`,
-      `Term-weeks: ${current.coverage.term_weeks_covered}`,
-      `TST rows capture: ${formatPercent(current.coverage.avg_click_pool_share, 1)} clicks`,
-      `TST rows capture: ${formatPercent(current.coverage.avg_purchase_pool_share, 1)} purchases`,
-      `Chart history: ${historyLabel}`,
-    ]
-  }
-
   return (
     <WprAnalyticsPanel
-      footer={<WprAnalyticsFooter items={footerItems} />}
+      footer={null}
     >
       <WeeklyGapChart
         weekly={viewModel.weekly}

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -18,7 +18,7 @@ test('dashboard shell loads weeks and the selected week bundle instead of the fu
   assert.match(shellSource, /useWprWeeksQuery/)
   assert.match(shellSource, /useWprWeekBundleQuery/)
   assert.match(shellSource, /useWprChangeLogWeekQuery/)
-  assert.match(shellSource, /useWprSourcesQuery\(activeTab === 'sources'\)/)
+  assert.match(shellSource, /useWprSourcesQuery\(market, activeTab === 'sources'\)/)
   assert.match(shellSource, /weekStartDates=\{weeksQuery\.data\.weekStartDates\}/)
 })
 
@@ -26,9 +26,9 @@ test('dashboard shell keeps chart bundles pinned to the default week while chang
   const shellSource = readFileSync(new URL('./wpr-dashboard-shell.tsx', import.meta.url), 'utf8')
 
   assert.match(shellSource, /const bundleWeek = weeksQuery\.data\?\.defaultWeek \?\? null/)
-  assert.match(shellSource, /useWprWeekBundleQuery\(bundleWeek, needsBundle\)/)
-  assert.match(shellSource, /useWprChangeLogWeekQuery\(bundleWeek, needsChartChangeEntries\)/)
-  assert.match(shellSource, /useWprChangeLogWeekQuery\(selectedWeek, activeTab === 'changelog'\)/)
+  assert.match(shellSource, /useWprWeekBundleQuery\(market, bundleWeek, needsBundle\)/)
+  assert.match(shellSource, /useWprChangeLogWeekQuery\(market, bundleWeek, needsChartChangeEntries\)/)
+  assert.match(shellSource, /useWprChangeLogWeekQuery\(market, selectedWeek, activeTab === 'changelog'\)/)
 })
 
 test('tst tab forwards change entries into the weekly panel', () => {
@@ -164,7 +164,7 @@ test('the sticky WPR top bar keeps tab navigation only', () => {
   assert.doesNotMatch(topBarSource, /onSelectWeek/)
 })
 
-test('selection tables own the shared week selector near the table header', () => {
+test('selection tables own table week controls near the table header', () => {
   const selectionPanelSource = readFileSync(new URL('./wpr-selection-panel.tsx', import.meta.url), 'utf8')
   const sqpSource = readFileSync(new URL('./tabs/sqp-selection-table.tsx', import.meta.url), 'utf8')
   const scpSource = readFileSync(new URL('./tabs/scp-selection-table.tsx', import.meta.url), 'utf8')
@@ -172,7 +172,8 @@ test('selection tables own the shared week selector near the table header', () =
   const tstSource = readFileSync(new URL('./tabs/tst-selection-table.tsx', import.meta.url), 'utf8')
 
   assert.match(selectionPanelSource, /toolbar\?: ReactNode/)
-  assert.match(sqpSource, /<WprWeekSelect/)
+  assert.match(sqpSource, /function SqpWeekStepper/)
+  assert.doesNotMatch(sqpSource, /<WprWeekSelect/)
   assert.match(scpSource, /<WprWeekSelect/)
   assert.match(brSource, /<WprWeekSelect/)
   assert.match(tstSource, /<WprWeekSelect/)

--- a/apps/argus/components/wpr/wpr-chart-shell.tsx
+++ b/apps/argus/components/wpr/wpr-chart-shell.tsx
@@ -70,17 +70,21 @@ export function WprChartShell({
   secondaryControls?: ReactNode
   children: ReactNode
 }) {
+  const hasControls = primaryControls !== undefined ? true : secondaryControls !== undefined
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1.5 }}>
-      <Box
-        sx={{
-          ...chartControlRailSx,
-          alignItems: 'flex-start',
-        }}
-      >
-        {primaryControls}
-        {secondaryControls}
-      </Box>
+      {hasControls ? (
+        <Box
+          sx={{
+            ...chartControlRailSx,
+            alignItems: 'flex-start',
+          }}
+        >
+          {primaryControls}
+          {secondaryControls}
+        </Box>
+      ) : null}
 
       <Box sx={chartViewportSx}>{children}</Box>
     </Box>

--- a/apps/argus/components/wpr/wpr-inline-chart-legend.tsx
+++ b/apps/argus/components/wpr/wpr-inline-chart-legend.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import { Box } from '@mui/material'
+
+export type WprInlineChartLegendItem<TKey extends string> = {
+  key: TKey
+  label: string
+  color: string
+  active: boolean
+  dash?: boolean
+}
+
+export function WprInlineChartLegend<TKey extends string>({
+  chartId,
+  items,
+  onToggle,
+}: {
+  chartId: string
+  items: Array<WprInlineChartLegendItem<TKey>>
+  onToggle: (key: TKey) => void
+}) {
+  return (
+    <Box
+      data-chart-legend={chartId}
+      aria-label={`${chartId} chart legend`}
+      sx={{
+        minHeight: 22,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: { xs: 1.2, sm: 1.75 },
+        flexWrap: 'wrap',
+        userSelect: 'none',
+      }}
+    >
+      {items.map((item) => (
+        <Box
+          key={item.key}
+          data-legend-item={item.key}
+          data-active={item.active ? 'true' : 'false'}
+          aria-label={`${item.label} series`}
+          onMouseDown={(event) => {
+            event.preventDefault()
+          }}
+          onClick={() => {
+            onToggle(item.key)
+          }}
+          sx={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 0.55,
+            cursor: 'pointer',
+            outline: 0,
+            color: item.active ? 'rgba(255,255,255,0.68)' : 'rgba(255,255,255,0.34)',
+            fontSize: '0.5rem',
+            fontWeight: 600,
+            lineHeight: 1,
+            whiteSpace: 'nowrap',
+          }}
+        >
+          <Box
+            component="span"
+            sx={{
+              width: 15,
+              borderTop: `2px solid ${item.color}`,
+              borderTopStyle: item.dash === true ? 'dashed' : 'solid',
+              borderRadius: 1,
+              opacity: item.active ? 1 : 0.28,
+            }}
+          />
+          <Box component="span">{item.label}</Box>
+        </Box>
+      ))}
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary
- normalizes SQP query volume into the same weekly line chart instead of the old bar/panel treatment
- replaces bulky chart metric buttons with a centered clickable inline legend across SQP/SCP/BR/TST
- adds SQP table context for selected terms, active terms, and total SV so W04-style spikes are traceable from the table

## Business logic note
- W04 total SV spike is explained by selected-term volume, not ingestion: selected terms total 169,269 SV with 84 active terms, led by Clear Tarp / tarp
- The chart now keeps Q Vol visible as a normal metric so volume-driven interpretation is visible beside Impr Share, CTR x, ATC x, and CVR x

## Verification
- pnpm --filter @targon/argus exec tsx lib/wpr/sqp-view-model.test.ts
- pnpm --filter @targon/argus exec tsx components/wpr/wpr-change-props.test.ts
- pnpm --filter @targon/argus exec tsx components/wpr/tabs/sqp-weekly-panel.test.tsx
- pnpm --filter @targon/argus type-check
- git diff --check
