### PR TITLE
promote: dev to main for Argus cases unavailable runtime

### DIFF
--- a/apps/argus/app/(app)/cases/market-route.test.ts
+++ b/apps/argus/app/(app)/cases/market-route.test.ts
@@ -20,3 +20,11 @@ test('case market pages keep supported-market data load failures out of Next 404
   assert.doesNotMatch(datedMarketSource, /try\s*\{/)
   assert.doesNotMatch(datedMarketSource, /catch\s*\{\s*notFound\(\)\s*;?\s*\}/)
 })
+
+test('case unavailable page is a client component because MUI receives sx functions', () => {
+  const unavailablePageSource = readRouteSource(
+    '../../../components/cases/cases-unavailable-page.tsx',
+  )
+
+  assert.match(unavailablePageSource, /^'use client'\n/)
+})

--- a/apps/argus/components/cases/cases-unavailable-page.tsx
+++ b/apps/argus/components/cases/cases-unavailable-page.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import Link from 'next/link'
 import WarningAmberIcon from '@mui/icons-material/WarningAmber'
 import { Alert, Box, Button, Stack, Typography } from '@mui/material'


### PR DESCRIPTION
## Summary
- promote dev after Argus cases unavailable runtime fix

## Included PRs
- #5286 fix(argus): render cases unavailable state on client

## Verification
- PR #5286 checks passed before promotion
- browser-access lane b verified /argus/cases/us and /argus/cases/uk no longer show application errors on the runtime hotfix