### PR TITLE
fix(xplan): align workbook sheet structures

### DIFF
--- a/apps/xplan/app/[sheet]/page.tsx
+++ b/apps/xplan/app/[sheet]/page.tsx
@@ -28,7 +28,7 @@ import {
   type POProfitabilityData,
 } from '@/components/sheets/po-profitability-section';
 import type { OpsInputRow } from '@/components/sheets/custom-ops-planning-grid';
-import type { OpsBatchRow } from '@/components/sheets/custom-ops-cost-grid';
+import { CustomOpsCostGrid, type OpsBatchRow } from '@/components/sheets/custom-ops-cost-grid';
 import type { OpsTimelineRow } from '@/components/sheets/ops-planning-timeline';
 import type { PurchasePaymentRow } from '@/components/sheets/custom-purchase-payments-grid';
 import type {
@@ -107,6 +107,14 @@ import type { PlanningCalendar } from '@/lib/planning';
 import { weekLabelForWeekNumber, type PlanningWeekConfig } from '@/lib/calculations/planning-week';
 import { formatDateDisplay, toIsoDate } from '@/lib/utils/dates';
 import {
+  computeForecastWorkbookRow,
+  computePoFinanceWorkbookRow,
+  computePoTableWorkbookRow,
+  EXCEL_FORECAST_METRICS,
+  type ForecastWorkbookRow,
+  type PoTableWorkbookInput,
+} from '@/lib/calculations/workbook-parity';
+import {
   sellerboardReportTimeZoneForRegion,
   currencyForRegion,
   localeForRegion,
@@ -116,14 +124,14 @@ import {
 } from '@/lib/strategy-region';
 
 const SALES_METRICS = [
-  'stockStart',
+  'inbound',
+  'threePl',
+  'fba',
+  'fbaCoverWeeks',
+  'totalCoverWeeks',
   'actualSales',
   'forecastSales',
-  'systemForecastSales',
   'finalSales',
-  'finalSalesError',
-  'stockWeeks',
-  'stockEnd',
 ] as const;
 type SalesMetric = (typeof SALES_METRICS)[number];
 
@@ -161,6 +169,16 @@ function toNumberSafe(value: number | bigint | null | undefined): number {
   if (typeof value === 'bigint') return Number(value);
   const numeric = Number(value);
   return Number.isNaN(numeric) ? 0 : numeric;
+}
+
+function toOptionalNumber(
+  value: number | bigint | Prisma.Decimal | null | undefined,
+): number | null {
+  if (value == null) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'bigint') return Number(value);
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
 }
 
 function formatNumeric(value: number | null | undefined, fractionDigits = 2): string {
@@ -221,6 +239,8 @@ function serializePurchaseOrder(order: PurchaseOrderInput): PurchaseOrderSeriali
     quantity: Number(order.quantity ?? 0),
     poDate: serializeDate(order.poDate),
     poWeekNumber: order.poWeekNumber ?? null,
+    poClass: order.poClass ?? null,
+    inboundWeekOverride: serializeDate(order.inboundWeekOverride),
     productionWeeks: order.productionWeeks ?? null,
     sourceWeeks: order.sourceWeeks ?? null,
     oceanWeeks: order.oceanWeeks ?? null,
@@ -289,6 +309,11 @@ function serializePurchaseOrder(order: PurchaseOrderInput): PurchaseOrderSeriali
         overrideFbaFee: batch.overrideFbaFee ?? null,
         overrideReferralRate: batch.overrideReferralRate ?? null,
         overrideStoragePerMonth: batch.overrideStoragePerMonth ?? null,
+        cartonSide1Cm: batch.cartonSide1Cm ?? null,
+        cartonSide2Cm: batch.cartonSide2Cm ?? null,
+        cartonSide3Cm: batch.cartonSide3Cm ?? null,
+        cartonWeightKg: batch.cartonWeightKg ?? null,
+        unitsPerCarton: batch.unitsPerCarton ?? null,
       })) ?? [],
   };
 }
