### PR TITLE
fix(talos): update inbound smoke and deploy hooks

### DIFF
--- a/apps/sso/playwright.config.ts
+++ b/apps/sso/playwright.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       {
         command: 'node tests/fixtures/callback-target-server.mjs',
         cwd: __dirname,
-        url: 'http://127.0.0.1:3321/operations/purchase-orders',
+        url: 'http://127.0.0.1:3321/operations/inbound',
         reuseExistingServer: false,
       },
     ],

--- a/apps/sso/tests/fixtures/callback-target-server.mjs
+++ b/apps/sso/tests/fixtures/callback-target-server.mjs
@@ -5,16 +5,16 @@ const port = 3321
 
 const routes = new Map([
   [
-    '/operations/purchase-orders',
+    '/operations/inbound',
     `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Purchase Orders</title>
+    <title>Inbound</title>
   </head>
   <body>
     <main>
-      <h1>Purchase Orders</h1>
+      <h1>Inbound</h1>
       <p>Talos callback target</p>
     </main>
   </body>

--- a/apps/sso/tests/fixtures/dev-login.ts
+++ b/apps/sso/tests/fixtures/dev-login.ts
@@ -2,7 +2,7 @@ import type { Page } from '@playwright/test'
 import { encode } from 'next-auth/jwt'
 
 export const portalBaseUrl = 'http://127.0.0.1:3320'
-export const talosBaseUrl = 'http://localhost:3321/operations/purchase-orders'
+export const talosBaseUrl = 'http://localhost:3321/operations/inbound'
 export const demoEmail = 'e2e@targonglobal.com'
 export const sessionCookieName = 'targon.next-auth.session-token'
 const portalAuthSecret = 'playwright-portal-auth-secret-000000000000'

--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -27,7 +27,7 @@ const hostedRouteChecks: HostedRouteCheck[] = [
   { name: 'argus', path: '/argus/wpr', visibleText: 'Weekly performance reporting' },
   { name: 'talos-dashboard', path: '/talos/dashboard', visibleText: 'Dashboard' },
   { name: 'talos-inventory', path: '/talos/operations/inventory', visibleText: 'Inventory' },
-  { name: 'talos-purchase-orders', path: '/talos/operations/purchase-orders', visibleText: 'Purchase Orders' },
+  { name: 'talos-inbound', path: '/talos/operations/inbound', visibleText: 'Inbound' },
   { name: 'talos-products', path: '/talos/config/products', visibleText: 'Products' },
 ]
 

--- a/apps/sso/tests/login.spec.ts
+++ b/apps/sso/tests/login.spec.ts
@@ -48,7 +48,7 @@ test('portal recovers from a stale encrypted session cookie and still redirects 
   ])
 
   const response = await page.request.get(
-    `${portalBaseUrl}/login/google?callbackUrl=${encodeURIComponent('/talos/operations/purchase-orders')}`,
+    `${portalBaseUrl}/login/google?callbackUrl=${encodeURIComponent('/talos/operations/inbound')}`,
     {
       maxRedirects: 0,
     },

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -169,22 +169,22 @@ build_talos_changed_migrate_cmd() {
     commands+=("pnpm --filter $workspace db:migrate:warehouse-billing-config")
   any_changed "apps/talos/scripts/migrations/add-warehouse-sku-storage-configs.ts" &&
     commands+=("pnpm --filter $workspace db:migrate:warehouse-sku-storage-configs")
-  any_changed "apps/talos/scripts/migrations/add-purchase-order-document-table.ts" &&
-    commands+=("pnpm --filter $workspace db:migrate:purchase-order-documents")
-  any_changed "apps/talos/scripts/migrations/add-fulfillment-orders-foundation.ts" &&
-    commands+=("pnpm --filter $workspace db:migrate:fulfillment-orders-foundation")
-  any_changed "apps/talos/scripts/migrations/add-fulfillment-orders-amazon-fields.ts" &&
-    commands+=("pnpm --filter $workspace db:migrate:fulfillment-orders-amazon-fields")
+  any_changed "apps/talos/scripts/migrations/add-inbound-document-table.ts" &&
+    commands+=("pnpm --filter $workspace db:migrate:inbound-documents")
+  any_changed "apps/talos/scripts/migrations/add-outbound-orders-foundation.ts" &&
+    commands+=("pnpm --filter $workspace db:migrate:outbound-orders-foundation")
+  any_changed "apps/talos/scripts/migrations/add-outbound-orders-amazon-fields.ts" &&
+    commands+=("pnpm --filter $workspace db:migrate:outbound-orders-amazon-fields")
   any_changed "apps/talos/scripts/migrations/replace-batch-with-lot-ref.ts" &&
     commands+=("pnpm --filter $workspace db:migrate:replace-batch-with-lot-ref")
-  any_changed "apps/talos/scripts/migrations/add-po-product-assignments.ts" &&
-    commands+=("pnpm --filter $workspace db:migrate:po-product-assignments")
+  any_changed "apps/talos/scripts/migrations/add-inbound-product-assignments.ts" &&
+    commands+=("pnpm --filter $workspace db:migrate:inbound-product-assignments")
   any_changed "apps/talos/scripts/migrations/supply-chain-reference-convention.ts" &&
     commands+=("pnpm --filter $workspace db:migrate:supply-chain-reference-convention")
   any_changed "apps/talos/scripts/migrations/ensure-erd-v10-views.ts" &&
     commands+=("pnpm --filter $workspace db:migrate:erd-v10-views")
-  any_changed "apps/talos/scripts/migrations/normalize-po-base-currency.ts" &&
-    commands+=("pnpm --filter $workspace db:migrate:po-base-currency")
+  any_changed "apps/talos/scripts/migrations/normalize-inbound-base-currency.ts" &&
+    commands+=("pnpm --filter $workspace db:migrate:inbound-base-currency")
 
   if [[ ${#commands[@]} -eq 0 ]]; then
     return 1
@@ -273,7 +273,7 @@ case "$app_key" in
     app_dir="$REPO_DIR/apps/talos"
     pm2_name="${PM2_PREFIX}-talos"
     prisma_cmd="pnpm --filter $workspace db:generate"
-    talos_full_migrate_cmd="pnpm --filter $workspace db:migrate:tenant-schema && pnpm --filter $workspace db:migrate:sku-dimensions && pnpm --filter $workspace db:migrate:sku-reference-fee-columns && pnpm --filter $workspace db:migrate:sku-subcategory && pnpm --filter $workspace db:migrate:sku-amazon-reference-weight && pnpm --filter $workspace db:migrate:sku-amazon-listing-price && pnpm --filter $workspace db:migrate:sku-amazon-categories && pnpm --filter $workspace db:migrate:sku-amazon-item-dimensions && pnpm --filter $workspace db:migrate:supplier-defaults && pnpm --filter $workspace db:migrate:warehouse-billing-config && pnpm --filter $workspace db:migrate:warehouse-sku-storage-configs && pnpm --filter $workspace db:migrate:purchase-order-documents && pnpm --filter $workspace db:migrate:fulfillment-orders-foundation && pnpm --filter $workspace db:migrate:fulfillment-orders-amazon-fields && pnpm --filter $workspace db:migrate:replace-batch-with-lot-ref && pnpm --filter $workspace db:migrate:po-product-assignments && pnpm --filter $workspace db:migrate:supply-chain-reference-convention && pnpm --filter $workspace db:migrate:erd-v10-views && pnpm --filter $workspace db:migrate:po-base-currency"
+    talos_full_migrate_cmd="pnpm --filter $workspace db:migrate:tenant-schema && pnpm --filter $workspace db:migrate:sku-dimensions && pnpm --filter $workspace db:migrate:sku-reference-fee-columns && pnpm --filter $workspace db:migrate:sku-subcategory && pnpm --filter $workspace db:migrate:sku-amazon-reference-weight && pnpm --filter $workspace db:migrate:sku-amazon-listing-price && pnpm --filter $workspace db:migrate:sku-amazon-categories && pnpm --filter $workspace db:migrate:sku-amazon-item-dimensions && pnpm --filter $workspace db:migrate:supplier-defaults && pnpm --filter $workspace db:migrate:warehouse-billing-config && pnpm --filter $workspace db:migrate:warehouse-sku-storage-configs && pnpm --filter $workspace db:migrate:inbound-documents && pnpm --filter $workspace db:migrate:outbound-orders-foundation && pnpm --filter $workspace db:migrate:outbound-orders-amazon-fields && pnpm --filter $workspace db:migrate:replace-batch-with-lot-ref && pnpm --filter $workspace db:migrate:inbound-product-assignments && pnpm --filter $workspace db:migrate:supply-chain-reference-convention && pnpm --filter $workspace db:migrate:erd-v10-views && pnpm --filter $workspace db:migrate:inbound-base-currency"
     migrate_cmd="$talos_full_migrate_cmd"
     build_cmd="pnpm --filter $workspace build"
     ;;


### PR DESCRIPTION
## Summary
- Update hosted SSO smoke/deep-link fixtures from Talos purchase orders to the new inbound route.
- Update Talos deploy migration hooks from old purchase/fulfillment script names to inbound/outbound script names.

## Validation
- `bash -n scripts/deploy-app.sh`
- `pnpm --dir apps/sso type-check`
- `pnpm --dir apps/sso test:auth-contracts`
- Active stale route search over SSO, deploy script, Talos source/scripts, package scripts, and shared packages returned no purchase-orders/fulfillment-orders Talos references.