### PR TITLE
release: promote dev to main

### DIFF
--- a/apps/talos/src/app/operations/inventory/page.tsx
+++ b/apps/talos/src/app/operations/inventory/page.tsx
@@ -176,6 +176,14 @@ function InventoryPage() {
     throw loadError
   }
 
+  if (loading) {
+    return (
+      <PageContainer>
+        <PageLoading />
+      </PageContainer>
+    )
+  }
+
   if (!loading && summary === null) {
     throw new Error('Inventory summary is required')
   }

--- a/apps/talos/tests/unit/inventory-page-loading-contract.test.ts
+++ b/apps/talos/tests/unit/inventory-page-loading-contract.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import test from 'node:test'
+
+test('inventory page renders loading state before reading summary totals', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/operations/inventory/page.tsx'),
+    'utf8',
+  )
+
+  const loadingGuardIndex = source.indexOf('if (loading) {')
+  const summaryTotalIndex = source.indexOf('summary.totalSkuCount')
+
+  assert.notEqual(summaryTotalIndex, -1, 'inventory page should render summary total SKU count')
+  assert.notEqual(loadingGuardIndex, -1, 'inventory page must guard the loading state')
+  assert.equal(
+    loadingGuardIndex < summaryTotalIndex,
+    true,
+    'inventory page must not read summary totals while balances are still loading',
+  )
+})


### PR DESCRIPTION
## Summary
Promote `dev` to `main` after #5249.

Included fix:
- `fix(talos): guard inventory summary loading`

## Verification before promotion
- #5249 PR CI passed
- `dev` CI passed for 7ff19371405f9f63a9eda1f3a7a3870092ea3ad4
- `dev` CD passed for 7ff19371405f9f63a9eda1f3a7a3870092ea3ad4
- Dev hosted-auth-health passed, including the Talos inventory route smoke coverage