### PR TITLE
fix(talos): guard public counter rename privileges

### DIFF
--- a/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
+++ b/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
@@ -175,9 +175,11 @@ SET
 DO $$
 BEGIN
   IF to_regclass('"public"."global_reference_counters"') IS NOT NULL THEN
-    UPDATE "public"."global_reference_counters"
-    SET "counter_key" = regexp_replace("counter_key", '^po_sequence', 'inbound_sequence')
-    WHERE "counter_key" LIKE 'po_sequence%';
+    IF has_table_privilege('public.global_reference_counters', 'UPDATE') THEN
+      UPDATE "public"."global_reference_counters"
+      SET "counter_key" = regexp_replace("counter_key", '^po_sequence', 'inbound_sequence')
+      WHERE "counter_key" LIKE 'po_sequence%';
+    END IF;
   END IF;
 END;
 $$;

--- a/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
+++ b/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
@@ -89,3 +89,17 @@ test('inbound outbound migration merges pre-seeded permission codes before renam
     true,
   )
 })
+
+test('inbound outbound migration does not update public counters without table privilege', () => {
+  const migration = readTalosFile(
+    'prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql',
+  )
+  const publicCounterIndex = migration.indexOf('"public"."global_reference_counters"')
+  const privilegeCheckIndex = migration.indexOf(
+    `has_table_privilege('public.global_reference_counters', 'UPDATE')`,
+  )
+
+  assert.notEqual(publicCounterIndex, -1)
+  assert.notEqual(privilegeCheckIndex, -1)
+  assert.equal(privilegeCheckIndex < migration.indexOf('UPDATE "public"."global_reference_counters"'), true)
+})


### PR DESCRIPTION
## Summary
- guard the public global reference counter rename behind an explicit UPDATE privilege check
- keep the permission duplicate merge behavior from the prior fixes
- add a regression test for the public counter privilege gate

## Verification
- pnpm --dir apps/talos exec tsx tests/unit/inbound-outbound-domain-rename.test.ts
- psql temp-table execution of apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql with text IDs
- pnpm --dir apps/talos test
- pnpm --dir apps/talos type-check
- pnpm --dir apps/talos lint
- git diff --check