### PR TITLE
chore: promote dev to main for portal audit env

### DIFF
--- a/.github/workflows/talos-db-audit.yml
+++ b/.github/workflows/talos-db-audit.yml
@@ -9,6 +9,8 @@ jobs:
   portal-db-audit:
     runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 10
+    env:
+      TARGONOS_DEV_DIR: ${{ vars.TARGONOS_DEV_DIR }}
     steps:
       - name: Run portal ownership and privilege audit
         shell: bash


### PR DESCRIPTION
## Summary
- promote dev after XPLAN workbook parity and Portal DB audit workflow repair

## Verification
- dev CI run 24949194782 passed
- dev CD run 24949194797 passed
- Portal DB Ownership Audit run 24949197518 passed