### PR TITLE
fix(argus): harden UK monitoring backend

### DIFF
--- a/apps/argus/scripts/api/daily-account-health/collect.mjs
+++ b/apps/argus/scripts/api/daily-account-health/collect.mjs
@@ -24,6 +24,7 @@ const OUTPUT_DIR = path.join(MONITORING_BASE, 'Daily', 'Account Health Dashboard
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'account-health.csv')
 const REPORT_TIMEOUT_MS = 2 * 60 * 60 * 1000
 const POLL_INTERVAL_MS = 15_000
+const ACTIVE_REPORT_REUSE_MAX_AGE_MS = 30 * 60 * 1000
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/
 
 const HEADERS = [
@@ -129,6 +130,7 @@ function createClient() {
 }
 
 async function findReusableReport(client, marketplaceId) {
+  const nowMs = Date.now()
   const response = await client.callAPI({
     operation: 'getReports',
     endpoint: 'reports',
@@ -143,7 +145,12 @@ async function findReusableReport(client, marketplaceId) {
     .filter((report) => report?.marketplaceIds?.includes(marketplaceId))
     .filter((report) => {
       const status = report?.processingStatus
-      return status === 'IN_PROGRESS' || status === 'IN_QUEUE'
+      return ACTIVE_REPORT_STATUSES.has(status)
+    })
+    .filter((report) => {
+      const createdMs = Date.parse(report?.createdTime)
+      if (!Number.isFinite(createdMs)) return false
+      return nowMs - createdMs <= ACTIVE_REPORT_REUSE_MAX_AGE_MS
     })
     .sort((left, right) => String(right?.createdTime ?? '').localeCompare(String(left?.createdTime ?? '')))
 

--- a/apps/argus/scripts/api/daily-account-health/collect.test.mjs
+++ b/apps/argus/scripts/api/daily-account-health/collect.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+const source = readFileSync(new URL('./collect.mjs', import.meta.url), 'utf8')
+
+test('account health skips stale active reports instead of pinning launchd', () => {
+  assert.match(source, /ACTIVE_REPORT_REUSE_MAX_AGE_MS = 30 \* 60 \* 1000/)
+  assert.match(source, /Date\.parse\(report\?\.createdTime\)/)
+  assert.match(source, /nowMs - createdMs <= ACTIVE_REPORT_REUSE_MAX_AGE_MS/)
+})

--- a/apps/argus/scripts/api/weekly-sources/run.sh
+++ b/apps/argus/scripts/api/weekly-sources/run.sh
@@ -77,10 +77,6 @@ if [ -z "$START_DATE" ] && [ -n "$END_DATE" ]; then
   exit 1
 fi
 
-DATE_FLAGS=""
-if [ -n "$START_DATE" ]; then
-  DATE_FLAGS="--start-date $START_DATE --end-date $END_DATE"
-fi
 MARKET_FLAG="--market $MARKET"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') — $1" >> "$LOG"; }
@@ -91,6 +87,33 @@ if ! NODE_BIN="$(command -v node)"; then
   log "FAILED: Node.js not found in PATH=$PATH"
   exit 1
 fi
+
+if [ -z "$START_DATE" ]; then
+  IFS='|' read -r START_DATE END_DATE <<<"$("$NODE_BIN" - <<'NODE'
+const formatDate = (date) => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+const today = new Date()
+const todayLocal = new Date(today.getFullYear(), today.getMonth(), today.getDate())
+const day = todayLocal.getDay()
+let daysBackToCompletedSaturday = day === 6 ? 7 : (day + 1) % 7
+if (day === 0) {
+  daysBackToCompletedSaturday += 7
+}
+const weekEndDate = new Date(todayLocal)
+weekEndDate.setDate(weekEndDate.getDate() - daysBackToCompletedSaturday)
+const weekStartDate = new Date(weekEndDate)
+weekStartDate.setDate(weekStartDate.getDate() - 6)
+process.stdout.write(`${formatDate(weekStartDate)}|${formatDate(weekEndDate)}`)
+NODE
+)"
+fi
+
+DATE_FLAGS="--start-date $START_DATE --end-date $END_DATE"
+log "Weekly API source window: $START_DATE..$END_DATE"
 
 RUN_STARTED_AT_MS="$("$NODE_BIN" -e 'process.stdout.write(String(Date.now()))')"
 RUN_STARTED_AT_ISO="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"

--- a/apps/argus/scripts/api/weekly-sources/run.test.mjs
+++ b/apps/argus/scripts/api/weekly-sources/run.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+const source = readFileSync(new URL('./run.sh', import.meta.url), 'utf8')
+
+test('weekly API no-arg Sunday run uses the last fully available API week', () => {
+  assert.match(source, /if \[ -z "\$START_DATE" \]/)
+  assert.match(source, /if \(day === 0\) \{/)
+  assert.match(source, /daysBackToCompletedSaturday \+= 7/)
+  assert.match(source, /DATE_FLAGS="--start-date \$START_DATE --end-date \$END_DATE"/)
+  assert.match(source, /Weekly API source window: \$START_DATE\.\.\$END_DATE/)
+})

--- a/apps/argus/scripts/browser/common.sh
+++ b/apps/argus/scripts/browser/common.sh
@@ -365,6 +365,56 @@ argus_market() {
   esac
 }
 
+argus_market_env_suffix() {
+  local market
+  market="$(argus_market)"
+  case "$market" in
+    us)
+      printf '%s' 'US'
+      ;;
+    uk)
+      printf '%s' 'UK'
+      ;;
+  esac
+}
+
+argus_market_env_name() {
+  local base_name="$1"
+  printf '%s_%s' "$base_name" "$(argus_market_env_suffix)"
+}
+
+require_market_env() {
+  local base_name="$1"
+  require_env "$(argus_market_env_name "$base_name")"
+}
+
+argus_tmp_log_path() {
+  local log_name="$1"
+  local market
+  market="$(argus_market)"
+  case "$market" in
+    us)
+      printf '/tmp/%s.log' "$log_name"
+      ;;
+    uk)
+      printf '/tmp/%s-%s.log' "$log_name" "$market"
+      ;;
+  esac
+}
+
+seller_central_host_globs() {
+  local host
+  host="$(require_market_env ARGUS_SELLER_CENTRAL_HOST)"
+  case "$(argus_market)" in
+    us)
+      printf '%s' "$host,amazon.com"
+      ;;
+    uk)
+      printf '%s' "$host,amazon.co.uk,amazon.com"
+      ;;
+  esac
+}
+
 argus_sales_root() {
   local market
   local env_name
@@ -395,7 +445,14 @@ PY
 
 is_amazon_login_url() {
   local url="${1:-}"
-  [[ "$url" == *"amazon.com/ap/"* || "$url" == *"signin"* ]]
+  case "$url" in
+    *"amazon.com/ap/"*|*"amazon.co.uk/ap/"*|*"signin"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 copy_file_with_node() {

--- a/apps/argus/scripts/browser/common.test.sh
+++ b/apps/argus/scripts/browser/common.test.sh
@@ -97,6 +97,35 @@ bash -lc '
 set -euo pipefail
 source "'"$SCRIPT_DIR"'/common.sh"
 
+ARGUS_MARKET=uk
+ARGUS_SELLER_CENTRAL_HOST_UK="sellercentral.amazon.co.uk"
+ARGUS_EXAMPLE_VALUE_UK="uk-value"
+
+if [ "$(argus_market_env_suffix)" != "UK" ]; then
+  echo "expected UK market env suffix" >&2
+  exit 1
+fi
+
+if [ "$(argus_market_env_name ARGUS_EXAMPLE_VALUE)" != "ARGUS_EXAMPLE_VALUE_UK" ]; then
+  echo "expected UK market env name" >&2
+  exit 1
+fi
+
+if [ "$(require_market_env ARGUS_EXAMPLE_VALUE)" != "uk-value" ]; then
+  echo "expected UK market env value" >&2
+  exit 1
+fi
+
+if [ "$(argus_tmp_log_path weekly-poe)" != "/tmp/weekly-poe-uk.log" ]; then
+  echo "expected UK-specific tmp log path" >&2
+  exit 1
+fi
+
+if [ "$(seller_central_host_globs)" != "sellercentral.amazon.co.uk,amazon.co.uk,amazon.com" ]; then
+  echo "expected UK Seller Central host globs" >&2
+  exit 1
+fi
+
 if [ "$(bitwarden_login_username "sellercentral.amazon.com" "shoaibgondal@targonglobal.com")" != "shoaibgondal@targonglobal.com" ]; then
   echo "expected sellercentral URI host match for username lookup" >&2
   exit 1

--- a/apps/argus/scripts/browser/relogin.sh
+++ b/apps/argus/scripts/browser/relogin.sh
@@ -5,15 +5,21 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
+load_monitoring_env
 
-TARGET_URL="${1:-https://sellercentral.amazon.com/home}"
+if [ "$#" -gt 0 ]; then
+  TARGET_URL="$1"
+else
+  TARGET_URL="$(require_market_env ARGUS_SELLER_CENTRAL_HOME_URL)"
+fi
 SELLER_CENTRAL_LOGIN_USERNAME="shoaibgondal@targonglobal.com"
-SELLER_CENTRAL_LOGIN_QUERY="${ARGUS_SELLER_CENTRAL_BITWARDEN_QUERY:-sellercentral.amazon.com}"
-SELLER_CENTRAL_ACCOUNT_LABEL="Targon LLC"
-SELLER_CENTRAL_MARKETPLACE_LABEL="United States"
+SELLER_CENTRAL_LOGIN_QUERY="$(require_market_env ARGUS_SELLER_CENTRAL_BITWARDEN_QUERY)"
+SELLER_CENTRAL_ACCOUNT_LABEL="$(require_market_env ARGUS_SELLER_CENTRAL_ACCOUNT_LABEL)"
+SELLER_CENTRAL_MARKETPLACE_LABEL="$(require_market_env ARGUS_SELLER_CENTRAL_MARKETPLACE_LABEL)"
+SELLER_CENTRAL_HOSTS="$(seller_central_host_globs)"
 SC_EMAIL="$(bitwarden_login_username "$SELLER_CENTRAL_LOGIN_QUERY" "$SELLER_CENTRAL_LOGIN_USERNAME")"
 SC_PASSWORD="$(bitwarden_login_password "$SELLER_CENTRAL_LOGIN_QUERY" "$SELLER_CENTRAL_LOGIN_USERNAME")"
-LOG="/tmp/sc-relogin.log"
+LOG="$(argus_tmp_log_path sc-relogin)"
 SELLER_TAB_ID=""
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') — $1" >> "$LOG"; }
@@ -41,7 +47,7 @@ tab_url_for_id() {
 }
 
 ensure_seller_tab() {
-  SELLER_TAB_ID="$(run_chrome_helper ensure-tab-id "$TARGET_URL" "sellercentral.amazon.com,amazon.com")"
+  SELLER_TAB_ID="$(run_chrome_helper ensure-tab-id "$TARGET_URL" "$SELLER_CENTRAL_HOSTS")"
 }
 
 run_js() {

--- a/apps/argus/scripts/browser/relogin.test.mjs
+++ b/apps/argus/scripts/browser/relogin.test.mjs
@@ -9,8 +9,16 @@ test('relogin uses the shared Seller Central account', () => {
 })
 
 test('relogin uses Bitwarden TOTP and does not depend on chat OTP helpers', () => {
-  assert.match(reloginScript, /bitwarden_login_totp "sellercentral\.amazon\.com" "\$SELLER_CENTRAL_LOGIN_USERNAME"/)
+  assert.match(reloginScript, /SELLER_CENTRAL_LOGIN_QUERY="\$\(require_market_env ARGUS_SELLER_CENTRAL_BITWARDEN_QUERY\)"/)
+  assert.match(reloginScript, /bitwarden_login_totp "\$SELLER_CENTRAL_LOGIN_QUERY" "\$SELLER_CENTRAL_LOGIN_USERNAME"/)
   assert.doesNotMatch(reloginScript, /SELLER_CENTRAL_CHAT_HELPER|latest-chat-code|fetch_chat_verification_code/)
+})
+
+test('relogin resolves Seller Central account and host by market', () => {
+  assert.match(reloginScript, /TARGET_URL="\$\(require_market_env ARGUS_SELLER_CENTRAL_HOME_URL\)"/)
+  assert.match(reloginScript, /SELLER_CENTRAL_ACCOUNT_LABEL="\$\(require_market_env ARGUS_SELLER_CENTRAL_ACCOUNT_LABEL\)"/)
+  assert.match(reloginScript, /SELLER_CENTRAL_MARKETPLACE_LABEL="\$\(require_market_env ARGUS_SELLER_CENTRAL_MARKETPLACE_LABEL\)"/)
+  assert.match(reloginScript, /SELLER_CENTRAL_HOSTS="\$\(seller_central_host_globs\)"/)
 })
 
 test('relogin does not keep an email OTP recovery branch', () => {

--- a/apps/argus/scripts/browser/run-weekly.sh
+++ b/apps/argus/scripts/browser/run-weekly.sh
@@ -88,8 +88,9 @@ run_script() {
   local name="$1"
   local script="$2"
   local detail_log="$3"
+  local detail_log_env="$4"
   log "Running: $name"
-  if ARGUS_MARKET="$MARKET" bash "$script"; then
+  if env ARGUS_MARKET="$MARKET" "$detail_log_env=$detail_log" bash "$script"; then
     log "OK: $name"
   else
     local exit_code=$?
@@ -101,11 +102,11 @@ run_script() {
   sleep 5
 }
 
-run_script "Category Insights" "$SCRIPT_DIR/weekly-category-insights/collect.sh" "/tmp/weekly-category-insights.log"
-run_script "Product Opportunity Explorer" "$SCRIPT_DIR/weekly-poe/collect.sh" "/tmp/weekly-poe.log"
-run_script "ScaleInsights" "$SCRIPT_DIR/weekly-scaleinsights/collect.sh" "/tmp/weekly-scaleinsights.log"
+run_script "Category Insights" "$SCRIPT_DIR/weekly-category-insights/collect.sh" "$(argus_tmp_log_path weekly-category-insights)" "ARGUS_CATEGORY_INSIGHTS_LOG"
+run_script "Product Opportunity Explorer" "$SCRIPT_DIR/weekly-poe/collect.sh" "$(argus_tmp_log_path weekly-poe)" "ARGUS_POE_LOG"
+run_script "ScaleInsights" "$SCRIPT_DIR/weekly-scaleinsights/collect.sh" "$(argus_tmp_log_path weekly-scaleinsights)" "ARGUS_SCALEINSIGHTS_LOG"
 log "Brand Metrics note: $BRAND_METRICS_SOURCE_LIMIT_NOTE"
-run_script "Brand Metrics" "$SCRIPT_DIR/weekly-brand-metrics/collect.sh" "/tmp/weekly-brand-metrics.log"
+run_script "Brand Metrics" "$SCRIPT_DIR/weekly-brand-metrics/collect.sh" "$(argus_tmp_log_path weekly-brand-metrics)" "ARGUS_BRAND_METRICS_LOG"
 
 if [ "$FAILED" -eq 0 ]; then
   log "Running: WPR workspace sync"

--- a/apps/argus/scripts/browser/weekly-brand-metrics/collect.sh
+++ b/apps/argus/scripts/browser/weekly-brand-metrics/collect.sh
@@ -9,9 +9,9 @@ load_monitoring_env
 
 DEST="${ARGUS_BRAND_METRICS_DEST:-$(argus_monitoring_root)/Weekly/Ad Console/Brand Metrics (Browser)}"
 DL="${ARGUS_BRAND_METRICS_DOWNLOAD_DIR:-$HOME/Downloads}"
-LOG="${ARGUS_BRAND_METRICS_LOG:-/tmp/weekly-brand-metrics.log}"
-TARGET_URL_BASE="https://advertising.amazon.com/bb/bm/overview?entityId=ENTITY2JBRT701DBI1P&brand=1113309&category=228899"
-DOWNLOAD_PATTERN="$DL/Caelum_Star_*_Overview_*.csv"
+LOG="${ARGUS_BRAND_METRICS_LOG:-$(argus_tmp_log_path weekly-brand-metrics)}"
+TARGET_URL_BASE="$(require_market_env ARGUS_BRAND_METRICS_URL_BASE)"
+DOWNLOAD_PATTERN="$DL/$(require_market_env ARGUS_BRAND_METRICS_DOWNLOAD_GLOB)"
 REFERENCE_DATE="$(date '+%Y-%m-%d')"
 
 if [ "$#" -eq 2 ]; then
@@ -49,25 +49,26 @@ process.stdout.write(value == null ? "" : String(value));
 
 page_state() {
   run_js '(() => {
-    const clean = (value) => String(value || "").replace(/\s+/g, " ").trim();
+    const clean = (value) => String(value ?? "").replace(/\s+/g, " ").trim();
     const bodyText = clean(document.body ? document.body.innerText : "");
-    const dateButton = Array.from(document.querySelectorAll("button")).find((el) =>
-      clean(el.innerText || el.textContent).startsWith("Date range")
+    const dateButton = Array.from(document.querySelectorAll("button,[role=button]")).find((el) =>
+      clean(el.innerText ?? el.textContent).startsWith("Date range")
     );
     const exportButton = Array.from(document.querySelectorAll("button")).find((el) =>
-      clean(el.innerText || el.textContent) === "Export"
+      clean(el.innerText ?? el.textContent) === "Export"
     );
-    const currentPeriod = bodyText.match(/Current period \(([^)]+)\)/)?.[1] || "";
+    const currentPeriod = bodyText.match(/Current period \(([^)]+)\)/)?.[1] ?? "";
     const noData = bodyText.includes("No data available");
-    const loginRequired =
-      location.href.includes("signin") ||
-      location.href.includes("/ap/") ||
-      /sign in|enter the characters you see below|solve this puzzle/i.test(bodyText);
+    const loginRequired = [
+      location.href.includes("signin"),
+      location.href.includes("/ap/"),
+      /sign in|enter the characters you see below|solve this puzzle/i.test(bodyText),
+    ].some(Boolean);
 
     return JSON.stringify({
-      href: location.href || "",
-      title: document.title || "",
-      dateButtonText: clean(dateButton?.innerText || dateButton?.textContent || ""),
+      href: location.href ?? "",
+      title: document.title ?? "",
+      dateButtonText: clean(dateButton?.innerText ?? dateButton?.textContent ?? ""),
       exportPresent: Boolean(exportButton),
       currentPeriod,
       noData,
@@ -125,9 +126,9 @@ PY
 
 open_date_picker() {
   run_js '(() => {
-    const clean = (value) => String(value || "").replace(/\s+/g, " ").trim();
-    const button = Array.from(document.querySelectorAll("button")).find((el) =>
-      clean(el.innerText || el.textContent).startsWith("Date range")
+    const clean = (value) => String(value ?? "").replace(/\s+/g, " ").trim();
+    const button = Array.from(document.querySelectorAll("button,[role=button]")).find((el) =>
+      clean(el.innerText ?? el.textContent).startsWith("Date range")
     );
     if (!button) return "NO_DATE_BUTTON";
     button.click();
@@ -135,16 +136,32 @@ open_date_picker() {
   })();'
 }
 
+wait_open_date_picker() {
+  local status=""
+
+  for _ in $(seq 1 30); do
+    status="$(open_date_picker)"
+    if [ "$status" = "DATE_PICKER_OPENED" ]; then
+      printf '%s' "$status"
+      return 0
+    fi
+    sleep 2
+  done
+
+  printf '%s' "$status"
+  return 1
+}
+
 apply_last_available_week() {
   run_js '(() => {
-    const clean = (value) => String(value || "").replace(/\s+/g, " ").trim();
+    const clean = (value) => String(value ?? "").replace(/\s+/g, " ").trim();
     const option = Array.from(document.querySelectorAll("[role=option], button, div, span")).find((el) =>
-      clean(el.innerText || el.textContent) === "Last available week"
+      clean(el.innerText ?? el.textContent) === "Last available week"
     );
     if (!option) return "NO_LAST_AVAILABLE_WEEK_OPTION";
     option.click();
     const save = Array.from(document.querySelectorAll("button")).find((el) =>
-      clean(el.innerText || el.textContent) === "Save"
+      clean(el.innerText ?? el.textContent) === "Save"
     );
     if (!save) return "NO_SAVE_BUTTON";
     save.click();
@@ -345,7 +362,7 @@ sleep 8
 wait_tab
 
 current_url="$(tab_url)"
-if [[ "$current_url" == *"signin"* || "$current_url" == *"/ap/"* ]]; then
+if is_amazon_login_url "$current_url"; then
   log "FAILED: Brand Metrics requires an authenticated Chrome session"
   exit 1
 fi
@@ -363,7 +380,7 @@ if [ "$REQUEST_MODE" = "explicit-week" ]; then
     exit 1
   fi
 else
-  if [ "$(open_date_picker)" != "DATE_PICKER_OPENED" ]; then
+  if [ "$(wait_open_date_picker)" != "DATE_PICKER_OPENED" ]; then
     log "FAILED: Brand Metrics date picker button not found"
     exit 1
   fi

--- a/apps/argus/scripts/browser/weekly-category-insights/collect.sh
+++ b/apps/argus/scripts/browser/weekly-category-insights/collect.sh
@@ -8,15 +8,15 @@ source "$SCRIPT_DIR/../common.sh"
 load_monitoring_env
 
 DEST="${ARGUS_CATEGORY_INSIGHTS_DEST:-$(argus_monitoring_root)/Weekly/Category Insights (Browser)}"
-LOG="${ARGUS_CATEGORY_INSIGHTS_LOG:-/tmp/weekly-category-insights.log}"
-TARGET_URL="https://sellercentral.amazon.com/selection/category-insights"
-TARGET_MARKETPLACE_ID="ATVPDKIKX0DER"
-TARGET_MARKETPLACE_LABEL="United States"
-TARGET_SEARCH_TERM="Painting Drop Cloths"
-TARGET_CATEGORY_ID="Tools & Home Improvement"
-TARGET_PRODUCT_TYPE_ID="BUILDING_MATERIAL"
-TARGET_PRODUCT_TYPE_LABEL="Building Material"
-TARGET_BROWSE_NODE_ID="13399811"
+LOG="${ARGUS_CATEGORY_INSIGHTS_LOG:-$(argus_tmp_log_path weekly-category-insights)}"
+TARGET_URL="$(require_market_env ARGUS_CATEGORY_INSIGHTS_URL)"
+TARGET_MARKETPLACE_ID="$(require_market_env ARGUS_CATEGORY_INSIGHTS_MARKETPLACE_ID)"
+TARGET_MARKETPLACE_LABEL="$(require_market_env ARGUS_CATEGORY_INSIGHTS_MARKETPLACE_LABEL)"
+TARGET_SEARCH_TERM="$(require_market_env ARGUS_CATEGORY_INSIGHTS_SEARCH_TERM)"
+TARGET_CATEGORY_ID="$(require_market_env ARGUS_CATEGORY_INSIGHTS_CATEGORY_ID)"
+TARGET_PRODUCT_TYPE_ID="$(require_market_env ARGUS_CATEGORY_INSIGHTS_PRODUCT_TYPE_ID)"
+TARGET_PRODUCT_TYPE_LABEL="$(require_market_env ARGUS_CATEGORY_INSIGHTS_PRODUCT_TYPE_LABEL)"
+TARGET_BROWSE_NODE_ID="$(require_market_env ARGUS_CATEGORY_INSIGHTS_BROWSE_NODE_ID)"
 
 IFS='|' read -r WEEK_NUM START_DATE END_DATE PREFIX <<<"$(latest_complete_week_context)"
 TODAY=$(date '+%Y-%m-%d')
@@ -31,6 +31,27 @@ open_window() { TAB_ID="$(run_chrome_helper open-window-tab "$1")"; }
 run_js() { run_chrome_helper run-js-tab-id "$TAB_ID" "$1"; }
 wait_tab() { run_chrome_helper wait-tab-id "$TAB_ID" >/dev/null; }
 tab_url() { run_chrome_helper get-url-tab-id "$TAB_ID"; }
+
+wait_for_target_page() {
+  local expected_url="$1"
+  local actual_href=""
+
+  for _ in $(seq 1 60); do
+    actual_href="$(run_js "location.href")"
+    if [ "$actual_href" = "$expected_url" ]; then
+      printf '%s' "$actual_href"
+      return 0
+    fi
+    if is_amazon_login_url "$actual_href"; then
+      printf '%s' "$actual_href"
+      return 0
+    fi
+    sleep 1
+  done
+
+  printf '%s' "$actual_href"
+  return 1
+}
 
 json_stringify() {
   "$NODE_BIN" -e '
@@ -99,13 +120,14 @@ post_json_from_page() {
   path_literal=$(json_stringify "$path")
   payload_literal=$(json_stringify "$payload")
   js="(() => {
+    const endpoint = new URL(${path_literal}, location.origin).toString();
     const xhr = new XMLHttpRequest();
-    xhr.open('POST', ${path_literal}, false);
+    xhr.open('POST', endpoint, false);
     xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
     xhr.send(${payload_literal});
     if (xhr.status !== 200) {
       const responseText = xhr.responseText ?? '';
-      throw new Error('HTTP ' + xhr.status + ' from ' + ${path_literal} + ': ' + responseText.slice(0, 500));
+      throw new Error('HTTP ' + xhr.status + ' from ' + endpoint + ': ' + responseText.slice(0, 500));
     }
     return xhr.responseText;
   })();"
@@ -337,12 +359,18 @@ log "Starting weekly Category Insights: $PREFIX"
 open_window "$TARGET_URL"
 wait_tab
 
-current_url=$(tab_url)
+current_url="$(wait_for_target_page "$TARGET_URL")"
 if is_amazon_login_url "$current_url"; then
   log "Seller Central session expired — attempting relogin"
   bash "$SCRIPT_DIR/../relogin.sh" "$TARGET_URL"
   open_window "$TARGET_URL"
   wait_tab
+  current_url="$(wait_for_target_page "$TARGET_URL")"
+fi
+
+if [ "$current_url" != "$TARGET_URL" ]; then
+  log "FAILED: Category Insights route stabilized on unexpected URL $current_url"
+  exit 1
 fi
 
 SEARCH_PAYLOAD="$(build_search_payload)"

--- a/apps/argus/scripts/browser/weekly-market-config.test.mjs
+++ b/apps/argus/scripts/browser/weekly-market-config.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { readFileSync } from 'node:fs'
+
+const categoryInsights = readFileSync(new URL('./weekly-category-insights/collect.sh', import.meta.url), 'utf8')
+const poe = readFileSync(new URL('./weekly-poe/collect.sh', import.meta.url), 'utf8')
+const scaleInsights = readFileSync(new URL('./weekly-scaleinsights/collect.sh', import.meta.url), 'utf8')
+const brandMetrics = readFileSync(new URL('./weekly-brand-metrics/collect.sh', import.meta.url), 'utf8')
+const runWeekly = readFileSync(new URL('./run-weekly.sh', import.meta.url), 'utf8')
+
+test('weekly browser collectors require market-specific source config', () => {
+  assert.match(categoryInsights, /require_market_env ARGUS_CATEGORY_INSIGHTS_URL/)
+  assert.match(categoryInsights, /require_market_env ARGUS_CATEGORY_INSIGHTS_MARKETPLACE_ID/)
+  assert.match(poe, /require_market_env ARGUS_POE_TARGET_URL_BASE/)
+  assert.match(scaleInsights, /require_market_env ARGUS_SCALEINSIGHTS_COUNTRY_CODE/)
+  assert.match(brandMetrics, /require_market_env ARGUS_BRAND_METRICS_URL_BASE/)
+})
+
+test('weekly browser collectors no longer hardcode US-only source ids', () => {
+  assert.doesNotMatch(poe, /84dd9c9ba70c2b6df8c7bacb37f9a326/)
+  assert.doesNotMatch(scaleInsights, /COUNTRY_CODE="US"/)
+  assert.doesNotMatch(brandMetrics, /ENTITY2JBRT701DBI1P/)
+  assert.doesNotMatch(categoryInsights, /TARGET_MARKETPLACE_ID="ATVPDKIKX0DER"/)
+})
+
+test('weekly browser runner passes market-specific detail logs into child collectors', () => {
+  assert.match(runWeekly, /argus_tmp_log_path weekly-category-insights/)
+  assert.match(runWeekly, /ARGUS_CATEGORY_INSIGHTS_LOG/)
+  assert.match(runWeekly, /argus_tmp_log_path weekly-poe/)
+  assert.match(runWeekly, /ARGUS_POE_LOG/)
+  assert.match(runWeekly, /argus_tmp_log_path weekly-scaleinsights/)
+  assert.match(runWeekly, /ARGUS_SCALEINSIGHTS_LOG/)
+  assert.match(runWeekly, /argus_tmp_log_path weekly-brand-metrics/)
+  assert.match(runWeekly, /ARGUS_BRAND_METRICS_LOG/)
+})
+
+test('ScaleInsights reruns reuse an existing same-week XLSX', () => {
+  assert.match(scaleInsights, /target_file="\$DEST\/\$\{PREFIX\}_SI-KeywordRanking\.xlsx"/)
+  assert.match(scaleInsights, /target_size="\$\(stat -f '%z' "\$target_file"\)"/)
+  assert.match(scaleInsights, /Saved: \$\{PREFIX\}_SI-KeywordRanking\.xlsx already current/)
+})

--- a/apps/argus/scripts/browser/weekly-poe/collect.sh
+++ b/apps/argus/scripts/browser/weekly-poe/collect.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Weekly Product Opportunity Explorer CSV download via Chrome.
+# Weekly Product Opportunity Explorer CSV capture via the authenticated POE GraphQL backend.
 
 set -euo pipefail
 
@@ -8,8 +8,11 @@ source "$SCRIPT_DIR/../common.sh"
 load_monitoring_env
 
 DEST="${ARGUS_POE_DEST:-$(argus_monitoring_root)/Weekly/Product Opportunity Explorer (Browser)}"
-LOG="${ARGUS_POE_LOG:-/tmp/weekly-poe.log}"
-TARGET_URL_BASE="https://sellercentral.amazon.com/opportunity-explorer/explore/niche/84dd9c9ba70c2b6df8c7bacb37f9a326"
+LOG="${ARGUS_POE_LOG:-$(argus_tmp_log_path weekly-poe)}"
+TARGET_URL_BASE="$(require_market_env ARGUS_POE_TARGET_URL_BASE)"
+TARGET_URL_BASE_PATH="$("$NODE_BIN" -e 'const url = new URL(process.argv[1]); process.stdout.write(url.pathname.replace(/\/$/, ""));' "$TARGET_URL_BASE")"
+TARGET_NICHE_ID="$("$NODE_BIN" -e 'const parts = new URL(process.argv[1]).pathname.split("/").filter(Boolean); const index = parts.indexOf("niche"); if (index === -1) throw new Error("POE target URL must include /niche/{id}"); if (!parts[index + 1]) throw new Error("POE target URL must include /niche/{id}"); process.stdout.write(parts[index + 1]);' "$TARGET_URL_BASE")"
+TARGET_MARKETPLACE_ID="$(require_market_env AMAZON_MARKETPLACE_ID)"
 
 IFS='|' read -r WEEK_NUM START_DATE END_DATE PREFIX <<<"$(latest_complete_week_context)"
 
@@ -24,6 +27,23 @@ wait_tab() { run_chrome_helper wait-tab-id "$TAB_ID" >/dev/null; }
 tab_url() { run_chrome_helper get-url-tab-id "$TAB_ID"; }
 navigate_tab() { run_chrome_helper navigate-tab-id "$TAB_ID" "$1" >/dev/null; }
 
+wait_for_expected_path() {
+  local expected_path="$1"
+  local actual_path=""
+
+  for _ in $(seq 1 60); do
+    actual_path="$(run_js "location.pathname")"
+    if [ "$actual_path" = "$expected_path" ]; then
+      printf '%s' "$actual_path"
+      return 0
+    fi
+    sleep 1
+  done
+
+  printf '%s' "$actual_path"
+  return 1
+}
+
 ensure_route_loaded() {
   local target_url="$1"
 
@@ -35,7 +55,7 @@ ensure_route_loaded() {
   wait_tab
 
   local current_url
-  current_url=$(tab_url)
+  current_url="$(tab_url)"
   if is_amazon_login_url "$current_url"; then
     log "Seller Central session expired — attempting relogin"
     bash "$SCRIPT_DIR/../relogin.sh" "$target_url"
@@ -48,93 +68,109 @@ ensure_route_loaded() {
   fi
 }
 
-wait_for_expected_path() {
-  local expected_path="$1"
-  local actual_path=""
+fetch_graphql_payload() {
+  local js
+  js="$("$NODE_BIN" - "$TARGET_NICHE_ID" "$TARGET_MARKETPLACE_ID" <<'NODE'
+const nicheId = process.argv[2];
+const marketplaceId = process.argv[3];
+const query = `
+query getNiche($nicheInput: NicheInput!) {
+  niche(request: $nicheInput) {
+    nicheId
+    obfuscatedMarketplaceId
+    nicheTitle
+    currency
+    lastUpdatedTimeISO8601
+  }
+  asinMetrics(request: $nicheInput) {
+    asin
+    asinTitle
+    brand
+    category
+    launchDate
+    clickCountT360
+    clickShareT360
+    avgPriceT360
+    currency
+    totalReviews
+    customerRating
+    bestSellersRanking
+    avgSellerVendorCountT360
+  }
+  searchTermMetrics(request: $nicheInput) {
+    searchTerm
+    searchVolumeT360
+    searchVolumeQoq
+    searchVolumeGrowthT180
+    clickShareT360
+    searchConversionRateT360
+    topClickedProducts {
+      asin
+      asinTitle
+      obfuscatedMarketplaceId
+    }
+  }
+}
+`;
 
-  for _ in $(seq 1 20); do
-    actual_path=$(run_js "location.pathname")
-    if [ "$actual_path" = "$expected_path" ]; then
-      printf '%s' "$actual_path"
-      return 0
-    fi
-    sleep 1
-  done
+const body = JSON.stringify({
+  operationName: 'getNiche',
+  query,
+  variables: {
+    nicheInput: {
+      nicheId,
+      obfuscatedMarketplaceId: marketplaceId,
+    },
+  },
+});
 
-  printf '%s' "$actual_path"
-  return 1
+process.stdout.write(`(() => fetch('/ox-api/graphql', {
+  method: 'POST',
+  credentials: 'same-origin',
+  headers: {
+    'content-type': 'application/json',
+    'anti-csrftoken-a2z': document.querySelector('meta[name="anti-csrftoken-a2z"]')?.content ?? '',
+  },
+  body: ${JSON.stringify(body)},
+}).then(async (response) => {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error('POE GraphQL HTTP ' + response.status + ': ' + text.slice(0, 500));
+  }
+  return text;
+}))();`);
+NODE
+)"
+  run_js "$js"
 }
 
-download_export() {
-  local route_path="$1"
-  local expected_tab="$2"
-  local output_name="$3"
-  local target_url="${TARGET_URL_BASE}/${route_path}"
-  local expected_path
-  local download_js
-  local download_payload=""
-  local download_status=""
+write_csvs() {
+  local payload="$1"
+  local payload_file
 
-  ensure_route_loaded "$target_url"
-  expected_path="/opportunity-explorer/explore/niche/84dd9c9ba70c2b6df8c7bacb37f9a326/${route_path}"
-
-  if ! actual_path=$(wait_for_expected_path "$expected_path"); then
-    log "FAILED: ${expected_tab} route stabilized on unexpected path ${actual_path}"
-    exit 1
-  fi
-
-  download_js="$("$NODE_BIN" -e '
-const expectedPath = process.argv[1];
-const expectedTab = process.argv[2];
-process.stdout.write(`(() => {
-  const normalize = (value) => String(value ?? "").replace(/\\s+/g, " ").trim();
-  if (location.pathname !== ${JSON.stringify(expectedPath)}) {
-    return JSON.stringify({ status: "UNEXPECTED_PATH", path: location.pathname });
-  }
-  const tab = Array.from(document.querySelectorAll("kat-tab,button,a,span,div")).find((element) => normalize(element.innerText ?? element.textContent) === ${JSON.stringify(expectedTab)});
-  if (!tab) {
-    return JSON.stringify({ status: "MISSING_TAB", tab: ${JSON.stringify(expectedTab)} });
-  }
-  const link = Array.from(document.querySelectorAll("a,button")).find((element) => normalize(element.innerText ?? element.textContent) === "Download");
-  if (!link) {
-    return JSON.stringify({ status: "NO_DOWNLOAD_BUTTON", tab: ${JSON.stringify(expectedTab)} });
-  }
-  if (!link.href) {
-    return JSON.stringify({ status: "NO_DOWNLOAD_BUTTON", tab: ${JSON.stringify(expectedTab)} });
-  }
-  const request = new XMLHttpRequest();
-  request.open("GET", link.href, false);
-  request.send();
-  return JSON.stringify({
-    status: request.status && request.status !== 200 ? \`FETCH_FAILED_\${request.status}\` : "OK",
-    tab: ${JSON.stringify(expectedTab)},
-    content: request.responseText ?? ""
-  });
-})();`);
-' "$expected_path" "$expected_tab")"
-
-  for _ in $(seq 1 10); do
-    download_payload=$(run_js "$download_js")
-    download_status=$("$NODE_BIN" -e 'const payload = JSON.parse(process.argv[1]); process.stdout.write(payload.status ?? "");' "$download_payload")
-    if [ "$download_status" = "OK" ]; then
-      break
-    fi
-    sleep 2
-  done
-
-  if [ "$download_status" != "OK" ]; then
-    log "FAILED: ${expected_tab} download fetch returned $download_status"
-    exit 1
-  fi
-
-  $NODE_BIN -e 'const payload = JSON.parse(process.argv[1]); process.stdout.write(payload.content ?? "");' "$download_payload" \
-    | write_stdin_to_file_with_node "$DEST/$output_name"
-  log "Saved: $output_name"
+  payload_file="$(mktemp "/tmp/argus-poe-$(argus_market)-XXXXXX.json")"
+  printf '%s' "$payload" | write_stdin_to_file_with_node "$payload_file"
+  "$NODE_BIN" "$SCRIPT_DIR/write-graphql-csvs.mjs" \
+    "$payload_file" \
+    "$DEST/${PREFIX}_POE.csv" \
+    "$DEST/${PREFIX}_POE-SearchTerms.csv"
+  rm -f "$payload_file"
 }
 
 log "Starting weekly POE: $PREFIX"
 
-download_export "product" "Products" "${PREFIX}_POE.csv"
-download_export "search-queries" "Search Terms" "${PREFIX}_POE-SearchTerms.csv"
+ensure_route_loaded "${TARGET_URL_BASE}/product"
+
+expected_path="${TARGET_URL_BASE_PATH}/product"
+if ! current_path="$(wait_for_expected_path "$expected_path")"; then
+  log "FAILED: POE route stabilized on unexpected path $current_path"
+  exit 1
+fi
+
+payload="$(fetch_graphql_payload)"
+write_csvs "$payload"
+
+log "Saved: ${PREFIX}_POE.csv"
+log "Saved: ${PREFIX}_POE-SearchTerms.csv"
 log "Done"
 tail -100 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"

--- a/apps/argus/scripts/browser/weekly-poe/write-graphql-csvs.mjs
+++ b/apps/argus/scripts/browser/weekly-poe/write-graphql-csvs.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+
+const [payloadPath, productsPath, searchTermsPath] = process.argv.slice(2)
+
+if (!payloadPath || !productsPath || !searchTermsPath) {
+  throw new Error('Usage: write-graphql-csvs.mjs <payload.json> <products.csv> <search-terms.csv>')
+}
+
+const payload = JSON.parse(fs.readFileSync(payloadPath, 'utf8'))
+const data = payload.data
+
+if (!data?.niche) {
+  throw new Error('POE GraphQL payload is missing niche data')
+}
+
+if (!Array.isArray(data.asinMetrics) || data.asinMetrics.length === 0) {
+  throw new Error('POE GraphQL payload is missing asinMetrics rows')
+}
+
+if (!Array.isArray(data.searchTermMetrics) || data.searchTermMetrics.length === 0) {
+  throw new Error('POE GraphQL payload is missing searchTermMetrics rows')
+}
+
+const { niche } = data
+if (!niche.nicheTitle || !niche.currency || !niche.lastUpdatedTimeISO8601) {
+  throw new Error('POE GraphQL niche data is missing title, currency, or lastUpdatedTimeISO8601')
+}
+
+function csvEscape(value) {
+  if (value === null || value === undefined) return ''
+  const text = String(value)
+  if (/[",\n]/.test(text)) return `"${text.replace(/"/g, '""')}"`
+  return text
+}
+
+function row(values) {
+  return `${values.map(csvEscape).join(',')}\n`
+}
+
+function numberText(value) {
+  if (value === null || value === undefined || value === '') return ''
+  const number = Number(value)
+  if (!Number.isFinite(number)) return String(value)
+  return Number.isInteger(number) ? String(number) : String(number)
+}
+
+function lastUpdatedText(value) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`Invalid POE lastUpdatedTimeISO8601: ${value}`)
+  }
+  return `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()}`
+}
+
+function preamble(tabName) {
+  return [
+    `Niche Name: ${niche.nicheTitle}`,
+    tabName,
+    `Last updated on ${lastUpdatedText(niche.lastUpdatedTimeISO8601)}`,
+    '',
+  ].join('\n')
+}
+
+function writeProductsCsv() {
+  const currency = niche.currency
+  const lines = [
+    `${preamble('Niche Details - Products Tab')}\n`,
+    row([
+      'Product Name',
+      'ASIN',
+      'Brand',
+      'Category',
+      'Launch Date',
+      'Niche Click Count (Past 360 days)',
+      'Click Share (Past 360 days)',
+      `Average Selling Price (Past 360 days) (${currency})`,
+      'Total Ratings',
+      'Average Customer Rating',
+      'Average BSR',
+      'Average # of Sellers and Vendors (Past 360 days)',
+    ]),
+  ]
+
+  for (const item of data.asinMetrics) {
+    lines.push(
+      row([
+        item.asinTitle,
+        item.asin,
+        item.brand,
+        item.category,
+        item.launchDate,
+        numberText(item.clickCountT360),
+        numberText(item.clickShareT360),
+        numberText(item.avgPriceT360),
+        numberText(item.totalReviews),
+        numberText(item.customerRating),
+        numberText(item.bestSellersRanking),
+        numberText(item.avgSellerVendorCountT360),
+      ]),
+    )
+  }
+
+  fs.writeFileSync(productsPath, lines.join(''))
+}
+
+function writeSearchTermsCsv() {
+  const lines = [
+    `${preamble('Niche Details - Search Terms Tab')}\n`,
+    row([
+      'Search Term',
+      'Search Volume (Past 360 days)',
+      'Search Volume Growth (Past 90 days)',
+      'Search Volume Growth (Past 180 days)',
+      'Click Share (Past 360 days)',
+      'Search Conversion Rate (Past 360 days)',
+      'Top Clicked Product 1 (Title)',
+      'Top Clicked Product 1 (Asin)',
+      'Top Clicked Product 2 (Title)',
+      'Top Clicked Product 2 (Asin)',
+      'Top Clicked Product 3 (Title)',
+      'Top Clicked Product 3 (Asin)',
+    ]),
+  ]
+
+  for (const item of data.searchTermMetrics) {
+    const topClickedProducts = Array.isArray(item.topClickedProducts) ? item.topClickedProducts : []
+    lines.push(
+      row([
+        item.searchTerm,
+        numberText(item.searchVolumeT360),
+        numberText(item.searchVolumeQoq),
+        numberText(item.searchVolumeGrowthT180),
+        numberText(item.clickShareT360),
+        numberText(item.searchConversionRateT360),
+        topClickedProducts[0]?.asinTitle,
+        topClickedProducts[0]?.asin,
+        topClickedProducts[1]?.asinTitle,
+        topClickedProducts[1]?.asin,
+        topClickedProducts[2]?.asinTitle,
+        topClickedProducts[2]?.asin,
+      ]),
+    )
+  }
+
+  fs.writeFileSync(searchTermsPath, lines.join(''))
+}
+
+writeProductsCsv()
+writeSearchTermsCsv()

--- a/apps/argus/scripts/browser/weekly-scaleinsights/collect.sh
+++ b/apps/argus/scripts/browser/weekly-scaleinsights/collect.sh
@@ -10,9 +10,9 @@ load_monitoring_env
 
 DEST="${ARGUS_SCALEINSIGHTS_DEST:-$(argus_monitoring_root)/Weekly/ScaleInsights/KeywordRanking (Browser)}"
 DL="${ARGUS_SCALEINSIGHTS_DOWNLOAD_DIR:-$HOME/Downloads}"
-LOG="${ARGUS_SCALEINSIGHTS_LOG:-/tmp/weekly-scaleinsights.log}"
+LOG="${ARGUS_SCALEINSIGHTS_LOG:-$(argus_tmp_log_path weekly-scaleinsights)}"
 TARGET_URL="https://portal.scaleinsights.com/KeywordRanking"
-COUNTRY_CODE="US"
+COUNTRY_CODE="$(require_market_env ARGUS_SCALEINSIGHTS_COUNTRY_CODE)"
 
 if [ "$#" -eq 2 ]; then
   START_DATE="$1"
@@ -33,6 +33,20 @@ wait_tab() { run_chrome_helper wait-tab-id "$TAB_ID" >/dev/null; }
 tab_url() { run_chrome_helper get-url-tab-id "$TAB_ID"; }
 
 log "Starting weekly ScaleInsights: $PREFIX"
+
+target_file="$DEST/${PREFIX}_SI-KeywordRanking.xlsx"
+if [ -f "$target_file" ]; then
+  target_size="$(stat -f '%z' "$target_file")"
+  log "Existing ScaleInsights target: $target_file size=$target_size"
+  if [ "$target_size" -gt 0 ]; then
+    log "Saved: ${PREFIX}_SI-KeywordRanking.xlsx already current"
+    log "Done"
+    tail -100 "$LOG" > "$LOG.tmp" && mv "$LOG.tmp" "$LOG"
+    exit 0
+  fi
+else
+  log "Existing ScaleInsights target missing: $target_file"
+fi
 
 open_window "$TARGET_URL"
 wait_tab
@@ -119,7 +133,7 @@ if ! downloaded_file="$(wait_for_new_matching_file "$download_pattern" "$baselin
   exit 1
 fi
 
-copy_file_with_node "$downloaded_file" "$DEST/${PREFIX}_SI-KeywordRanking.xlsx"
+copy_file_with_node "$downloaded_file" "$target_file"
 
 log "Saved: ${PREFIX}_SI-KeywordRanking.xlsx"
 log "Done"


### PR DESCRIPTION
## Summary
- harden Argus market-aware browser/API monitoring scripts for US and UK launchd runs
- switch UK POE capture to the authenticated POE GraphQL backend and write canonical POE CSVs
- make same-week ScaleInsights reruns idempotent when the target XLSX already exists
- prevent Sunday no-arg weekly API runs from requesting unpublished same-week Brand Analytics data
- prevent account-health launchd runs from pinning stale active SP-API reports

## Validation
- `bash -n apps/argus/scripts/api/weekly-sources/run.sh apps/argus/scripts/browser/relogin.sh apps/argus/scripts/browser/run-weekly.sh apps/argus/scripts/browser/weekly-category-insights/collect.sh apps/argus/scripts/browser/weekly-poe/collect.sh apps/argus/scripts/browser/weekly-scaleinsights/collect.sh apps/argus/scripts/browser/weekly-brand-metrics/collect.sh`
- `bash apps/argus/scripts/browser/common.test.sh`
- `node --test apps/argus/scripts/browser/relogin.test.mjs apps/argus/scripts/browser/weekly-market-config.test.mjs apps/argus/scripts/api/daily-account-health/collect.test.mjs apps/argus/scripts/api/weekly-sources/run.test.mjs`
- `node --check apps/argus/scripts/browser/weekly-poe/write-graphql-csvs.mjs`
- `python3 apps/argus/scripts/wpr/test_rebuild_wpr.py`
- `python3 apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py`
- `pnpm --filter @targon/argus lint`
- `pnpm --filter @targon/argus type-check`

## Live verification
- all 12 Argus launchd labels show exit `0` locally
- latest US and UK weekly API and weekly browser shared-drive run logs are `ok`
- shared-drive artifact check found `missing=0` across checked US/UK Monitoring and WPR outputs
