### PR TITLE
fix(talos): guard inventory summary loading

### DIFF
--- a/apps/talos/src/app/operations/inventory/page.tsx
+++ b/apps/talos/src/app/operations/inventory/page.tsx
@@ -176,6 +176,14 @@ function InventoryPage() {
     throw loadError
   }
 
+  if (loading) {
+    return (
+      <PageContainer>
+        <PageLoading />
+      </PageContainer>
+    )
+  }
+
   if (!loading && summary === null) {
     throw new Error('Inventory summary is required')
   }

--- a/apps/talos/tests/unit/inventory-page-loading-contract.test.ts
+++ b/apps/talos/tests/unit/inventory-page-loading-contract.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import test from 'node:test'
+
+test('inventory page renders loading state before reading summary totals', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/operations/inventory/page.tsx'),
+    'utf8',
+  )
+
+  const loadingGuardIndex = source.indexOf('if (loading) {')
+  const summaryTotalIndex = source.indexOf('summary.totalSkuCount')
+
+  assert.notEqual(summaryTotalIndex, -1, 'inventory page should render summary total SKU count')
+  assert.notEqual(loadingGuardIndex, -1, 'inventory page must guard the loading state')
+  assert.equal(
+    loadingGuardIndex < summaryTotalIndex,
+    true,
+    'inventory page must not read summary totals while balances are still loading',
+  )
+})


### PR DESCRIPTION
## Summary
- Render the inventory page loading state while `/api/inventory/balances` is still in flight.
- Add a regression contract test that prevents the page from reading `summary.totalSkuCount` before the loading guard.

## Root cause
`summary` starts as `null` and is populated only after the balances API returns. The authenticated inventory page skipped the `loading` state and rendered the table immediately, so the footer read `summary.totalSkuCount` while `summary` was still null.

## Verification
- `pnpm --filter @targon/talos exec tsx tests/unit/inventory-page-loading-contract.test.ts` failed before the fix and passes after it.
- `pnpm --filter @targon/talos test`
- `pnpm --filter @targon/talos type-check:app`
- `git diff --check`