### PR TITLE
fix(argus): render cases unavailable state on client

### DIFF
--- a/apps/argus/app/(app)/cases/market-route.test.ts
+++ b/apps/argus/app/(app)/cases/market-route.test.ts
@@ -20,3 +20,11 @@ test('case market pages keep supported-market data load failures out of Next 404
   assert.doesNotMatch(datedMarketSource, /try\s*\{/)
   assert.doesNotMatch(datedMarketSource, /catch\s*\{\s*notFound\(\)\s*;?\s*\}/)
 })
+
+test('case unavailable page is a client component because MUI receives sx functions', () => {
+  const unavailablePageSource = readRouteSource(
+    '../../../components/cases/cases-unavailable-page.tsx',
+  )
+
+  assert.match(unavailablePageSource, /^'use client'\n/)
+})

--- a/apps/argus/components/cases/cases-unavailable-page.tsx
+++ b/apps/argus/components/cases/cases-unavailable-page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import { Alert, Box, Button, Stack, Typography } from '@mui/material'


### PR DESCRIPTION
## Summary
- mark the Argus cases unavailable state as a client component so MUI sx functions and Link component props do not cross the server/client boundary
- add a regression test that keeps the unavailable state client-rendered

## Verification
- pnpm exec tsx --test 'apps/argus/app/(app)/cases/market-route.test.ts' apps/argus/lib/cases/route-state.test.ts apps/argus/lib/cases/reader.test.ts\n- pnpm --filter @targon/argus lint\n- NEXT_PUBLIC_APP_URL=https://os.targonglobal.com pnpm --filter @targon/argus build\n- browser-access lane b: https://os.targonglobal.com/argus/cases/us and /uk render unavailable state with no fresh browser errors or failed Argus responses