### PR TITLE
fix(talos): preserve migration owner env during deploy

### DIFF
--- a/apps/argus/package.json
+++ b/apps/argus/package.json
@@ -11,7 +11,7 @@
     "media:remove-bad-source-gallery-revisions": "tsx scripts/remove-bad-source-gallery-revisions.ts",
     "media:upload-local-to-s3": "tsx scripts/upload-local-media-to-s3.ts",
     "lint": "eslint app components lib middleware.ts",
-    "type-check": "prisma generate --schema prisma/schema.prisma && tsc --noEmit --skipLibCheck"
+    "type-check": "node -e \"require('fs').rmSync('.next/types', { recursive: true, force: true })\" && prisma generate --schema prisma/schema.prisma && tsc --noEmit --skipLibCheck"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.2",

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -637,6 +637,7 @@ run_pm2_sanitized() {
   DATABASE_URL= \
   DATABASE_URL_US= \
   DATABASE_URL_UK= \
+  TALOS_PRESERVE_DATABASE_ENV= \
   PORTAL_DB_URL= \
   PGDATABASE= \
   PGHOST= \
@@ -1184,6 +1185,14 @@ if compute_changed_files; then
   log "Detected ${#changed_files[@]} changed files for deploy range ${deploy_base_sha:-unknown}..${deploy_head_sha:-unknown}"
 else
   warn "Could not determine changed files for this deployment; using safe defaults"
+fi
+
+if [[ "$app_key" == "talos" && "$changed_files_available" == "true" ]]; then
+  if talos_changed_migrate_cmd="$(build_talos_changed_migrate_cmd)"; then
+    migrate_cmd="$talos_changed_migrate_cmd"
+  else
+    migrate_cmd=""
+  fi
 fi
 
 # Step 2: Install dependencies

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -77,6 +77,13 @@ test('atlas dev deploy no longer falls back to db push on migrate errors', () =>
   )
 })
 
+test('talos deploy runs only changed migrations when deploy range is known', () => {
+  assert.match(
+    deployScript,
+    /if \[\[ "\$app_key" == "talos" && "\$changed_files_available" == "true" \]\]; then[\s\S]*?talos_changed_migrate_cmd="\$\(build_talos_changed_migrate_cmd\)"[\s\S]*?migrate_cmd=""/,
+  )
+})
+
 test('hosted deploys load exact shared and app env files without .env.local fallback', () => {
   assert.match(
     deployScript,
@@ -184,6 +191,7 @@ test('pm2 starts scrub workflow-inherited database and hosted runtime env', () =
     'DATABASE_URL',
     'DATABASE_URL_US',
     'DATABASE_URL_UK',
+    'TALOS_PRESERVE_DATABASE_ENV',
     'PORTAL_DB_URL',
     'PGHOSTADDR',
     'PGPASSFILE',


### PR DESCRIPTION
## Summary
- skip Talos migrations when the deploy range has no Talos schema or migration changes
- preserve owner database URLs when Talos migration scripts load app env
- scrub the preservation flag before PM2 starts
- clean stale Argus Next type files before typecheck

## Tests
- node --test scripts/deploy-app.test.cjs scripts/verify-ci-env-contracts.test.mjs scripts/lib/shared-env.test.cjs
- node scripts/verify-ci-env-contracts.mjs
- pnpm typecheck
- git diff --check