### PR TITLE
chore: promote Talos inbound/outbound fixes

### DIFF
--- a/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
+++ b/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
@@ -112,6 +112,52 @@ SELECT pg_temp.talos_rename_index('idx_inventory_transactions_purchase_order_lin
 SELECT pg_temp.talos_rename_index('idx_inventory_transactions_fulfillment_order', 'idx_inventory_transactions_outbound_order');
 SELECT pg_temp.talos_rename_index('idx_inventory_transactions_fulfillment_order_line', 'idx_inventory_transactions_outbound_order_line');
 
+DO $$
+DECLARE
+  legacy_permission record;
+  target_permission_code text;
+  target_permission_id uuid;
+BEGIN
+  FOR legacy_permission IN
+    SELECT "id", "code"
+    FROM "permissions"
+    WHERE "code" LIKE 'po.%'
+       OR "code" LIKE 'fo.%'
+  LOOP
+    target_permission_code := regexp_replace(regexp_replace(legacy_permission."code", '^po\.', 'inbound.'), '^fo\.', 'outbound.');
+
+    SELECT "id"
+    INTO target_permission_id
+    FROM "permissions"
+    WHERE "code" = target_permission_code;
+
+    IF target_permission_id IS NOT NULL THEN
+      INSERT INTO "user_permissions" ("id", "user_id", "permission_id", "granted_by_id", "granted_at")
+      SELECT
+        md5(user_permission."id"::text || ':' || target_permission_id::text)::uuid,
+        user_permission."user_id",
+        target_permission_id,
+        user_permission."granted_by_id",
+        user_permission."granted_at"
+      FROM "user_permissions" user_permission
+      WHERE user_permission."permission_id" = legacy_permission."id"
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "user_permissions" existing_permission
+          WHERE existing_permission."user_id" = user_permission."user_id"
+            AND existing_permission."permission_id" = target_permission_id
+        );
+
+      DELETE FROM "user_permissions"
+      WHERE "permission_id" = legacy_permission."id";
+
+      DELETE FROM "permissions"
+      WHERE "id" = legacy_permission."id";
+    END IF;
+  END LOOP;
+END;
+$$;
+
 UPDATE "permissions"
 SET
   "code" = regexp_replace(regexp_replace("code", '^po\.', 'inbound.'), '^fo\.', 'outbound.'),

--- a/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
+++ b/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
@@ -175,9 +175,11 @@ SET
 DO $$
 BEGIN
   IF to_regclass('"public"."global_reference_counters"') IS NOT NULL THEN
-    UPDATE "public"."global_reference_counters"
-    SET "counter_key" = regexp_replace("counter_key", '^po_sequence', 'inbound_sequence')
-    WHERE "counter_key" LIKE 'po_sequence%';
+    IF has_table_privilege('public.global_reference_counters', 'UPDATE') THEN
+      UPDATE "public"."global_reference_counters"
+      SET "counter_key" = regexp_replace("counter_key", '^po_sequence', 'inbound_sequence')
+      WHERE "counter_key" LIKE 'po_sequence%';
+    END IF;
   END IF;
 END;
 $$;

--- a/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
+++ b/apps/talos/prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql
@@ -116,7 +116,7 @@ DO $$
 DECLARE
   legacy_permission record;
   target_permission_code text;
-  target_permission_id uuid;
+  target_permission_id text;
 BEGIN
   FOR legacy_permission IN
     SELECT "id", "code"
@@ -126,7 +126,7 @@ BEGIN
   LOOP
     target_permission_code := regexp_replace(regexp_replace(legacy_permission."code", '^po\.', 'inbound.'), '^fo\.', 'outbound.');
 
-    SELECT "id"
+    SELECT "id"::text
     INTO target_permission_id
     FROM "permissions"
     WHERE "code" = target_permission_code;
@@ -134,18 +134,18 @@ BEGIN
     IF target_permission_id IS NOT NULL THEN
       INSERT INTO "user_permissions" ("id", "user_id", "permission_id", "granted_by_id", "granted_at")
       SELECT
