### PR TITLE
fix(argus): keep cases markets out of 404 on missing data

### DIFF
--- a/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx
+++ b/apps/argus/app/(app)/cases/[market]/[reportDate]/page.tsx
@@ -1,10 +1,7 @@
 import { notFound } from 'next/navigation';
-import {
-  readCaseReportBundle,
-  type CaseReportBundle,
-  type CaseReportMarketSlug,
-} from '@/lib/cases/reader';
 import { CasesDrilldownPage } from '@/components/cases/cases-drilldown-page';
+import { CasesUnavailablePage } from '@/components/cases/cases-unavailable-page';
+import { resolveDatedCaseReportRouteState } from '@/lib/cases/route-state';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,13 +14,26 @@ type CaseReportPageProps = {
 
 export default async function DatedCaseReportPage({ params }: CaseReportPageProps) {
   const { market, reportDate } = await params;
+  const routeState = await resolveDatedCaseReportRouteState(market, reportDate);
 
-  let bundle: CaseReportBundle;
-  try {
-    bundle = await readCaseReportBundle(market as CaseReportMarketSlug, reportDate);
-  } catch {
+  if (routeState.kind === 'not_found') {
     notFound();
   }
 
-  return <CasesDrilldownPage key={`${bundle.marketSlug}:${bundle.reportDate}`} bundle={bundle} />;
+  if (routeState.kind === 'unavailable') {
+    return (
+      <CasesUnavailablePage
+        marketLabel={routeState.marketLabel}
+        marketSlug={routeState.marketSlug}
+        reportDate={routeState.reportDate}
+      />
+    );
+  }
+
+  return (
+    <CasesDrilldownPage
+      key={`${routeState.bundle.marketSlug}:${routeState.bundle.reportDate}`}
+      bundle={routeState.bundle}
+    />
+  );
 }

--- a/apps/argus/app/(app)/cases/[market]/page.tsx
+++ b/apps/argus/app/(app)/cases/[market]/page.tsx
@@ -1,8 +1,6 @@
 import { notFound, redirect } from 'next/navigation';
-import {
-  readCaseReportBundle,
-  type CaseReportMarketSlug,
-} from '@/lib/cases/reader';
+import { CasesUnavailablePage } from '@/components/cases/cases-unavailable-page';
+import { resolveLatestCaseReportRouteState } from '@/lib/cases/route-state';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,14 +12,20 @@ type MarketLatestPageProps = {
 
 export default async function MarketLatestCaseReportPage({ params }: MarketLatestPageProps) {
   const { market } = await params;
-  let reportDate: string;
+  const routeState = await resolveLatestCaseReportRouteState(market);
 
-  try {
-    const bundle = await readCaseReportBundle(market as CaseReportMarketSlug);
-    reportDate = bundle.reportDate;
-  } catch {
+  if (routeState.kind === 'not_found') {
     notFound();
   }
 
-  redirect(`/cases/${market}/${reportDate}`);
+  if (routeState.kind === 'unavailable') {
+    return (
+      <CasesUnavailablePage
+        marketLabel={routeState.marketLabel}
+        marketSlug={routeState.marketSlug}
+      />
+    );
+  }
+
+  redirect(`/cases/${routeState.marketSlug}/${routeState.reportDate}`);
 }

--- a/apps/argus/app/(app)/cases/market-route.test.ts
+++ b/apps/argus/app/(app)/cases/market-route.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+function readRouteSource(relativePath: string): string {
+  return readFileSync(new URL(relativePath, import.meta.url), 'utf8')
+}
+
+test('case market pages keep supported-market data load failures out of Next 404s', () => {
+  const latestMarketSource = readRouteSource('./[market]/page.tsx')
+  const datedMarketSource = readRouteSource('./[market]/[reportDate]/page.tsx')
+
+  assert.match(latestMarketSource, /resolveLatestCaseReportRouteState/)
+  assert.match(latestMarketSource, /CasesUnavailablePage/)
+  assert.doesNotMatch(latestMarketSource, /try\s*\{/)
+  assert.doesNotMatch(latestMarketSource, /catch\s*\{\s*notFound\(\)\s*;?\s*\}/)
+
+  assert.match(datedMarketSource, /resolveDatedCaseReportRouteState/)
+  assert.match(datedMarketSource, /CasesUnavailablePage/)
+  assert.doesNotMatch(datedMarketSource, /try\s*\{/)
+  assert.doesNotMatch(datedMarketSource, /catch\s*\{\s*notFound\(\)\s*;?\s*\}/)
+})

--- a/apps/argus/components/cases/cases-unavailable-page.tsx
+++ b/apps/argus/components/cases/cases-unavailable-page.tsx
@@ -1,0 +1,112 @@
+import Link from 'next/link'
+import WarningAmberIcon from '@mui/icons-material/WarningAmber'
+import { Alert, Box, Button, Stack, Typography } from '@mui/material'
+import type { CaseReportMarketSlug } from '@/lib/cases/reader'
+import {
+  getCaseQueueBorderColor,
+  getCaseQueueMutedTextColor,
+} from '@/lib/cases/theme'
+
+const CASE_MARKET_LINKS: Array<{ slug: CaseReportMarketSlug; label: string }> = [
+  { slug: 'us', label: 'USA - Dust Sheets' },
+  { slug: 'uk', label: 'UK - Dust Sheets' },
+]
+
+type CasesUnavailablePageProps = {
+  marketLabel: string
+  marketSlug: CaseReportMarketSlug
+  reportDate?: string
+}
+
+export function CasesUnavailablePage({
+  marketLabel,
+  marketSlug,
+  reportDate,
+}: CasesUnavailablePageProps) {
+  const reportLabel = reportDate === undefined ? 'Latest report' : `Report ${reportDate}`
+
+  return (
+    <Stack spacing={1.5}>
+      <Box
+        sx={(theme) => ({
+          pb: 1.5,
+          borderBottom: '1px solid',
+          borderColor: getCaseQueueBorderColor(theme.palette.mode),
+        })}
+      >
+        <Stack
+          direction={{ xs: 'column', md: 'row' }}
+          spacing={1}
+          alignItems={{ xs: 'stretch', md: 'center' }}
+          justifyContent="space-between"
+        >
+          <Stack spacing={0.25}>
+            <Typography variant="overline" color="text.secondary">
+              Cases
+            </Typography>
+            <Typography variant="h5" fontWeight={800}>
+              {marketLabel}
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={(theme) => ({ color: getCaseQueueMutedTextColor(theme.palette.mode) })}
+            >
+              {reportLabel}
+            </Typography>
+          </Stack>
+
+          <Stack direction="row" spacing={1}>
+            {CASE_MARKET_LINKS.map((market) => (
+              <Button
+                key={market.slug}
+                component={Link}
+                href={`/cases/${market.slug}`}
+                size="small"
+                variant={market.slug === marketSlug ? 'contained' : 'outlined'}
+              >
+                {market.label}
+              </Button>
+            ))}
+          </Stack>
+        </Stack>
+      </Box>
+
+      <Alert severity="warning" icon={<WarningAmberIcon fontSize="small" />}>
+        Case report data could not be loaded by this runtime. The route is active; refresh the
+        case-agent export or source mount for this market.
+      </Alert>
+
+      <Box
+        sx={(theme) => ({
+          minHeight: 360,
+          display: 'grid',
+          placeItems: 'center',
+          border: '1px solid',
+          borderColor: getCaseQueueBorderColor(theme.palette.mode),
+          borderRadius: 1,
+          px: 2,
+          textAlign: 'center',
+          bgcolor:
+            theme.palette.mode === 'dark'
+              ? 'rgba(255, 255, 255, 0.02)'
+              : 'rgba(0, 44, 81, 0.02)',
+        })}
+      >
+        <Stack spacing={0.75} alignItems="center">
+          <Typography variant="subtitle1" fontWeight={800}>
+            No case report bundle available
+          </Typography>
+          <Typography
+            variant="body2"
+            sx={(theme) => ({
+              maxWidth: 560,
+              color: getCaseQueueMutedTextColor(theme.palette.mode),
+            })}
+          >
+            Argus could not read the JSON snapshot and case state needed for this market.
+          </Typography>
+        </Stack>
+      </Box>
+    </Stack>
+  )
+}

--- a/apps/argus/lib/cases/reader-core.ts
+++ b/apps/argus/lib/cases/reader-core.ts
@@ -94,12 +94,24 @@ export type CaseReportBundle = ParsedCaseReport & {
   generatedAt: string | null;
 };
 
+export function isCaseReportMarketSlug(value: string): value is CaseReportMarketSlug {
+  return Object.prototype.hasOwnProperty.call(CASE_MARKETS, value);
+}
+
+export function isCaseReportDate(value: string): boolean {
+  return REPORT_DATE_PATTERN.test(value);
+}
+
 function resolveMarketConfig(marketSlug: CaseReportMarketSlug) {
   const market = CASE_MARKETS[marketSlug];
   if (market === undefined) {
     throw new Error(`Unsupported case report market: ${marketSlug}`);
   }
   return market;
+}
+
+export function readCaseReportMarketLabel(marketSlug: CaseReportMarketSlug): string {
+  return resolveMarketConfig(marketSlug).label;
 }
 
 function readRequiredObject(

--- a/apps/argus/lib/cases/reader.test.ts
+++ b/apps/argus/lib/cases/reader.test.ts
@@ -4,7 +4,10 @@ import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import {
+  isCaseReportDate,
+  isCaseReportMarketSlug,
   parseCaseReportSnapshotJson,
+  readCaseReportMarketLabel,
   readCaseReportBundleFromCaseRoot,
 } from './reader-core'
 
@@ -91,6 +94,18 @@ test('parseCaseReportSnapshotJson extracts entity sections and case rows', () =>
   assert.equal(report.sections[0]?.rows[0]?.nextStep, 'Reply from the primary inbox.')
   assert.equal(report.sections[1]?.entity, 'NIGS LTD')
   assert.equal(report.sections[1]?.rows[0]?.issue, 'Weights and dimensions review')
+})
+
+test('case report route helpers identify supported markets and report dates', () => {
+  assert.equal(isCaseReportMarketSlug('us'), true)
+  assert.equal(isCaseReportMarketSlug('uk'), true)
+  assert.equal(isCaseReportMarketSlug('usa'), false)
+  assert.equal(isCaseReportMarketSlug(''), false)
+  assert.equal(readCaseReportMarketLabel('us'), 'USA - Dust Sheets')
+  assert.equal(readCaseReportMarketLabel('uk'), 'UK - Dust Sheets')
+  assert.equal(isCaseReportDate('2026-04-29'), true)
+  assert.equal(isCaseReportDate('2026-4-29'), false)
+  assert.equal(isCaseReportDate('current'), false)
 })
 
 test('parseCaseReportSnapshotJson normalizes looping rows to Watching', () => {

--- a/apps/argus/lib/cases/route-state.test.ts
+++ b/apps/argus/lib/cases/route-state.test.ts
@@ -1,0 +1,104 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  resolveDatedCaseReportRouteState,
+  resolveLatestCaseReportRouteState,
+} from './route-state'
+import {
+  readCaseReportMarketLabel,
+  type CaseReportBundle,
+  type CaseReportMarketSlug,
+} from './reader-core'
+
+function buildCaseReportBundle(
+  marketSlug: CaseReportMarketSlug,
+  reportDate: string,
+): CaseReportBundle {
+  return {
+    reportDate,
+    marketCode: marketSlug.toUpperCase(),
+    sections: [],
+    marketSlug,
+    marketLabel: readCaseReportMarketLabel(marketSlug),
+    caseRoot: '/tmp/cases',
+    reportPath: '/tmp/cases/reports/report.json',
+    caseJsonPath: '/tmp/cases/case.json',
+    availableReportDates: [reportDate],
+    reportSectionsByDate: {
+      [reportDate]: [],
+    },
+    daySummaries: [],
+    trackedCaseIds: [],
+    caseRecordsById: {},
+    generatedAt: null,
+  }
+}
+
+test('latest case route redirects when the supported market bundle loads', async () => {
+  const state = await resolveLatestCaseReportRouteState('us', async (marketSlug) =>
+    buildCaseReportBundle(marketSlug, '2026-04-29'),
+  )
+
+  assert.deepEqual(state, {
+    kind: 'redirect',
+    marketSlug: 'us',
+    reportDate: '2026-04-29',
+  })
+})
+
+test('latest case route renders unavailable state instead of 404 when bundle loading fails', async () => {
+  const state = await resolveLatestCaseReportRouteState('uk', async () => {
+    throw new Error('case source unavailable')
+  })
+
+  assert.deepEqual(state, {
+    kind: 'unavailable',
+    marketLabel: 'UK - Dust Sheets',
+    marketSlug: 'uk',
+  })
+})
+
+test('latest case route rejects unsupported markets before reading data', async () => {
+  let readerCalled = false
+  const state = await resolveLatestCaseReportRouteState('de', async () => {
+    readerCalled = true
+    throw new Error('reader should not run')
+  })
+
+  assert.deepEqual(state, { kind: 'not_found' })
+  assert.equal(readerCalled, false)
+})
+
+test('dated case route returns the loaded bundle for supported market and date', async () => {
+  const bundle = buildCaseReportBundle('us', '2026-04-29')
+  const state = await resolveDatedCaseReportRouteState('us', '2026-04-29', async () => bundle)
+
+  assert.deepEqual(state, {
+    kind: 'bundle',
+    bundle,
+  })
+})
+
+test('dated case route renders unavailable state instead of 404 when bundle loading fails', async () => {
+  const state = await resolveDatedCaseReportRouteState('us', '2026-04-29', async () => {
+    throw new Error('case source unavailable')
+  })
+
+  assert.deepEqual(state, {
+    kind: 'unavailable',
+    marketLabel: 'USA - Dust Sheets',
+    marketSlug: 'us',
+    reportDate: '2026-04-29',
+  })
+})
+
+test('dated case route rejects malformed report dates before reading data', async () => {
+  let readerCalled = false
+  const state = await resolveDatedCaseReportRouteState('us', 'latest', async () => {
+    readerCalled = true
+    throw new Error('reader should not run')
+  })
+
+  assert.deepEqual(state, { kind: 'not_found' })
+  assert.equal(readerCalled, false)
+})

--- a/apps/argus/lib/cases/route-state.ts
+++ b/apps/argus/lib/cases/route-state.ts
@@ -1,0 +1,75 @@
+import {
+  isCaseReportDate,
+  isCaseReportMarketSlug,
+  readCaseReportBundle,
+  readCaseReportMarketLabel,
+  type CaseReportBundle,
+  type CaseReportMarketSlug,
+} from './reader-core'
+
+type CaseReportBundleReader = (
+  marketSlug: CaseReportMarketSlug,
+  requestedReportDate?: string,
+) => Promise<CaseReportBundle>
+
+type CaseReportUnavailableState = {
+  kind: 'unavailable'
+  marketLabel: string
+  marketSlug: CaseReportMarketSlug
+  reportDate?: string
+}
+
+export type LatestCaseReportRouteState =
+  | { kind: 'not_found' }
+  | { kind: 'redirect'; marketSlug: CaseReportMarketSlug; reportDate: string }
+  | CaseReportUnavailableState
+
+export type DatedCaseReportRouteState =
+  | { kind: 'not_found' }
+  | { kind: 'bundle'; bundle: CaseReportBundle }
+  | CaseReportUnavailableState
+
+export async function resolveLatestCaseReportRouteState(
+  market: string,
+  readBundle: CaseReportBundleReader = readCaseReportBundle,
+): Promise<LatestCaseReportRouteState> {
+  if (isCaseReportMarketSlug(market) === false) {
+    return { kind: 'not_found' }
+  }
+
+  try {
+    const bundle = await readBundle(market)
+    return { kind: 'redirect', marketSlug: market, reportDate: bundle.reportDate }
+  } catch {
+    return {
+      kind: 'unavailable',
+      marketLabel: readCaseReportMarketLabel(market),
+      marketSlug: market,
+    }
+  }
+}
+
+export async function resolveDatedCaseReportRouteState(
+  market: string,
+  reportDate: string,
+  readBundle: CaseReportBundleReader = readCaseReportBundle,
+): Promise<DatedCaseReportRouteState> {
+  if (isCaseReportMarketSlug(market) === false) {
+    return { kind: 'not_found' }
+  }
+  if (isCaseReportDate(reportDate) === false) {
+    return { kind: 'not_found' }
+  }
+
+  try {
+    const bundle = await readBundle(market, reportDate)
+    return { kind: 'bundle', bundle }
+  } catch {
+    return {
+      kind: 'unavailable',
+      marketLabel: readCaseReportMarketLabel(market),
+      marketSlug: market,
+      reportDate,
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Keep supported Argus cases market routes (`/cases/us`, `/cases/uk`, and dated variants) from returning Next 404 when the case-report bundle cannot be loaded by the runtime.
- Preserve true 404 behavior for unsupported market slugs and malformed report dates.
- Add a compact unavailable state plus behavior/source regression tests for the route decision path.

## Root Cause
The market pages caught every `readCaseReportBundle` failure and called `notFound()`. On hosted runtimes where the local case export path is unavailable, valid routes became 404s.

## Verification
- `pnpm exec tsx --test 'apps/argus/app/(app)/cases/market-route.test.ts' apps/argus/lib/cases/reader.test.ts apps/argus/lib/cases/route-state.test.ts`
- `pnpm --filter @targon/argus lint`
- `pnpm --filter @targon/argus type-check`
- `NEXT_PUBLIC_APP_URL=https://dev-os.targonglobal.com/argus BASE_PATH=/argus NEXT_PUBLIC_BASE_PATH=/argus PORTAL_AUTH_URL=https://dev-os.targonglobal.com NEXT_PUBLIC_PORTAL_AUTH_URL=https://dev-os.targonglobal.com PORTAL_AUTH_SECRET=ci-portal-auth-secret NEXTAUTH_SECRET=ci-nextauth-secret DATABASE_URL=postgresql://user:password@localhost:5432/portal_db?schema=argus_dev pnpm --filter @targon/argus build`