### PR TITLE
fix(talos): handle preseeded permission rename collisions

### DIFF
--- a/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
+++ b/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
@@ -112,6 +112,52 @@ SELECT pg_temp.talos_rename_index('idx_inventory_transactions_purchase_order_lin
 SELECT pg_temp.talos_rename_index('idx_inventory_transactions_fulfillment_order', 'idx_inventory_transactions_outbound_order');
 SELECT pg_temp.talos_rename_index('idx_inventory_transactions_fulfillment_order_line', 'idx_inventory_transactions_outbound_order_line');
 
+DO $$
+DECLARE
+  legacy_permission record;
+  target_permission_code text;
+  target_permission_id uuid;
+BEGIN
+  FOR legacy_permission IN
+    SELECT "id", "code"
+    FROM "permissions"
+    WHERE "code" LIKE 'po.%'
+       OR "code" LIKE 'fo.%'
+  LOOP
+    target_permission_code := regexp_replace(regexp_replace(legacy_permission."code", '^po\.', 'inbound.'), '^fo\.', 'outbound.');
+
+    SELECT "id"
+    INTO target_permission_id
+    FROM "permissions"
+    WHERE "code" = target_permission_code;
+
+    IF target_permission_id IS NOT NULL THEN
+      INSERT INTO "user_permissions" ("id", "user_id", "permission_id", "granted_by_id", "granted_at")
+      SELECT
+        md5(user_permission."id"::text || ':' || target_permission_id::text)::uuid,
+        user_permission."user_id",
+        target_permission_id,
+        user_permission."granted_by_id",
+        user_permission."granted_at"
+      FROM "user_permissions" user_permission
+      WHERE user_permission."permission_id" = legacy_permission."id"
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "user_permissions" existing_permission
+          WHERE existing_permission."user_id" = user_permission."user_id"
+            AND existing_permission."permission_id" = target_permission_id
+        );
+
+      DELETE FROM "user_permissions"
+      WHERE "permission_id" = legacy_permission."id";
+
+      DELETE FROM "permissions"
+      WHERE "id" = legacy_permission."id";
+    END IF;
+  END LOOP;
+END;
+$$;
+
 UPDATE "permissions"
 SET
   "code" = regexp_replace(regexp_replace("code", '^po\.', 'inbound.'), '^fo\.', 'outbound.'),

--- a/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
+++ b/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
@@ -65,3 +65,23 @@ test('Prisma schema maps the renamed inbound and outbound database tables and co
   assert.equal(schema.includes(`@map("${legacyColumnMap}")`), false)
   assert.equal(schema.includes(`@map("${legacyOutboundColumnMap}")`), false)
 })
+
+test('inbound outbound migration merges pre-seeded permission codes before renaming legacy codes', () => {
+  const migration = readTalosFile(
+    'prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql',
+  )
+  const mergeBlockIndex = migration.indexOf('FOR legacy_permission IN')
+  const permissionUpdateIndex = migration.indexOf('UPDATE "permissions"')
+
+  assert.notEqual(mergeBlockIndex, -1)
+  assert.equal(mergeBlockIndex < permissionUpdateIndex, true)
+  assert.equal(migration.includes('target_permission_id'), true)
+  assert.equal(migration.includes('DELETE FROM "user_permissions"'), true)
+  assert.equal(migration.includes('DELETE FROM "permissions"'), true)
+  assert.equal(
+    migration.includes(
+      `regexp_replace(regexp_replace(legacy_permission."code", '^po\\.', 'inbound.'), '^fo\\.', 'outbound.')`,
+    ),
+    true,
+  )
+})


### PR DESCRIPTION
## Summary
- merge legacy po/fo permission grants into pre-seeded inbound/outbound permission rows before renaming codes
- keep non-duplicated legacy permission rows on the existing rename path
- add a static regression test covering the migration order and duplicate-merge block

## Verification
- pnpm --dir apps/talos exec tsx tests/unit/inbound-outbound-domain-rename.test.ts
- psql temp-table execution of apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
- pnpm --dir apps/talos test
- pnpm --dir apps/talos type-check
- pnpm --dir apps/talos lint
- git diff --check