### PR TITLE
fix(talos): preserve owner migration env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
       - name: Run CI contract tests
         run: |
           pnpm run test:auth-topology
+          node --test scripts/deploy-app.test.cjs scripts/detect-cd-affected-apps.test.cjs scripts/lib/shared-env.test.cjs
           node --test scripts/verify-ci-env-contracts.test.mjs
           node --test scripts/verify-promotion-ready.test.mjs
       - name: Run auth contract tests

--- a/apps/talos/scripts/load-env.ts
+++ b/apps/talos/scripts/load-env.ts
@@ -13,6 +13,12 @@ const { loadEnvForApp } = require('../../../scripts/lib/shared-env.cjs') as {
 }
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const PRESERVED_DATABASE_ENV_KEYS = [
+  'TALOS_ADMIN_DATABASE_URL',
+  'DATABASE_URL',
+  'DATABASE_URL_US',
+  'DATABASE_URL_UK',
+] as const
 
 function resolveScriptEnvMode() {
   if (process.env.TALOS_ENV_MODE && process.env.TALOS_ENV_MODE.trim().length > 0) {
@@ -25,14 +31,38 @@ function resolveScriptEnvMode() {
 }
 
 export function loadAppScriptEnv(appName: string) {
+  const preservedDatabaseEnv = captureDatabaseEnvForMigration()
   loadEnvForApp({
     repoRoot: REPO_ROOT,
     appName,
     mode: resolveScriptEnvMode(),
     targetEnv: process.env,
   })
+  restoreDatabaseEnvForMigration(preservedDatabaseEnv)
 }
 
 export function loadTalosScriptEnv() {
   loadAppScriptEnv('talos')
+}
+
+function captureDatabaseEnvForMigration() {
+  const captured: Array<[string, string]> = []
+  if (process.env.TALOS_PRESERVE_DATABASE_ENV !== '1') {
+    return captured
+  }
+
+  for (const key of PRESERVED_DATABASE_ENV_KEYS) {
+    const value = process.env[key]
+    if (typeof value === 'string' && value.trim().length > 0) {
+      captured.push([key, value])
+    }
+  }
+
+  return captured
+}
+
+function restoreDatabaseEnvForMigration(captured: Array<[string, string]>) {
+  for (const [key, value] of captured) {
+    process.env[key] = value
+  }
 }

--- a/scripts/db/talos-db-common.sh
+++ b/scripts/db/talos-db-common.sh
@@ -29,7 +29,7 @@ load_talos_env_if_needed() {
   fi
 
   local exports
-  if ! exports="$("$repo_dir/scripts/load-app-env.js" --app talos --mode "$mode")"; then
+  if ! exports="$(node "$repo_dir/scripts/load-app-env.js" --app talos --mode "$mode")"; then
     return 1
   fi
 

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -1036,6 +1036,7 @@ prepare_talos_owner_migration_env() {
   fi
 
   export DATABASE_URL="$DATABASE_URL_US"
+  export TALOS_PRESERVE_DATABASE_ENV="1"
 }
 
 prepare_owner_migration_env() {

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -1,10 +1,13 @@
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const { spawnSync } = require('node:child_process')
 const fs = require('node:fs')
 const path = require('node:path')
 
 const rootDir = path.resolve(__dirname, '..')
 const deployScript = fs.readFileSync(path.join(rootDir, 'scripts', 'deploy-app.sh'), 'utf8')
+const talosDbCommon = fs.readFileSync(path.join(rootDir, 'scripts', 'db', 'talos-db-common.sh'), 'utf8')
+const talosLoadEnv = fs.readFileSync(path.join(rootDir, 'apps', 'talos', 'scripts', 'load-env.ts'), 'utf8')
 const authPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'packages', 'auth', 'package.json'), 'utf8'))
 
 test('auth package exposes a deploy-safe prisma migrate command', () => {
@@ -105,6 +108,59 @@ test('argus deploy requires explicit media backend before prebuild repair', () =
   assert.match(
     deployScript,
     /if \[\[ "\$media_backend" == "s3" \]\]; then[\s\S]*?Skipping Argus local media repair/,
+  )
+})
+
+test('talos owner migrations keep explicit owner database env after loading app env', () => {
+  assert.match(
+    deployScript,
+    /prepare_talos_owner_migration_env\(\)[\s\S]*?export TALOS_PRESERVE_DATABASE_ENV="1"/,
+  )
+  assert.match(
+    talosLoadEnv,
+    /if \(process\.env\.TALOS_PRESERVE_DATABASE_ENV !== '1'\) \{[\s\S]*?return captured/,
+  )
+  assert.match(talosLoadEnv, /'DATABASE_URL_US'/)
+  assert.match(talosLoadEnv, /'DATABASE_URL_UK'/)
+  assert.match(talosLoadEnv, /restoreDatabaseEnvForMigration\(preservedDatabaseEnv\)/)
+})
+
+test('talos script env loader preserves owner database urls at runtime', () => {
+  const script = `
+    import assert from 'node:assert/strict'
+    import { loadTalosScriptEnv } from './scripts/load-env.ts'
+
+    loadTalosScriptEnv()
+
+    assert.equal(process.env.DATABASE_URL_US, 'postgresql://portal_talos@localhost:5432/portal_db_dev?schema=dev_talos_us')
+    assert.equal(process.env.DATABASE_URL_UK, 'postgresql://portal_talos@localhost:5432/portal_db_dev?schema=dev_talos_uk')
+    assert.equal(process.env.DATABASE_URL, 'postgresql://portal_talos@localhost:5432/portal_db_dev?schema=dev_talos_us')
+  `
+
+  const result = spawnSync('pnpm', ['--filter', '@targon/talos', 'exec', 'tsx', '-e', script], {
+    cwd: rootDir,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      TALOS_ENV_MODE: 'ci',
+      TALOS_PRESERVE_DATABASE_ENV: '1',
+      DATABASE_URL_US: 'postgresql://portal_talos@localhost:5432/portal_db_dev?schema=dev_talos_us',
+      DATABASE_URL_UK: 'postgresql://portal_talos@localhost:5432/portal_db_dev?schema=dev_talos_uk',
+      DATABASE_URL: 'postgresql://portal_talos@localhost:5432/portal_db_dev?schema=dev_talos_us',
+    },
+  })
+
+  assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`)
+})
+
+test('talos db shell helpers run load-app-env through node', () => {
+  assert.match(
+    talosDbCommon,
+    /exports="\$\(node "\$repo_dir\/scripts\/load-app-env\.js" --app talos --mode "\$mode"\)"/,
+  )
+  assert.doesNotMatch(
+    talosDbCommon,
+    /exports="\$\("\$repo_dir\/scripts\/load-app-env\.js"/,
   )
 })
 


### PR DESCRIPTION
## Summary
- preserve explicit Talos owner DB URLs during migration script env loading
- run Talos DB helper env loading through node instead of requiring executable permissions
- add deploy/env contract coverage to CI

## Verification
- git diff --check
- node --test scripts/deploy-app.test.cjs scripts/detect-cd-affected-apps.test.cjs scripts/lib/shared-env.test.cjs
- node --test scripts/verify-ci-env-contracts.test.mjs scripts/verify-promotion-ready.test.mjs
- pnpm --filter @targon/talos type-check
- TALOS_ENV_MODE=ci pnpm --filter @targon/talos build
- TALOS_ENV_MODE=ci pnpm --filter @targon/talos test
- TALOS_ENV_MODE=ci owner-url db:migrate:sku-dimensions