### PR TITLE
release: promote dev to main

### DIFF
--- a/apps/sso/package.json
+++ b/apps/sso/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "node ../../scripts/run-next-port.js start",
     "type-check": "tsc --noEmit",
-    "test:auth-contracts": "tsx --test lib/auth-logger.test.ts lib/auth-route-recovery.test.ts tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts scripts/ensure-hosted-smoke-user-lib.test.ts",
+    "test:auth-contracts": "tsx --test lib/auth-logger.test.ts lib/auth-route-recovery.test.ts tests/active-tenant.route.test.ts tests/fixtures/hosted-smoke-config.test.ts tests/fixtures/hosted-auth.test.ts scripts/ensure-hosted-smoke-user-lib.test.ts",
     "test:auth-smoke": "pnpm run test:auth-contracts && playwright test --grep \"portal login|stale encrypted session|authenticated launcher|auth cleanup\"",
     "test:e2e": "playwright test",
     "test:hosted-smoke": "pnpm run test:auth-contracts && PLAYWRIGHT_HOSTED_ONLY=1 playwright test tests/hosted-deep-links.spec.ts --workers=1",

--- a/apps/sso/tests/fixtures/hosted-auth.test.ts
+++ b/apps/sso/tests/fixtures/hosted-auth.test.ts
@@ -1,0 +1,8 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isHostedCriticalStatusCode } from './hosted-auth'
+
+test('hosted response tracker treats same-origin 404 responses as critical', () => {
+  assert.equal(isHostedCriticalStatusCode(404), true)
+})

--- a/apps/sso/tests/fixtures/hosted-auth.ts
+++ b/apps/sso/tests/fixtures/hosted-auth.ts
@@ -16,13 +16,17 @@ type CriticalResponseRecord = {
   url: string
 }
 
-const criticalStatusCodes = new Set([401, 403, 500, 502])
+const criticalStatusCodes = new Set([401, 403, 404, 500, 502])
 const trackedResourceTypes = new Set(['document', 'fetch', 'xhr'])
 const hostedErrorMarkers = [
   'Bad gateway',
   'Error code 502',
   "Unexpected token '<'",
 ] as const