-        md5(user_permission."id"::text || ':' || target_permission_id::text)::uuid,
+        md5(user_permission."id"::text || ':' || target_permission_id),
         user_permission."user_id",
         target_permission_id,
         user_permission."granted_by_id",
         user_permission."granted_at"
       FROM "user_permissions" user_permission
-      WHERE user_permission."permission_id" = legacy_permission."id"
+      WHERE user_permission."permission_id"::text = legacy_permission."id"::text
         AND NOT EXISTS (
           SELECT 1
           FROM "user_permissions" existing_permission
           WHERE existing_permission."user_id" = user_permission."user_id"
-            AND existing_permission."permission_id" = target_permission_id
+            AND existing_permission."permission_id"::text = target_permission_id
         );
 
       DELETE FROM "user_permissions"

--- a/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
+++ b/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
@@ -89,3 +89,17 @@ test('inbound outbound migration merges pre-seeded permission codes before renam
     true,
   )
 })
+
+test('inbound outbound migration does not update public counters without table privilege', () => {
+  const migration = readTalosFile(
+    'prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql',
+  )
+  const publicCounterIndex = migration.indexOf('"public"."global_reference_counters"')
+  const privilegeCheckIndex = migration.indexOf(
+    `has_table_privilege('public.global_reference_counters', 'UPDATE')`,
+  )
+
+  assert.notEqual(publicCounterIndex, -1)
+  assert.notEqual(privilegeCheckIndex, -1)
+  assert.equal(privilegeCheckIndex < migration.indexOf('UPDATE "public"."global_reference_counters"'), true)
+})

--- a/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
+++ b/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
@@ -65,3 +65,23 @@ test('Prisma schema maps the renamed inbound and outbound database tables and co
   assert.equal(schema.includes(`@map("${legacyColumnMap}")`), false)
   assert.equal(schema.includes(`@map("${legacyOutboundColumnMap}")`), false)
 })
+
+test('inbound outbound migration merges pre-seeded permission codes before renaming legacy codes', () => {
+  const migration = readTalosFile(
+    'prisma/migrations/20260428183000_inbound_outbound_domain_rename/migration.sql',
+  )
+  const mergeBlockIndex = migration.indexOf('FOR legacy_permission IN')
+  const permissionUpdateIndex = migration.indexOf('UPDATE "permissions"')
+
+  assert.notEqual(mergeBlockIndex, -1)
+  assert.equal(mergeBlockIndex < permissionUpdateIndex, true)
+  assert.equal(migration.includes('target_permission_id'), true)
+  assert.equal(migration.includes('DELETE FROM "user_permissions"'), true)
+  assert.equal(migration.includes('DELETE FROM "permissions"'), true)
+  assert.equal(
+    migration.includes(
+      `regexp_replace(regexp_replace(legacy_permission."code", '^po\\.', 'inbound.'), '^fo\\.', 'outbound.')`,
+    ),
+    true,
+  )
+})

--- a/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
+++ b/apps/talos/tests/unit/inbound-outbound-domain-rename.test.ts
@@ -76,6 +76,10 @@ test('inbound outbound migration merges pre-seeded permission codes before renam
   assert.notEqual(mergeBlockIndex, -1)
   assert.equal(mergeBlockIndex < permissionUpdateIndex, true)
   assert.equal(migration.includes('target_permission_id'), true)
+  assert.equal(migration.includes('target_permission_id uuid'), false)
+  assert.equal(migration.includes('::uuid'), false)
+  assert.equal(migration.includes('legacy_permission."id"::text'), true)
+  assert.equal(migration.includes('user_permission."permission_id"::text'), true)
   assert.equal(migration.includes('DELETE FROM "user_permissions"'), true)
   assert.equal(migration.includes('DELETE FROM "permissions"'), true)
   assert.equal(


### PR DESCRIPTION
Promotes the Talos inbound/outbound rename and the deployment migration recovery fixes from dev to main.\n\nVerified before promotion:\n- dev CI run 25081636956 passed\n- dev CD run 25081636928 passed\n- main_talos_us and main_talos_uk Prisma migrations are up to date after recovery\n- main DB has inbound/outbound tables and permissions with no legacy po/fo records