### PR TITLE
fix(talos): match permission id types in rename migration

### DIFF
--- a/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
+++ b/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
@@ -116,7 +116,7 @@ DO $$
 DECLARE
   legacy_permission record;
   target_permission_code text;
-  target_permission_id uuid;
+  target_permission_id text;
 BEGIN
   FOR legacy_permission IN
     SELECT "id", "code"
@@ -126,7 +126,7 @@ BEGIN
   LOOP
     target_permission_code := regexp_replace(regexp_replace(legacy_permission."code", '^po\.', 'inbound.'), '^fo\.', 'outbound.');
 
-    SELECT "id"
+    SELECT "id"::text
     INTO target_permission_id
     FROM "permissions"
     WHERE "code" = target_permission_code;
@@ -134,18 +134,18 @@ BEGIN
     IF target_permission_id IS NOT NULL THEN
       INSERT INTO "user_permissions" ("id", "user_id", "permission_id", "granted_by_id", "granted_at")
       SELECT
-        md5(user_permission."id"::text || ':' || target_permission_id::text)::uuid,
+        md5(user_permission."id"::text || ':' || target_permission_id),
         user_permission."user_id",
         target_permission_id,
         user_permission."granted_by_id",
         user_permission."granted_at"
       FROM "user_permissions" user_permission
-      WHERE user_permission."permission_id" = legacy_permission."id"
+      WHERE user_permission."permission_id"::text = legacy_permission."id"::text
         AND NOT EXISTS (
           SELECT 1
           FROM "user_permissions" existing_permission
           WHERE existing_permission."user_id" = user_permission."user_id"
-            AND existing_permission."permission_id" = target_permission_id
+            AND existing_permission."permission_id"::text = target_permission_id
         );
 
       DELETE FROM "user_permissions"

--- a/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
+++ b/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
@@ -76,6 +76,10 @@ test('inbound outbound migration merges pre-seeded permission codes before renam
   assert.notEqual(mergeBlockIndex, -1)
   assert.equal(mergeBlockIndex < permissionUpdateIndex, true)
   assert.equal(migration.includes('target_permission_id'), true)
+  assert.equal(migration.includes('target_permission_id uuid'), false)
+  assert.equal(migration.includes('::uuid'), false)
+  assert.equal(migration.includes('legacy_permission."id"::text'), true)
+  assert.equal(migration.includes('user_permission."permission_id"::text'), true)
   assert.equal(migration.includes('DELETE FROM "user_permissions"'), true)
   assert.equal(migration.includes('DELETE FROM "permissions"'), true)
   assert.equal(


### PR DESCRIPTION
## Summary
- compare permission grant IDs as text in the inbound/outbound rename migration
- remove uuid-only casts from the duplicate permission merge block
- add a regression assertion for the active tenant permission ID type

## Verification
- pnpm --dir apps/talos exec tsx tests/unit/inbound-outbound-domain-rename.test.ts
- psql temp-table execution of apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql with text IDs
- pnpm --dir apps/talos test
- pnpm --dir apps/talos type-check
- pnpm --dir apps/talos lint
- git diff --check