### PR TITLE
fix(argus): exclude incomplete WPR chart weeks

### DIFF
--- a/apps/argus/components/wpr/tabs/sqp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-tab.tsx
@@ -3,10 +3,10 @@
 import { useEffect } from 'react'
 import { Box, Stack } from '@mui/material'
 import {
+  allSelectableSqpRootIds,
+  allSelectableSqpTermIds,
   createSqpSelectionViewModel,
-  defaultSqpRootIds,
   rootTermIds,
-  selectableSqpTermIdsForRoots,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { buildBundleWeekStartDateLookup } from '@/lib/wpr/week-display'
@@ -82,12 +82,10 @@ export default function SqpTab({
     const filteredExpandedIds = filterIds(expandedSqpRootIds, rootIdSet)
 
     if (!hasInitializedSqpSelection) {
-      const initialRootIds = defaultSqpRootIds(bundle)
-      const initialClusterId = initialRootIds[0]
       replaceState({
-        selectedClusterId: initialClusterId === undefined ? null : initialClusterId,
-        selectedSqpRootIds: new Set(initialRootIds),
-        selectedSqpTermIds: new Set(selectableSqpTermIdsForRoots(bundle, initialRootIds)),
+        selectedClusterId: null,
+        selectedSqpRootIds: new Set<string>(),
+        selectedSqpTermIds: new Set<string>(),
         expandedSqpRootIds: new Set<string>(),
         hasInitializedSqpSelection: true,
       })
@@ -229,12 +227,11 @@ export default function SqpTab({
   }
 
   const handleSelectAll = () => {
-    const initialRootIds = defaultSqpRootIds(bundle)
-    const initialClusterId = initialRootIds[0]
+    const rootIds = allSelectableSqpRootIds(bundle)
     replaceSqpSelection({
-      rootIds: initialRootIds,
-      termIds: selectableSqpTermIdsForRoots(bundle, initialRootIds),
-      clusterId: initialClusterId === undefined ? null : initialClusterId,
+      rootIds,
+      termIds: allSelectableSqpTermIds(bundle),
+      clusterId: firstSetMember(new Set(rootIds)),
       hasInitialized: true,
     })
   }

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -234,3 +234,16 @@ test('SQP and TST clear invalid persisted root selections instead of picking a f
     /if \(selectedCompetitorRootIds\.size > 0 && filteredRootIds\.length === 0\) \{[\s\S]*setSelectedCompetitorRootIds\(\[defaultRootId\]\)[\s\S]*setSelectedCompetitorTermIds\(competitorRootTermIds\(bundle, defaultRootId\)\)/,
   )
 })
+
+test('SQP header bulk select uses every selectable root and term', () => {
+  const sqpSource = readFileSync(new URL('./tabs/sqp-tab.tsx', import.meta.url), 'utf8')
+
+  assert.match(
+    sqpSource,
+    /const handleSelectAll = \(\) => \{[\s\S]*const rootIds = allSelectableSqpRootIds\(bundle\)[\s\S]*rootIds,[\s\S]*termIds: allSelectableSqpTermIds\(bundle\)/,
+  )
+  assert.doesNotMatch(
+    sqpSource,
+    /const handleSelectAll = \(\) => \{[\s\S]*defaultSqpRootIds\(bundle\)/,
+  )
+})

--- a/apps/argus/lib/wpr/reader-market.test.ts
+++ b/apps/argus/lib/wpr/reader-market.test.ts
@@ -106,30 +106,43 @@ function buildWeekBundle(anchorWeek: string) {
   }
 }
 
-function writePayload(dataDir: string, week: string) {
-  const bundle = buildWeekBundle(week)
+const weekStartDateByLabel: Record<string, string> = {
+  W07: '2026-02-08',
+  W08: '2026-02-15',
+  W16: '2026-04-12',
+  W17: '2026-04-19',
+  W18: '2026-04-26',
+}
+
+function writePayload(dataDir: string, stableWeek: string, latestCompletedWeek: string) {
+  const currentWeek = 'W18'
+  const weeks = [stableWeek, latestCompletedWeek, currentWeek]
+  const windowsByWeek: Record<string, ReturnType<typeof buildWeekBundle>> = {}
+  const weekStartDates: Record<string, string> = {}
+  const changeLogByWeek: Record<string, unknown[]> = {}
+  for (const week of weeks) {
+    windowsByWeek[week] = buildWeekBundle(week)
+    weekStartDates[week] = weekStartDateByLabel[week]
+    changeLogByWeek[week] = []
+  }
+  const bundle = windowsByWeek[currentWeek]
   writeFileSync(
     path.join(dataDir, 'wpr-data-latest.json'),
     JSON.stringify({
       ...bundle,
-      defaultWeek: week,
-      weekStartDates: {
-        [week]: '2026-04-12',
-      },
+      defaultWeek: currentWeek,
+      weeks,
+      weekStartDates,
       sourceOverview: {
-        week_labels: [week],
-        latest_week: week,
-        weeks_with_data: 1,
+        week_labels: weeks,
+        latest_week: currentWeek,
+        weeks_with_data: weeks.length,
         source_completeness: 'ok',
         critical_gaps: [],
         matrix: [],
       },
-      windowsByWeek: {
-        [week]: bundle,
-      },
-      changeLogByWeek: {
-        [week]: [],
-      },
+      windowsByWeek,
+      changeLogByWeek,
       audit: {},
     }),
   )
@@ -138,8 +151,8 @@ function writePayload(dataDir: string, week: string) {
 test('getWprWeekSummary caches payloads by market and path', async () => {
   const usDataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-us-'))
   const ukDataDir = mkdtempSync(path.join(tmpdir(), 'argus-wpr-uk-'))
-  writePayload(usDataDir, 'W16')
-  writePayload(ukDataDir, 'W07')
+  writePayload(usDataDir, 'W16', 'W17')
+  writePayload(ukDataDir, 'W07', 'W08')
 
   process.env.ARGUS_SALES_ROOT_US = path.join(usDataDir, '..', '..')
   process.env.ARGUS_SALES_ROOT_UK = path.join(ukDataDir, '..', '..')
@@ -153,7 +166,7 @@ test('getWprWeekSummary caches payloads by market and path', async () => {
   assert.equal(ukSummary.defaultWeek, 'W07')
 })
 
-test('createWprWeekSummary excludes the current in-progress week by default', () => {
+test('createWprWeekSummary excludes current and newest completed weeks by default', () => {
   const summary = createWprWeekSummary({
     defaultWeek: 'W18',
     weeks: ['W16', 'W17', 'W18'],
@@ -164,10 +177,9 @@ test('createWprWeekSummary excludes the current in-progress week by default', ()
     },
   }, new Date('2026-04-28T16:00:00.000Z'))
 
-  assert.equal(summary.defaultWeek, 'W17')
-  assert.deepEqual(summary.weeks, ['W16', 'W17'])
+  assert.equal(summary.defaultWeek, 'W16')
+  assert.deepEqual(summary.weeks, ['W16'])
   assert.deepEqual(summary.weekStartDates, {
     W16: '2026-04-12',
-    W17: '2026-04-19',
   })
 })

--- a/apps/argus/lib/wpr/reader.ts
+++ b/apps/argus/lib/wpr/reader.ts
@@ -98,15 +98,24 @@ function resolveCompletedWeeks(
   return completedWeeks;
 }
 
+function resolveStableWeeks(
+  weeks: WeekLabel[],
+  weekStartDates: Record<WeekLabel, string>,
+  today: Date,
+): WeekLabel[] {
+  const completedWeeks = resolveCompletedWeeks(weeks, weekStartDates, today);
+  if (completedWeeks.length <= 1) {
+    throw new Error('No stable WPR chart weeks are available.');
+  }
+
+  return completedWeeks.slice(0, completedWeeks.length - 1);
+}
+
 export function createWprWeekSummary(
   payload: Pick<WprPayload, 'defaultWeek' | 'weeks' | 'weekStartDates'>,
   today = new Date(),
 ): WprWeekSummaryResponse {
-  const weeks = resolveCompletedWeeks(payload.weeks, payload.weekStartDates, today);
-  if (weeks.length === 0) {
-    throw new Error('No completed WPR weeks are available.');
-  }
-
+  const weeks = resolveStableWeeks(payload.weeks, payload.weekStartDates, today);
   let defaultWeek = payload.defaultWeek;
   if (!weeks.includes(defaultWeek)) {
     defaultWeek = weeks[weeks.length - 1];

--- a/apps/argus/lib/wpr/sqp-view-model.test.ts
+++ b/apps/argus/lib/wpr/sqp-view-model.test.ts
@@ -1,6 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import {
+  allSelectableSqpRootIds,
   allSelectableSqpTermIds,
   createSqpSelectionViewModel,
   defaultSqpRootIds,
@@ -475,6 +476,16 @@ test('allSelectableSqpTermIds returns every term shown in the selection table', 
     'cluster-1::term-1',
     'cluster-1::term-2',
     'cluster-2::term-1',
+  ])
+})
+
+test('allSelectableSqpRootIds returns every root shown in the selection table', () => {
+  const bundle = buildBundle()
+  bundle.defaultClusterIds = ['cluster-1']
+
+  assert.deepEqual(allSelectableSqpRootIds(bundle), [
+    'cluster-1',
+    'cluster-2',
   ])
 })
 

--- a/apps/argus/lib/wpr/sqp-view-model.ts
+++ b/apps/argus/lib/wpr/sqp-view-model.ts
@@ -196,6 +196,10 @@ function allRootIds(bundle: WprWeekBundle): string[] {
   return bundle.clusters.map((cluster) => cluster.id)
 }
 
+export function allSelectableSqpRootIds(bundle: WprWeekBundle): string[] {
+  return allRootIds(bundle)
+}
+
 export function defaultSqpRootIds(bundle: WprWeekBundle): string[] {
   const rootIds = allRootIds(bundle)
   const rootIdSet = new Set(rootIds)
@@ -244,7 +248,7 @@ export function selectableSqpTermIdsForRoots(bundle: WprWeekBundle, rootIds: str
 }
 
 export function allSelectableSqpTermIds(bundle: WprWeekBundle): string[] {
-  return selectableSqpTermIdsForRoots(bundle, allRootIds(bundle))
+  return selectableSqpTermIdsForRoots(bundle, allSelectableSqpRootIds(bundle))
 }
 
 function selectedRootIdsList(bundle: WprWeekBundle, selectedRootIds: Set<string>): string[] {

--- a/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
@@ -2362,8 +2362,8 @@ def select_default_week_label(
     week_meta: dict[str, dict[str, object]],
     today: date | None = None,
 ) -> str:
-    completed_weeks = completed_week_order(week_order, week_meta, today)
-    return completed_weeks[-1]
+    chart_weeks = chart_week_order(week_order, week_meta, today)
+    return chart_weeks[-1]
 
 
 def completed_week_order(
@@ -2384,6 +2384,17 @@ def completed_week_order(
         raise ValueError("No completed WPR weeks are available.")
 
     return completed_weeks
+
+
+def chart_week_order(
+    week_order: list[str],
+    week_meta: dict[str, dict[str, object]],
+    today: date | None = None,
+) -> list[str]:
+    completed_weeks = completed_week_order(week_order, week_meta, today)
+    if len(completed_weeks) <= 1:
+        raise ValueError("No stable WPR chart weeks are available.")
+    return completed_weeks[:-1]
 
 
 def build_brand_metrics_window(
@@ -10294,18 +10305,18 @@ def main() -> None:
         windows_by_week[anchor_week] = window_bundle
         audits_by_week[anchor_week] = window_audit
 
-    completed_weeks = completed_week_order(week_order, week_meta)
-    default_week_label = completed_weeks[-1]
+    chart_weeks = chart_week_order(week_order, week_meta)
+    default_week_label = chart_weeks[-1]
     default_bundle = windows_by_week[default_week_label]
     audit_output = audits_by_week[default_week_label]
-    completed_week_start_dates = {
+    chart_week_start_dates = {
         week_label: week_start_dates[week_label]
-        for week_label in completed_weeks
+        for week_label in chart_weeks
     }
     payload = build_payload(
         default_bundle,
-        completed_weeks,
-        completed_week_start_dates,
+        chart_weeks,
+        chart_week_start_dates,
         source_overview,
         windows_by_week,
         change_log_by_week,

--- a/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
@@ -62,34 +62,36 @@ class MarketTaxonomyTest(unittest.TestCase):
 
 
 class DefaultWeekSelectionTest(unittest.TestCase):
-    def test_defaults_to_latest_completed_week(self) -> None:
+    def test_defaults_to_latest_stable_week(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             data_dir = Path(tmp_dir) / "Sales" / "WPR" / "wpr-workspace" / "output"
             data_dir.mkdir(parents=True, exist_ok=True)
             module = load_module(data_dir)
             week_meta = {
+                "W16": {"week_number": 16, "week_label": "W16", "start_date": "2026-04-12"},
                 "W17": {"week_number": 17, "week_label": "W17", "start_date": "2026-04-19"},
                 "W18": {"week_number": 18, "week_label": "W18", "start_date": "2026-04-26"},
             }
 
             self.assertEqual(
-                module.select_default_week_label(["W17", "W18"], week_meta, module.date(2026, 4, 28)),
-                "W17",
+                module.select_default_week_label(["W16", "W17", "W18"], week_meta, module.date(2026, 4, 28)),
+                "W16",
             )
 
-    def test_completed_week_order_excludes_current_week(self) -> None:
+    def test_chart_week_order_excludes_current_and_newest_completed_week(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             data_dir = Path(tmp_dir) / "Sales" / "WPR" / "wpr-workspace" / "output"
             data_dir.mkdir(parents=True, exist_ok=True)
             module = load_module(data_dir)
             week_meta = {
+                "W16": {"week_number": 16, "week_label": "W16", "start_date": "2026-04-12"},
                 "W17": {"week_number": 17, "week_label": "W17", "start_date": "2026-04-19"},
                 "W18": {"week_number": 18, "week_label": "W18", "start_date": "2026-04-26"},
             }
 
             self.assertEqual(
-                module.completed_week_order(["W17", "W18"], week_meta, module.date(2026, 4, 28)),
-                ["W17"],
+                module.chart_week_order(["W16", "W17", "W18"], week_meta, module.date(2026, 4, 28)),
+                ["W16"],
             )
 
 


### PR DESCRIPTION
## Summary
- exclude the current and newest completed WPR weeks from chart/default week selection
- keep SQP first-load selection empty and make the header checkbox select every SQP root/term
- update WPR reader, dashboard generator, and coverage tests for stable chart weeks

## Verification
- pnpm --filter @targon/argus exec tsx --test components/wpr/wpr-change-props.test.ts lib/wpr/sqp-view-model.test.ts lib/wpr/reader-market.test.ts lib/wpr/payload-contract.test.ts app/api/wpr/payload/route.test.ts app/api/wpr/changelog-week-route.test.ts
- python3 -m unittest apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
- pnpm --filter @targon/argus type-check
- live local API: /argus/api/wpr/weeks returns defaultWeek W16 with W17/W18 absent