### PR TITLE
chore: promote Talos deploy migration fix

### DIFF
--- a/apps/talos/package.json
+++ b/apps/talos/package.json
@@ -20,6 +20,7 @@
     "test": "pnpm db:generate && find src tests -type f -name '*.test.ts' -print0 2>/dev/null | xargs -0 -n1 tsx",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
     "db:migrate:tenant-schema": "tsx scripts/migrations/ensure-talos-tenant-schema.ts",
     "db:migrate:sku-dimensions": "tsx scripts/migrations/add-sku-dimension-columns.ts",
     "db:migrate:sku-batch-attributes": "tsx scripts/migrations/add-sku-batch-attribute-columns.ts",

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -145,7 +145,12 @@ build_talos_changed_migrate_cmd() {
     return 0
   fi
 
-  local commands=()
+  if any_changed_under "apps/talos/prisma/migrations/"; then
+    printf '%s' "$talos_full_migrate_cmd"
+    return 0
+  fi
+
+  local commands=("$talos_prisma_migrate_cmd")
 
   any_changed "apps/talos/scripts/migrations/ensure-talos-tenant-schema.ts" &&
     commands+=("pnpm --filter $workspace db:migrate:tenant-schema")
@@ -186,10 +191,6 @@ build_talos_changed_migrate_cmd() {
   any_changed "apps/talos/scripts/migrations/normalize-inbound-base-currency.ts" &&
     commands+=("pnpm --filter $workspace db:migrate:inbound-base-currency")
 
-  if [[ ${#commands[@]} -eq 0 ]]; then
-    return 1
-  fi
-
   join_commands "${commands[@]}"
 }
 
@@ -201,6 +202,7 @@ deploy_git_sha="${DEPLOY_GIT_SHA:-}"
 deploy_base_sha="${DEPLOY_BASE_SHA:-}"
 deploy_head_sha="${DEPLOY_HEAD_SHA:-}"
 migrate_cmd=""
+talos_prisma_migrate_cmd=""
 talos_full_migrate_cmd=""
 install_mode=""
 changed_files_available="false"
@@ -273,7 +275,8 @@ case "$app_key" in
     app_dir="$REPO_DIR/apps/talos"
     pm2_name="${PM2_PREFIX}-talos"
     prisma_cmd="pnpm --filter $workspace db:generate"
-    talos_full_migrate_cmd="pnpm --filter $workspace db:migrate:tenant-schema && pnpm --filter $workspace db:migrate:sku-dimensions && pnpm --filter $workspace db:migrate:sku-reference-fee-columns && pnpm --filter $workspace db:migrate:sku-subcategory && pnpm --filter $workspace db:migrate:sku-amazon-reference-weight && pnpm --filter $workspace db:migrate:sku-amazon-listing-price && pnpm --filter $workspace db:migrate:sku-amazon-categories && pnpm --filter $workspace db:migrate:sku-amazon-item-dimensions && pnpm --filter $workspace db:migrate:supplier-defaults && pnpm --filter $workspace db:migrate:warehouse-billing-config && pnpm --filter $workspace db:migrate:warehouse-sku-storage-configs && pnpm --filter $workspace db:migrate:inbound-documents && pnpm --filter $workspace db:migrate:outbound-orders-foundation && pnpm --filter $workspace db:migrate:outbound-orders-amazon-fields && pnpm --filter $workspace db:migrate:replace-batch-with-lot-ref && pnpm --filter $workspace db:migrate:inbound-product-assignments && pnpm --filter $workspace db:migrate:supply-chain-reference-convention && pnpm --filter $workspace db:migrate:erd-v10-views && pnpm --filter $workspace db:migrate:inbound-base-currency"
+    talos_prisma_migrate_cmd="DATABASE_URL=\"\$DATABASE_URL_US\" pnpm --filter $workspace db:migrate:deploy && DATABASE_URL=\"\$DATABASE_URL_UK\" pnpm --filter $workspace db:migrate:deploy"
+    talos_full_migrate_cmd="$talos_prisma_migrate_cmd && pnpm --filter $workspace db:migrate:tenant-schema && pnpm --filter $workspace db:migrate:sku-dimensions && pnpm --filter $workspace db:migrate:sku-reference-fee-columns && pnpm --filter $workspace db:migrate:sku-subcategory && pnpm --filter $workspace db:migrate:sku-amazon-reference-weight && pnpm --filter $workspace db:migrate:sku-amazon-listing-price && pnpm --filter $workspace db:migrate:sku-amazon-categories && pnpm --filter $workspace db:migrate:sku-amazon-item-dimensions && pnpm --filter $workspace db:migrate:supplier-defaults && pnpm --filter $workspace db:migrate:warehouse-billing-config && pnpm --filter $workspace db:migrate:warehouse-sku-storage-configs && pnpm --filter $workspace db:migrate:inbound-documents && pnpm --filter $workspace db:migrate:outbound-orders-foundation && pnpm --filter $workspace db:migrate:outbound-orders-amazon-fields && pnpm --filter $workspace db:migrate:replace-batch-with-lot-ref && pnpm --filter $workspace db:migrate:inbound-product-assignments && pnpm --filter $workspace db:migrate:supply-chain-reference-convention && pnpm --filter $workspace db:migrate:erd-v10-views && pnpm --filter $workspace db:migrate:inbound-base-currency"
     migrate_cmd="$talos_full_migrate_cmd"
     build_cmd="pnpm --filter $workspace build"
     ;;

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -9,10 +9,18 @@ const deployScript = fs.readFileSync(path.join(rootDir, 'scripts', 'deploy-app.s
 const talosDbCommon = fs.readFileSync(path.join(rootDir, 'scripts', 'db', 'talos-db-common.sh'), 'utf8')
 const talosLoadEnv = fs.readFileSync(path.join(rootDir, 'apps', 'talos', 'scripts', 'load-env.ts'), 'utf8')
 const authPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'packages', 'auth', 'package.json'), 'utf8'))
+const talosPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps', 'talos', 'package.json'), 'utf8'))
 
 test('auth package exposes a deploy-safe prisma migrate command', () => {
   assert.equal(
     authPackage.scripts['prisma:migrate:deploy'],
+    'prisma migrate deploy --schema prisma/schema.prisma',
+  )
+})
+
+test('talos package exposes a deploy-safe prisma migrate command', () => {
+  assert.equal(
+    talosPackage.scripts['db:migrate:deploy'],
     'prisma migrate deploy --schema prisma/schema.prisma',
   )
 })
@@ -81,6 +89,21 @@ test('talos deploy runs only changed migrations when deploy range is known', () 
   assert.match(
     deployScript,
     /if \[\[ "\$app_key" == "talos" && "\$changed_files_available" == "true" \]\]; then[\s\S]*?talos_changed_migrate_cmd="\$\(build_talos_changed_migrate_cmd\)"[\s\S]*?migrate_cmd=""/,
+  )
+})
+
+test('talos deploy always applies pending prisma migrations for both tenant schemas first', () => {
+  assert.match(
+    deployScript,
+    /talos_prisma_migrate_cmd="DATABASE_URL=\\"\\\$DATABASE_URL_US\\" pnpm --filter \$workspace db:migrate:deploy && DATABASE_URL=\\"\\\$DATABASE_URL_UK\\" pnpm --filter \$workspace db:migrate:deploy"/,
+  )
+  assert.match(
+    deployScript,
+    /talos_full_migrate_cmd="\$talos_prisma_migrate_cmd && pnpm --filter \$workspace db:migrate:tenant-schema/,
+  )
+  assert.match(
+    deployScript,
+    /local commands=\("\$talos_prisma_migrate_cmd"\)/,
   )
 })
 


### PR DESCRIPTION
## Summary
- Promote `dev` to `main` after PR #5275 fixed the Talos deploy path.
- Includes the Talos deploy hook that runs Prisma `migrate deploy` for both tenant schemas before tenant-schema/manual migrations.

## Validation
- PR #5275 CI passed before merge to `dev`.
- `dev` push CI passed for `fbe284290286e43c4aa4910c6a02e991e3a94c3a`.
- `dev` push CD passed for `fbe284290286e43c4aa4910c6a02e991e3a94c3a`, including deploy and hosted-auth-health.

## Deploy context
- This promotion resolves the failed `main` Talos deploy where `ensure-talos-tenant-schema.ts` ran before the inbound/outbound Prisma rename migration had been applied.