### PR TITLE
release: promote dev to main

### DIFF
--- a/apps/argus/.env.dev.ci
+++ b/apps/argus/.env.dev.ci
@@ -15,3 +15,7 @@ ARGUS_SALES_ROOT_UK=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@t
 WPR_DATA_DIR_US=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/WPR/wpr-workspace/output
 WPR_DATA_DIR_UK=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - UK/Sales/WPR/wpr-workspace/output
 WPR_DATA_DIR=/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales/WPR/wpr-workspace/output
+ARGUS_MEDIA_BACKEND=s3
+ARGUS_MEDIA_S3_PREFIX=argus/us/listings/dev
+S3_BUCKET_NAME=wms-development-459288913318
+S3_BUCKET_REGION=us-east-1

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -1090,6 +1090,13 @@ validate_plutus_qbo_env() {
   fi
 }
 
+validate_hermes_env() {
+  if [[ "${HERMES_AUTO_MIGRATE:-}" == "1" ]]; then
+    error "HERMES_AUTO_MIGRATE must be 0 for hosted hermes deployments"
+    exit 1
+  fi
+}
+
 require_non_empty_env_var() {
   local key="$1"
   local value="${!key:-}"
@@ -1104,8 +1111,8 @@ normalize_argus_media_backend() {
   local raw="${ARGUS_MEDIA_BACKEND:-}"
 
   if [[ -z "${raw//[[:space:]]/}" ]]; then
-    printf 'local'
-    return 0
+    error "ARGUS_MEDIA_BACKEND is required for argus deployments"
+    exit 1
   fi
 
   local normalized
@@ -1361,6 +1368,10 @@ apply_hosted_env_overrides
 
 if [[ "$app_key" == "plutus" ]]; then
   validate_plutus_qbo_env
+fi
+
+if [[ "$app_key" == "hermes" ]]; then
+  validate_hermes_env
 fi
 
 if [[ "$app_key" == "argus" ]]; then

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -97,6 +97,28 @@ test('hosted deploys load exact shared and app env files without .env.local fall
   )
 })
 
+test('argus deploy requires explicit media backend before prebuild repair', () => {
+  assert.match(
+    deployScript,
+    /normalize_argus_media_backend\(\)[\s\S]*?error "ARGUS_MEDIA_BACKEND is required for argus deployments"/,
+  )
+  assert.match(
+    deployScript,
+    /if \[\[ "\$media_backend" == "s3" \]\]; then[\s\S]*?Skipping Argus local media repair/,
+  )
+})
+
+test('hermes hosted deploy rejects runtime auto migration', () => {
+  assert.match(
+    deployScript,
+    /validate_hermes_env\(\)[\s\S]*?HERMES_AUTO_MIGRATE must be 0 for hosted hermes deployments/,
+  )
+  assert.match(
+    deployScript,
+    /if \[\[ "\$app_key" == "hermes" \]\]; then\s+validate_hermes_env\s+fi/,
+  )
+})
+
 test('pm2 starts scrub workflow-inherited database and hosted runtime env', () => {
   const match = deployScript.match(/run_pm2_sanitized\(\) \{[\s\S]*?\n\}/)
   assert.ok(match, 'run_pm2_sanitized block should exist')


### PR DESCRIPTION
Promotes the current `dev` tip to `main` after the protected sync chain moved `dev` forward.

Evidence before opening:
- `origin/dev...origin/main` is `4 0`, so `main` is behind current `dev` and has no unique commits.
- Previous main CD run `24965208811` passed before the latest dev-side sync and Argus deploy-env fix landed.