### PR TITLE
fix(xplan): wire portal audit dev dir

### DIFF
--- a/.github/workflows/talos-db-audit.yml
+++ b/.github/workflows/talos-db-audit.yml
@@ -9,6 +9,8 @@ jobs:
   portal-db-audit:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 10
+    env:
+      TARGONOS_DEV_DIR: ${{ vars.TARGONOS_DEV_DIR }}
     steps:
       - name: Run portal ownership and privilege audit
         shell: bash


### PR DESCRIPTION
## Summary
- pass the existing TARGONOS_DEV_DIR repo variable into the scheduled Portal DB Ownership Audit workflow
- corrected local portal_dev_external privilege drift by revoking inherited portal_talos membership on the runner DB

## Verification
- bash scripts/db/check-portal-ownership.sh