### PR TITLE
fix(talos): source outbound inventory from shipments

### DIFF
--- a/apps/talos/src/app/api/inventory/balances/route.ts
+++ b/apps/talos/src/app/api/inventory/balances/route.ts
@@ -84,17 +84,13 @@ export const GET = withAuth(async (req, session) => {
       purchaseOrder: {
         select: { orderNumber: true },
       },
-      fulfillmentOrder: {
-        select: { foNumber: true },
-      },
     },
   })
 
-  const ledgerTransactions = transactions.map(({ purchaseOrder, fulfillmentOrder, ...transaction }) => ({
+  const ledgerTransactions = transactions.map(({ purchaseOrder, ...transaction }) => ({
     ...transaction,
     transactionDate: transaction.transactionDate,
     purchaseOrderNumber: purchaseOrder?.orderNumber ? toPublicOrderNumber(purchaseOrder.orderNumber) : null,
-    fulfillmentOrderNumber: fulfillmentOrder?.foNumber ?? null,
   }))
 
   const aggregated = aggregateInventoryTransactions(ledgerTransactions)
@@ -154,8 +150,6 @@ export const GET = withAuth(async (req, session) => {
       lastTransactionReference: balance.lastTransactionReference ?? undefined,
       purchaseOrderId: balance.purchaseOrderId ?? null,
       purchaseOrderNumber: balance.purchaseOrderNumber ? toPublicOrderNumber(balance.purchaseOrderNumber) : null,
-      fulfillmentOrderId: balance.fulfillmentOrderId ?? null,
-      fulfillmentOrderNumber: balance.fulfillmentOrderNumber ?? null,
       receiveTransaction
     }
   })

--- a/apps/talos/src/app/operations/inventory/page.tsx
+++ b/apps/talos/src/app/operations/inventory/page.tsx
@@ -623,16 +623,22 @@ function InventoryPage() {
                           : ('neutral' as const)
 
                     const sourceNumber =
-                      balance.fulfillmentOrderNumber ?? balance.purchaseOrderNumber ?? null
-                    const sourceHref = balance.fulfillmentOrderId
-                      ? `/operations/fulfillment-orders/${balance.fulfillmentOrderId}`
-                      : balance.purchaseOrderId
-                        ? `/operations/purchase-orders/${balance.purchaseOrderId}`
-                        : null
+                      movementType === 'negative'
+                        ? balance.lastTransactionReference ?? null
+                        : balance.purchaseOrderNumber ?? null
+                    const sourceHref =
+                      movementType === 'negative'
+                        ? balance.lastTransactionId
+                          ? `/operations/transactions/${balance.lastTransactionId}`
+                          : null
+                        : balance.purchaseOrderId
+                          ? `/operations/purchase-orders/${balance.purchaseOrderId}`
+                          : null
                     const sourceDisplay = sourceNumber ?? (sourceHref ? 'View' : '—')
                     const firstReceiveMeta = balance.receiveTransaction
                       ? `First receive: ${formatLedgerTimestamp(balance.receiveTransaction.transactionDate) ?? '—'} by ${balance.receiveTransaction.createdBy?.fullName ?? 'Unknown'}`
                       : null
+                    const sourceTitle = [sourceNumber, firstReceiveMeta].filter(Boolean).join('\n')
                     let warehouseDisplay = balance.warehouse.code
                     if (warehouseDisplay.length === 0) {
                       warehouseDisplay = balance.warehouse.name
@@ -648,9 +654,7 @@ function InventoryPage() {
                       >
                         <td
                           className="px-2 py-2 text-sm font-semibold text-foreground truncate"
-                          title={
-                            [sourceNumber, firstReceiveMeta].filter(Boolean).join('\n') || undefined
-                          }
+                          title={sourceTitle.length > 0 ? sourceTitle : undefined}
                         >
                           {sourceHref ? (
                             <Link

--- a/apps/talos/src/hooks/useInventoryFilters.ts
+++ b/apps/talos/src/hooks/useInventoryFilters.ts
@@ -72,8 +72,6 @@ export interface InventoryBalance {
   lastTransactionReference?: string | null
   purchaseOrderId: string | null
   purchaseOrderNumber: string | null
-  fulfillmentOrderId?: string | null
-  fulfillmentOrderNumber?: string | null
   receiveTransaction?: {
     createdBy?: {
       fullName: string

--- a/apps/talos/tests/unit/inventory-page-loading-contract.test.ts
+++ b/apps/talos/tests/unit/inventory-page-loading-contract.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import test from 'node:test'
+import { aggregateInventoryTransactions } from '@targon/ledger'
 
 test('inventory page renders loading state before reading summary totals', () => {
   const source = readFileSync(
@@ -19,4 +20,57 @@ test('inventory page renders loading state before reading summary totals', () =>
     true,
     'inventory page must not read summary totals while balances are still loading',
   )
+})
+
+test('inventory outbound source uses Amazon shipment references instead of local fulfillment orders', () => {
+  const source = readFileSync(
+    join(process.cwd(), 'src/app/operations/inventory/page.tsx'),
+    'utf8',
+  )
+  const balancesApi = readFileSync(
+    join(process.cwd(), 'src/app/api/inventory/balances/route.ts'),
+    'utf8',
+  )
+  const inventoryHook = readFileSync(
+    join(process.cwd(), 'src/hooks/useInventoryFilters.ts'),
+    'utf8',
+  )
+
+  assert.equal(source.includes('/operations/fulfillment-orders/'), false)
+  assert.equal(source.includes('fulfillmentOrderId'), false)
+  assert.equal(source.includes('fulfillmentOrderNumber'), false)
+  assert.equal(balancesApi.includes('fulfillmentOrder:'), false)
+  assert.equal(balancesApi.includes('fulfillmentOrderId'), false)
+  assert.equal(balancesApi.includes('fulfillmentOrderNumber'), false)
+  assert.equal(inventoryHook.includes('fulfillmentOrderId'), false)
+  assert.equal(inventoryHook.includes('fulfillmentOrderNumber'), false)
+  assert.equal(source.includes('lastTransactionReference'), true)
+})
+
+test('ledger groups outbound inventory by shipment reference when legacy fulfillment order ids are present', () => {
+  const transactionDate = new Date('2026-01-07T12:00:00.000Z')
+  const result = aggregateInventoryTransactions([
+    {
+      id: 'ship-tx-1',
+      transactionDate,
+      transactionType: 'SHIP',
+      warehouseCode: 'FMC',
+      warehouseName: 'FMC',
+      skuCode: 'SKU-1',
+      skuDescription: 'Test SKU',
+      lotRef: 'LOT-A',
+      cartonsIn: 0,
+      cartonsOut: 12,
+      unitsPerCarton: 10,
+      referenceId: 'FBA123SHIPMENT',
+      fulfillmentOrderId: 'fo-local-1',
+      fulfillmentOrderNumber: 'FO-0001',
+    },
+  ])
+
+  assert.equal(result.balances.length, 1)
+  assert.equal(result.balances[0].id, 'FMC::SKU-1::LOT-A::FBA123SHIPMENT')
+  assert.equal(result.balances[0].lastTransactionReference, 'FBA123SHIPMENT')
+  assert.equal(result.balances[0].fulfillmentOrderId, null)
+  assert.equal(result.balances[0].fulfillmentOrderNumber, null)
 })

--- a/packages/ledger/src/inventory.ts
+++ b/packages/ledger/src/inventory.ts
@@ -29,7 +29,7 @@ export function aggregateInventoryTransactions(
   const balances = new Map<string, BalanceAccumulator>()
 
   for (const transaction of transactions) {
-    const sourceId = transaction.fulfillmentOrderId ?? transaction.purchaseOrderId ?? '_none_'
+    const sourceId = resolveInventoryBalanceSourceId(transaction)
     const key = [transaction.warehouseCode, transaction.skuCode, transaction.lotRef, sourceId].join('::')
     let current = balances.get(key)
 
@@ -88,19 +88,6 @@ export function aggregateInventoryTransactions(
         }
       } else if (transaction.purchaseOrderNumber) {
         current.purchaseOrderNumber = transaction.purchaseOrderNumber
-      }
-
-      if (transaction.fulfillmentOrderId) {
-        const foIdChanged = current.fulfillmentOrderId !== transaction.fulfillmentOrderId
-        current.fulfillmentOrderId = transaction.fulfillmentOrderId
-
-        if (transaction.fulfillmentOrderNumber) {
-          current.fulfillmentOrderNumber = transaction.fulfillmentOrderNumber
-        } else if (foIdChanged) {
-          current.fulfillmentOrderNumber = null
-        }
-      } else if (transaction.fulfillmentOrderNumber) {
-        current.fulfillmentOrderNumber = transaction.fulfillmentOrderNumber
       }
     }
 
@@ -167,6 +154,22 @@ export function aggregateInventoryTransactions(
       lotsOutOfStock: balanceArray.length - lotsWithInventory
     }
   }
+}
+
+function resolveInventoryBalanceSourceId(transaction: InventoryTransactionRecord): string {
+  if (transaction.purchaseOrderId) {
+    return transaction.purchaseOrderId
+  }
+
+  if (transaction.transactionType === 'SHIP') {
+    if (!transaction.referenceId) {
+      throw new Error('SHIP inventory transactions must provide referenceId')
+    }
+
+    return transaction.referenceId
+  }
+
+  return '_none_'
 }
 
 function resolveCartonsPerPallet(balance: BalanceAccumulator): number {


### PR DESCRIPTION
## Summary
- source outbound inventory balances from shipment/reference ids instead of local fulfillment order ids
- stop the inventory balances API and inventory table from returning or linking local fulfillment order source fields
- add regression coverage for the inventory page/API contract and ledger outbound grouping

## Root Cause
The Amazon shipments page was already converted, but inventory balances still joined `FulfillmentOrder`, returned FO source fields, and linked outbound source cells to local FO detail routes.

## Validation
- `pnpm --dir apps/talos exec tsx tests/unit/inventory-page-loading-contract.test.ts` red/green verified
- `pnpm --dir apps/talos test`
- `pnpm --dir apps/talos type-check`
- `pnpm --dir apps/talos lint` (0 errors, 9 pre-existing warnings)
- `pnpm --dir packages/ledger type-check`
- Browser/API verified `/talos/operations/inventory`: outbound row shows shipment reference `12345678`, zero FO detail links, and `/talos/api/inventory/balances` returns no FO source fields