### PR TITLE
fix(website): repair home scrolling and nav

### DIFF
--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -13,6 +13,8 @@
   --ring: 0 194 185;
 
   --radius-card: 24px;
+  --tg-header-height: 65px;
+  --tg-panel-height: calc(100svh - var(--tg-header-height));
 }
 
 html {
@@ -146,7 +148,8 @@ button:focus-visible,
 
 html.tg-home {
   scroll-behavior: smooth;
-  scroll-snap-type: y mandatory;
+  scroll-padding-top: var(--tg-header-height);
+  scroll-snap-type: y proximity;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -174,18 +177,19 @@ body.tg-home footer {
   margin-top: 0;
 }
 
-.tg-snap {
-  scroll-snap-align: start;
-  scroll-snap-stop: always;
-  min-height: 100svh;
-  position: relative;
-  overflow: hidden;
+.tg-section-eyebrow {
+  font-size: 0.875rem;
+  font-weight: 700;
+  letter-spacing: 0.36em;
+  line-height: 1.1;
+  text-transform: uppercase;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .tg-snap {
-    scroll-snap-stop: normal;
-  }
+.tg-snap {
+  scroll-snap-align: start;
+  min-height: var(--tg-panel-height);
+  position: relative;
+  overflow: hidden;
 }
 
 /*
@@ -193,12 +197,12 @@ body.tg-home footer {
 */
 
 body.tg-home .tg-values {
-  min-height: 100svh;
+  min-height: var(--tg-panel-height);
 }
 
 body.tg-home .tg-value-row {
   height: 100%;
-  min-height: 100svh;
+  min-height: var(--tg-panel-height);
   display: flex;
   flex-direction: column;
 }
@@ -212,7 +216,7 @@ body.tg-home .tg-value-row {
 body.tg-home .tg-value-panel {
   position: relative;
   flex: 1 1 0%;
-  min-height: 25vh;
+  min-height: calc(var(--tg-panel-height) / 4);
   overflow: hidden;
   border-bottom: 1px solid rgba(255, 255, 255, 0.10);
   transition: flex-grow 700ms cubic-bezier(0.25, 1, 0.5, 1);

--- a/apps/website/src/app/page.tsx
+++ b/apps/website/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
           <div className="absolute inset-0 bg-gradient-to-b from-black/65 via-black/20 to-black/85" />
         </div>
 
-        <Container className="relative z-10 flex min-h-[100svh] flex-col items-center justify-center px-6 text-center">
+        <Container className="relative z-10 flex min-h-[var(--tg-panel-height)] flex-col items-center justify-center px-6 text-center">
           <div
             aria-hidden
             className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-[60%] select-none blur-[2px]"
@@ -99,9 +99,9 @@ export default function HomePage() {
           <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/80" />
         </div>
 
-        <Container className="relative z-10 flex min-h-[100svh] flex-col items-center justify-center px-6 text-center">
+        <Container className="relative z-10 flex min-h-[var(--tg-panel-height)] flex-col items-center justify-center px-6 text-center">
           <Reveal>
-            <div className="text-xs font-bold uppercase tracking-[0.5em] text-accent/90">
+            <div data-home-eyebrow className="tg-section-eyebrow text-accent/90">
               Targon’s purpose
             </div>
           </Reveal>
@@ -125,9 +125,12 @@ export default function HomePage() {
           <div className="absolute inset-0 bg-gradient-to-t from-black via-ink/40 to-black" />
         </div>
 
-        <Container className="relative z-10 flex min-h-[100svh] flex-col items-center justify-center px-6 text-center">
+        <Container className="relative z-10 flex min-h-[var(--tg-panel-height)] flex-col items-center justify-center px-6 text-center">
           <Reveal>
-            <div className="inline-flex items-center gap-3 border-b border-white/10 pb-4 text-xs font-bold uppercase tracking-[0.5em] text-white/50">
+            <div
+              data-home-eyebrow
+              className="tg-section-eyebrow inline-flex items-center gap-3 border-b border-white/10 pb-4 text-white/50"
+            >
               Mission
             </div>
           </Reveal>
@@ -151,9 +154,12 @@ export default function HomePage() {
           <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/70" />
         </div>
 
-        <Container className="relative z-10 flex min-h-[100svh] flex-col items-center justify-center px-6 text-center">
+        <Container className="relative z-10 flex min-h-[var(--tg-panel-height)] flex-col items-center justify-center px-6 text-center">
           <Reveal>
-            <span className="inline-flex items-center rounded-pill border border-white/20 bg-black/20 px-6 py-2 text-xs font-bold uppercase tracking-[0.3em] text-white backdrop-blur-md">
+            <span
+              data-home-eyebrow
+              className="tg-section-eyebrow inline-flex items-center rounded-pill border border-white/20 bg-black/20 px-6 py-2 text-white backdrop-blur-md"
+            >
               Vision
             </span>
           </Reveal>
@@ -172,7 +178,9 @@ export default function HomePage() {
         <div className="absolute left-0 right-0 top-0 z-20 flex items-start justify-between p-6 md:p-10">
           <div>
             <Reveal>
-              <h2 className="text-xs font-bold uppercase tracking-[0.3em] text-accent">Core values</h2>
+              <h2 data-home-eyebrow className="tg-section-eyebrow text-accent">
+                Core values
+              </h2>
             </Reveal>
             <Reveal delay={100}>
               <div className="mt-3 h-0.5 w-16 bg-accent/50" />
@@ -290,7 +298,7 @@ export default function HomePage() {
             <div className="grid items-end gap-8 md:grid-cols-12">
               <div className="text-center md:col-span-5 md:text-left">
                 <Reveal>
-                  <div className="text-xs font-bold uppercase tracking-[0.5em] text-accent/90">
+                  <div data-home-eyebrow className="tg-section-eyebrow text-accent/90">
                     Products
                   </div>
                 </Reveal>

--- a/apps/website/src/components/Header.tsx
+++ b/apps/website/src/components/Header.tsx
@@ -9,17 +9,37 @@ import { cn } from '@/lib/utils';
 import { site } from '@/content/site';
 import { Container } from '@/components/Container';
 
-const navLinks = [
+const productNavLinks = [
   { label: 'Packs', href: '/cs/us/packs' },
   { label: 'Where to buy', href: '/cs/us/where-to-buy' },
   { label: 'Support', href: '/cs/us/support' },
   { label: 'About', href: '/cs/us/about' }
 ];
 
+const homeNavLinks = [
+  { label: 'Purpose', href: '#purpose' },
+  { label: 'Mission', href: '#mission' },
+  { label: 'Vision', href: '#vision' },
+  { label: 'Values', href: '#values' },
+  { label: 'Our Brands', href: '#products' }
+];
+
 export function Header() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
+  const navLinks = pathname === '/' ? homeNavLinks : productNavLinks;
+  const isActiveLink = (href: string) => {
+    if (href.startsWith('#')) {
+      return false;
+    }
+
+    if (pathname === href) {
+      return true;
+    }
+
+    return pathname.startsWith(`${href}/`);
+  };
 
   // Close the mobile menu on navigation.
   useEffect(() => {
@@ -59,7 +79,7 @@ export function Header() {
 
         <nav className="hidden items-center gap-6 md:flex">
           {navLinks.map((l) => {
-            const active = pathname === l.href || pathname.startsWith(`${l.href}/`);
+            const active = isActiveLink(l.href);
             return (
               <Link
                 key={l.href}
@@ -99,11 +119,12 @@ export function Header() {
           <Container className="py-4">
             <div className="grid gap-2">
               {navLinks.map((l) => {
-                const active = pathname === l.href || pathname.startsWith(`${l.href}/`);
+                const active = isActiveLink(l.href);
                 return (
                   <Link
                     key={l.href}
                     href={l.href}
+                    onClick={() => setMobileOpen(false)}
                     className={cn(
                       'rounded-pill px-4 py-3 text-sm font-semibold text-white/70 hover:bg-white/5 hover:text-white',
                       active ? 'bg-white/5 text-white' : null


### PR DESCRIPTION
## Summary
- fixes homepage scroll snapping so normal wheel scrolling can reach Products and the footer across viewport sizes
- updates the homepage top nav to Purpose, Mission, Vision, Values, and Our Brands
- standardizes the small homepage section labels at a larger shared size

## Verification
- pnpm --filter @targon/website type-check
- pnpm --filter @targon/website build
- git diff --check
- Playwright viewport matrix for homepage scrolling and CS page scroll regressions
