### PR TITLE
fix(argus): improve WPR selection and ASIN labels

### DIFF
--- a/apps/argus/components/wpr/change-timeline.tsx
+++ b/apps/argus/components/wpr/change-timeline.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mui/material';
 import { getPublicBasePath } from '@/lib/base-path';
 import { appendMarketParam, type ArgusMarket } from '@/lib/argus-market';
+import { formatAsinReference } from '@/lib/product-labels';
 import {
   formatWprChangeCategory,
   getWprChangeCategoryColor,
@@ -118,12 +119,12 @@ const chipSx = {
   whiteSpace: 'nowrap' as const,
 };
 
-function compactList(values: string[]): string {
+function compactAsinList(values: string[]): string {
   if (values.length === 0) {
     return '—';
   }
 
-  return values.join(', ');
+  return values.map((value) => formatAsinReference(value)).join(', ');
 }
 
 function summaryText(entry: WprChangeLogEntry): string {
@@ -454,7 +455,7 @@ export default function ChangeTimeline({
                           whiteSpace: 'normal',
                         }}
                       >
-                        {compactList(entry.asins)}
+                        {compactAsinList(entry.asins)}
                       </Typography>
                     </Box>
 

--- a/apps/argus/components/wpr/tabs/business-reports-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/business-reports-selection-table.tsx
@@ -15,6 +15,7 @@ import {
   wprSelectionMetricCellSx,
 } from '@/components/wpr/wpr-selection-panel'
 import WprWeekSelect from '@/components/wpr/wpr-week-select'
+import { formatAsinDisplayName } from '@/lib/product-labels'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import type { WprSortDirection, WprSortState } from '@/lib/wpr/dashboard-state'
 import {
@@ -221,7 +222,7 @@ export default function BusinessReportsSelectionTable({
                   </TableCell>
                   <MetricCell
                     align="left"
-                    value={`${row.asin}\n${row.is_target ? 'Target ASIN' : 'Catalog ASIN'} · ${currentRecord === null ? 0 : 1} / 1 weeks`}
+                    value={`${formatAsinDisplayName(row)}\n${row.asin} · ${row.is_target ? 'Target ASIN' : 'Catalog ASIN'} · ${currentRecord === null ? 0 : 1} / 1 weeks`}
                   />
                   <MetricCell align="right" value={formatCount(currentRecord === null ? 0 : 1)} />
                   <MetricCell align="right" value={sessionsValue} />

--- a/apps/argus/components/wpr/tabs/scp-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/scp-selection-table.tsx
@@ -15,6 +15,7 @@ import {
   wprSelectionMetricCellSx,
 } from '@/components/wpr/wpr-selection-panel'
 import WprWeekSelect from '@/components/wpr/wpr-week-select'
+import { formatAsinDisplayName } from '@/lib/product-labels'
 import { getBulkSelectionAction } from '@/lib/wpr/bulk-selection'
 import type { WprSortDirection, WprSortState } from '@/lib/wpr/dashboard-state'
 import {
@@ -208,7 +209,7 @@ export default function ScpSelectionTable({
                   </TableCell>
                   <MetricCell
                     align="left"
-                    value={`${row.asin}\n${row.is_target ? 'Target ASIN' : 'Catalog ASIN'} · ${weeksPresent} / 1 weeks`}
+                    value={`${formatAsinDisplayName(row)}\n${row.asin} · ${row.is_target ? 'Target ASIN' : 'Catalog ASIN'} · ${weeksPresent} / 1 weeks`}
                   />
                   <MetricCell align="right" value={formatCount(weeksPresent)} />
                   <MetricCell align="right" value={formatCount(current.impressions)} />

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -247,3 +247,15 @@ test('SQP header bulk select uses every selectable root and term', () => {
     /const handleSelectAll = \(\) => \{[\s\S]*defaultSqpRootIds\(bundle\)/,
   )
 })
+
+test('WPR ASIN surfaces render readable ASIN labels with raw ASIN traceability', () => {
+  const scpSelectionSource = readFileSync(new URL('./tabs/scp-selection-table.tsx', import.meta.url), 'utf8')
+  const brSelectionSource = readFileSync(new URL('./tabs/business-reports-selection-table.tsx', import.meta.url), 'utf8')
+  const changelogSource = readFileSync(new URL('./change-timeline.tsx', import.meta.url), 'utf8')
+
+  assert.match(scpSelectionSource, /formatAsinDisplayName\(row\)/)
+  assert.match(scpSelectionSource, /\$\{row\.asin\}/)
+  assert.match(brSelectionSource, /formatAsinDisplayName\(row\)/)
+  assert.match(brSelectionSource, /\$\{row\.asin\}/)
+  assert.match(changelogSource, /formatAsinReference/)
+})

--- a/apps/argus/lib/asin-labels.json
+++ b/apps/argus/lib/asin-labels.json
@@ -1,0 +1,16 @@
+{
+  "B0FLKJ7WWM": "Caelum Star 1 Pack 12x9 ft Extra Large",
+  "B0CR1GSBQ9": "Caelum Star 3 Pack 12x9 ft Extra Large",
+  "B09HXC3NL8": "Caelum Star 6 Pack 12x9 ft Extra Large",
+  "B0FP66CWQ6": "Caelum Star 12 Pack 12x9 ft Extra Large",
+  "B0C7ZQ3VZL": "Caelum Star 3 PK - Light",
+  "B0CR1H3VSF": "Caelum Star 10 PK - Light",
+  "B0CW3L6PQH": "Caelum Star 12 x 9 - Cotton",
+  "B0CW3N48K1": "Caelum Star 12 x 4 - Cotton",
+  "B0DHDTPGCP": "Caelum Star 6 PK - Strong",
+  "B0DHDTPGGP": "Caelum Star 6 PK - Strong",
+  "B0DQDWV1SV": "Axgatoxe 6-Pack 12 x 9 ft Plastic Drop Cloth",
+  "B0CWS3848Y": "Ecotez 6 Pack 12 x 9 ft Plastic Drop Cloth",
+  "B08QZHS7V6": "ARVO 3 Pack 12ft x 9ft Plastic Dust Sheets",
+  "B09SZJ2MC8": "Raulde 6 Pack 12 x 10ft Plastic Dust Sheets"
+}

--- a/apps/argus/lib/email/template.ts
+++ b/apps/argus/lib/email/template.ts
@@ -6,6 +6,7 @@ import type {
   MonitoringSnapshotRecord,
   MonitoringStateRecord,
 } from '@/lib/monitoring/types'
+import { formatAsinDisplayName } from '@/lib/product-labels'
 import { formatEmailDateTime, formatEmailCurrency, formatEmailNumber } from './format'
 
 // ─── Brand ──────────────────────────────────────────────────
@@ -77,11 +78,13 @@ export function buildAlertEmailHtml(
   const detectedAt = formatEmailDateTime(event.timestamp)
   const comparedTo = event.baselineTimestamp ? formatEmailDateTime(event.baselineTimestamp) : null
 
-  // Product display name: prefer label, fallback to snapshot title, then ASIN
-  const productName = event.label
-    ?? event.currentSnapshot?.title
-    ?? event.baselineSnapshot?.title
-    ?? event.asin
+  const productName = formatAsinDisplayName({
+    asin: event.asin,
+    label: event.label,
+    brand: event.currentSnapshot?.brand ?? event.baselineSnapshot?.brand,
+    size: event.currentSnapshot?.size ?? event.baselineSnapshot?.size,
+    title: event.currentSnapshot?.title ?? event.baselineSnapshot?.title,
+  })
   const safeProductName = esc(productName.length > 70 ? productName.slice(0, 67) + '...' : productName)
   const safeAsin = esc(event.asin)
   const safeHeadline = esc(event.headline)

--- a/apps/argus/lib/monitoring/labels.test.ts
+++ b/apps/argus/lib/monitoring/labels.test.ts
@@ -24,3 +24,12 @@ test('formatMonitoringLabel uses title identity before brand when size is missin
     '6 Pack 12x9 ft Extra Large',
   )
 })
+
+test('formatMonitoringLabel uses known ASIN names when label lookup only has the ASIN', () => {
+  assert.equal(
+    formatMonitoringLabel({
+      asin: 'B0CWS3848Y',
+    }),
+    'Ecotez 6 Pack 12 x 9 ft Plastic Drop Cloth',
+  )
+})

--- a/apps/argus/lib/monitoring/labels.ts
+++ b/apps/argus/lib/monitoring/labels.ts
@@ -1,10 +1,10 @@
 import type { MonitoringStateRecord } from './types'
-import { formatProductLabel } from '@/lib/product-labels'
+import { formatAsinDisplayName } from '@/lib/product-labels'
 
 export type MonitoringLabelSource =
   | Pick<MonitoringStateRecord, 'asin' | 'brand' | 'size' | 'title'>
   | { asin: string; brand?: string | null; size?: string | null; title?: string | null }
 
 export function formatMonitoringLabel(source: MonitoringLabelSource): string {
-  return formatProductLabel(source)
+  return formatAsinDisplayName(source)
 }

--- a/apps/argus/lib/product-labels.test.ts
+++ b/apps/argus/lib/product-labels.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { formatAmazonTitleLabel, formatProductLabel } from './product-labels'
+import { formatAmazonTitleLabel, formatAsinDisplayName, formatAsinReference, formatProductLabel } from './product-labels'
 
 test('formatProductLabel prefers a curated non-ASIN label', () => {
   assert.equal(
@@ -44,4 +44,30 @@ test('formatAmazonTitleLabel creates a short title label', () => {
     }),
     'Portable greenhouse kit with reinforced cover',
   )
+})
+
+test('formatAsinDisplayName maps tracked ASINs to readable product names', () => {
+  assert.equal(formatAsinDisplayName({ asin: 'b09hxc3nl8' }), 'Caelum Star 6 Pack 12x9 ft Extra Large')
+  assert.equal(formatAsinDisplayName({ asin: 'B0DQDWV1SV' }), 'Axgatoxe 6-Pack 12 x 9 ft Plastic Drop Cloth')
+  assert.equal(formatAsinDisplayName({ asin: 'B08QZHS7V6' }), 'ARVO 3 Pack 12ft x 9ft Plastic Dust Sheets')
+})
+
+test('formatAsinDisplayName still prefers explicit product metadata', () => {
+  assert.equal(
+    formatAsinDisplayName({
+      asin: 'B09HXC3NL8',
+      label: 'White Greenhouse',
+      brand: 'Targon',
+      size: '12 x 9',
+    }),
+    'White Greenhouse',
+  )
+})
+
+test('formatAsinReference keeps the raw ASIN available after the readable name', () => {
+  assert.equal(
+    formatAsinReference('B09HXC3NL8'),
+    'Caelum Star 6 Pack 12x9 ft Extra Large (B09HXC3NL8)',
+  )
+  assert.equal(formatAsinReference('B000000001'), 'B000000001')
 })

--- a/apps/argus/lib/product-labels.ts
+++ b/apps/argus/lib/product-labels.ts
@@ -1,3 +1,5 @@
+import asinLabels from './asin-labels.json'
+
 export interface ProductLabelSource {
   asin: string
   label?: string | null
@@ -14,10 +16,22 @@ export interface AmazonTitleLabelSource {
   title?: string | null
 }
 
+export const KNOWN_ASIN_LABELS: Record<string, string> = asinLabels
+
 function clean(value: string | null | undefined): string {
   if (value === null) return ''
   if (value === undefined) return ''
   return value.trim()
+}
+
+function normalizeAsin(value: string): string {
+  return value.trim().toUpperCase()
+}
+
+function knownAsinLabel(asin: string): string {
+  const label = KNOWN_ASIN_LABELS[asin]
+  if (label !== undefined) return label
+  return ''
 }
 
 function firstText(values: Array<string | null | undefined>): string {
@@ -51,7 +65,7 @@ function limitWords(text: string, maxWords: number): string {
 }
 
 export function formatProductLabel(source: ProductLabelSource): string {
-  const asin = source.asin.trim().toUpperCase()
+  const asin = normalizeAsin(source.asin)
   const label = clean(source.label)
   if (label.length > 0 && label.toUpperCase() !== asin) return label
 
@@ -68,7 +82,7 @@ export function formatProductLabel(source: ProductLabelSource): string {
 }
 
 export function formatAmazonTitleLabel(source: AmazonTitleLabelSource): string {
-  const asin = source.asin.trim().toUpperCase()
+  const asin = normalizeAsin(source.asin)
   const title = clean(source.title)
   if (title.length === 0) return asin
 
@@ -77,4 +91,22 @@ export function formatAmazonTitleLabel(source: AmazonTitleLabelSource): string {
   const titleLabel = limitWords(titleWithoutBrand, 6)
   if (titleLabel.length === 0) return brand
   return titleLabel
+}
+
+export function formatAsinDisplayName(source: ProductLabelSource): string {
+  const asin = normalizeAsin(source.asin)
+  const label = formatProductLabel(source)
+  if (label !== asin) return label
+
+  const asinLabel = knownAsinLabel(asin)
+  if (asinLabel.length > 0) return asinLabel
+
+  return asin
+}
+
+export function formatAsinReference(asinValue: string): string {
+  const asin = normalizeAsin(asinValue)
+  const displayName = formatAsinDisplayName({ asin })
+  if (displayName === asin) return asin
+  return `${displayName} (${asin})`
 }

--- a/apps/argus/lib/wpr/business-reports-view-model.test.ts
+++ b/apps/argus/lib/wpr/business-reports-view-model.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { createBusinessReportsSelectionViewModel } from './business-reports-view-model'
+import { createBusinessReportsSelectionViewModel, sortBusinessReportsRows } from './business-reports-view-model'
 import type {
   WprBusinessAsinRow,
   WprBusinessDailyPoint,
@@ -205,4 +205,16 @@ test('createBusinessReportsSelectionViewModel returns all rows when every ASIN i
   assert.equal(vm.current?.buy_box_percentage, (0.75 * 180 + 0.6 * 90) / 270)
   assert.equal(vm.weekly.length, window.weekly.length)
   assert.equal(vm.isAllSelected, true)
+})
+
+test('sortBusinessReportsRows orders the ASIN column by readable product name', () => {
+  const window = buildBusinessWindow()
+  const rows = [
+    buildBusinessAsinRow('asin-a', 'B09HXC3NL8', window.asins[0].current_week, window.asins[0].weekly),
+    buildBusinessAsinRow('asin-b', 'B0DQDWV1SV', window.asins[1].current_week, window.asins[1].weekly),
+  ]
+
+  const sorted = sortBusinessReportsRows(rows, { key: 'asin', dir: 'asc' }, 'W16')
+
+  assert.deepEqual(sorted.map((row) => row.asin), ['B0DQDWV1SV', 'B09HXC3NL8'])
 })

--- a/apps/argus/lib/wpr/business-reports-view-model.ts
+++ b/apps/argus/lib/wpr/business-reports-view-model.ts
@@ -1,3 +1,4 @@
+import { formatAsinDisplayName } from '@/lib/product-labels'
 import type { WprSortDirection, WprSortState } from './dashboard-state'
 import type {
   WeekLabel,
@@ -288,7 +289,7 @@ export function businessReportsSortValueForRow(
   selectedWeek: WeekLabel,
 ): number | string {
   const current = selectedWeekBusinessMetrics(row.weekly, selectedWeek)
-  if (key === 'asin') return row.asin
+  if (key === 'asin') return formatAsinDisplayName(row)
   if (key === 'weeks_present_selected_week') return selectedWeekBusinessRecord(row.weekly, selectedWeek) === null ? 0 : 1
   if (key === 'sessions') return current.sessions
   if (key === 'page_views') return current.page_views

--- a/apps/argus/lib/wpr/scp-view-model.test.ts
+++ b/apps/argus/lib/wpr/scp-view-model.test.ts
@@ -1,6 +1,6 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { createScpSelectionViewModel } from './scp-view-model'
+import { createScpSelectionViewModel, sortScpRows } from './scp-view-model'
 import type { WprScpAsinRow, WprScpMetrics, WprScpWeekMetrics, WprScpWindow } from './types'
 
 function buildScpMetrics(overrides: Partial<WprScpMetrics>): WprScpMetrics {
@@ -182,4 +182,16 @@ test('createScpSelectionViewModel returns an empty selection when no ASINs are s
   assert.equal(vm.current, null)
   assert.deepEqual(vm.weekly, [])
   assert.equal(vm.isAllSelected, false)
+})
+
+test('sortScpRows orders the ASIN column by readable product name', () => {
+  const window = buildScpWindow()
+  const rows = [
+    buildScpAsinRow('asin-a', 'B09HXC3NL8', window.asins[0].current_week, window.asins[0].weekly),
+    buildScpAsinRow('asin-b', 'B0DQDWV1SV', window.asins[1].current_week, window.asins[1].weekly),
+  ]
+
+  const sorted = sortScpRows(rows, { key: 'asin', dir: 'asc' }, 'W16', null)
+
+  assert.deepEqual(sorted.map((row) => row.asin), ['B0DQDWV1SV', 'B09HXC3NL8'])
 })

--- a/apps/argus/lib/wpr/scp-view-model.ts
+++ b/apps/argus/lib/wpr/scp-view-model.ts
@@ -1,3 +1,4 @@
+import { formatAsinDisplayName } from '@/lib/product-labels'
 import type { WprSortDirection, WprSortState } from './dashboard-state'
 import type { WeekLabel, WprScpAsinRow, WprScpMetrics, WprScpWeekMetrics, WprScpWindow } from './types'
 
@@ -251,7 +252,7 @@ export function scpSortValueForRow(
   selectedWeek: WeekLabel,
 ): number | string {
   const current = selectedWeekScpMetrics(row.weekly, selectedWeek)
-  if (key === 'asin') return row.asin
+  if (key === 'asin') return formatAsinDisplayName(row)
   if (key === 'weeks_present_selected_week') return selectedWeekScpRecord(row.weekly, selectedWeek) === null ? 0 : 1
   if (key === 'impressions') return current.impressions
   if (key === 'clicks') return current.clicks

--- a/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
@@ -24,6 +24,29 @@ ARGUS_MARKET = MARKET_CONFIG.market
 COMPETITOR_ASIN = MARKET_CONFIG.competitor_asin
 COMPETITOR_BRAND = MARKET_CONFIG.competitor_brand
 COMPETITOR_CONFIG_SOURCE = "market_config"
+APP_ROOT = Path(__file__).resolve().parents[2]
+ASIN_LABELS_PATH = APP_ROOT / "lib" / "asin-labels.json"
+KNOWN_ASIN_LABELS = json.loads(ASIN_LABELS_PATH.read_text(encoding="utf-8"))
+
+
+def normalize_asin(value: object) -> str:
+    return str(value).strip().upper()
+
+
+def format_asin_display_name(asin_value: object) -> str:
+    asin = normalize_asin(asin_value)
+    label = KNOWN_ASIN_LABELS.get(asin)
+    if label is not None:
+        return label
+    return asin
+
+
+def format_asin_reference(asin_value: object) -> str:
+    asin = normalize_asin(asin_value)
+    label = KNOWN_ASIN_LABELS.get(asin)
+    if label is not None:
+        return f"{label} ({asin})"
+    return asin
 
 
 def parse_float(value: object) -> float:
@@ -3651,6 +3674,7 @@ def build_window_bundle(
 
 def build_html(data: dict[str, object]) -> str:
     data_json = json.dumps(data, separators=(",", ":"))
+    asin_labels_json = json.dumps(KNOWN_ASIN_LABELS, separators=(",", ":"))
     template = """<!doctype html>
 <html lang="en">
 <head>
@@ -5173,6 +5197,7 @@ def build_html(data: dict[str, object]) -> str:
 
 <script>
   var reportData = __DATA__;
+  var asinDisplayNames = __ASIN_LABELS__;
 
   var selectedWeekLabel = reportData.defaultWeek;
   var activeData = reportData.windowsByWeek[reportData.defaultWeek];
@@ -5640,7 +5665,7 @@ def build_html(data: dict[str, object]) -> str:
 
   function scpSortValueForRow(row, key) {
     var current = selectedWeekScpMetrics(row.weekly);
-    if (key === "asin") return row.asin;
+    if (key === "asin") return formatAsinDisplayName(row);
     if (key === "impressions") return current.impressions;
     if (key === "clicks") return current.clicks;
     if (key === "ctr") return current.ctr;
@@ -5659,7 +5684,7 @@ def build_html(data: dict[str, object]) -> str:
 
   function brSortValueForRow(row, key) {
     var current = selectedWeekBusinessMetrics(row.weekly);
-    if (key === "asin") return row.asin;
+    if (key === "asin") return formatAsinDisplayName(row);
     if (key === "weeks_present_selected_week") return row.weeks_present_selected_week;
     if (key === "sessions") return current.sessions;
     if (key === "page_views") return current.page_views;
@@ -5723,6 +5748,24 @@ def build_html(data: dict[str, object]) -> str:
     var div = document.createElement("div");
     div.textContent = value;
     return div.innerHTML;
+  }
+
+  function normalizeAsin(value) {
+    return String(value).trim().toUpperCase();
+  }
+
+  function formatAsinDisplayName(row) {
+    var asin = normalizeAsin(row.asin);
+    var label = asinDisplayNames[asin];
+    if (label !== undefined) return label;
+    return asin;
+  }
+
+  function formatAsinReference(value) {
+    var asin = normalizeAsin(value);
+    var label = asinDisplayNames[asin];
+    if (label !== undefined) return label + " (" + asin + ")";
+    return asin;
   }
 
   function clusterColor(cluster) {
@@ -8162,7 +8205,7 @@ def build_html(data: dict[str, object]) -> str:
       }
       html += '<tr class="' + rowClass.trim() + '" data-scp-asin-row="' + escapeHtml(row.id) + '">';
       html += '<td class="check-col"><input type="checkbox" data-scp-asin-checkbox="' + escapeHtml(row.id) + '"' + (selection.selectedIds.indexOf(row.id) !== -1 ? ' checked' : '') + '></td>';
-      html += '<td><div class="group-name-stack"><div class="group-name-main">' + escapeHtml(row.asin) + '</div><div class="group-name-meta">' + (row.is_target ? 'Target ASIN' : 'Catalog ASIN') + ' · ' + row.weeks_present_selected_week + ' / 1 weeks</div></div></td>';
+      html += '<td><div class="group-name-stack"><div class="group-name-main">' + escapeHtml(formatAsinDisplayName(row)) + '</div><div class="group-name-meta">' + escapeHtml(row.asin) + ' · ' + (row.is_target ? 'Target ASIN' : 'Catalog ASIN') + ' · ' + row.weeks_present_selected_week + ' / 1 weeks</div></div></td>';
       html += '<td>' + row.weeks_present_selected_week + '</td>';
       html += '<td>' + fmtNumber(current.impressions) + '</td>';
       html += '<td>' + fmtPct(safeDiv(current.impressions, total.impressions)) + '</td>';
@@ -8222,7 +8265,7 @@ def build_html(data: dict[str, object]) -> str:
       }
       html += '<tr class="' + rowClass.trim() + '" data-br-asin-row="' + escapeHtml(row.id) + '">';
       html += '<td class="check-col"><input type="checkbox" data-br-asin-checkbox="' + escapeHtml(row.id) + '"' + (selection.selectedIds.indexOf(row.id) !== -1 ? ' checked' : '') + '></td>';
-      html += '<td><div class="group-name-stack"><div class="group-name-main">' + escapeHtml(row.asin) + '</div><div class="group-name-meta">' + (row.is_target ? 'Target ASIN' : 'Catalog ASIN') + ' · ' + row.weeks_present_selected_week + ' / 1 weeks</div></div></td>';
+      html += '<td><div class="group-name-stack"><div class="group-name-main">' + escapeHtml(formatAsinDisplayName(row)) + '</div><div class="group-name-meta">' + escapeHtml(row.asin) + ' · ' + (row.is_target ? 'Target ASIN' : 'Catalog ASIN') + ' · ' + row.weeks_present_selected_week + ' / 1 weeks</div></div></td>';
       html += '<td>' + row.weeks_present_selected_week + '</td>';
       html += '<td>' + (hasWeek ? fmtNumber(current.sessions) : '—') + '</td>';
       html += '<td>' + (hasWeek ? fmtNumber(current.page_views) : '—') + '</td>';
@@ -9379,7 +9422,7 @@ def build_html(data: dict[str, object]) -> str:
       if (!summary && entry.highlights && entry.highlights.length > 0) {
         summary = entry.highlights.join(" | ");
       }
-      var asins = entry.asins && entry.asins.length > 0 ? entry.asins.join(", ") : "—";
+      var asins = entry.asins && entry.asins.length > 0 ? entry.asins.map(formatAsinReference).join(", ") : "—";
       var fields = entry.field_labels && entry.field_labels.length > 0 ? entry.field_labels.join(", ") : "—";
       html += '<tr>';
       html += '<td><span class="change-log-week">W' + escapeHtml(entry.week_label.replace(/^W/, "")) + '</span></td>';
@@ -10188,7 +10231,7 @@ def build_html(data: dict[str, object]) -> str:
 </body>
 </html>
 """
-    return template.replace("__DATA__", data_json)
+    return template.replace("__DATA__", data_json).replace("__ASIN_LABELS__", asin_labels_json)
 
 
 

--- a/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
@@ -61,6 +61,31 @@ class MarketTaxonomyTest(unittest.TestCase):
             )
 
 
+class AsinLabelFormattingTest(unittest.TestCase):
+    def test_formats_known_asins_with_readable_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir) / "Sales" / "WPR" / "wpr-workspace" / "output"
+            data_dir.mkdir(parents=True, exist_ok=True)
+            module = load_module(data_dir)
+
+            self.assertEqual(
+                module.format_asin_reference("B09HXC3NL8"),
+                "Caelum Star 6 Pack 12x9 ft Extra Large (B09HXC3NL8)",
+            )
+            self.assertEqual(
+                module.format_asin_reference("B08QZHS7V6"),
+                "ARVO 3 Pack 12ft x 9ft Plastic Dust Sheets (B08QZHS7V6)",
+            )
+
+    def test_unknown_asin_references_remain_raw(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir) / "Sales" / "WPR" / "wpr-workspace" / "output"
+            data_dir.mkdir(parents=True, exist_ok=True)
+            module = load_module(data_dir)
+
+            self.assertEqual(module.format_asin_reference("B000000001"), "B000000001")
+
+
 class DefaultWeekSelectionTest(unittest.TestCase):
     def test_defaults_to_latest_stable_week(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- add readable ASIN display names across Argus WPR, monitoring labels, alert emails, and static WPR exports while retaining raw ASIN traceability
- make WPR charts/default data use the latest stable week so the incomplete newest week is excluded by default
- keep SQP bulk header selection deterministic across all selectable roots and terms

## Verification
- pnpm --filter @targon/argus exec tsx --test lib/product-labels.test.ts lib/monitoring/labels.test.ts lib/wpr/scp-view-model.test.ts lib/wpr/business-reports-view-model.test.ts components/wpr/wpr-change-props.test.ts
- python3 -m unittest apps.argus.scripts.wpr.test_build_intent_cluster_dashboard
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/argus type-check
- pnpm --filter @targon/argus build
- Browser: http://localhost:41316/argus/wpr renders W16 as the latest chart/table week, excludes W17, SQP header toggles from 0 roots/0 selected to 12 roots/480 selected, and SCP shows readable ASIN names with raw ASINs retained.