@@ -625,38 +650,32 @@ function columnKey(productIndex: number, metric: SalesMetric) {
 
 function metricHeader(metric: SalesMetric): NestedHeaderCell {
   switch (metric) {
-    case 'stockStart':
-      return 'Stock Start';
+    case 'inbound':
+      return EXCEL_FORECAST_METRICS[0];
+    case 'threePl':
+      return EXCEL_FORECAST_METRICS[1];
+    case 'fba':
+      return EXCEL_FORECAST_METRICS[2];
+    case 'fbaCoverWeeks':
+      return EXCEL_FORECAST_METRICS[3];
+    case 'totalCoverWeeks':
+      return EXCEL_FORECAST_METRICS[4];
     case 'actualSales':
-      return 'Actual';
+      return EXCEL_FORECAST_METRICS[5];
     case 'forecastSales':
-      return 'Planner';
-    case 'systemForecastSales':
-      return 'System';
+      return EXCEL_FORECAST_METRICS[6];
     case 'finalSales':
-      return {
-        label: 'Demand',
-        title: 'Demand precedence: Override (if set) → Actual → Planner → System.',
-      };
-    case 'finalSalesError':
-      return {
-        label: '% Error',
-        title: 'Percent error between actual and forecast sales when both values are present.',
-      };
-    case 'stockWeeks':
-      return {
-        label: 'Cover (w)',
-        title:
-          'Cover (weeks) = projected Stock Start ÷ projected Demand (higher is safer). ∞ means Demand is 0 for that week.',
-      };
-    case 'stockEnd':
-      return 'Stock Qty';
+      return EXCEL_FORECAST_METRICS[7];
     default:
       return metric;
   }
 }
 
-async function getProductSetupView(strategyId: string) {
+async function getProductSetupView(
+  strategyId: string,
+  activeYear: number,
+  strategyRegion: StrategyRegion,
+) {
   const prismaAny = prisma as unknown as Record<string, unknown>;
   const productDelegate = prismaAny.product as
     | { findMany: (args?: unknown) => Promise<Product[]> }
@@ -676,8 +695,22 @@ async function getProductSetupView(strategyId: string) {
         findMany: (args?: unknown) => Promise<LeadTimeOverride[]>;
       }
     | undefined;
+  const productSetupYearDelegate = prismaAny.productSetupYear as
+    | {
+        findMany: (args?: unknown) => Promise<
+          Array<{
+            productId: string;
+            openingStock: number | Prisma.Decimal | null;
+            nextYearOpeningOverride: number | Prisma.Decimal | null;
+            notes: string | null;
+            totalCoverThresholdWeeks: number | Prisma.Decimal | null;
+            fbaCoverThresholdWeeks: number | Prisma.Decimal | null;
+          }>
+        >;
+      }
+    | undefined;
 
-  const [products, businessParameters, leadStages, leadOverrides] = await Promise.all([
+  const [products, businessParameters, leadStages, leadOverrides, setupYears] = await Promise.all([
     safeFindMany<Product[]>(
       productDelegate,
       { where: { strategyId }, orderBy: { name: 'asc' } },
@@ -701,6 +734,12 @@ async function getProductSetupView(strategyId: string) {
       { where: { product: { strategyId } } },
       [],
       'leadTimeOverride',
+    ),
+    safeFindMany(
+      productSetupYearDelegate,
+      { where: { strategyId, year: activeYear } },
+      [],
+      'productSetupYear',
     ),
   ]);
 
@@ -765,6 +804,30 @@ async function getProductSetupView(strategyId: string) {
       name: product.name,
     }));
 
+  const setupByProductId = new Map(setupYears.map((row) => [row.productId, row]));
+  const workbookSetupRows = productRows.map((product) => {
+    const setupRow = setupByProductId.get(product.id);
+    return {
+      productId: product.id,
+      sku: product.sku,
+      openingStock: formatNumeric(toOptionalNumber(setupRow?.openingStock ?? null), 0),
+      nextYearOpeningOverride: formatNumeric(
+        toOptionalNumber(setupRow?.nextYearOpeningOverride ?? null),
+        0,
+      ),
+      notes: setupRow?.notes ?? '',
+      region: strategyRegion,
+      totalCoverThresholdWeeks: formatNumeric(
+        toOptionalNumber(setupRow?.totalCoverThresholdWeeks ?? null),
+        2,
+      ),
+      fbaCoverThresholdWeeks: formatNumeric(
+        toOptionalNumber(setupRow?.fbaCoverThresholdWeeks ?? null),
+        2,
+      ),
+    };
+  });
+
   const leadStageTemplateViews = mapLeadStageTemplates(leadStages).map((stage) => ({
     id: stage.id,
     label: stage.label,
@@ -790,6 +853,7 @@ async function getProductSetupView(strategyId: string) {
 
   return {
     products: productRows,
+    workbookSetupRows,
     operationsParameters,
     salesParameters,
     financeParameters,
@@ -1326,8 +1390,22 @@ async function loadFinancialData(planning: PlanningCalendar, strategyId: string,
         findMany: (args?: unknown) => Promise<SalesWeekFinancialsRow[]>;
       }
     | undefined;
+  const productSetupYearDelegate = prismaAny.productSetupYear as
+    | {
+        findMany: (args?: unknown) => Promise<
+          Array<{
+            productId: string;
+            year: number;
+            openingStock: number | Prisma.Decimal | null;
+            totalCoverThresholdWeeks: number | Prisma.Decimal | null;
+            fbaCoverThresholdWeeks: number | Prisma.Decimal | null;
+          }>
+        >;
+      }
+    | undefined;
 
-  const [operations, salesRows, profitOverrideRows, cashOverrideRows] = await Promise.all([
+  const [operations, salesRows, profitOverrideRows, cashOverrideRows, productSetupYears] =
+    await Promise.all([
     loadOperationsContext(strategyId, planning.calendar),
     safeFindMany<SalesWeek[]>(
       salesDelegate,
@@ -1346,6 +1424,12 @@ async function loadFinancialData(planning: PlanningCalendar, strategyId: string,
       { where: { strategyId }, orderBy: { weekNumber: 'asc' } },
       [],
       'cashFlowWeek',
+    ),
+    safeFindMany(
+      productSetupYearDelegate,
+      { where: { strategyId } },
+      [],
+      'productSetupYear',
     ),
   ]);
 
@@ -1411,6 +1495,7 @@ async function loadFinancialData(planning: PlanningCalendar, strategyId: string,
     derivedOrders,
     salesOverrides,
     profitOverrides,
+    productSetupYears,
     salesPlan,
     actualFinancials,
     profit,
@@ -1446,35 +1531,78 @@ async function getOpsPlanningView(
   const visibleOrders = derivedOrders;
   const visibleOrderIds = new Set(visibleOrders.map((item) => item.derived.id));
 
-  const inputRows: OpsInputRow[] = visibleOrders.map(({ input, derived, productName }) => ({
-    id: input.id,
-    productId: input.productId,
-    orderCode: input.orderCode,
-    poDate: formatDate(input.poDate ?? null),
-    productionStart: toIsoDate(input.productionStart ?? null) ?? '',
-    productionComplete: toIsoDate(input.productionComplete ?? null) ?? '',
-    sourceDeparture: toIsoDate(input.sourceDeparture ?? null) ?? '',
-    portEta: toIsoDate(input.portEta ?? null) ?? '',
-    availableDate: toIsoDate(input.availableDate ?? null) ?? '',
-    productName,
-    shipName: input.shipName ?? '',
-    containerNumber: input.containerNumber ?? input.transportReference ?? '',
-    quantity: formatNumeric(input.quantity ?? null, 0),
-    pay1Date: formatDate(input.pay1Date ?? null),
-    productionWeeks: formatNumeric(derived.stageProfile.productionWeeks),
-    sourceWeeks: formatNumeric(derived.stageProfile.sourceWeeks),
-    oceanWeeks: formatNumeric(derived.stageProfile.oceanWeeks),
-    finalWeeks: formatNumeric(derived.stageProfile.finalWeeks),
-    sellingPrice: formatNumeric(input.overrideSellingPrice ?? null),
-    manufacturingCost: formatNumeric(input.overrideManufacturingCost ?? null),
-    freightCost: formatNumeric(input.overrideFreightCost ?? null),
-    tariffRate: formatPercentDecimal(input.overrideTariffRate ?? null),
-    tacosPercent: formatPercentDecimal(input.overrideTacosPercent ?? null),
-    fbaFee: formatNumeric(input.overrideFbaFee ?? null),
-    referralRate: formatPercentDecimal(input.overrideReferralRate ?? null),
-    storagePerMonth: formatNumeric(input.overrideStoragePerMonth ?? null),
-    status: input.status,
-  }));
+  const poWorkbookInputs: PoTableWorkbookInput[] = visibleOrders.map(({ input, derived }) => {
+    const primaryBatch = input.batchTableRows?.[0] ?? null;
+    const totalStageWeeks =
+      derived.stageProfile.productionWeeks +
+      derived.stageProfile.sourceWeeks +
+      derived.stageProfile.oceanWeeks +
+      derived.stageProfile.finalWeeks;
+    return {
+      orderCode: input.orderCode,
+      product: context.productNameById.get(primaryBatch?.productId ?? input.productId) ?? '',
+      quantity: input.quantity,
+      unitsPerCarton: primaryBatch?.unitsPerCarton ?? null,
+      cartonLengthCm: primaryBatch?.cartonSide1Cm ?? null,
+      cartonWidthCm: primaryBatch?.cartonSide2Cm ?? null,
+      cartonHeightCm: primaryBatch?.cartonSide3Cm ?? null,
+      mfgStart: derived.productionStart,
+      arrivalWeeks: derived.stageProfile.oceanWeeks,
+      warehouseWeeks: totalStageWeeks,
+      inboundWeekOverride: input.inboundWeekOverride ?? null,
+      region: strategyRegion,
+    };
+  });
+
+  const inputRows: OpsInputRow[] = visibleOrders.map(({ input, derived, productName }, index) => {
+    const primaryBatch = input.batchTableRows?.[0] ?? null;
+    const workbookInput = poWorkbookInputs[index];
+    const workbookRow = workbookInput
+      ? computePoTableWorkbookRow(workbookInput, poWorkbookInputs, index)
+      : null;
+    return {
+      id: input.id,
+      productId: input.productId,
+      orderCode: input.orderCode,
+      poDate: formatDate(input.poDate ?? null),
+      poClass: input.poClass ?? '',
+      productionStart: toIsoDate(input.productionStart ?? derived.productionStart ?? null) ?? '',
+      productionComplete: toIsoDate(input.productionComplete ?? null) ?? '',
+      sourceDeparture: toIsoDate(input.sourceDeparture ?? null) ?? '',
+      portEta: toIsoDate(input.portEta ?? null) ?? '',
+      availableDate: toIsoDate(input.availableDate ?? null) ?? '',
+      inboundWeekOverride: toIsoDate(input.inboundWeekOverride ?? null) ?? '',
+      inboundWeek: toIsoDate(workbookRow?.inboundWeek ?? derived.availableDate ?? null) ?? '',
+      productName,
+      shipName: input.shipName ?? '',
+      containerNumber: input.containerNumber ?? input.transportReference ?? '',
+      quantity: formatNumeric(input.quantity ?? null, 0),
+      unitsPerCarton: formatNumeric(primaryBatch?.unitsPerCarton ?? null, 0),
+      carton: formatNumeric(workbookRow?.carton ?? null, 0),
+      cartonSide1Cm: formatNumeric(primaryBatch?.cartonSide1Cm ?? null, 2),
+      cartonSide2Cm: formatNumeric(primaryBatch?.cartonSide2Cm ?? null, 2),
+      cartonSide3Cm: formatNumeric(primaryBatch?.cartonSide3Cm ?? null, 2),
+      cbm: formatNumeric(workbookRow?.cbm ?? null, 3),
+      poTotalQty: formatNumeric(workbookRow?.poTotalQty ?? null, 0),
+      poFirstRow: formatNumeric(workbookRow?.poFirstRow ?? null, 0),
+      notes: input.notes ?? '',
+      region: strategyRegion,
+      pay1Date: formatDate(input.pay1Date ?? null),
+      productionWeeks: formatNumeric(derived.stageProfile.productionWeeks),
+      sourceWeeks: formatNumeric(derived.stageProfile.sourceWeeks),
+      oceanWeeks: formatNumeric(derived.stageProfile.oceanWeeks),
+      finalWeeks: formatNumeric(derived.stageProfile.finalWeeks),
+      sellingPrice: formatNumeric(input.overrideSellingPrice ?? null),
+      manufacturingCost: formatNumeric(input.overrideManufacturingCost ?? null),
+      freightCost: formatNumeric(input.overrideFreightCost ?? null),
+      tariffRate: formatPercentDecimal(input.overrideTariffRate ?? null),
+      tacosPercent: formatPercentDecimal(input.overrideTacosPercent ?? null),
+      fbaFee: formatNumeric(input.overrideFbaFee ?? null),
+      referralRate: formatPercentDecimal(input.overrideReferralRate ?? null),
+      storagePerMonth: formatNumeric(input.overrideStoragePerMonth ?? null),
+      status: input.status,
+    };
+  });
 
   const timelineRows: OpsTimelineRow[] = visibleOrders.map(({ derived, productName }) => ({
     id: derived.id,
@@ -1582,6 +1710,54 @@ async function getOpsPlanningView(
     }),
   );
 
+  const poFinanceLookupRows = rawPurchaseOrders
+    .filter((order) => visibleOrderIds.has(order.id))
+    .flatMap((order) => {
+      const derived = derivedByOrderId.get(order.id);
+      const batches = Array.isArray(order.batchTableRows) ? order.batchTableRows : [];
+      return batches.map((batch) => {
+        const totalStageWeeks = derived
+          ? derived.stageProfile.productionWeeks +
+            derived.stageProfile.sourceWeeks +
+            derived.stageProfile.oceanWeeks +
+            derived.stageProfile.finalWeeks
+          : null;
+        return {
+          orderCode: order.orderCode,
+          product: context.productNameById.get(batch.productId) ?? '',
+          quantity: toOptionalNumber(batch.quantity),
+          unitsPerCarton: toOptionalNumber(
+            (batch as BatchTableRow & { unitsPerCarton?: number | null }).unitsPerCarton ?? null,
+          ),
+          cartonLengthCm: toOptionalNumber(
+            (batch as BatchTableRow & { cartonSide1Cm?: Prisma.Decimal | number | null })
+              .cartonSide1Cm ?? null,
+          ),
+          cartonWidthCm: toOptionalNumber(
+            (batch as BatchTableRow & { cartonSide2Cm?: Prisma.Decimal | number | null })
+              .cartonSide2Cm ?? null,
+          ),
+          cartonHeightCm: toOptionalNumber(
+            (batch as BatchTableRow & { cartonSide3Cm?: Prisma.Decimal | number | null })
+              .cartonSide3Cm ?? null,
+          ),
+          mfgStart: derived?.productionStart ?? order.productionStart ?? null,
+          arrivalWeeks: derived?.stageProfile.oceanWeeks ?? null,
+          warehouseWeeks: totalStageWeeks,
+          inboundWeekOverride:
+            (order as PurchaseOrder & { inboundWeekOverride?: Date | null })
+              .inboundWeekOverride ?? null,
+          region: strategyRegion,
+        } satisfies PoTableWorkbookInput;
+      });
+    });
+  const poFinanceLookupDerived = poFinanceLookupRows.map((row, index) => ({
+    orderCode: row.orderCode,
+    product: row.product,
+    region: row.region,
+    carton: computePoTableWorkbookRow(row, poFinanceLookupRows, index).carton,
+  }));
+
   const batchRows = rawPurchaseOrders
     .filter((order) => visibleOrderIds.has(order.id))
     .flatMap((order) => {
@@ -1593,6 +1769,24 @@ async function getOpsPlanningView(
         batchCode: batch.batchCode ?? undefined,
         productId: batch.productId,
         productName: context.productNameById.get(batch.productId) ?? '',
+        carton: formatNumeric(
+          computePoFinanceWorkbookRow({
+            orderCode: order.orderCode,
+            product: context.productNameById.get(batch.productId) ?? '',
+            region: strategyRegion,
+            poTableRows: poFinanceLookupDerived,
+            sellPrice: null,
+            manufacturingCost: null,
+            freightCost: null,
+            tariffCost: null,
+            tacosPercent: null,
+            fbaFee: null,
+            referralPercent: null,
+            storageCost: null,
+          }).carton,
+          0,
+        ),
+        region: strategyRegion,
         quantity: formatNumeric(toNumberSafe(batch.quantity), 0),
         sellingPrice: formatNumeric(
           batch.overrideSellingPrice ?? order.overrideSellingPrice ?? null,
@@ -1818,9 +2012,9 @@ function getSalesPlanningView(
   const nestedHeaders: NestedHeaderCell[][] = hasProducts
     ? [
         ['', '', ''],
-        ['Week', 'Date', 'Inbound PO'],
+        ['WEEK', 'DATE', 'Notes'],
       ]
-    : [['Week', 'Date', 'Inbound PO']];
+    : [['WEEK', 'DATE', 'Notes']];
 
   productList.forEach((product, productIdx) => {
     nestedHeaders[0].push({ label: productLabel(product), colspan: SALES_METRICS.length });
@@ -1849,6 +2043,13 @@ function getSalesPlanningView(
   }
 
   const currentWeekNumber = weekNumberForDate(asOfDate, planning.calendar);
+  const setupYear = activeSegment?.year ?? null;
+  const setupByProductId = new Map(
+    financialData.productSetupYears
+      .filter((row) => setupYear == null || row.year === setupYear)
+      .map((row) => [row.productId, row]),
+  );
+  const previousForecastByProductId = new Map<string, ForecastWorkbookRow>();
 
   const segmentForWeek = (weekNumber: number): YearSegment | null => {
     if (!planning.yearSegments.length) return null;
@@ -1900,45 +2101,57 @@ function getSalesPlanningView(
         row[`p${productIdx}_hasInbound`] = 'true';
       }
       row[`p${productIdx}_arrivals`] = formatNumeric(derived?.arrivals ?? null, 0);
+      const setupRow = setupByProductId.get(product.id);
+      const forecastRow = computeForecastWorkbookRow({
+        openingStock: toOptionalNumber(setupRow?.openingStock ?? null),
+        inbound: derived?.arrivals ?? null,
+        actual: derived?.actualSales ?? null,
+        planner: derived?.forecastSales ?? null,
+        final: derived?.finalSales ?? null,
+        previous: previousForecastByProductId.get(product.id) ?? null,
+      });
+      previousForecastByProductId.set(product.id, forecastRow);
 
       SALES_METRICS.forEach((metric) => {
         const key = columnKey(productIdx, metric);
         switch (metric) {
-          case 'stockStart':
-            row[key] = formatNumeric(derived?.stockStart ?? null, 0);
+          case 'inbound':
+            row[key] = formatNumeric(forecastRow.inbound, 0);
+            break;
+          case 'threePl':
+            row[key] = formatNumeric(forecastRow.threePl, 0);
+            break;
+          case 'fba':
+            row[key] = formatNumeric(forecastRow.fba, 0);
+            break;
+          case 'fbaCoverWeeks':
+            if (!Number.isFinite(forecastRow.fbaCoverWeeks)) {
+              row[key] = '∞';
+            } else {
+              row[key] = formatNumeric(forecastRow.fbaCoverWeeks, 2);
+            }
+            break;
+          case 'totalCoverWeeks':
+            if (!Number.isFinite(forecastRow.totalCoverWeeks)) {
+              row[key] = '∞';
+            } else {
+              row[key] = formatNumeric(forecastRow.totalCoverWeeks, 2);
+            }
             break;
           case 'actualSales':
-            row[key] = formatNumeric(derived?.actualSales ?? null, 0);
+            row[key] = formatNumeric(forecastRow.actual, 0);
             break;
           case 'forecastSales':
-            row[key] = formatNumeric(derived?.forecastSales ?? null, 0);
-            break;
-          case 'systemForecastSales':
-            row[key] = formatNumeric(derived?.systemForecastSales ?? null, 0);
+            row[key] = formatNumeric(forecastRow.planner, 0);
             break;
           case 'finalSales':
-            row[key] = formatNumeric(derived?.finalSales ?? null, 0);
+            row[key] = formatNumeric(forecastRow.final, 0);
             if (derived?.finalSalesSource) {
               row[`p${productIdx}_finalSalesSource`] = derived.finalSalesSource;
             }
             if (derived?.systemForecastVersion) {
               row[`p${productIdx}_systemForecastVersion`] = derived.systemForecastVersion;
             }
-            break;
-          case 'finalSalesError':
-            row[key] = formatPercent(derived?.finalPercentError ?? null, 1);
-            break;
-          case 'stockWeeks':
-            if (derived?.stockWeeks == null) {
-              row[key] = '';
-            } else if (!Number.isFinite(derived.stockWeeks)) {
-              row[key] = '∞';
-            } else {
-              row[key] = formatNumeric(derived.stockWeeks, 2);
-            }
-            break;
-          case 'stockEnd':
-            row[key] = formatNumeric(derived?.stockEnd ?? null, 0);
             break;
           default:
             break;
@@ -2542,8 +2755,21 @@ export default async function SheetPage({ params, searchParams }: SheetPageProps
       const allStrategyIds = strategies.map((s) => s.id);
       const [productSetupView, keyParametersByStrategyId] = await Promise.all([
         strategyId
-          ? getProductSetupView(strategyId)
-          : Promise.resolve({ products: [], operationsParameters: [], salesParameters: [], financeParameters: [], leadStageTemplates: [], leadTimeProfiles: {}, leadTimeOverrideIds: [] }),
+          ? getProductSetupView(
+              strategyId,
+              activeYear ?? new Date().getUTCFullYear(),
+              strategyRegion,
+            )
+          : Promise.resolve({
+              products: [],
+              workbookSetupRows: [],
+              operationsParameters: [],
+              salesParameters: [],
+              financeParameters: [],
+              leadStageTemplates: [],
+              leadTimeProfiles: {},
+              leadTimeOverrideIds: [],
+            }),
         getKeyParametersForAllStrategies(allStrategyIds),
       ]);
 
@@ -2552,7 +2778,9 @@ export default async function SheetPage({ params, searchParams }: SheetPageProps
           strategies={strategies}
           activeStrategyId={resolvedStrategyId}
           viewer={viewer}
+          activeYear={activeYear ?? new Date().getUTCFullYear()}
           products={productSetupView.products}
+          workbookSetupRows={productSetupView.workbookSetupRows}
           operationsParameters={productSetupView.operationsParameters}
           salesParameters={productSetupView.salesParameters}
           financeParameters={productSetupView.financeParameters}
@@ -2748,7 +2976,28 @@ export default async function SheetPage({ params, searchParams }: SheetPageProps
       );
       break;
     }
-    case '6-po-profitability': {
+    case '6-po-finances': {
+      const activeStrategyId = requireStrategyId();
+      const view = await getOpsPlanningView(
+        activeStrategyId,
+        strategyRegion,
+        planningCalendar,
+        activeSegment,
+      );
+      const productOptions = view.calculator.products
+        .map((product) => ({ id: product.id, name: productLabel(product) }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+      tabularContent = (
+        <CustomOpsCostGrid
+          rows={view.batchTableRows}
+          scrollKey={`po-finances:${activeStrategyId}`}
+          products={productOptions}
+        />
+      );
+      visualContent = tabularContent;
+      break;
+    }
+    case '8-po-profitability': {
       const activeStrategyId = requireStrategyId();
       const data = await getFinancialData();
       const view = getPOProfitabilityView(data, planningCalendar, reportAsOfDate);

--- a/apps/xplan/app/api/v1/xplan/product-setup/route.ts
+++ b/apps/xplan/app/api/v1/xplan/product-setup/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from 'next/server';
+import { Prisma } from '@targon/prisma-xplan';
+import { z } from 'zod';
+import prisma from '@/lib/prisma';
+import { withXPlanAuth } from '@/lib/api/auth';
+import { requireXPlanStrategyAccess } from '@/lib/api/strategy-guard';
+
+const numericFields = [
+  'openingStock',
+  'nextYearOpeningOverride',
+  'totalCoverThresholdWeeks',
+  'fbaCoverThresholdWeeks',
+] as const;
+
+const textFields = ['notes'] as const;
+
+const integerFields = new Set<string>(['openingStock', 'nextYearOpeningOverride']);
+const prismaAny = prisma as unknown as {
+  productSetupYear: {
+    upsert: (args: unknown) => Promise<unknown>;
+  };
+};
+
+const updateSchema = z.object({
+  strategyId: z.string().min(1),
+  year: z.number().int().min(2000).max(2100),
+  updates: z
+    .array(
+      z.object({
+        productId: z.string().min(1),
+        values: z.record(z.string(), z.string().nullable().optional()),
+      }),
+    )
+    .min(1),
+});
+
+function parseNumberField(field: string, value: string | null | undefined): number | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (trimmed === '') return null;
+  const cleaned = trimmed.replace(/[$,%\s]/g, '').replace(/,/g, '');
+  const parsed = Number(cleaned);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${field} must be numeric`);
+  }
+  if (integerFields.has(field)) {
+    return Math.round(parsed);
+  }
+  return parsed;
+}
+
+export const PUT = withXPlanAuth(async (request: Request, session) => {
+  const body = await request.json();
+  const parsed = updateSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+  }
+
+  const { strategyId, year, updates } = parsed.data;
+  const { response } = await requireXPlanStrategyAccess(strategyId, session);
+  if (response) return response;
+
+  const productIds = updates.map((update) => update.productId);
+  const products = await prisma.product.findMany({
+    where: { id: { in: productIds }, strategyId },
+    select: { id: true },
+  });
+  const validProductIds = new Set(products.map((product) => product.id));
+  const invalidProduct = productIds.find((productId) => !validProductIds.has(productId));
+  if (invalidProduct) {
+    return NextResponse.json({ error: 'Product does not belong to strategy' }, { status: 400 });
+  }
+
+  try {
+    await prisma.$transaction(
+      updates.map((update) => {
+        const data: Record<string, unknown> = {};
+
+        for (const field of numericFields) {
+          if (!(field in update.values)) continue;
+          const parsedValue = parseNumberField(field, update.values[field]);
+          data[field] =
+            parsedValue == null ? null : new Prisma.Decimal(parsedValue.toFixed(2));
+          if (integerFields.has(field)) {
+            data[field] = parsedValue;
+          }
+        }
+
+        for (const field of textFields) {
+          if (!(field in update.values)) continue;
+          const rawValue = update.values[field];
+          data[field] = rawValue == null ? null : rawValue;
+        }
+
+        return prismaAny.productSetupYear.upsert({
+          where: {
+            strategyId_productId_year: {
+              strategyId,
+              productId: update.productId,
+              year,
+            },
+          },
+          update: data,
+          create: {
+            strategyId,
+            productId: update.productId,
+            year,
+            ...data,
+          },
+        });
+      }),
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unable to update setup values';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  return NextResponse.json({ ok: true });
+});

--- a/apps/xplan/app/api/v1/xplan/purchase-orders/route.ts
+++ b/apps/xplan/app/api/v1/xplan/purchase-orders/route.ts
@@ -16,6 +16,8 @@ const allowedFields = [
   'orderCode',
   'poDate',
   'poWeekNumber',
+  'poClass',
+  'inboundWeekOverride',
   'quantity',
   'productionWeeks',
   'sourceWeeks',
@@ -91,6 +93,7 @@ const weekNumberFields: Record<string, true> = {
 
 const dateFields: Record<string, true> = {
   poDate: true,
+  inboundWeekOverride: true,
   pay1Date: true,
   pay2Date: true,
   pay3Date: true,
@@ -449,6 +452,7 @@ export const PUT = withXPlanAuth(async (request: Request, session) => {
           data[field] = incoming;
         } else if (
           field === 'orderCode' ||
+          field === 'poClass' ||
           field === 'transportReference' ||
           field === 'shipName' ||
           field === 'containerNumber'
@@ -619,6 +623,7 @@ export const POST = withXPlanAuth(async (request: Request, session) => {
     quantity: safeQuantity,
     poDate: normalizedPoDate,
     poWeekNumber,
+    poClass: 'Planned',
     productionWeeks: new Prisma.Decimal(
       resolveStageDefaultWeeks(stageDefaults, OPS_STAGE_DEFAULT_LABELS.production),
     ),

--- a/apps/xplan/components/sheets/custom-ops-cost-grid.tsx
+++ b/apps/xplan/components/sheets/custom-ops-cost-grid.tsx
@@ -17,8 +17,6 @@ import { usePersistentScroll } from '@/hooks/usePersistentScroll';
 import {
   useOpsPlanningStore,
   type CellEdit,
-  type ProfitDisplayMode,
-  type TariffInputMode,
 } from '@/stores';
 import { cn } from '@/lib/utils';
 import { getSelectionBorderBoxShadow } from '@/lib/grid/selection-border';
@@ -52,6 +50,8 @@ export type OpsBatchRow = {
   batchCode?: string;
   productId: string;
   productName: string;
+  carton: string;
+  region: string;
   quantity: string;
   sellingPrice: string;
   manufacturingCost: string;
@@ -203,13 +203,12 @@ function normalizeRange(range: CellRange): {
 }
 
 const COLUMNS_BEFORE_TARIFF: ColumnDef[] = [
-  { key: 'orderCode', header: 'PO Code', width: 140, type: 'text', editable: false },
-  { key: 'productName', header: 'Product', width: 140, type: 'dropdown', editable: true },
-  { key: 'cartonSide1Cm', header: 'Carton', width: 120, type: 'carton', editable: true },
-  { key: 'quantity', header: 'Qty', width: 100, type: 'numeric', editable: true, precision: 0 },
+  { key: 'orderCode', header: 'PO CODE', width: 140, type: 'text', editable: false },
+  { key: 'productName', header: 'PRODUCT', width: 150, type: 'dropdown', editable: true },
+  { key: 'carton', header: 'CARTON', width: 100, type: 'numeric', editable: false, precision: 0 },
   {
     key: 'sellingPrice',
-    header: 'Sell $',
+    header: 'SELL $',
     width: 100,
     type: 'numeric',
     editable: true,
@@ -217,7 +216,7 @@ const COLUMNS_BEFORE_TARIFF: ColumnDef[] = [
   },
   {
     key: 'manufacturingCost',
-    header: 'Mfg $',
+    header: 'MFG $',
     width: 100,
     type: 'numeric',
     editable: true,
@@ -225,7 +224,7 @@ const COLUMNS_BEFORE_TARIFF: ColumnDef[] = [
   },
   {
     key: 'freightCost',
-    header: 'Freight $',
+    header: 'FREIGHT $',
     width: 100,
     type: 'numeric',
     editable: true,
@@ -233,18 +232,9 @@ const COLUMNS_BEFORE_TARIFF: ColumnDef[] = [
   },
 ];
 
-const TARIFF_RATE_COLUMN: ColumnDef = {
-  key: 'tariffRate',
-  header: 'Tariff %',
-  width: 110,
-  type: 'percent',
-  editable: true,
-  precision: 2,
-};
-
 const TARIFF_COST_COLUMN: ColumnDef = {
   key: 'tariffCost',
-  header: 'Tariff $',
+  header: 'TARIFF $',
   width: 120,
   type: 'numeric',
   editable: true,
@@ -254,7 +244,7 @@ const TARIFF_COST_COLUMN: ColumnDef = {
 const COLUMNS_AFTER_TARIFF: ColumnDef[] = [
   {
     key: 'tacosPercent',
-    header: 'TACoS %',
+    header: 'TACOS %',
     width: 110,
     type: 'percent',
     editable: true,
@@ -263,7 +253,7 @@ const COLUMNS_AFTER_TARIFF: ColumnDef[] = [
   { key: 'fbaFee', header: 'FBA $', width: 110, type: 'numeric', editable: true, precision: 3 },
   {
     key: 'referralRate',
-    header: 'Referral %',
+    header: 'REFERRAL %',
     width: 130,
     type: 'percent',
     editable: true,
@@ -271,23 +261,13 @@ const COLUMNS_AFTER_TARIFF: ColumnDef[] = [
   },
   {
     key: 'storagePerMonth',
-    header: 'Storage $',
+    header: 'STORAGE $',
     width: 120,
     type: 'numeric',
     editable: true,
     precision: 3,
   },
 ];
-
-// Units per carton column (separate from carton dimensions modal)
-const UNITS_PER_CARTON_COLUMN: ColumnDef = {
-  key: 'unitsPerCarton',
-  header: 'Units/Ctn',
-  width: 90,
-  type: 'numeric',
-  editable: true,
-  precision: 0,
-};
 
 /**
  * Compute total CBM for a batch row.
@@ -319,8 +299,6 @@ function computeCbm(row: OpsBatchRow): number | null {
   return cbmPerCarton * totalCartons;
 }
 
-// TariffInputMode and ProfitDisplayMode imported from @/stores
-
 const CELL_ID_PREFIX = 'xplan-ops-batch';
 
 function sanitizeDomId(value: string): string {
@@ -347,72 +325,43 @@ export function CustomOpsCostGrid({
   onSync,
 }: CustomOpsCostGridProps) {
   // Get state and actions from zustand store
-  const tariffInputMode = useOpsPlanningStore((s) => s.tariffInputMode);
-  const profitDisplayMode = useOpsPlanningStore((s) => s.profitDisplayMode);
-  const toggleTariffMode = useOpsPlanningStore((s) => s.toggleTariffMode);
-  const setProfitMode = useOpsPlanningStore((s) => s.setProfitMode);
   const recordEdits = useOpsPlanningStore((s) => s.recordEdits);
   const storeUndo = useOpsPlanningStore((s) => s.undo);
   const storeRedo = useOpsPlanningStore((s) => s.redo);
 
   const columns = useMemo(() => {
-    const tariffColumn = tariffInputMode === 'cost' ? TARIFF_COST_COLUMN : TARIFF_RATE_COLUMN;
-    const profitColumns: ColumnDef[] =
-      profitDisplayMode === 'percent'
-        ? [
-            {
-              key: 'grossProfit',
-              header: 'GP %',
-              width: 80,
-              type: 'percent',
-              editable: false,
-              precision: 2,
-              computed: true,
-            },
-            {
-              key: 'netProfit',
-              header: 'NP %',
-              width: 80,
-              type: 'percent',
-              editable: false,
-              precision: 2,
-              computed: true,
-            },
-          ]
-        : [
-              {
-                key: 'grossProfit',
-                header: 'GP $',
-                width: 90,
-                type: 'numeric',
-                editable: false,
-                precision: profitDisplayMode === 'total' ? 0 : 2,
-                computed: true,
-              },
-              {
-                key: 'netProfit',
-                header: 'NP $',
-                width: 90,
-                type: 'numeric',
-                editable: false,
-                precision: profitDisplayMode === 'total' ? 0 : 2,
-                computed: true,
-              },
-            ];
+    const tariffColumn = TARIFF_COST_COLUMN;
+    const profitColumns: ColumnDef[] = [
+      {
+        key: 'grossProfit',
+        header: 'GP $',
+        width: 90,
+        type: 'numeric',
+        editable: false,
+        precision: 2,
+        computed: true,
+      },
+      {
+        key: 'netProfit',
+        header: 'NP $',
+        width: 90,
+        type: 'numeric',
+        editable: false,
+        precision: 2,
+        computed: true,
+      },
+    ];
 
-    // Add computed CBM column
-    const cbmColumn: ColumnDef = {
-      key: 'cbm',
-      header: 'CBM',
-      width: 70,
-      type: 'numeric',
+    const regionColumn: ColumnDef = {
+      key: 'region',
+      header: 'REGION',
+      width: 95,
+      type: 'text',
       editable: false,
-      precision: 3,
-      computed: true,
     };
 
-    return [...COLUMNS_BEFORE_TARIFF, tariffColumn, ...COLUMNS_AFTER_TARIFF, UNITS_PER_CARTON_COLUMN, cbmColumn, ...profitColumns];
-  }, [profitDisplayMode, tariffInputMode]);
+    return [...COLUMNS_BEFORE_TARIFF, tariffColumn, ...COLUMNS_AFTER_TARIFF, ...profitColumns, regionColumn];
+  }, []);
 
   const [localRows, setLocalRows] = useState<OpsBatchRow[]>(rows);
   const [editingCell, setEditingCell] = useState<{
@@ -586,11 +535,6 @@ export function CustomOpsCostGrid({
       tableScrollRef.current?.focus();
     });
   }, []);
-
-  const toggleTariffInputMode = useCallback(() => {
-    cancelEditing();
-    toggleTariffMode();
-  }, [cancelEditing, toggleTariffMode]);
 
   const commitEdit = useCallback(
     (overrideValue?: string) => {
@@ -1453,37 +1397,13 @@ export function CustomOpsCostGrid({
     };
   }, []);
 
-  // Monetary fields that should be affected by the profit display mode (total vs per-unit)
-  const MONETARY_FIELDS: Set<keyof OpsBatchRow> = new Set([
-    'sellingPrice',
-    'manufacturingCost',
-    'freightCost',
-    'tariffCost',
-    'fbaFee',
-    'storagePerMonth',
-  ]);
-
   const formatDisplayValue = (row: OpsBatchRow, column: ColumnDef): string => {
     if (column.key === 'grossProfit' || column.key === 'netProfit') {
       const metrics = computeProfitMetrics(row);
       const precision = column.precision ?? 2;
 
       const raw =
-        column.key === 'grossProfit'
-          ? column.type === 'percent'
-            ? metrics.grossMargin
-            : profitDisplayMode === 'total'
-              ? metrics.grossProfitTotal
-              : metrics.grossProfitPerUnit
-          : column.type === 'percent'
-            ? metrics.netMargin
-            : profitDisplayMode === 'total'
-              ? metrics.netProfitTotal
-              : metrics.netProfitPerUnit;
-
-      if (column.type === 'percent') {
-        return `${(raw * 100).toFixed(precision)}%`;
-      }
+        column.key === 'grossProfit' ? metrics.grossProfitPerUnit : metrics.netProfitPerUnit;
 
       const formatter = new Intl.NumberFormat('en-US', {
         style: 'currency',
@@ -1517,8 +1437,10 @@ export function CustomOpsCostGrid({
     if (column.type === 'numeric') {
       const num = sanitizeNumeric(value);
       if (Number.isNaN(num)) return value;
-      // Don't show $ prefix for quantity or carton dimension fields
-      if (column.key === 'quantity' || column.key === 'unitsPerCarton') return num.toLocaleString();
+      // Don't show $ prefix for count or carton dimension fields
+      if (column.key === 'quantity' || column.key === 'unitsPerCarton' || column.key === 'carton') {
+        return num.toLocaleString();
+      }
       if (
         column.key === 'cartonSide1Cm' ||
         column.key === 'cartonSide2Cm' ||
@@ -1528,30 +1450,12 @@ export function CustomOpsCostGrid({
         return num.toFixed(column.precision ?? 2);
       }
 
-      // Apply total mode multiplier for monetary fields
-      if (MONETARY_FIELDS.has(column.key) && profitDisplayMode === 'total') {
-        const quantity = sanitizeNumeric(row.quantity);
-        const total = Number.isFinite(quantity) ? num * quantity : num;
-        const precision = profitDisplayMode === 'total' ? 0 : (column.precision ?? 2);
-        return `$${total.toFixed(precision).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
-      }
-
       return `$${num.toFixed(column.precision ?? 2)}`;
     }
 
     if (column.type === 'percent') {
       const num = sanitizeNumeric(value);
       if (Number.isNaN(num)) return value;
-
-      // In total mode, show TACoS and Referral as dollar amounts
-      if (profitDisplayMode === 'total' && (column.key === 'tacosPercent' || column.key === 'referralRate')) {
-        const sellingPrice = sanitizeNumeric(row.sellingPrice);
-        const quantity = sanitizeNumeric(row.quantity);
-        if (Number.isFinite(sellingPrice) && Number.isFinite(quantity)) {
-          const dollarAmount = sellingPrice * num * quantity;
-          return `$${dollarAmount.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`;
-        }
-      }
 
       return `${(num * 100).toFixed(column.precision ?? 2)}%`;
     }
@@ -1703,16 +1607,8 @@ export function CustomOpsCostGrid({
                 const metrics = computeProfitMetrics(row);
                 const raw =
                   column.key === 'grossProfit'
-                    ? column.type === 'percent'
-                      ? metrics.grossMargin
-                      : profitDisplayMode === 'total'
-                        ? metrics.grossProfitTotal
-                        : metrics.grossProfitPerUnit
-                    : column.type === 'percent'
-                      ? metrics.netMargin
-                      : profitDisplayMode === 'total'
-                        ? metrics.netProfitTotal
-                        : metrics.netProfitPerUnit;
+                    ? metrics.grossProfitPerUnit
+                    : metrics.netProfitPerUnit;
                 if (raw > 0) return 'text-emerald-700 dark:text-emerald-300';
                 if (raw < 0) return 'text-rose-700 dark:text-rose-300';
                 return '';
@@ -1737,54 +1633,10 @@ export function CustomOpsCostGrid({
       <header className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-1">
           <h2 className="text-sm font-bold uppercase tracking-[0.2em] text-cyan-700 dark:text-cyan-300/80">
-            Batch Table
+            PO Finances Table
           </h2>
         </div>
         <div className="flex flex-wrap items-center gap-2">
-          <div className="inline-flex rounded-lg border border-emerald-500/25 bg-emerald-500/10 p-0.5 text-xs font-semibold uppercase tracking-wide text-emerald-800 shadow-sm dark:border-emerald-300/40 dark:bg-emerald-300/15 dark:text-emerald-100">
-            <button
-              type="button"
-              onClick={() => setProfitMode('unit')}
-              className={cn(
-                'rounded-md px-2 py-1 transition',
-                profitDisplayMode === 'unit'
-                  ? 'bg-white text-emerald-900 shadow-sm dark:bg-slate-900/60 dark:text-emerald-100'
-                  : 'text-emerald-800/80 hover:text-emerald-900 dark:text-emerald-100 dark:hover:text-white',
-              )}
-              aria-pressed={profitDisplayMode === 'unit'}
-              title="Show profit per unit"
-            >
-              Per unit
-            </button>
-            <button
-              type="button"
-              onClick={() => setProfitMode('total')}
-              className={cn(
-                'rounded-md px-2 py-1 transition',
-                profitDisplayMode === 'total'
-                  ? 'bg-white text-emerald-900 shadow-sm dark:bg-slate-900/60 dark:text-emerald-100'
-                  : 'text-emerald-800/80 hover:text-emerald-900 dark:text-emerald-100 dark:hover:text-white',
-              )}
-              aria-pressed={profitDisplayMode === 'total'}
-              title="Show total profit for the batch"
-            >
-              Absolute
-            </button>
-            <button
-              type="button"
-              onClick={() => setProfitMode('percent')}
-              className={cn(
-                'rounded-md px-2 py-1 transition',
-                profitDisplayMode === 'percent'
-                  ? 'bg-white text-emerald-900 shadow-sm dark:bg-slate-900/60 dark:text-emerald-100'
-                  : 'text-emerald-800/80 hover:text-emerald-900 dark:text-emerald-100 dark:hover:text-white',
-              )}
-              aria-pressed={profitDisplayMode === 'percent'}
-              title="Show profit margins (%)"
-            >
-              %
-            </button>
-          </div>
           {onAddBatch ? (
             <button
               type="button"
@@ -1838,26 +1690,7 @@ export function CustomOpsCostGrid({
                     style={{ minWidth: column.width }}
                     className="sticky top-0 z-10 h-10 whitespace-nowrap border-b border-r bg-muted px-2 py-2 text-left text-xs font-semibold uppercase tracking-[0.12em] text-cyan-700 last:border-r-0 dark:text-cyan-300/80"
                   >
-                    {column.key === 'tariffRate' || column.key === 'tariffCost' ? (
-                      <button
-                        type="button"
-                        className="inline-flex w-full items-center justify-center rounded-md border border-cyan-500/30 bg-cyan-500/10 px-2 py-1 text-xs font-extrabold uppercase tracking-[0.12em] text-cyan-700 transition hover:bg-cyan-500/20 dark:border-cyan-300/35 dark:bg-cyan-300/10 dark:text-cyan-200 dark:hover:bg-cyan-300/20"
-                        onClick={(event) => {
-                          event.preventDefault();
-                          event.stopPropagation();
-                          toggleTariffInputMode();
-                        }}
-                        title={
-                          tariffInputMode === 'rate'
-                            ? 'Switch to Tariff $/unit'
-                            : 'Switch to Tariff %'
-                        }
-                      >
-                        {column.header}
-                      </button>
-                    ) : (
-                      column.header
-                    )}
+                    {column.header}
                   </TableHead>
                 ))}
               </TableRow>

--- a/apps/xplan/components/sheets/custom-ops-planning-grid.tsx
+++ b/apps/xplan/components/sheets/custom-ops-planning-grid.tsx
@@ -35,15 +35,28 @@ export type OpsInputRow = {
   productId: string;
   orderCode: string;
   poDate: string;
+  poClass: string;
   productionStart: string;
   productionComplete: string;
   sourceDeparture: string;
   portEta: string;
   availableDate: string;
+  inboundWeekOverride: string;
+  inboundWeek: string;
   shipName: string;
   containerNumber: string;
   productName: string;
   quantity: string;
+  unitsPerCarton: string;
+  carton: string;
+  cartonSide1Cm: string;
+  cartonSide2Cm: string;
+  cartonSide3Cm: string;
+  cbm: string;
+  poTotalQty: string;
+  poFirstRow: string;
+  notes: string;
+  region: string;
   pay1Date: string;
   productionWeeks: string;
   sourceWeeks: string;
@@ -96,6 +109,14 @@ const STAGE_OVERRIDE_FIELDS: Record<StageWeeksKey, StageOverrideKey> = STAGE_CON
 
 const NUMERIC_PRECISION: Partial<Record<keyof OpsInputRow, number>> = {
   quantity: 0,
+  unitsPerCarton: 0,
+  carton: 0,
+  cartonSide1Cm: 2,
+  cartonSide2Cm: 2,
+  cartonSide3Cm: 2,
+  cbm: 3,
+  poTotalQty: 0,
+  poFirstRow: 0,
   productionWeeks: 2,
   sourceWeeks: 2,
   oceanWeeks: 2,
@@ -112,6 +133,14 @@ const NUMERIC_PRECISION: Partial<Record<keyof OpsInputRow, number>> = {
 
 const NUMERIC_FIELDS = new Set<keyof OpsInputRow>([
   'quantity',
+  'unitsPerCarton',
+  'carton',
+  'cartonSide1Cm',
+  'cartonSide2Cm',
+  'cartonSide3Cm',
+  'cbm',
+  'poTotalQty',
+  'poFirstRow',
   'productionWeeks',
   'sourceWeeks',
   'oceanWeeks',
@@ -129,6 +158,8 @@ const NUMERIC_FIELDS = new Set<keyof OpsInputRow>([
 const DATE_FIELDS = new Set<keyof OpsInputRow>([
   'poDate',
   'productionStart',
+  'inboundWeekOverride',
+  'inboundWeek',
   'pay1Date',
   'productionComplete',
   'sourceDeparture',
@@ -416,22 +447,59 @@ function formatPurchaseOrderStatus(value: string): string {
 }
 
 const COLUMNS: ColumnDef[] = [
-  { key: 'orderCode', header: 'PO Code', width: 150, type: 'text', editable: true },
-  { key: 'productionStart', header: 'Mfg Start', width: 130, type: 'date', editable: true },
-  { key: 'shipName', header: 'Ship', width: 160, type: 'text', editable: true },
-  { key: 'containerNumber', header: 'Container #', width: 160, type: 'text', editable: true },
+  { key: 'orderCode', header: 'PO CODE', width: 150, type: 'text', editable: true },
+  { key: 'productName', header: 'PRODUCT', width: 180, type: 'text', editable: false },
+  { key: 'quantity', header: 'QTY', width: 95, type: 'numeric', editable: true, precision: 0 },
+  {
+    key: 'unitsPerCarton',
+    header: 'UNITS/CTN',
+    width: 110,
+    type: 'numeric',
+    editable: false,
+    precision: 0,
+  },
+  { key: 'carton', header: 'CARTON', width: 95, type: 'numeric', editable: false, precision: 0 },
+  {
+    key: 'cartonSide1Cm',
+    header: 'CTN L (CM)',
+    width: 115,
+    type: 'numeric',
+    editable: false,
+    precision: 2,
+  },
+  {
+    key: 'cartonSide2Cm',
+    header: 'CTN W (CM)',
+    width: 115,
+    type: 'numeric',
+    editable: false,
+    precision: 2,
+  },
+  {
+    key: 'cartonSide3Cm',
+    header: 'CTN H (CM)',
+    width: 115,
+    type: 'numeric',
+    editable: false,
+    precision: 2,
+  },
+  { key: 'cbm', header: 'CBM', width: 95, type: 'numeric', editable: false, precision: 3 },
+  { key: 'productionStart', header: 'MFG START', width: 130, type: 'date', editable: true },
+  { key: 'shipName', header: 'SHIP', width: 160, type: 'text', editable: true },
+  { key: 'containerNumber', header: 'CONTAINER #', width: 160, type: 'text', editable: true },
   {
     key: 'status',
-    header: 'Status',
+    header: 'STATUS',
     width: 130,
     type: 'dropdown',
     editable: true,
     options: PURCHASE_ORDER_STATUS_OPTIONS,
   },
+  { key: 'poClass', header: 'PO CLASS', width: 140, type: 'text', editable: true },
   {
     key: 'productionWeeks',
-    header: 'Manufacturing',
-    headerWeeks: 'Mfg (wk)',
+    header: 'MFG (WK)',
+    headerWeeks: 'MFG (WK)',
     headerDates: 'Mfg Done',
     width: 130,
     type: 'stage',
@@ -440,8 +508,8 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: 'sourceWeeks',
-    header: 'Ocean Departure',
-    headerWeeks: 'Depart (wk)',
+    header: 'DEPART (WK)',
+    headerWeeks: 'DEPART (WK)',
     headerDates: 'Departure',
     width: 130,
     type: 'stage',
@@ -450,8 +518,8 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: 'oceanWeeks',
-    header: 'Ocean Transit',
-    headerWeeks: 'Arrival (wk)',
+    header: 'ARRIVAL (WK)',
+    headerWeeks: 'ARRIVAL (WK)',
     headerDates: 'Port Arrival',
     width: 130,
     type: 'stage',
@@ -460,14 +528,46 @@ const COLUMNS: ColumnDef[] = [
   },
   {
     key: 'finalWeeks',
-    header: 'Final Delivery',
-    headerWeeks: 'WH (wk)',
+    header: 'WH (WK)',
+    headerWeeks: 'WH (WK)',
     headerDates: 'Warehouse',
     width: 130,
     type: 'stage',
     editable: true,
     precision: 2,
   },
+  {
+    key: 'inboundWeekOverride',
+    header: 'INBOUND WK OVERRIDE',
+    width: 170,
+    type: 'date',
+    editable: true,
+  },
+  {
+    key: 'inboundWeek',
+    header: 'INBOUND WK',
+    width: 130,
+    type: 'date',
+    editable: false,
+  },
+  {
+    key: 'poTotalQty',
+    header: 'PO TOTAL QTY',
+    width: 130,
+    type: 'numeric',
+    editable: false,
+    precision: 0,
+  },
+  { key: 'notes', header: 'NOTES', width: 190, type: 'text', editable: true },
+  {
+    key: 'poFirstRow',
+    header: 'PO FIRST ROW',
+    width: 135,
+    type: 'numeric',
+    editable: false,
+    precision: 0,
+  },
+  { key: 'region', header: 'REGION', width: 95, type: 'text', editable: false },
 ];
 
 // StageMode imported from @/stores

--- a/apps/xplan/components/sheets/ops-planning-workspace.tsx
+++ b/apps/xplan/components/sheets/ops-planning-workspace.tsx
@@ -86,6 +86,8 @@ export type PurchaseOrderSerialized = {
   quantity: number;
   poDate?: string | null;
   poWeekNumber?: number | null;
+  poClass?: string | null;
+  inboundWeekOverride?: string | null;
   productionWeeks?: number | null;
   sourceWeeks?: number | null;
   oceanWeeks?: number | null;
@@ -154,6 +156,11 @@ export type PurchaseOrderSerialized = {
     overrideFbaFee?: number | null;
     overrideReferralRate?: number | null;
     overrideStoragePerMonth?: number | null;
+    cartonSide1Cm?: number | null;
+    cartonSide2Cm?: number | null;
+    cartonSide3Cm?: number | null;
+    cartonWeightKg?: number | null;
+    unitsPerCarton?: number | null;
   }>;
 };
 
@@ -215,6 +222,7 @@ interface OpsPlanningWorkspaceProps {
   calculator: OpsPlanningCalculatorPayload;
   timelineMonths: { start: string; end: string; label: string }[];
   mode?: 'tabular' | 'visual';
+  showPoFinanceTable?: boolean;
 }
 
 type ConfirmAction =
@@ -374,6 +382,8 @@ function deserializeOrders(
     quantity: order.quantity,
     poDate: parseDateValue(order.poDate),
     poWeekNumber: order.poWeekNumber ?? null,
+    poClass: order.poClass ?? null,
+    inboundWeekOverride: parseDateValue(order.inboundWeekOverride),
     productionWeeks: normalizeStageWeeks(
       'productionWeeks',
       order.productionWeeks ?? null,
@@ -448,6 +458,11 @@ function deserializeOrders(
         overrideFbaFee: batch.overrideFbaFee ?? null,
         overrideReferralRate: batch.overrideReferralRate ?? null,
         overrideStoragePerMonth: batch.overrideStoragePerMonth ?? null,
+        cartonSide1Cm: batch.cartonSide1Cm ?? null,
+        cartonSide2Cm: batch.cartonSide2Cm ?? null,
+        cartonSide3Cm: batch.cartonSide3Cm ?? null,
+        cartonWeightKg: batch.cartonWeightKg ?? null,
+        unitsPerCarton: batch.unitsPerCarton ?? null,
       })) ?? [],
   }));
 }
@@ -467,6 +482,8 @@ function mergeOrders(
         productId: row.productId,
         quantity: parseInteger(row.quantity, 0),
         poDate: parseDateValue(row.poDate),
+        poClass: row.poClass ? row.poClass : null,
+        inboundWeekOverride: parseDateValue(row.inboundWeekOverride),
         productionWeeks: normalizeStageWeeks(
           'productionWeeks',
           parseNumber(row.productionWeeks),
@@ -517,6 +534,8 @@ function mergeOrders(
       orderCode: row.orderCode,
       productId: row.productId,
       quantity: parseInteger(row.quantity, base.quantity ?? 0),
+      poClass: row.poClass ? row.poClass : null,
+      inboundWeekOverride: parseDateValue(row.inboundWeekOverride) ?? base.inboundWeekOverride ?? null,
       pay1Date: parseDateValue(row.pay1Date),
       productionWeeks: normalizeStageWeeks(
         'productionWeeks',
@@ -752,6 +771,7 @@ export function OpsPlanningWorkspace({
   calculator,
   timelineMonths,
   mode = 'tabular',
+  showPoFinanceTable = false,
 }: OpsPlanningWorkspaceProps) {
   const isVisualMode = mode === 'visual';
   const router = useRouter();
@@ -807,6 +827,8 @@ export function OpsPlanningWorkspace({
       batchCode: batch.batchCode ?? undefined,
       productId: batch.productId,
       productName: productNameIndex.get(batch.productId) ?? '',
+      carton: '',
+      region: '',
       quantity:
         batch.quantity == null
           ? ''
@@ -1409,6 +1431,8 @@ export function OpsPlanningWorkspace({
           batchCode: created.batchCode ?? undefined,
           productId: created.productId,
           productName: productNameIndex.get(created.productId) ?? '',
+          carton: '',
+          region: '',
           quantity: formatNumericInput(created.quantity ?? 0, 0),
           sellingPrice: '',
           manufacturingCost: '',
@@ -2320,21 +2344,23 @@ export function OpsPlanningWorkspace({
             </section>
           ) : null}
 
-          <CustomOpsCostGrid
-            rows={visibleBatches}
-            activeOrderId={activeOrderId}
-            activeBatchId={activeBatchId}
-            scrollKey={`ops-planning:batch:${strategyId}`}
-            onSelectOrder={(orderId) => setActiveOrderId(orderId)}
-            onSelectBatch={handleSelectBatch}
-            onRowsChange={handleBatchRowsChange}
-            onAddBatch={handleAddBatch}
-            onDeleteBatch={handleDeleteBatch}
-            disableAdd={isPending || !activeOrderId}
-            disableDelete={isPending}
-            products={productOptions}
-            onSync={handleCostSync}
-          />
+          {showPoFinanceTable ? (
+            <CustomOpsCostGrid
+              rows={visibleBatches}
+              activeOrderId={activeOrderId}
+              activeBatchId={activeBatchId}
+              scrollKey={`ops-planning:batch:${strategyId}`}
+              onSelectOrder={(orderId) => setActiveOrderId(orderId)}
+              onSelectBatch={handleSelectBatch}
+              onRowsChange={handleBatchRowsChange}
+              onAddBatch={handleAddBatch}
+              onDeleteBatch={handleDeleteBatch}
+              disableAdd={isPending || !activeOrderId}
+              disableDelete={isPending}
+              products={productOptions}
+              onSync={handleCostSync}
+            />
+          ) : null}
           <CustomPurchasePaymentsGrid
             payments={visiblePayments}
             activeOrderId={activeOrderId}

--- a/apps/xplan/components/sheets/sales-planning-grid.tsx
+++ b/apps/xplan/components/sheets/sales-planning-grid.tsx
@@ -48,6 +48,10 @@ import {
   parseNumericInput,
   sanitizeNumeric,
 } from '@/components/sheets/validators';
+import {
+  computeForecastWorkbookRow,
+  type ForecastWorkbookRow,
+} from '@/lib/calculations/workbook-parity';
 import { useMutationQueue } from '@/hooks/useMutationQueue';
 import { usePersistentScroll } from '@/hooks/usePersistentScroll';
 import { usePersistentState } from '@/hooks/usePersistentState';
@@ -78,20 +82,17 @@ type SalesRow = {
 type ColumnMeta = Record<string, { productId: string; field: string }>;
 type NestedHeaderCell = string | { label: string; colspan?: number; rowspan?: number };
 
-const editableMetrics = new Set(['actualSales', 'forecastSales']);
+const editableMetrics = new Set(['actualSales', 'forecastSales', 'finalSales']);
 const BASE_SALES_METRICS = [
-  'stockStart',
+  'inbound',
+  'threePl',
+  'fba',
+  'fbaCoverWeeks',
+  'totalCoverWeeks',
   'actualSales',
   'forecastSales',
-  'systemForecastSales',
   'finalSales',
-  'finalSalesError',
 ] as const;
-const STOCK_METRIC_OPTIONS = [
-  { id: 'stockWeeks', label: 'Cover (w)' },
-  { id: 'stockEnd', label: 'Stock Qty' },
-] as const;
-type StockMetricId = (typeof STOCK_METRIC_OPTIONS)[number]['id'];
 
 function isEditableMetric(field: string | undefined) {
   return Boolean(field && editableMetrics.has(field));
@@ -350,14 +351,7 @@ export function SalesPlanningGrid({
   const focusContext = useContext(SalesPlanningFocusContext);
   const focusProductId = focusContext?.focusProductId ?? 'ALL';
 
-  const [activeStockMetric, setActiveStockMetric] = usePersistentState<StockMetricId>(
-    'xplan:sales-grid:metric',
-    'stockWeeks',
-  );
-  const [showFinalError, setShowFinalError] = usePersistentState<boolean>(
-    'xplan:sales-grid:show-final-error',
-    false,
-  );
+  const activeStockMetric = 'fbaCoverWeeks';
 
   const warningThreshold = Number.isFinite(stockWarningWeeks)
     ? stockWarningWeeks
@@ -406,17 +400,7 @@ export function SalesPlanningGrid({
     [data, visibleRowIndices],
   );
 
-  const visibleMetrics = useMemo(() => {
-    const metrics = new Set<string>([
-      'stockStart',
-      'actualSales',
-      'forecastSales',
-      'systemForecastSales',
-    ]);
-    metrics.add(showFinalError ? 'finalSalesError' : 'finalSales');
-    metrics.add(activeStockMetric);
-    return metrics;
-  }, [activeStockMetric, showFinalError]);
+  const visibleMetrics = useMemo(() => new Set<string>(BASE_SALES_METRICS), []);
 
   const keyByProductField = useMemo(() => {
     const map = new Map<string, Record<string, string>>();
@@ -434,12 +418,12 @@ export function SalesPlanningGrid({
     const map = new Map<string, string>();
     for (const key of columnKeys) {
       const meta = columnMeta[key];
-      if (meta?.field === 'stockWeeks') {
+      if (meta?.field === activeStockMetric) {
         map.set(meta.productId, key);
       }
     }
     return map;
-  }, [columnKeys, columnMeta]);
+  }, [activeStockMetric, columnKeys, columnMeta]);
 
   const weekDateByNumber = useMemo(() => {
     const map = new Map<number, string>();
@@ -495,11 +479,7 @@ export function SalesPlanningGrid({
         : productOptions.filter((product) => product.id === focusProductId);
     return base.filter((product) => {
       const keys = keyByProductField.get(product.id) ?? {};
-      return (
-        BASE_SALES_METRICS.some((metric) => keys[metric]) &&
-        Boolean(keys.stockWeeks) &&
-        Boolean(keys.stockEnd)
-      );
+      return BASE_SALES_METRICS.some((metric) => keys[metric]);
     });
   }, [focusProductId, keyByProductField, productOptions]);
 
@@ -532,15 +512,14 @@ export function SalesPlanningGrid({
 
     displayedProducts.forEach((product) => {
       const keys = keyByProductField.get(product.id) ?? {};
-      const stockStartKey = keys.stockStart;
-      if (!stockStartKey) return;
-      const inboundKey = stockStartKey.replace(/_stockStart$/, '_hasInbound');
+      const inboundKey = keys.inbound;
+      if (!inboundKey) return;
 
       const inboundWeeks = new Set<number>();
       for (const row of data) {
         const week = Number(row?.weekNumber);
         if (!Number.isFinite(week) || !row) continue;
-        if (row[inboundKey] === 'true') inboundWeeks.add(week);
+        if (Number(row[inboundKey]) > 0) inboundWeeks.add(week);
       }
 
       map.set(product.id, inboundWeeks);
@@ -550,21 +529,14 @@ export function SalesPlanningGrid({
   }, [data, displayedProducts, keyByProductField]);
 
   const metricSequence = useMemo(() => {
-    return [
-      'stockStart',
-      'actualSales',
-      'forecastSales',
-      'systemForecastSales',
-      showFinalError ? 'finalSalesError' : 'finalSales',
-      activeStockMetric,
-    ];
-  }, [activeStockMetric, showFinalError]);
+    return [...BASE_SALES_METRICS];
+  }, []);
 
   const columns = useMemo(() => {
     const baseColumns = [
       columnHelper.accessor('weekLabel', {
         id: 'weekLabel',
-        header: () => 'Week',
+        header: () => 'WEEK',
         cell: (info) => (
           <span className="flex items-center gap-1">
             {info.getValue()}
@@ -578,12 +550,12 @@ export function SalesPlanningGrid({
       }),
       columnHelper.accessor('weekDate', {
         id: 'weekDate',
-        header: () => 'Date',
+        header: () => 'DATE',
         meta: { sticky: true, stickyOffset: 80, width: 120, kind: 'pinned' },
       }),
       columnHelper.accessor((row) => row.arrivalDetail ?? '', {
         id: 'arrivalDetail',
-        header: () => 'Inbound PO',
+        header: () => 'Notes',
         meta: { sticky: true, stickyOffset: 200, width: 140, kind: 'pinned' },
       }),
     ];
@@ -599,45 +571,15 @@ export function SalesPlanningGrid({
             id: key,
             header: () => {
               const labelMap: Record<string, string> = {
-                stockStart: 'Stock Start',
-                actualSales: 'Actual',
-                forecastSales: 'Planner',
-                systemForecastSales: 'System',
-                finalSales: 'Demand',
-                finalSalesError: '% Error',
-                stockWeeks: 'Cover (w)',
-                stockEnd: 'Stock Qty',
+                inbound: 'INBOUND',
+                threePl: '3PL',
+                fba: 'FBA',
+                fbaCoverWeeks: 'FBA COVER (W)',
+                totalCoverWeeks: 'TOTAL COVER (W)',
+                actualSales: 'ACTUAL',
+                forecastSales: 'PLANNER',
+                finalSales: 'FINAL',
               };
-
-              if (field === activeStockMetric) {
-                return (
-                  <button
-                    type="button"
-                    className="rounded border bg-secondary px-2 py-0.5 text-xs font-medium hover:bg-secondary/80"
-                    onClick={() =>
-                      preserveGridScroll(() =>
-                        setActiveStockMetric((prev) =>
-                          prev === 'stockWeeks' ? 'stockEnd' : 'stockWeeks',
-                        ),
-                      )
-                    }
-                  >
-                    {labelMap[field]}
-                  </button>
-                );
-              }
-
-              if (field === (showFinalError ? 'finalSalesError' : 'finalSales')) {
-                return (
-                  <button
-                    type="button"
-                    className="rounded border bg-secondary px-2 py-0.5 text-xs font-medium hover:bg-secondary/80"
-                    onClick={() => preserveGridScroll(() => setShowFinalError((prev) => !prev))}
-                  >
-                    {labelMap[field]}
-                  </button>
-                );
-              }
 
               return (
                 <span className="text-xs font-medium text-muted-foreground">
@@ -658,15 +600,10 @@ export function SalesPlanningGrid({
 
     return [...baseColumns, ...productColumns];
   }, [
-    activeStockMetric,
     columnHelper,
     displayedProducts,
     keyByProductField,
     metricSequence,
-    preserveGridScroll,
-    setActiveStockMetric,
-    setShowFinalError,
-    showFinalError,
   ]);
 
   const table = useReactTable({
@@ -746,103 +683,77 @@ export function SalesPlanningGrid({
         keysByField.set(meta.field, key);
       }
 
-      const stockStartKey = keysByField.get('stockStart');
+      const inboundKey = keysByField.get('inbound');
+      const threePlKey = keysByField.get('threePl');
+      const fbaKey = keysByField.get('fba');
+      const fbaCoverWeeksKey = keysByField.get('fbaCoverWeeks');
+      const totalCoverWeeksKey = keysByField.get('totalCoverWeeks');
       const actualSalesKey = keysByField.get('actualSales');
       const forecastSalesKey = keysByField.get('forecastSales');
-      const systemForecastSalesKey = keysByField.get('systemForecastSales');
       const finalSalesKey = keysByField.get('finalSales');
-      const finalSalesErrorKey = keysByField.get('finalSalesError');
-      const stockWeeksKey = keysByField.get('stockWeeks');
-      const stockEndKey = keysByField.get('stockEnd');
 
       if (
-        !stockStartKey ||
+        !inboundKey ||
+        !threePlKey ||
+        !fbaKey ||
+        !fbaCoverWeeksKey ||
+        !totalCoverWeeksKey ||
         !actualSalesKey ||
         !forecastSalesKey ||
-        !systemForecastSalesKey ||
-        !finalSalesKey ||
-        !finalSalesErrorKey ||
-        !stockWeeksKey ||
-        !stockEndKey
+        !finalSalesKey
       ) {
         return nextData;
       }
 
       const n = nextData.length;
-      const previousStockStart: number[] = new Array(n);
-      const previousStockEnd: number[] = new Array(n);
-      const actual: Array<number | null> = new Array(n);
-      const forecast: Array<number | null> = new Array(n);
-      const systemForecast: Array<number | null> = new Array(n);
-
-      for (let i = 0; i < n; i += 1) {
-        const row = nextData[i];
-        previousStockStart[i] = parseNumericInput(row?.[stockStartKey]) ?? 0;
-        previousStockEnd[i] = parseNumericInput(row?.[stockEndKey]) ?? 0;
-        actual[i] = parseNumericInput(row?.[actualSalesKey]);
-        forecast[i] = parseNumericInput(row?.[forecastSalesKey]);
-        systemForecast[i] = parseNumericInput(row?.[systemForecastSalesKey]);
-      }
-
-      const arrivalsKey = stockStartKey.replace(/_stockStart$/, '_arrivals');
-      const arrivals: number[] = new Array(n).fill(0);
-      for (let i = 0; i < n; i += 1) {
-        const row = nextData[i];
-        arrivals[i] = parseNumericInput(row?.[arrivalsKey]) ?? 0;
-      }
-
-      const baseStartOverrides = new Map<number, number>();
-      if (n > 0) {
-        baseStartOverrides.set(0, previousStockStart[0] - arrivals[0]);
-      }
-      for (let i = 1; i < n; i += 1) {
-        const baseStart = previousStockStart[i] - arrivals[i];
-        if (baseStart !== previousStockEnd[i - 1]) {
-          baseStartOverrides.set(i, baseStart);
-        }
-      }
-
-      const nextStockStart: number[] = new Array(n);
+      const nextThreePl: number[] = new Array(n);
+      const nextFba: number[] = new Array(n);
+      const nextFbaCoverWeeks: number[] = new Array(n);
+      const nextTotalCoverWeeks: number[] = new Array(n);
       const nextFinalSales: number[] = new Array(n);
-      const nextStockEnd: number[] = new Array(n);
-      const nextError: Array<number | null> = new Array(n);
       const nextDemandSource: string[] = new Array(n);
+      const finalSalesSourceKey = finalSalesKey.replace(/_finalSales$/, '_finalSalesSource');
 
-      nextStockStart[0] = previousStockStart[0];
+      let previousForecast: ForecastWorkbookRow | null = null;
 
       for (let i = 0; i < n; i += 1) {
-        const demand = actual[i] ?? forecast[i] ?? systemForecast[i] ?? 0;
-        nextFinalSales[i] = Math.max(0, demand);
-        nextStockEnd[i] = Math.max(0, nextStockStart[i] - nextFinalSales[i]);
+        const row = nextData[i];
+        const actual = parseNumericInput(row?.[actualSalesKey]);
+        const forecast = parseNumericInput(row?.[forecastSalesKey]);
+        const currentFinal = parseNumericInput(row?.[finalSalesKey]);
+        const sourceRaw = (row?.[finalSalesSourceKey] ?? '').trim();
+        const explicitFinal =
+          sourceRaw === 'OVERRIDE' || sourceRaw === 'SYSTEM' ? currentFinal : null;
+        const openingStock =
+          i === 0
+            ? (parseNumericInput(row?.[threePlKey]) ?? 0) + (parseNumericInput(row?.[fbaKey]) ?? 0)
+            : null;
+        const forecastRow = computeForecastWorkbookRow({
+          openingStock,
+          inbound: parseNumericInput(row?.[inboundKey]),
+          actual,
+          planner: forecast,
+          final: explicitFinal,
+          previous: previousForecast,
+        });
+        previousForecast = forecastRow;
+
+        nextThreePl[i] = forecastRow.threePl;
+        nextFba[i] = forecastRow.fba;
+        nextFbaCoverWeeks[i] = forecastRow.fbaCoverWeeks;
+        nextTotalCoverWeeks[i] = forecastRow.totalCoverWeeks;
+        nextFinalSales[i] = forecastRow.final;
 
         nextDemandSource[i] =
-          actual[i] != null
+          actual != null
             ? 'ACTUAL'
-            : forecast[i] != null
+            : forecast != null
               ? 'PLANNER'
-              : systemForecast[i] != null
-                ? 'SYSTEM'
-                : 'ZERO';
-
-        if (i + 1 < n) {
-          const baseStartOverride = baseStartOverrides.get(i + 1);
-          const baseStart = baseStartOverride != null ? baseStartOverride : nextStockEnd[i];
-          nextStockStart[i + 1] = baseStart + arrivals[i + 1];
-        }
-
-        if (actual[i] != null && forecast[i] != null && forecast[i] !== 0) {
-          nextError[i] = (actual[i]! - forecast[i]!) / Math.abs(forecast[i]!);
-        } else {
-          nextError[i] = null;
-        }
-      }
-
-      const nextStockWeeks: number[] = new Array(n);
-      for (let i = 0; i < n; i += 1) {
-        const demand = nextFinalSales[i] ?? 0;
-        const stockStart = nextStockStart[i] ?? 0;
-        nextStockWeeks[i] =
-          demand > 0 ? stockStart / demand : stockStart > 0 ? Number.POSITIVE_INFINITY : 0;
+                : sourceRaw === 'SYSTEM' && currentFinal != null
+                  ? 'SYSTEM'
+                  : sourceRaw === 'OVERRIDE' && currentFinal != null
+                    ? 'OVERRIDE'
+                    : 'ZERO';
       }
 
       if (Number.isFinite(warningThreshold) && warningThreshold > 0) {
@@ -854,7 +765,7 @@ export function SalesPlanningGrid({
           let hasBeenAbove = false;
           let breachIndex: number | null = null;
           for (let i = 0; i < n; i += 1) {
-            const weeksValue = nextStockWeeks[i];
+            const weeksValue = nextFbaCoverWeeks[i];
             if (!Number.isFinite(weeksValue)) {
               hasBeenAbove = true;
               continue;
@@ -908,31 +819,29 @@ export function SalesPlanningGrid({
       for (let i = 0; i < n; i += 1) {
         const row = nextData[i];
 
-        const stockStartValue = Number.isFinite(nextStockStart[i])
-          ? nextStockStart[i].toFixed(0)
-          : '';
+        const threePlValue = Number.isFinite(nextThreePl[i]) ? nextThreePl[i].toFixed(0) : '';
+        const fbaValue = Number.isFinite(nextFba[i]) ? nextFba[i].toFixed(0) : '';
         const finalSalesValue = Number.isFinite(nextFinalSales[i])
           ? nextFinalSales[i].toFixed(0)
           : '';
-        const stockEndValue = Number.isFinite(nextStockEnd[i]) ? nextStockEnd[i].toFixed(0) : '';
-        const stockWeeksValue = Number.isFinite(nextStockWeeks[i])
-          ? nextStockWeeks[i].toFixed(2)
+        const fbaCoverWeeksValue = Number.isFinite(nextFbaCoverWeeks[i])
+          ? nextFbaCoverWeeks[i].toFixed(2)
           : '∞';
-        const errorValue = nextError[i] == null ? '' : `${(nextError[i]! * 100).toFixed(1)}%`;
-        const demandSourceKey = finalSalesKey.replace(/_finalSales$/, '_finalSalesSource');
+        const totalCoverWeeksValue = Number.isFinite(nextTotalCoverWeeks[i])
+          ? nextTotalCoverWeeks[i].toFixed(2)
+          : '∞';
         const demandSourceValue = nextDemandSource[i] ?? '';
 
-        if (row?.[stockStartKey] !== stockStartValue)
-          changes.push([i, stockStartKey, stockStartValue]);
+        if (row?.[threePlKey] !== threePlValue) changes.push([i, threePlKey, threePlValue]);
+        if (row?.[fbaKey] !== fbaValue) changes.push([i, fbaKey, fbaValue]);
         if (row?.[finalSalesKey] !== finalSalesValue)
           changes.push([i, finalSalesKey, finalSalesValue]);
-        if (row?.[stockEndKey] !== stockEndValue) changes.push([i, stockEndKey, stockEndValue]);
-        if (row?.[stockWeeksKey] !== stockWeeksValue)
-          changes.push([i, stockWeeksKey, stockWeeksValue]);
-        if (row?.[finalSalesErrorKey] !== errorValue)
-          changes.push([i, finalSalesErrorKey, errorValue]);
-        if (row?.[demandSourceKey] !== demandSourceValue)
-          changes.push([i, demandSourceKey, demandSourceValue]);
+        if (row?.[fbaCoverWeeksKey] !== fbaCoverWeeksValue)
+          changes.push([i, fbaCoverWeeksKey, fbaCoverWeeksValue]);
+        if (row?.[totalCoverWeeksKey] !== totalCoverWeeksValue)
+          changes.push([i, totalCoverWeeksKey, totalCoverWeeksValue]);
+        if (row?.[finalSalesSourceKey] !== demandSourceValue)
+          changes.push([i, finalSalesSourceKey, demandSourceValue]);
       }
 
       const startIndex = Math.max(0, Math.min(n - 1, startRowIndex ?? 0));
@@ -1061,6 +970,12 @@ export function SalesPlanningGrid({
           // Update local state
           const current = next[absoluteRowIndex] ?? { ...row };
           current[edit.columnId] = edit.value;
+          if (colMeta.field === 'finalSales') {
+            current[edit.columnId.replace(/_finalSales$/, '_finalSalesSource')] = 'OVERRIDE';
+          } else if (colMeta.field === 'actualSales' || colMeta.field === 'forecastSales') {
+            current[edit.columnId.replace(/_(actualSales|forecastSales)$/, '_finalSalesSource')] =
+              '';
+          }
           next[absoluteRowIndex] = current;
 
           // Track for derived field recalculation
@@ -1181,6 +1096,12 @@ export function SalesPlanningGrid({
             ...(next[absoluteRowIndex] ?? {}),
           };
           current[edit.columnId] = edit.value;
+          if (colMeta.field === 'finalSales') {
+            current[edit.columnId.replace(/_finalSales$/, '_finalSalesSource')] = 'OVERRIDE';
+          } else if (colMeta.field === 'actualSales' || colMeta.field === 'forecastSales') {
+            current[edit.columnId.replace(/_(actualSales|forecastSales)$/, '_finalSalesSource')] =
+              '';
+          }
           touchedRows.set(absoluteRowIndex, current);
         });
 
@@ -2216,43 +2137,15 @@ export function SalesPlanningGrid({
   const renderMetricHeader = useCallback(
     (field: string) => {
       const labelMap: Record<string, string> = {
-        stockStart: 'Stock Start',
-        actualSales: 'Actual',
-        forecastSales: 'Planner',
-        systemForecastSales: 'System',
-        finalSales: 'Demand',
-        finalSalesError: '% Error',
-        stockWeeks: 'Cover (w)',
-        stockEnd: 'Stock Qty',
+        inbound: 'INBOUND',
+        threePl: '3PL',
+        fba: 'FBA',
+        fbaCoverWeeks: 'FBA COVER (W)',
+        totalCoverWeeks: 'TOTAL COVER (W)',
+        actualSales: 'ACTUAL',
+        forecastSales: 'PLANNER',
+        finalSales: 'FINAL',
       };
-
-      if (field === activeStockMetric) {
-        return (
-          <button
-            type="button"
-            className="rounded border bg-secondary px-2 py-0.5 text-xs font-medium hover:bg-secondary/80"
-            onClick={() =>
-              preserveGridScroll(() =>
-                setActiveStockMetric((prev) => (prev === 'stockWeeks' ? 'stockEnd' : 'stockWeeks')),
-              )
-            }
-          >
-            {labelMap[field]}
-          </button>
-        );
-      }
-
-      if (field === (showFinalError ? 'finalSalesError' : 'finalSales')) {
-        return (
-          <button
-            type="button"
-            className="rounded border bg-secondary px-2 py-0.5 text-xs font-medium hover:bg-secondary/80"
-            onClick={() => preserveGridScroll(() => setShowFinalError((prev) => !prev))}
-          >
-            {labelMap[field]}
-          </button>
-        );
-      }
 
       return (
         <span className="text-xs font-medium text-muted-foreground">
@@ -2260,13 +2153,7 @@ export function SalesPlanningGrid({
         </span>
       );
     },
-    [
-      activeStockMetric,
-      preserveGridScroll,
-      setActiveStockMetric,
-      setShowFinalError,
-      showFinalError,
-    ],
+    [],
   );
 
   return (
@@ -2313,9 +2200,9 @@ export function SalesPlanningGrid({
                     | { sticky?: boolean; stickyOffset?: number; width?: number }
                     | undefined;
                   const labelMap: Record<string, string> = {
-                    weekLabel: 'Week',
-                    weekDate: 'Date',
-                    arrivalDetail: 'Inbound PO',
+                    weekLabel: 'WEEK',
+                    weekDate: 'DATE',
+                    arrivalDetail: 'Notes',
                   };
                   return (
                     <TableHead

--- a/apps/xplan/components/sheets/sales-planning-visual.tsx
+++ b/apps/xplan/components/sheets/sales-planning-visual.tsx
@@ -117,11 +117,11 @@ export function SalesPlanningVisual({
 
     const stockStartKey = columnKeys.find(
       (key) =>
-        columnMeta[key]?.productId === selectedProductId && columnMeta[key]?.field === 'stockStart',
+        columnMeta[key]?.productId === selectedProductId && columnMeta[key]?.field === 'fba',
     );
     const stockEndKey = columnKeys.find(
       (key) =>
-        columnMeta[key]?.productId === selectedProductId && columnMeta[key]?.field === 'stockEnd',
+        columnMeta[key]?.productId === selectedProductId && columnMeta[key]?.field === 'fba',
     );
     const finalSalesKey = columnKeys.find(
       (key) =>
@@ -330,7 +330,7 @@ export function SalesPlanningVisual({
       {/* Chart Card */}
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base">Stock Level Over Time</CardTitle>
+          <CardTitle className="text-base">FBA Stock Over Time</CardTitle>
           <CardDescription>Tracking inventory levels with shipment arrival markers</CardDescription>
         </CardHeader>
         <CardContent>
@@ -488,7 +488,7 @@ export function SalesPlanningVisual({
                     : 'text-slate-400 dark:text-slate-500'
                 }`}
               >
-                Stock Level
+                FBA Stock
               </span>
             </button>
             <button

--- a/apps/xplan/components/sheets/setup-workspace.tsx
+++ b/apps/xplan/components/sheets/setup-workspace.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { StrategyTable } from '@/components/sheets/strategy-table';
 import { SetupDefaultsBand } from '@/components/sheets/setup-defaults-band';
 import { SetupProductTable } from '@/components/sheets/setup-product-table';
+import { WorkbookSetupTable, type WorkbookSetupRow } from '@/components/sheets/workbook-setup-table';
 
 type ParameterList = Array<{
   id: string;
@@ -73,8 +74,10 @@ type LeadTimeOverrideId = {
 type SetupWorkspaceProps = {
   strategies: Strategy[];
   activeStrategyId: string | null;
+  activeYear: number;
   viewer: { id: string | null; email: string | null; isSuperAdmin: boolean };
   products: Array<{ id: string; sku: string; name: string }>;
+  workbookSetupRows: WorkbookSetupRow[];
   operationsParameters: ParameterList;
   salesParameters: ParameterList;
   financeParameters: ParameterList;
@@ -85,6 +88,7 @@ type SetupWorkspaceProps = {
 };
 
 const TABS = [
+  { id: 'workbook' as const, label: 'Workbook Setup' },
   { id: 'strategies' as const, label: 'Strategies' },
   { id: 'defaults' as const, label: 'Defaults & Products' },
 ];
@@ -94,8 +98,10 @@ type TabId = (typeof TABS)[number]['id'];
 export function SetupWorkspace({
   strategies,
   activeStrategyId,
+  activeYear,
   viewer,
   products,
+  workbookSetupRows,
   operationsParameters,
   salesParameters,
   financeParameters,
@@ -104,11 +110,13 @@ export function SetupWorkspace({
   leadTimeOverrideIds,
   keyParametersByStrategyId,
 }: SetupWorkspaceProps) {
-  const [activeTab, setActiveTab] = useState<TabId>('strategies');
+  const [activeTab, setActiveTab] = useState<TabId>(activeStrategyId ? 'workbook' : 'strategies');
 
   const hasStrategy = Boolean(activeStrategyId);
   const tabHelperText =
-    activeTab === 'strategies'
+    activeTab === 'workbook'
+      ? `${workbookSetupRows.length} SKU rows`
+      : activeTab === 'strategies'
       ? `${strategies.length} scenarios`
       : `${products.length} products`;
 
@@ -142,6 +150,14 @@ export function SetupWorkspace({
           activeStrategyId={activeStrategyId}
           viewer={viewer}
           keyParametersByStrategyId={keyParametersByStrategyId}
+        />
+      )}
+
+      {activeTab === 'workbook' && hasStrategy && (
+        <WorkbookSetupTable
+          strategyId={activeStrategyId!}
+          activeYear={activeYear}
+          rows={workbookSetupRows}
         />
       )}
 

--- a/apps/xplan/components/sheets/workbook-setup-table.tsx
+++ b/apps/xplan/components/sheets/workbook-setup-table.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import { useEffect, useState, type ChangeEvent } from 'react';
+import { toast } from 'sonner';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { withAppBasePath } from '@/lib/base-path';
+
+export type WorkbookSetupRow = {
+  productId: string;
+  sku: string;
+  openingStock: string;
+  nextYearOpeningOverride: string;
+  notes: string;
+  region: 'US' | 'UK';
+  totalCoverThresholdWeeks: string;
+  fbaCoverThresholdWeeks: string;
+};
+
+type EditableField = Exclude<keyof WorkbookSetupRow, 'productId' | 'sku' | 'region'>;
+
+type WorkbookSetupTableProps = {
+  strategyId: string;
+  activeYear: number;
+  rows: WorkbookSetupRow[];
+};
+
+const FIELD_LABELS: Record<EditableField, string> = {
+  openingStock: 'Opening Stock',
+  nextYearOpeningOverride: 'Opening Override',
+  notes: 'Notes',
+  totalCoverThresholdWeeks: 'Total Threshold (W)',
+  fbaCoverThresholdWeeks: 'FBA Threshold (W)',
+};
+
+function normalizeNumber(value: string, integer: boolean): string {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const parsed = Number(trimmed.replace(/[$,%\s]/g, '').replace(/,/g, ''));
+  if (!Number.isFinite(parsed)) {
+    throw new Error('Invalid number');
+  }
+  return integer ? String(Math.round(parsed)) : parsed.toFixed(2);
+}
+
+export function WorkbookSetupTable({ strategyId, activeYear, rows }: WorkbookSetupTableProps) {
+  const [localRows, setLocalRows] = useState(rows);
+  const [savingCell, setSavingCell] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLocalRows(rows);
+  }, [rows]);
+
+  const saveField = async (productId: string, field: EditableField, value: string) => {
+    const cellKey = `${productId}:${field}`;
+    setSavingCell(cellKey);
+    try {
+      const response = await fetch(withAppBasePath('/api/v1/xplan/product-setup'), {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          strategyId,
+          year: activeYear,
+          updates: [{ productId, values: { [field]: value } }],
+        }),
+      });
+      if (!response.ok) {
+        const payload = await response.json();
+        throw new Error(payload.error);
+      }
+      toast.success(`${FIELD_LABELS[field]} saved`, { id: 'workbook-setup-saved' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to save setup value';
+      toast.error(message, { id: 'workbook-setup-error' });
+    } finally {
+      setSavingCell(null);
+    }
+  };
+
+  const updateField = (productId: string, field: EditableField, value: string) => {
+    setLocalRows((current) =>
+      current.map((row) => (row.productId === productId ? { ...row, [field]: value } : row)),
+    );
+  };
+
+  const handleNumberBlur = (productId: string, field: EditableField, integer: boolean) => {
+    const row = localRows.find((candidate) => candidate.productId === productId);
+    if (!row) return;
+    try {
+      const normalized = normalizeNumber(row[field], integer);
+      updateField(productId, field, normalized);
+      void saveField(productId, field, normalized);
+    } catch {
+      toast.error('Enter a valid number', { id: 'workbook-setup-error' });
+    }
+  };
+
+  const inputClassName =
+    'h-8 min-w-[7rem] rounded-none border-0 bg-transparent px-2 text-sm shadow-none focus-visible:ring-1 focus-visible:ring-cyan-600';
+
+  return (
+    <div className="overflow-hidden rounded-xl border bg-card">
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow className="bg-muted/70 hover:bg-muted/70">
+              <TableHead className="h-9 min-w-[9rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                SKU
+              </TableHead>
+              <TableHead className="h-9 min-w-[10rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                Opening Stock {activeYear}
+              </TableHead>
+              <TableHead className="h-9 min-w-[12rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                {activeYear + 1} Opening Override
+              </TableHead>
+              <TableHead className="h-9 min-w-[15rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                Notes
+              </TableHead>
+              <TableHead className="h-9 min-w-[7rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                REGION
+              </TableHead>
+              <TableHead className="h-9 min-w-[11rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                Total Threshold (W)
+              </TableHead>
+              <TableHead className="h-9 min-w-[10rem] whitespace-nowrap text-xs font-bold uppercase tracking-wide">
+                FBA Threshold (W)
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {localRows.map((row) => (
+              <TableRow key={row.productId} className="h-9">
+                <TableCell className="h-9 whitespace-nowrap px-3 py-0 text-sm font-semibold">
+                  {row.sku}
+                </TableCell>
+                <TableCell className="h-9 p-0">
+                  <Input
+                    value={row.openingStock}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      updateField(row.productId, 'openingStock', event.target.value)
+                    }
+                    onBlur={() => handleNumberBlur(row.productId, 'openingStock', true)}
+                    disabled={savingCell === `${row.productId}:openingStock`}
+                    className={`${inputClassName} text-right tabular-nums`}
+                  />
+                </TableCell>
+                <TableCell className="h-9 p-0">
+                  <Input
+                    value={row.nextYearOpeningOverride}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      updateField(row.productId, 'nextYearOpeningOverride', event.target.value)
+                    }
+                    onBlur={() =>
+                      handleNumberBlur(row.productId, 'nextYearOpeningOverride', true)
+                    }
+                    disabled={savingCell === `${row.productId}:nextYearOpeningOverride`}
+                    className={`${inputClassName} text-right tabular-nums`}
+                  />
+                </TableCell>
+                <TableCell className="h-9 p-0">
+                  <Input
+                    value={row.notes}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      updateField(row.productId, 'notes', event.target.value)
+                    }
+                    onBlur={() => saveField(row.productId, 'notes', row.notes)}
+                    disabled={savingCell === `${row.productId}:notes`}
+                    className={inputClassName}
+                  />
+                </TableCell>
+                <TableCell className="h-9 whitespace-nowrap px-3 py-0 text-sm font-semibold">
+                  {row.region}
+                </TableCell>
+                <TableCell className="h-9 p-0">
+                  <Input
+                    value={row.totalCoverThresholdWeeks}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      updateField(row.productId, 'totalCoverThresholdWeeks', event.target.value)
+                    }
+                    onBlur={() =>
+                      handleNumberBlur(row.productId, 'totalCoverThresholdWeeks', false)
+                    }
+                    disabled={savingCell === `${row.productId}:totalCoverThresholdWeeks`}
+                    className={`${inputClassName} text-right tabular-nums`}
+                  />
+                </TableCell>
+                <TableCell className="h-9 p-0">
+                  <Input
+                    value={row.fbaCoverThresholdWeeks}
+                    onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                      updateField(row.productId, 'fbaCoverThresholdWeeks', event.target.value)
+                    }
+                    onBlur={() => handleNumberBlur(row.productId, 'fbaCoverThresholdWeeks', false)}
+                    disabled={savingCell === `${row.productId}:fbaCoverThresholdWeeks`}
+                    className={`${inputClassName} text-right tabular-nums`}
+                  />
+                </TableCell>
+              </TableRow>
+            ))}
+            {localRows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="h-16 text-center text-sm text-muted-foreground">
+                  No active SKU rows.
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/apps/xplan/lib/calculations/adapters.ts
+++ b/apps/xplan/lib/calculations/adapters.ts
@@ -106,6 +106,24 @@ export function mapPurchaseOrders(
               batch.overrideReferralRate != null ? Number(batch.overrideReferralRate) : null,
             overrideStoragePerMonth:
               batch.overrideStoragePerMonth != null ? Number(batch.overrideStoragePerMonth) : null,
+            cartonSide1Cm:
+              (batch as BatchTableRow & { cartonSide1Cm?: unknown }).cartonSide1Cm != null
+                ? Number((batch as BatchTableRow & { cartonSide1Cm?: unknown }).cartonSide1Cm)
+                : null,
+            cartonSide2Cm:
+              (batch as BatchTableRow & { cartonSide2Cm?: unknown }).cartonSide2Cm != null
+                ? Number((batch as BatchTableRow & { cartonSide2Cm?: unknown }).cartonSide2Cm)
+                : null,
+            cartonSide3Cm:
+              (batch as BatchTableRow & { cartonSide3Cm?: unknown }).cartonSide3Cm != null
+                ? Number((batch as BatchTableRow & { cartonSide3Cm?: unknown }).cartonSide3Cm)
+                : null,
+            cartonWeightKg:
+              (batch as BatchTableRow & { cartonWeightKg?: unknown }).cartonWeightKg != null
+                ? Number((batch as BatchTableRow & { cartonWeightKg?: unknown }).cartonWeightKg)
+                : null,
+            unitsPerCarton:
+              (batch as BatchTableRow & { unitsPerCarton?: number | null }).unitsPerCarton ?? null,
           }),
         )
       : [];
@@ -120,6 +138,10 @@ export function mapPurchaseOrders(
       quantity: batches.length > 0 ? totalBatchQuantity : coerceNumber(order.quantity),
       poDate: order.poDate ?? null,
       poWeekNumber: order.poWeekNumber ?? null,
+      poClass: (order as PurchaseOrder & { poClass?: string | null }).poClass ?? null,
+      inboundWeekOverride:
+        (order as PurchaseOrder & { inboundWeekOverride?: Date | null }).inboundWeekOverride ??
+        null,
       productionWeeks: normalizePositiveDecimal(order.productionWeeks),
       sourceWeeks: normalizePositiveDecimal(order.sourceWeeks),
       oceanWeeks: normalizePositiveDecimal(order.oceanWeeks),

--- a/apps/xplan/lib/calculations/ops.ts
+++ b/apps/xplan/lib/calculations/ops.ts
@@ -62,6 +62,8 @@ export interface PurchaseOrderDerived {
   batches: PurchaseOrderBatchDerived[];
   status: PurchaseOrderStatus;
   statusIcon?: string | null;
+  poClass?: string | null;
+  inboundWeekOverride?: Date | null;
   notes?: string | null;
   shipName?: string | null;
   containerNumber?: string | null;
@@ -297,6 +299,7 @@ function buildStageSchedule(
   const finalBaseWeekNumber = portEtaWeekNumber ?? inboundEtaWeekNumber ?? oceanBaseWeekNumber;
   const availableWeekNumber =
     normalizeWeekNumber(order.availableWeekNumber) ??
+    resolveWeekNumber(order.inboundWeekOverride ?? null, mapping) ??
     resolveWeekNumber(order.availableDate ?? null, mapping) ??
     (finalBaseWeekNumber != null ? finalBaseWeekNumber + stageOffsetWeeks(finalWeeks) : null);
 
@@ -329,6 +332,7 @@ function buildStageSchedule(
 
     const finalBaseFallback = portEtaFallback ?? inboundEtaFallback ?? oceanBaseFallback;
     const availableFallback =
+      order.inboundWeekOverride ??
       order.availableDate ??
       (finalBaseFallback ? addStageDurationDate(finalBaseFallback, finalWeeks) : null);
 
@@ -345,7 +349,7 @@ function buildStageSchedule(
   const productionCompleteForDiff = order.productionComplete ?? productionComplete ?? null;
   const sourceDepartureForDiff = order.sourceDeparture ?? sourceDeparture ?? null;
   const portEtaForDiff = order.portEta ?? portEta ?? null;
-  const availableForDiff = order.availableDate ?? availableDate ?? null;
+  const availableForDiff = order.inboundWeekOverride ?? order.availableDate ?? availableDate ?? null;
 
   const computedProductionWeeks = weeksBetweenDates(
     productionStartForDiff,
@@ -759,6 +763,8 @@ export function computePurchaseOrderDerived(
     batches: derivedBatches,
     status: order.status,
     statusIcon: order.statusIcon ?? STATUS_ICON_MAP[order.status],
+    poClass: order.poClass ?? null,
+    inboundWeekOverride: order.inboundWeekOverride ?? null,
     notes: order.notes ?? null,
     shipName: order.shipName ?? null,
     containerNumber: order.containerNumber ?? order.transportReference ?? null,

--- a/apps/xplan/lib/calculations/types.ts
+++ b/apps/xplan/lib/calculations/types.ts
@@ -79,6 +79,8 @@ export interface PurchaseOrderInput {
   productId: string;
   poDate?: Date | null;
   poWeekNumber?: number | null;
+  poClass?: string | null;
+  inboundWeekOverride?: Date | null;
   quantity: number;
   productionWeeks?: number | null;
   sourceWeeks?: number | null;

--- a/apps/xplan/lib/calculations/workbook-parity.ts
+++ b/apps/xplan/lib/calculations/workbook-parity.ts
@@ -1,0 +1,344 @@
+export function excelSetupColumns(year: number) {
+  return [
+    'SKU',
+    `Opening Stock ${year}`,
+    `${year + 1} Opening Override`,
+    'Notes',
+    'REGION',
+    'Total Threshold (W)',
+    'FBA Threshold (W)',
+  ] as const;
+}
+
+export const EXCEL_FORECAST_METRICS = [
+  'INBOUND',
+  '3PL',
+  'FBA',
+  'FBA COVER (W)',
+  'TOTAL COVER (W)',
+  'ACTUAL',
+  'PLANNER',
+  'FINAL',
+] as const;
+
+export const EXCEL_PO_TABLE_COLUMNS = [
+  'PO CODE',
+  'PRODUCT',
+  'QTY',
+  'UNITS/CTN',
+  'CARTON',
+  'CTN L (CM)',
+  'CTN W (CM)',
+  'CTN H (CM)',
+  'CBM',
+  'MFG START',
+  'SHIP',
+  'CONTAINER #',
+  'STATUS',
+  'PO CLASS',
+  'MFG (WK)',
+  'DEPART (WK)',
+  'ARRIVAL (WK)',
+  'WH (WK)',
+  'INBOUND WK OVERRIDE',
+  'INBOUND WK',
+  'PO TOTAL QTY',
+  'NOTES',
+  'PO FIRST ROW',
+  'REGION',
+] as const;
+
+export const EXCEL_PO_FINANCE_COLUMNS = [
+  'PO CODE',
+  'PRODUCT',
+  'CARTON',
+  'SELL $',
+  'MFG $',
+  'FREIGHT $',
+  'TARIFF $',
+  'TACOS %',
+  'FBA $',
+  'REFERRAL %',
+  'STORAGE $',
+  'GP $',
+  'NP $',
+  'REGION',
+] as const;
+
+export type WorkbookRegion = 'US' | 'UK';
+
+export type PoTableWorkbookInput = {
+  orderCode: string;
+  product: string;
+  quantity: number | null;
+  unitsPerCarton: number | null;
+  cartonLengthCm: number | null;
+  cartonWidthCm: number | null;
+  cartonHeightCm: number | null;
+  mfgStart: Date | null;
+  arrivalWeeks: number | null;
+  warehouseWeeks: number | null;
+  inboundWeekOverride?: Date | null;
+  region: WorkbookRegion;
+};
+
+export type PoTableWorkbookDerived = {
+  carton: number | null;
+  cbm: number | null;
+  inboundWeek: Date | null;
+  poTotalQty: number;
+  poFirstRow: number | null;
+};
+
+export type PoFinanceLookupRow = {
+  orderCode: string;
+  product: string;
+  region: WorkbookRegion;
+  carton: number | null;
+};
+
+export type PoFinanceWorkbookInput = {
+  orderCode: string;
+  product: string;
+  region: WorkbookRegion;
+  poTableRows: PoFinanceLookupRow[];
+  sellPrice: number | null;
+  manufacturingCost: number | null;
+  freightCost: number | null;
+  tariffCost: number | null;
+  tacosPercent: number | null;
+  fbaFee: number | null;
+  referralPercent: number | null;
+  storageCost: number | null;
+};
+
+export type PoFinanceWorkbookDerived = {
+  carton: number | null;
+  grossProfit: number | null;
+  netProfit: number | null;
+};
+
+export type ForecastWorkbookRowInput = {
+  openingStock: number | null;
+  inbound: number | null;
+  actual: number | null;
+  planner: number | null;
+  final?: number | null;
+  previous: ForecastWorkbookRow | null;
+};
+
+export type ForecastWorkbookRow = {
+  inbound: number;
+  threePl: number;
+  fba: number;
+  fbaCoverWeeks: number;
+  totalCoverWeeks: number;
+  actual: number | null;
+  planner: number | null;
+  final: number;
+};
+
+function finiteNumber(value: number | null | undefined): number | null {
+  if (value == null) return null;
+  return Number.isFinite(value) ? value : null;
+}
+
+function numberValue(value: number | null | undefined): number {
+  const numeric = finiteNumber(value);
+  return numeric == null ? 0 : numeric;
+}
+
+function roundTo(value: number, digits: number): number {
+  const multiplier = 10 ** digits;
+  return Math.round(value * multiplier) / multiplier;
+}
+
+function mondayForDate(date: Date): Date {
+  const utc = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  const day = utc.getUTCDay();
+  const mondayOffset = day === 0 ? -6 : 1 - day;
+  utc.setUTCDate(utc.getUTCDate() + mondayOffset);
+  return utc;
+}
+
+function addWeeks(date: Date, weeks: number): Date {
+  const copy = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  copy.setUTCDate(copy.getUTCDate() + Math.round(weeks * 7));
+  return copy;
+}
+
+export function computeCarton(quantity: number | null, unitsPerCarton: number | null): number | null {
+  const qty = finiteNumber(quantity);
+  const units = finiteNumber(unitsPerCarton);
+  if (qty == null) return null;
+  if (units == null) return null;
+  if (units <= 0) return null;
+  return Math.ceil(qty / units);
+}
+
+export function computeCbm(options: {
+  quantity: number | null;
+  unitsPerCarton: number | null;
+  cartonLengthCm: number | null;
+  cartonWidthCm: number | null;
+  cartonHeightCm: number | null;
+}): number | null {
+  const carton = computeCarton(options.quantity, options.unitsPerCarton);
+  const length = finiteNumber(options.cartonLengthCm);
+  const width = finiteNumber(options.cartonWidthCm);
+  const height = finiteNumber(options.cartonHeightCm);
+  if (carton == null) return null;
+  if (length == null) return null;
+  if (width == null) return null;
+  if (height == null) return null;
+  return roundTo((carton * length * width * height) / 1_000_000, 3);
+}
+
+export function computeInboundWeek(row: PoTableWorkbookInput): Date | null {
+  if (row.inboundWeekOverride) return mondayForDate(row.inboundWeekOverride);
+  if (!row.mfgStart) return null;
+  const warehouseWeeks = finiteNumber(row.warehouseWeeks);
+  const arrivalWeeks = finiteNumber(row.arrivalWeeks);
+  const offset = warehouseWeeks ?? arrivalWeeks;
+  if (offset == null) return null;
+  return mondayForDate(addWeeks(row.mfgStart, offset));
+}
+
+export function computePoTotalQty(
+  row: Pick<PoTableWorkbookInput, 'orderCode' | 'region'>,
+  rows: PoTableWorkbookInput[],
+): number {
+  return rows.reduce((sum, candidate) => {
+    if (candidate.orderCode !== row.orderCode) return sum;
+    if (candidate.region !== row.region) return sum;
+    return sum + numberValue(candidate.quantity);
+  }, 0);
+}
+
+export function computePoFirstRow(
+  row: PoTableWorkbookInput,
+  rows: PoTableWorkbookInput[],
+  index: number,
+): number | null {
+  const inboundWeek = computeInboundWeek(row);
+  if (!row.orderCode) return null;
+  if (!inboundWeek) return null;
+
+  let count = 0;
+  for (let rowIndex = 0; rowIndex <= index; rowIndex += 1) {
+    const candidate = rows[rowIndex];
+    if (!candidate) continue;
+    const candidateInbound = computeInboundWeek(candidate);
+    if (!candidateInbound) continue;
+    if (candidate.orderCode !== row.orderCode) continue;
+    if (candidate.region !== row.region) continue;
+    if (candidateInbound.getTime() !== inboundWeek.getTime()) continue;
+    count += 1;
+  }
+  return count;
+}
+
+export function computePoTableWorkbookRow(
+  row: PoTableWorkbookInput,
+  rows: PoTableWorkbookInput[],
+  index: number,
+): PoTableWorkbookDerived {
+  return {
+    carton: computeCarton(row.quantity, row.unitsPerCarton),
+    cbm: computeCbm({
+      quantity: row.quantity,
+      unitsPerCarton: row.unitsPerCarton,
+      cartonLengthCm: row.cartonLengthCm,
+      cartonWidthCm: row.cartonWidthCm,
+      cartonHeightCm: row.cartonHeightCm,
+    }),
+    inboundWeek: computeInboundWeek(row),
+    poTotalQty: computePoTotalQty(row, rows),
+    poFirstRow: computePoFirstRow(row, rows, index),
+  };
+}
+
+export function computePoFinanceWorkbookRow(
+  input: PoFinanceWorkbookInput,
+): PoFinanceWorkbookDerived {
+  const carton = input.poTableRows.reduce<number | null>((sum, row) => {
+    if (row.orderCode !== input.orderCode) return sum;
+    if (row.product !== input.product) return sum;
+    if (row.region !== input.region) return sum;
+    const cartonValue = finiteNumber(row.carton);
+    if (cartonValue == null) return sum;
+    return (sum ?? 0) + cartonValue;
+  }, null);
+
+  const hasEconomics = [
+    input.sellPrice,
+    input.manufacturingCost,
+    input.freightCost,
+    input.tariffCost,
+    input.tacosPercent,
+    input.fbaFee,
+    input.referralPercent,
+    input.storageCost,
+  ].some((value) => value != null);
+
+  if (!hasEconomics) {
+    return { carton, grossProfit: null, netProfit: null };
+  }
+
+  const sell = numberValue(input.sellPrice);
+  const grossProfit =
+    sell -
+    numberValue(input.manufacturingCost) -
+    numberValue(input.freightCost) -
+    numberValue(input.tariffCost) -
+    numberValue(input.fbaFee) -
+    sell * numberValue(input.referralPercent);
+  const netProfit =
+    grossProfit - numberValue(input.storageCost) - sell * numberValue(input.tacosPercent);
+
+  return { carton, grossProfit, netProfit };
+}
+
+function coverWeeks(numerator: number, final: number): number {
+  if (final === 0) {
+    return numerator > 0 ? Number.POSITIVE_INFINITY : 0;
+  }
+  return numerator / final;
+}
+
+export function computeForecastWorkbookRow(input: ForecastWorkbookRowInput): ForecastWorkbookRow {
+  const inbound = numberValue(input.inbound);
+  const actual = finiteNumber(input.actual);
+  const planner = finiteNumber(input.planner);
+  const explicitFinal = finiteNumber(input.final);
+  const final = explicitFinal ?? actual ?? planner ?? 0;
+
+  let threePl: number;
+  let fba: number;
+
+  if (input.previous) {
+    threePl = numberValue(input.previous.threePl) + inbound;
+    fba = Math.max(
+      0,
+      numberValue(input.previous.threePl) +
+        numberValue(input.previous.fba) +
+        numberValue(input.previous.inbound) -
+        numberValue(input.previous.final) -
+        threePl,
+    );
+  } else {
+    threePl = 0;
+    fba = Math.max(0, numberValue(input.openingStock) - threePl);
+  }
+
+  return {
+    inbound,
+    threePl,
+    fba,
+    fbaCoverWeeks: coverWeeks(fba, final),
+    totalCoverWeeks: coverWeeks(inbound + threePl + fba, final),
+    actual,
+    planner,
+    final,
+  };
+}

--- a/apps/xplan/lib/sheets.ts
+++ b/apps/xplan/lib/sheets.ts
@@ -13,8 +13,9 @@ export type SheetSlug =
   | '3-ops-planning'
   | '4-sales-planning'
   | '5-fin-planning-pl'
-  | '6-po-profitability'
-  | '7-fin-planning-cash-flow';
+  | '6-po-finances'
+  | '7-fin-planning-cash-flow'
+  | '8-po-profitability';
 
 export type LegacySheetSlug =
   | '0-strategies'
@@ -67,7 +68,14 @@ export const SHEETS: SheetConfig[] = [
     icon: LineChart,
   },
   {
-    slug: '6-po-profitability',
+    slug: '6-po-finances',
+    label: 'PO Finances',
+    shortLabel: 'PO Fin',
+    description: '',
+    icon: TrendingUp,
+  },
+  {
+    slug: '8-po-profitability',
     label: 'PO P&L',
     shortLabel: 'PO P&L',
     description: '',
@@ -92,8 +100,8 @@ export const LEGACY_SHEET_SLUG_REDIRECTS: Readonly<Record<LegacySheetSlug, Sheet
   '4-fin-planning-pl': '5-fin-planning-pl',
   '5-fin-planning-cash-flow': '7-fin-planning-cash-flow',
   '6-fin-planning-cash-flow': '7-fin-planning-cash-flow',
-  '6-po-profitability': '6-po-profitability',
-  '7-po-profitability': '6-po-profitability',
+  '6-po-profitability': '8-po-profitability',
+  '7-po-profitability': '8-po-profitability',
 };
 
 export function getCanonicalSheetSlug(slug: string): SheetSlug | undefined {

--- a/apps/xplan/lib/workbook.ts
+++ b/apps/xplan/lib/workbook.ts
@@ -118,8 +118,17 @@ export async function getWorkbookStatus(): Promise<WorkbookStatus> {
         relativeUpdatedAt: formatRelative(profitUpdatedAt ?? profitAgg._max.updatedAt),
         status: profitAgg._count.id > 0 ? 'complete' : 'todo',
       },
-      '6-po-profitability': {
-        slug: '6-po-profitability',
+      '6-po-finances': {
+        slug: '6-po-finances',
+        label: 'PO Finances',
+        description: '',
+        recordCount: purchaseOrderAgg._count.id,
+        lastUpdated: formatIso(purchaseOrderAgg._max.updatedAt),
+        relativeUpdatedAt: formatRelative(purchaseOrderAgg._max.updatedAt),
+        status: purchaseOrderAgg._count.id > 0 ? 'complete' : 'todo',
+      },
+      '8-po-profitability': {
+        slug: '8-po-profitability',
         label: 'PO P&L',
         description: '',
         recordCount: purchaseOrderAgg._count.id,

--- a/apps/xplan/prisma/migrations/20260426010000_workbook_structure_parity/migration.sql
+++ b/apps/xplan/prisma/migrations/20260426010000_workbook_structure_parity/migration.sql
@@ -1,0 +1,38 @@
+-- Add workbook-structure fields used by the Excel parity UI.
+
+ALTER TABLE "PurchaseOrder"
+ADD COLUMN "poClass" TEXT,
+ADD COLUMN "inboundWeekOverride" TIMESTAMP(3);
+
+CREATE TABLE "ProductSetupYear" (
+  "id" TEXT NOT NULL,
+  "strategyId" TEXT NOT NULL,
+  "productId" TEXT NOT NULL,
+  "year" INTEGER NOT NULL,
+  "openingStock" INTEGER,
+  "nextYearOpeningOverride" INTEGER,
+  "notes" TEXT,
+  "totalCoverThresholdWeeks" DECIMAL(8,2),
+  "fbaCoverThresholdWeeks" DECIMAL(8,2),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+
+  CONSTRAINT "ProductSetupYear_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ProductSetupYear_strategyId_productId_year_key"
+ON "ProductSetupYear"("strategyId", "productId", "year");
+
+CREATE INDEX "ProductSetupYear_strategyId_year_idx"
+ON "ProductSetupYear"("strategyId", "year");
+
+CREATE INDEX "ProductSetupYear_productId_idx"
+ON "ProductSetupYear"("productId");
+
+ALTER TABLE "ProductSetupYear"
+ADD CONSTRAINT "ProductSetupYear_strategyId_fkey"
+FOREIGN KEY ("strategyId") REFERENCES "Strategy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ProductSetupYear"
+ADD CONSTRAINT "ProductSetupYear_productId_fkey"
+FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/xplan/prisma/migrations/20260426013000_product_setup_year_privileges/migration.sql
+++ b/apps/xplan/prisma/migrations/20260426013000_product_setup_year_privileges/migration.sql
@@ -1,0 +1,7 @@
+-- Keep workbook setup storage aligned with the hardened XPLAN schema roles.
+
+ALTER TABLE "ProductSetupYear" OWNER TO portal_xplan;
+
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+ON TABLE "ProductSetupYear"
+TO portal_dev_external;

--- a/apps/xplan/prisma/schema.prisma
+++ b/apps/xplan/prisma/schema.prisma
@@ -32,6 +32,7 @@ model Strategy {
   strategyAssignees    StrategyAssignee[]
   salesWeeks           SalesWeek[]
   salesWeekFinancials  SalesWeekFinancials[]
+  productSetupYears    ProductSetupYear[]
   profitAndLossWeeks   ProfitAndLossWeek[]
   cashFlowWeeks        CashFlowWeek[]
   monthlySummaries     MonthlySummary[]
@@ -118,11 +119,33 @@ model Product {
   batchTableRows      BatchTableRow[]
   salesWeeks          SalesWeek[]
   salesWeekFinancials SalesWeekFinancials[]
+  setupYears          ProductSetupYear[]
 
   @@unique([strategyId, sku])
   @@index([strategyId])
   @@index([name])
   @@index([asin])
+}
+
+/// Year-scoped workbook setup inputs from Excel "Setup"
+model ProductSetupYear {
+  id                         String   @id @default(cuid())
+  strategyId                 String
+  productId                  String
+  year                       Int
+  openingStock               Int?
+  nextYearOpeningOverride    Int?
+  notes                      String?
+  totalCoverThresholdWeeks   Decimal? @db.Decimal(8, 2)
+  fbaCoverThresholdWeeks     Decimal? @db.Decimal(8, 2)
+  createdAt                  DateTime @default(now())
+  updatedAt                  DateTime @updatedAt
+  strategy                   Strategy @relation(fields: [strategyId], references: [id], onDelete: Cascade)
+  product                    Product  @relation(fields: [productId], references: [id], onDelete: Cascade)
+
+  @@unique([strategyId, productId, year])
+  @@index([strategyId, year])
+  @@index([productId])
 }
 
 /// Default lead time configuration ("1. Product Setup" -> LEAD TIME CONFIGURATION)
@@ -174,6 +197,8 @@ model PurchaseOrder {
   productId                 String
   poDate                    DateTime?
   poWeekNumber              Int?
+  poClass                   String?
+  inboundWeekOverride       DateTime?
   quantity                  Int
   productionWeeks           Decimal                @db.Decimal(5, 2)
   sourceWeeks               Decimal                @db.Decimal(5, 2)

--- a/apps/xplan/tests/ui/workbook-column-labels.test.tsx
+++ b/apps/xplan/tests/ui/workbook-column-labels.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CustomOpsCostGrid,
+  type OpsBatchRow,
+} from '@/components/sheets/custom-ops-cost-grid'
+import {
+  CustomOpsPlanningGrid,
+} from '@/components/sheets/custom-ops-planning-grid'
+import { SalesPlanningGrid } from '@/components/sheets/sales-planning-grid'
+import {
+  WorkbookSetupTable,
+  type WorkbookSetupRow,
+} from '@/components/sheets/workbook-setup-table'
+import { TooltipProvider } from '@/components/ui/tooltip'
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn((callback: FrameRequestCallback) => window.setTimeout(() => callback(Date.now()), 0)),
+  )
+  vi.stubGlobal(
+    'cancelAnimationFrame',
+    vi.fn((handle: number) => window.clearTimeout(handle)),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function expectLabels(labels: string[]) {
+  labels.forEach((label) => {
+    expect(screen.getByText(label)).toBeInTheDocument()
+  })
+}
+
+describe('workbook sheet column labels', () => {
+  it('renders Setup with the Excel setup columns', () => {
+    const rows: WorkbookSetupRow[] = [
+      {
+        productId: 'product-1',
+        sku: 'CS001',
+        openingStock: '100',
+        nextYearOpeningOverride: '',
+        notes: '',
+        region: 'US',
+        totalCoverThresholdWeeks: '8',
+        fbaCoverThresholdWeeks: '4',
+      },
+    ]
+
+    render(<WorkbookSetupTable strategyId="strategy-1" activeYear={2026} rows={rows} />)
+
+    expectLabels([
+      'SKU',
+      'Opening Stock 2026',
+      '2027 Opening Override',
+      'Notes',
+      'REGION',
+      'Total Threshold (W)',
+      'FBA Threshold (W)',
+    ])
+  })
+
+  it('renders PO Table with the Excel PO Table columns', () => {
+    render(<CustomOpsPlanningGrid rows={[]} />)
+
+    expectLabels([
+      'PO CODE',
+      'PRODUCT',
+      'QTY',
+      'UNITS/CTN',
+      'CARTON',
+      'CTN L (CM)',
+      'CTN W (CM)',
+      'CTN H (CM)',
+      'CBM',
+      'MFG START',
+      'SHIP',
+      'CONTAINER #',
+      'STATUS',
+      'PO CLASS',
+      'MFG (WK)',
+      'DEPART (WK)',
+      'ARRIVAL (WK)',
+      'WH (WK)',
+      'INBOUND WK OVERRIDE',
+      'INBOUND WK',
+      'PO TOTAL QTY',
+      'NOTES',
+      'PO FIRST ROW',
+      'REGION',
+    ])
+  })
+
+  it('renders PO Finances Table with the Excel finance columns', () => {
+    const rows: OpsBatchRow[] = []
+
+    render(<CustomOpsCostGrid rows={rows} products={[]} />)
+
+    expect(screen.getByText('PO Finances Table')).toBeInTheDocument()
+    expectLabels([
+      'PO CODE',
+      'PRODUCT',
+      'CARTON',
+      'SELL $',
+      'MFG $',
+      'FREIGHT $',
+      'TARIFF $',
+      'TACOS %',
+      'FBA $',
+      'REFERRAL %',
+      'STORAGE $',
+      'GP $',
+      'NP $',
+      'REGION',
+    ])
+  })
+
+  it('renders Forecast with base columns and one Excel SKU block', () => {
+    const metrics = [
+      'inbound',
+      'threePl',
+      'fba',
+      'fbaCoverWeeks',
+      'totalCoverWeeks',
+      'actualSales',
+      'forecastSales',
+      'finalSales',
+    ]
+    const columnMeta = Object.fromEntries(
+      metrics.map((field) => [`product-1_${field}`, { productId: 'product-1', field }]),
+    )
+    const row: {
+      weekNumber: string
+      weekLabel: string
+      weekDate: string
+      arrivalDetail: string
+      [key: string]: string
+    } = {
+      weekNumber: '1',
+      weekLabel: 'W1',
+      weekDate: '2026-01-05',
+      arrivalDetail: '',
+    }
+    metrics.forEach((field) => {
+      row[`product-1_${field}`] = '0'
+    })
+
+    render(
+      <TooltipProvider>
+        <SalesPlanningGrid
+          strategyId="strategy-1"
+          rows={[row]}
+          columnMeta={columnMeta}
+          columnKeys={['weekLabel', 'weekDate', 'arrivalDetail', ...Object.keys(columnMeta)]}
+          productOptions={[{ id: 'product-1', name: 'CS001' }]}
+          stockWarningWeeks={8}
+          leadTimeByProduct={{}}
+          batchAllocations={new Map()}
+          reorderCueByProduct={new Map()}
+        />
+      </TooltipProvider>,
+    )
+
+    expectLabels([
+      'WEEK',
+      'DATE',
+      'Notes',
+      'INBOUND',
+      '3PL',
+      'FBA',
+      'FBA COVER (W)',
+      'TOTAL COVER (W)',
+      'ACTUAL',
+      'PLANNER',
+      'FINAL',
+    ])
+  })
+})

--- a/apps/xplan/tests/unit/workbook-parity.test.ts
+++ b/apps/xplan/tests/unit/workbook-parity.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EXCEL_FORECAST_METRICS,
+  EXCEL_PO_FINANCE_COLUMNS,
+  EXCEL_PO_TABLE_COLUMNS,
+  computeForecastWorkbookRow,
+  computePoFinanceWorkbookRow,
+  computePoTableWorkbookRow,
+  excelSetupColumns,
+} from '@/lib/calculations/workbook-parity'
+
+const mfgStart = new Date('2026-04-17T00:00:00.000Z')
+
+describe('workbook visible column parity', () => {
+  it('keeps the Excel setup columns year-specific', () => {
+    expect(excelSetupColumns(2026)).toEqual([
+      'SKU',
+      'Opening Stock 2026',
+      '2027 Opening Override',
+      'Notes',
+      'REGION',
+      'Total Threshold (W)',
+      'FBA Threshold (W)',
+    ])
+  })
+
+  it('keeps the Excel PO Table labels separate from PO finance labels', () => {
+    expect(EXCEL_PO_TABLE_COLUMNS).toEqual([
+      'PO CODE',
+      'PRODUCT',
+      'QTY',
+      'UNITS/CTN',
+      'CARTON',
+      'CTN L (CM)',
+      'CTN W (CM)',
+      'CTN H (CM)',
+      'CBM',
+      'MFG START',
+      'SHIP',
+      'CONTAINER #',
+      'STATUS',
+      'PO CLASS',
+      'MFG (WK)',
+      'DEPART (WK)',
+      'ARRIVAL (WK)',
+      'WH (WK)',
+      'INBOUND WK OVERRIDE',
+      'INBOUND WK',
+      'PO TOTAL QTY',
+      'NOTES',
+      'PO FIRST ROW',
+      'REGION',
+    ])
+
+    expect(EXCEL_PO_FINANCE_COLUMNS).toEqual([
+      'PO CODE',
+      'PRODUCT',
+      'CARTON',
+      'SELL $',
+      'MFG $',
+      'FREIGHT $',
+      'TARIFF $',
+      'TACOS %',
+      'FBA $',
+      'REFERRAL %',
+      'STORAGE $',
+      'GP $',
+      'NP $',
+      'REGION',
+    ])
+  })
+})
+
+describe('workbook PO table parity', () => {
+  it('computes Excel PO Table derived columns', () => {
+    const poRows = [
+      {
+        orderCode: 'PO-18',
+        product: '1SD32M',
+        quantity: 1680,
+        unitsPerCarton: 84,
+        cartonLengthCm: 51.99,
+        cartonWidthCm: 42.42,
+        cartonHeightCm: 34.95,
+        mfgStart,
+        arrivalWeeks: 7,
+        warehouseWeeks: 8,
+        region: 'UK',
+      },
+      {
+        orderCode: 'PO-18',
+        product: 'CS010',
+        quantity: 840,
+        unitsPerCarton: 30,
+        cartonLengthCm: 25.98,
+        cartonWidthCm: 41.38,
+        cartonHeightCm: 59.99,
+        mfgStart,
+        arrivalWeeks: 7,
+        warehouseWeeks: 8,
+        region: 'UK',
+      },
+    ]
+
+    const first = computePoTableWorkbookRow(poRows[0], poRows, 0)
+    const second = computePoTableWorkbookRow(poRows[1], poRows, 1)
+
+    expect(first.carton).toBe(20)
+    expect(first.cbm).toBe(1.542)
+    expect(first.inboundWeek?.toISOString()).toBe('2026-06-08T00:00:00.000Z')
+    expect(first.poTotalQty).toBe(2520)
+    expect(first.poFirstRow).toBe(1)
+
+    expect(second.carton).toBe(28)
+    expect(second.cbm).toBe(1.806)
+    expect(second.inboundWeek?.toISOString()).toBe('2026-06-08T00:00:00.000Z')
+    expect(second.poTotalQty).toBe(2520)
+    expect(second.poFirstRow).toBe(2)
+  })
+})
+
+describe('workbook PO finance parity', () => {
+  it('computes Excel PO Finances Table values from separate PO table rows', () => {
+    const poTableRows = [
+      { orderCode: 'PO-20', product: 'CS007', region: 'UK', carton: 645 },
+      { orderCode: 'PO-20', product: 'CS010', region: 'UK', carton: 60 },
+    ]
+
+    const row = computePoFinanceWorkbookRow({
+      orderCode: 'PO-20',
+      product: 'CS007',
+      region: 'UK',
+      poTableRows,
+      sellPrice: 7.5161,
+      manufacturingCost: 0.4492,
+      freightCost: 0.1508,
+      tariffCost: 0,
+      tacosPercent: 0.12,
+      fbaFee: 1.23,
+      referralPercent: 0.15,
+      storageCost: 0.05,
+    })
+
+    expect(row.carton).toBe(645)
+    expect(row.grossProfit).toBeCloseTo(4.558685)
+    expect(row.netProfit).toBeCloseTo(3.606753)
+  })
+})
+
+describe('workbook forecast parity', () => {
+  it('uses the Excel forecast SKU block columns', () => {
+    expect(EXCEL_FORECAST_METRICS).toEqual([
+      'INBOUND',
+      '3PL',
+      'FBA',
+      'FBA COVER (W)',
+      'TOTAL COVER (W)',
+      'ACTUAL',
+      'PLANNER',
+      'FINAL',
+    ])
+  })
+
+  it('computes opening and carry-forward inventory like the forecast sheet', () => {
+    const first = computeForecastWorkbookRow({
+      openingStock: 44028,
+      inbound: 0,
+      actual: 1646,
+      planner: null,
+      previous: null,
+    })
+
+    expect(first.threePl).toBe(0)
+    expect(first.fba).toBe(44028)
+    expect(first.final).toBe(1646)
+    expect(first.fbaCoverWeeks).toBeCloseTo(26.7484811664)
+    expect(first.totalCoverWeeks).toBeCloseTo(26.7484811664)
+
+    const second = computeForecastWorkbookRow({
+      openingStock: 44028,
+      inbound: 0,
+      actual: null,
+      planner: 1116,
+      previous: first,
+    })
+
+    expect(second.threePl).toBe(0)
+    expect(second.fba).toBe(42382)
+    expect(second.final).toBe(1116)
+    expect(second.fbaCoverWeeks).toBeCloseTo(37.976702509)
+    expect(second.totalCoverWeeks).toBeCloseTo(37.976702509)
+  })
+
+  it('uses explicit final demand for overrides and system forecast fallback', () => {
+    const row = computeForecastWorkbookRow({
+      openingStock: 100,
+      inbound: 0,
+      actual: null,
+      planner: 20,
+      final: 12,
+      previous: null,
+    })
+
+    expect(row.final).toBe(12)
+    expect(row.fbaCoverWeeks).toBeCloseTo(8.333333333)
+    expect(row.totalCoverWeeks).toBeCloseTo(8.333333333)
+  })
+})


### PR DESCRIPTION
## Summary
- Align XPLAN setup, PO table, PO finances, and forecast sheets to the stable Excel workbook structure.
- Add setup-year persistence plus PO class and inbound-week override fields.
- Split PO economics into the new `6-po-finances` sheet and keep PO profitability as analytics.

## Validation
- `pnpm --filter @targon/xplan test`
- `pnpm --filter @targon/xplan lint`
- `pnpm --filter @targon/xplan type-check`
- Local route smoke: setup, ops planning, sales planning, PO finances, PO profitability returned 200.