+
+export function isHostedCriticalStatusCode(status: number): boolean {
+  return criticalStatusCodes.has(status)
+}
 
 function requireEnv(name: string): string {
   const value = process.env[name]
@@ -168,7 +172,7 @@ export function installHostedResponseTracker(page: Page) {
     }
 
     const status = response.status()
-    if (!criticalStatusCodes.has(status)) {
+    if (!isHostedCriticalStatusCode(status)) {
       return
     }
 

--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -25,6 +25,10 @@ const hostedRouteChecks: HostedRouteCheck[] = [
   { name: 'plutus', path: '/plutus/settlements', visibleText: 'Settlements' },
   { name: 'hermes', path: '/hermes/insights', visibleText: 'Insights' },
   { name: 'argus', path: '/argus/wpr', visibleText: 'Weekly performance reporting' },
+  { name: 'talos-dashboard', path: '/talos/dashboard', visibleText: 'Dashboard' },
+  { name: 'talos-inventory', path: '/talos/operations/inventory', visibleText: 'Inventory' },
+  { name: 'talos-purchase-orders', path: '/talos/operations/purchase-orders', visibleText: 'Purchase Orders' },
+  { name: 'talos-products', path: '/talos/config/products', visibleText: 'Products' },
 ]
 
 test.describe('hosted cross-app auth smoke', () => {

--- a/apps/talos/src/lib/api/talos-api-path.test.ts
+++ b/apps/talos/src/lib/api/talos-api-path.test.ts
@@ -1,16 +1,45 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
+function restoreEnv(name: string, value: string | undefined) {
+  if (typeof value === 'string') {
+    process.env[name] = value
+  } else {
+    delete process.env[name]
+  }
+}
+
 test('buildTalosApiPath prefixes Talos api paths exactly once', async () => {
-  const previousBasePath = process.env.NEXT_PUBLIC_BASE_PATH
+  const previousPublicBasePath = process.env.NEXT_PUBLIC_BASE_PATH
   process.env.NEXT_PUBLIC_BASE_PATH = '/talos'
 
-  const { buildTalosApiPath } = await import('./talos-api-path')
+  try {
+    const { buildTalosApiPath } = await import('./talos-api-path')
 
-  assert.equal(buildTalosApiPath('/api/warehouses'), '/talos/api/warehouses')
-  assert.equal(buildTalosApiPath('/talos/api/warehouses'), '/talos/api/warehouses')
-  assert.equal(buildTalosApiPath('/dashboard'), '/dashboard')
-  assert.throws(() => buildTalosApiPath('api/warehouses'), /must start with "\/"/i)
+    assert.equal(buildTalosApiPath('/api/warehouses'), '/talos/api/warehouses')
+    assert.equal(buildTalosApiPath('/talos/api/warehouses'), '/talos/api/warehouses')
+    assert.equal(buildTalosApiPath('/dashboard'), '/dashboard')
+    assert.throws(() => buildTalosApiPath('api/warehouses'), /must start with "\/"/i)
+  } finally {
+    restoreEnv('NEXT_PUBLIC_BASE_PATH', previousPublicBasePath)
+  }
+})
 
-  process.env.NEXT_PUBLIC_BASE_PATH = previousBasePath
+test('buildTalosApiPath rejects root api paths when no Talos base path is available', async () => {
+  const previousBasePath = process.env.BASE_PATH
+  const previousPublicBasePath = process.env.NEXT_PUBLIC_BASE_PATH
+  delete process.env.BASE_PATH
+  delete process.env.NEXT_PUBLIC_BASE_PATH
+
+  try {
+    const { buildTalosApiPath } = await import('./talos-api-path')
+
+    assert.throws(
+      () => buildTalosApiPath('/api/dashboard/overview'),
+      /Talos API paths require a base path/i,
+    )
+  } finally {
+    restoreEnv('BASE_PATH', previousBasePath)
+    restoreEnv('NEXT_PUBLIC_BASE_PATH', previousPublicBasePath)
+  }
 })

--- a/apps/talos/src/lib/api/talos-api-path.ts
+++ b/apps/talos/src/lib/api/talos-api-path.ts
@@ -5,6 +5,10 @@ export function buildTalosApiPath(path: string): string {
     throw new Error(`Talos paths must start with "/": ${path}`)
   }
 
+  if (path === '/api') {
+    return withBasePath(path)
+  }
+
   if (path.startsWith('/api/')) {
     return withBasePath(path)
   }

--- a/apps/talos/src/lib/utils/base-path.ts
+++ b/apps/talos/src/lib/utils/base-path.ts
@@ -45,6 +45,11 @@ function resolveInferencePath(pathname?: string): string {
  return ''
 }
 
+function isRootApiPath(path: string): boolean {
+ if (path === '/api') return true
+ return path.startsWith('/api/')
+}
+
 /**
  * Get the base path from environment or infer it from the active pathname.
  */
@@ -70,10 +75,15 @@ export function getBasePath(pathname?: string): string {
  */
 export function withBasePath(path: string, pathname?: string): string {
  const basePath = getBasePath(pathname)
- if (!basePath) return path
- 
  // Ensure path starts with /
  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+
+ if (!basePath) {
+  if (isRootApiPath(normalizedPath)) {
+   throw new Error(`Talos API paths require a base path; refusing root API path: ${normalizedPath}`)
+  }
+  return path
+ }
 
  if (normalizedPath === basePath || normalizedPath.startsWith(`${basePath}/`)) {
   return normalizedPath

--- a/apps/talos/src/lib/utils/patch-fetch.test.ts
+++ b/apps/talos/src/lib/utils/patch-fetch.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+test('patched fetch rejects non-json Talos API responses before the JSON parser', async () => {
+  const previousFetch = globalThis.fetch
+  const previousBasePath = process.env.BASE_PATH
+  const previousPublicBasePath = process.env.NEXT_PUBLIC_BASE_PATH
+  const apiPath = ['', 'api', 'dashboard', 'overview'].join('/')
+  let fetchedInput: RequestInfo | URL | undefined
+
+  try {
+    process.env.NEXT_PUBLIC_BASE_PATH = '/talos'
+    delete process.env.BASE_PATH
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchedInput = input
+      return new Response('<!DOCTYPE html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      })
+    }) as typeof fetch
+
+    await import(`./patch-fetch.ts?non-json-${Date.now()}`)
+
+    const response = await fetch(apiPath)
+    assert.equal(fetchedInput, '/talos/api/dashboard/overview')
+    await assert.rejects(
+      () => response.json(),
+      /Talos API expected JSON but received text\/html; charset=utf-8 from \/talos\/api\/dashboard\/overview \(404\)/,
+    )
+  } finally {
+    globalThis.fetch = previousFetch
+    if (typeof previousBasePath === 'string') {
+      process.env.BASE_PATH = previousBasePath
+    } else {
+      delete process.env.BASE_PATH
+    }
+    if (typeof previousPublicBasePath === 'string') {
+      process.env.NEXT_PUBLIC_BASE_PATH = previousPublicBasePath
+    } else {
+      delete process.env.NEXT_PUBLIC_BASE_PATH
+    }
+  }
+})

--- a/apps/talos/src/lib/utils/patch-fetch.ts
+++ b/apps/talos/src/lib/utils/patch-fetch.ts
@@ -1,7 +1,40 @@
 import { buildTalosApiPath } from '@/lib/api/talos-api-path'
 
-function shouldPrefix(input: RequestInfo | URL): input is string {
- return typeof input === 'string' && input.startsWith('/api/')
+const rootApiPath = '/api'
+const rootApiPrefix = `${rootApiPath}/`
+const talosApiPath = '/talos/api'
+const talosApiPrefix = `${talosApiPath}/`
+
+function isRootApiPath(pathname: string): boolean {
+ if (pathname === rootApiPath) return true
+ return pathname.startsWith(rootApiPrefix)
+}
+
+function isTalosApiPath(pathname: string): boolean {
+ if (pathname === talosApiPath) return true
+ return pathname.startsWith(talosApiPrefix)
+}
+
+function isJsonContentType(contentType: string): boolean {
+ const lowerContentType = contentType.toLowerCase()
+ if (lowerContentType.includes('application/json')) return true
+ return lowerContentType.includes('+json')
+}
+
+function guardJsonResponse(response: Response, requestPath: string): Response {
+ const originalJson = response.json.bind(response)
+ Object.defineProperty(response, 'json', {
+ configurable: true,
+ value: async () => {
+  const contentType = response.headers.get('content-type')?.trim() ?? ''
+  if (!isJsonContentType(contentType)) {
+   const received = contentType === '' ? 'no content-type' : contentType
+   throw new Error(`Talos API expected JSON but received ${received} from ${requestPath} (${response.status})`)
+  }
+  return originalJson()
+ },
+ })
+ return response
 }
 
 type FetchWithBasePathMarker = typeof globalThis.fetch & { __withBasePath?: boolean }
@@ -14,15 +47,28 @@ function patchGlobalFetch() {
  return
  }
 
- const patched = function (input: RequestInfo | URL, init?: RequestInit) {
- if (shouldPrefix(input)) {
- input = buildTalosApiPath(input)
+ const patched = async function (input: RequestInfo | URL, init?: RequestInit) {
+ let apiRequestPath: string | null = null
+
+ if (typeof input === 'string') {
+  if (isRootApiPath(input)) {
+   input = buildTalosApiPath(input)
+   apiRequestPath = input
+  } else if (isTalosApiPath(input)) {
+   apiRequestPath = input
+  }
  } else if (input instanceof URL) {
- if (input.pathname.startsWith('/api/')) {
- input = new URL(buildTalosApiPath(input.pathname) + input.search + input.hash, input.origin)
+  if (isRootApiPath(input.pathname)) {
+   const resolvedPath = buildTalosApiPath(input.pathname)
+   input = new URL(resolvedPath + input.search + input.hash, input.origin)
+   apiRequestPath = `${resolvedPath}${input.search}`
+  } else if (isTalosApiPath(input.pathname)) {
+   apiRequestPath = `${input.pathname}${input.search}`
+  }
  }
- }
- return originalFetch.call(this, input, init)
+
+ const response = await originalFetch.call(this, input, init)
+ return apiRequestPath ? guardJsonResponse(response, apiRequestPath) : response
  } as FetchWithBasePathMarker
 
  patched.__withBasePath = true


### PR DESCRIPTION
## Summary
Promote `dev` to `main` after #5246.

Included fix:
- `fix(talos): enforce api json contract`

## Verification before promotion
- #5246 PR CI passed
- `dev` CI passed for b59fc3fcb8c7d82a05cfb181a760fede379c7348
- `dev` CD passed for b59fc3fcb8c7d82a05cfb181a760fede379c7348
- Computer Use/browser verified dev version badge points to b59fc3fcb8c7d82a05cfb181a760fede379c7348
- `curl https://dev-os.targonglobal.com/talos/api/dashboard/overview` returns 401 JSON, while the root `/api/dashboard/overview` remains the portal HTML 404 that Talos must not call