### PR TITLE
fix(talos): use SP-API fee preview size tiers

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -565,7 +565,7 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                         {formatWeightDisplayFromKg(
                           row.comparison.reference.shipping.unitWeightKg,
                           unitSystem,
-                          3
+                          2
                         )}
                       </td>
                     ))}
@@ -582,7 +582,7 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                         {formatWeightDisplayFromKg(
                           row.comparison.reference.shipping.dimensionalWeightKg,
                           unitSystem,
-                          3
+                          2
                         )}
                       </td>
                     ))}
@@ -655,7 +655,7 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                         {formatWeightDisplayFromKg(
                           row.comparison.amazon.shipping.unitWeightKg,
                           unitSystem,
-                          3
+                          2
                         )}
                       </td>
                     ))}
@@ -672,7 +672,7 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                         {formatWeightDisplayFromKg(
                           row.comparison.amazon.shipping.dimensionalWeightKg,
                           unitSystem,
-                          3
+                          2
                         )}
                       </td>
                     ))}

--- a/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
+++ b/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
@@ -7,8 +7,14 @@ import {
 import {
   buildComparisonSkuRow,
   mergeAmazonCatalogPackageData,
+  type AmazonCatalogPackageData,
 } from '@/lib/amazon/fba-fee-discrepancies'
-import { calculateSizeTierForTenant, isAllowedSizeTierForTenant } from '@/lib/amazon/fees'
+import {
+  loadLatestFbaFeePreviewReportRows,
+  resolveFbaFeePreviewRow,
+  type FbaFeePreviewReportRow,
+} from '@/lib/amazon/fba-fee-preview-report'
+import { isAllowedSizeTierForTenant } from '@/lib/amazon/fees'
 import {
   escapeRegex,
   sanitizeForDisplay,
@@ -80,27 +86,35 @@ type ComparisonSkuDatabaseRow = Prisma.SkuGetPayload<{
   select: typeof comparisonSkuSelect
 }>
 
-async function buildLiveAmazonComparisonRow(row: ComparisonSkuDatabaseRow, tenantCode: TenantCode) {
+async function buildLiveAmazonComparisonRow(
+  row: ComparisonSkuDatabaseRow,
+  tenantCode: TenantCode,
+  feePreviewRows: FbaFeePreviewReportRow[]
+) {
   const comparisonRow = buildComparisonSkuRow(row)
   const asin = typeof row.asin === 'string' ? row.asin.trim() : ''
+
+  const feePreviewRow = resolveFbaFeePreviewRow(feePreviewRows, row.skuCode, asin ? asin : null)
+  if (feePreviewRow) {
+    const feePreviewData: AmazonCatalogPackageData = {
+      packageTriplet: feePreviewRow.packageTriplet,
+      packageWeightKg: feePreviewRow.packageWeightKg,
+      sizeTier: feePreviewRow.sizeTier,
+    }
+    return mergeAmazonCatalogPackageData(comparisonRow, feePreviewData)
+  }
+
   if (!asin) return comparisonRow
 
   const catalog = await getCatalogItem(asin, tenantCode)
   const attributes = catalog.attributes
   const amazonPackageTriplet = attributes ? parseCatalogItemPackageDimensions(attributes) : null
   const amazonPackageWeightKg = attributes ? parseCatalogItemPackageWeightKg(attributes) : null
-  const amazonSizeTier = calculateSizeTierForTenant(
-    tenantCode,
-    amazonPackageTriplet ? amazonPackageTriplet.side1Cm : null,
-    amazonPackageTriplet ? amazonPackageTriplet.side2Cm : null,
-    amazonPackageTriplet ? amazonPackageTriplet.side3Cm : null,
-    amazonPackageWeightKg
-  )
 
   return mergeAmazonCatalogPackageData(comparisonRow, {
     packageTriplet: amazonPackageTriplet,
     packageWeightKg: amazonPackageWeightKg,
-    sizeTier: amazonSizeTier,
+    sizeTier: null,
   })
 }
 
@@ -139,8 +153,9 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
     select: comparisonSkuSelect,
   })
 
+  const feePreviewRows = await loadLatestFbaFeePreviewReportRows(tenantCode)
   const comparisonSkus = await Promise.all(
-    skus.map(sku => buildLiveAmazonComparisonRow(sku, tenantCode))
+    skus.map(sku => buildLiveAmazonComparisonRow(sku, tenantCode, feePreviewRows))
   )
 
   return ApiResponses.success({ skus: comparisonSkus, total, page, pageSize })
@@ -191,6 +206,7 @@ export const PATCH = withRole(['admin', 'staff'], async (request, _session) => {
     select: comparisonSkuSelect,
   })
 
-  const comparisonSku = await buildLiveAmazonComparisonRow(updatedSku, tenantCode)
+  const feePreviewRows = await loadLatestFbaFeePreviewReportRows(tenantCode)
+  const comparisonSku = await buildLiveAmazonComparisonRow(updatedSku, tenantCode, feePreviewRows)
   return ApiResponses.success(comparisonSku)
 })

--- a/apps/talos/src/app/api/amazon/import-skus/route.ts
+++ b/apps/talos/src/app/api/amazon/import-skus/route.ts
@@ -12,9 +12,13 @@ import {
 import { sanitizeForDisplay } from '@/lib/security/input-sanitization'
 import {
   parseAmazonProductFees,
-  calculateSizeTierForTenant,
   getReferralFeePercentForTenant,
 } from '@/lib/amazon/fees'
+import {
+  loadLatestFbaFeePreviewReportRows,
+  resolveFbaFeePreviewRow,
+} from '@/lib/amazon/fba-fee-preview-report'
+import { truncateToDecimalPlaces } from '@/lib/number-precision'
 import { formatDimensionTripletCm, resolveDimensionTripletCm } from '@/lib/sku-dimensions'
 import { SKU_FIELD_LIMITS } from '@/lib/sku-constants'
 import { getCurrentTenantCode, getTenantPrisma } from '@/lib/tenant/server'
@@ -121,13 +125,13 @@ function convertMeasurementToCm(value: number, unit: string | undefined): number
   const normalized = unit.trim().toLowerCase()
   if (!normalized) return null
   if (normalized === 'inches' || normalized === 'inch' || normalized === 'in') {
-    return Number((value * 2.54).toFixed(2))
+    return truncateToDecimalPlaces(value * 2.54, 2)
   }
   if (normalized === 'centimeters' || normalized === 'centimetres' || normalized === 'cm') {
-    return Number(value.toFixed(2))
+    return truncateToDecimalPlaces(value, 2)
   }
   if (normalized === 'millimeters' || normalized === 'millimetres' || normalized === 'mm') {
-    return Number((value / 10).toFixed(2))
+    return truncateToDecimalPlaces(value / 10, 2)
   }
   return null
 }
@@ -147,19 +151,19 @@ function parseCatalogItemPackageWeightKg(attributes: {
   if (!normalized) return null
 
   if (normalized === 'kilograms' || normalized === 'kilogram' || normalized === 'kg') {
-    return Number(raw.toFixed(3))
+    return truncateToDecimalPlaces(raw, 2)
   }
 
   if (normalized === 'pounds' || normalized === 'pound' || normalized === 'lb' || normalized === 'lbs') {
-    return Number((raw * 0.453592).toFixed(3))
+    return truncateToDecimalPlaces(raw * 0.453592, 2)
   }
 
   if (normalized === 'grams' || normalized === 'gram' || normalized === 'g') {
-    return Number((raw / 1000).toFixed(3))
+    return truncateToDecimalPlaces(raw / 1000, 2)
   }
 
   if (normalized === 'ounces' || normalized === 'ounce' || normalized === 'oz') {
-    return Number((raw * 0.0283495).toFixed(3))
+    return truncateToDecimalPlaces(raw * 0.0283495, 2)
   }
 
   return null
@@ -180,19 +184,19 @@ function parseCatalogItemWeightKg(attributes: {
   if (!normalized) return null
 
   if (normalized === 'kilograms' || normalized === 'kilogram' || normalized === 'kg') {
-    return Number(raw.toFixed(3))
+    return truncateToDecimalPlaces(raw, 2)
   }
 
   if (normalized === 'pounds' || normalized === 'pound' || normalized === 'lb' || normalized === 'lbs') {
-    return Number((raw * 0.453592).toFixed(3))
+    return truncateToDecimalPlaces(raw * 0.453592, 2)
   }
 
   if (normalized === 'grams' || normalized === 'gram' || normalized === 'g') {
-    return Number((raw / 1000).toFixed(3))
+    return truncateToDecimalPlaces(raw / 1000, 2)
   }
 
   if (normalized === 'ounces' || normalized === 'ounce' || normalized === 'oz') {
-    return Number((raw * 0.0283495).toFixed(3))
+    return truncateToDecimalPlaces(raw * 0.0283495, 2)
   }
 
   return null
@@ -450,6 +454,7 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
 
   const listingResponse = await getListingsItems(tenantCode, { limit: 250 })
   const listings = listingResponse.items
+  const feePreviewRows = await loadLatestFbaFeePreviewReportRows(tenantCode)
 
   const listingBySkuCode = new Map<string, (typeof listings)[number]>()
   for (const listing of listings) {
@@ -639,15 +644,17 @@ export const POST = withRole(['admin', 'staff'], async (request, _session) => {
       )
     }
 
-    const calculatedSizeTier = calculateSizeTierForTenant(
-      tenantCode,
-      unitTriplet?.side1Cm ?? null,
-      unitTriplet?.side2Cm ?? null,
-      unitTriplet?.side3Cm ?? null,
-      unitWeightKg
-    )
-    if (calculatedSizeTier) {
-      amazonSizeTier = calculatedSizeTier
+    const feePreviewRow = resolveFbaFeePreviewRow(feePreviewRows, skuCode, asin)
+    if (feePreviewRow) {
+      if (feePreviewRow.packageTriplet) {
+        unitTriplet = feePreviewRow.packageTriplet
+      }
+      if (feePreviewRow.packageWeightKg !== null) {
+        unitWeightKg = feePreviewRow.packageWeightKg
+      }
+      if (feePreviewRow.sizeTier !== null) {
+        amazonSizeTier = feePreviewRow.sizeTier
+      }
     }
 
     try {

--- a/apps/talos/src/app/api/amazon/sync/route.ts
+++ b/apps/talos/src/app/api/amazon/sync/route.ts
@@ -3,6 +3,7 @@ import { withAuth } from '@/lib/api/auth-wrapper'
 import { getTenantPrisma, getCurrentTenantCode } from '@/lib/tenant/server'
 import { getInventory, getCatalogItem } from '@/lib/amazon/client'
 import { calculateSizeTierForTenant } from '@/lib/amazon/fees'
+import { truncateToDecimalPlaces } from '@/lib/number-precision'
 import { formatDimensionTripletCm } from '@/lib/sku-dimensions'
 import { SKU_FIELD_LIMITS } from '@/lib/sku-constants'
 import type { Session } from 'next-auth'
@@ -17,13 +18,13 @@ function convertMeasurementToCm(value: number, unit: string | undefined): number
   const normalized = unit.trim().toLowerCase()
   if (!normalized) return null
   if (normalized === 'inches' || normalized === 'inch' || normalized === 'in') {
-    return Number((value * 2.54).toFixed(2))
+    return truncateToDecimalPlaces(value * 2.54, 2)
   }
   if (normalized === 'centimeters' || normalized === 'centimetres' || normalized === 'cm') {
-    return Number(value.toFixed(2))
+    return truncateToDecimalPlaces(value, 2)
   }
   if (normalized === 'millimeters' || normalized === 'millimetres' || normalized === 'mm') {
-    return Number((value / 10).toFixed(2))
+    return truncateToDecimalPlaces(value / 10, 2)
   }
   return null
 }
@@ -72,16 +73,16 @@ function convertWeightToKg(value: number, unit: string | undefined): number | nu
   const normalized = unit.trim().toLowerCase()
   if (!normalized) return null
   if (normalized === 'kilograms' || normalized === 'kilogram' || normalized === 'kg') {
-    return Number(value.toFixed(3))
+    return truncateToDecimalPlaces(value, 2)
   }
   if (normalized === 'pounds' || normalized === 'pound' || normalized === 'lb' || normalized === 'lbs') {
-    return Number((value * 0.453592).toFixed(3))
+    return truncateToDecimalPlaces(value * 0.453592, 2)
   }
   if (normalized === 'grams' || normalized === 'gram' || normalized === 'g') {
-    return Number((value / 1000).toFixed(3))
+    return truncateToDecimalPlaces(value / 1000, 2)
   }
   if (normalized === 'ounces' || normalized === 'ounce' || normalized === 'oz') {
-    return Number((value * 0.0283495).toFixed(3))
+    return truncateToDecimalPlaces(value * 0.0283495, 2)
   }
   return null
 }

--- a/apps/talos/src/lib/amazon/catalog-normalization.ts
+++ b/apps/talos/src/lib/amazon/catalog-normalization.ts
@@ -1,4 +1,5 @@
 import { sanitizeForDisplay } from '@/lib/security/input-sanitization'
+import { truncateToDecimalPlaces } from '@/lib/number-precision'
 import { resolveDimensionTripletCm, sortDimensionTripletCm } from '@/lib/sku-dimensions'
 
 type CatalogMeasurement = {
@@ -27,13 +28,13 @@ function convertMeasurementToCm(value: number, unit: string | undefined): number
   const normalized = unit.trim().toLowerCase()
   if (!normalized) return null
   if (normalized === 'inches' || normalized === 'inch' || normalized === 'in') {
-    return Number((value * 2.54).toFixed(2))
+    return truncateToDecimalPlaces(value * 2.54, 2)
   }
   if (normalized === 'centimeters' || normalized === 'centimetres' || normalized === 'cm') {
-    return Number(value.toFixed(2))
+    return truncateToDecimalPlaces(value, 2)
   }
   if (normalized === 'millimeters' || normalized === 'millimetres' || normalized === 'mm') {
-    return Number((value / 10).toFixed(2))
+    return truncateToDecimalPlaces(value / 10, 2)
   }
   return null
 }
@@ -69,7 +70,7 @@ function parseCatalogWeightKg(measurement: CatalogMeasurement | null | undefined
   if (!normalized) return null
 
   if (normalized === 'kilograms' || normalized === 'kilogram' || normalized === 'kg') {
-    return Number(raw.toFixed(3))
+    return truncateToDecimalPlaces(raw, 2)
   }
 
   if (
@@ -78,15 +79,15 @@ function parseCatalogWeightKg(measurement: CatalogMeasurement | null | undefined
     normalized === 'lb' ||
     normalized === 'lbs'
   ) {
-    return Number((raw * 0.453592).toFixed(3))
+    return truncateToDecimalPlaces(raw * 0.453592, 2)
   }
 
   if (normalized === 'grams' || normalized === 'gram' || normalized === 'g') {
-    return Number((raw / 1000).toFixed(3))
+    return truncateToDecimalPlaces(raw / 1000, 2)
   }
 
   if (normalized === 'ounces' || normalized === 'ounce' || normalized === 'oz') {
-    return Number((raw * 0.0283495).toFixed(3))
+    return truncateToDecimalPlaces(raw * 0.0283495, 2)
   }
 
   return null

--- a/apps/talos/src/lib/amazon/client.ts
+++ b/apps/talos/src/lib/amazon/client.ts
@@ -6,6 +6,7 @@ import { getAmazonSpApiConfigFromEnv, type AmazonSpApiConfig } from '@/lib/amazo
 
 type SellingPartnerApiClient = {
   callAPI: (params: Record<string, unknown>) => Promise<unknown>
+  download: (document: unknown) => Promise<unknown>
 }
 
 type AmazonInventorySummary = {
@@ -143,6 +144,15 @@ type AmazonOutboundShipmentsResponse = {
     NextToken?: string
   }
   errors?: AmazonErrorDetail[]
+}
+
+type AmazonReportsResponse = {
+  reports?: Array<{
+    reportId?: string
+    reportDocumentId?: string
+    createdTime?: string
+    processingStatus?: string
+  }>
 }
 
 type AmazonOutboundShipmentItemsResponse = {
@@ -454,6 +464,53 @@ export function getAmazonClient(tenantCode?: TenantCode): SellingPartnerApiClien
   const client = createAmazonClient(config)
   clientCache.set(key, client)
   return client
+}
+
+export async function getLatestAmazonReportDocumentText(
+  tenantCode: TenantCode,
+  reportType: string
+): Promise<string | null> {
+  const config = getAmazonSpApiConfigFromEnv(tenantCode)
+  if (!config) return null
+  const createdSince = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+
+  const reportsResponse = await callAmazonApi<AmazonReportsResponse>(tenantCode, {
+    operation: 'getReports',
+    endpoint: 'reports',
+    query: {
+      reportTypes: [reportType],
+      processingStatuses: ['DONE'],
+      marketplaceIds: [config.marketplaceId],
+      createdSince,
+    },
+  })
+
+  const reports = Array.isArray(reportsResponse.reports) ? reportsResponse.reports : []
+  let latestReport: AmazonReportsResponse['reports'][number] | null = null
+  for (const report of reports) {
+    if (!report.reportDocumentId) continue
+    if (latestReport === null) {
+      latestReport = report
+      continue
+    }
+    if (String(report.createdTime) > String(latestReport.createdTime)) {
+      latestReport = report
+    }
+  }
+
+  if (latestReport === null) return null
+  if (!latestReport.reportDocumentId) return null
+
+  const reportDocument = await callAmazonApi<unknown>(tenantCode, {
+    operation: 'getReportDocument',
+    endpoint: 'reports',
+    path: { reportDocumentId: latestReport.reportDocumentId },
+  })
+
+  const downloaded = await getAmazonClient(tenantCode).download(reportDocument)
+  if (Buffer.isBuffer(downloaded)) return downloaded.toString('utf8')
+  if (typeof downloaded === 'string') return downloaded
+  return String(downloaded)
 }
 
 export async function getListingsItems(

--- a/apps/talos/src/lib/amazon/fba-fee-preview-report.ts
+++ b/apps/talos/src/lib/amazon/fba-fee-preview-report.ts
@@ -1,0 +1,173 @@
+import type { DimensionTriplet } from '@/lib/amazon/fba-fee-discrepancies'
+import { getSizeTierOptionsForTenant } from '@/lib/amazon/fees'
+import { truncateToDecimalPlaces } from '@/lib/number-precision'
+import type { TenantCode } from '@/lib/tenant/constants'
+import { resolveDimensionTripletCm, sortDimensionTripletCm } from '@/lib/sku-dimensions'
+
+const FBA_FEE_PREVIEW_REPORT_TYPE = 'GET_FBA_ESTIMATED_FBA_FEES_TXT_DATA'
+
+export type FbaFeePreviewReportRow = {
+  sku: string
+  asin: string | null
+  packageTriplet: DimensionTriplet | null
+  packageWeightKg: number | null
+  sizeTier: string | null
+}
+
+function normalizeHeader(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function normalizeTierKey(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function parseFiniteNumber(value: string | null): number | null {
+  if (value === null) return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function lengthToCm(value: number | null, unit: string | null): number | null {
+  if (value === null) return null
+  if (unit === null) return null
+  const normalized = unit.trim().toLowerCase()
+  if (['centimeters', 'centimetres', 'cm'].includes(normalized)) {
+    return truncateToDecimalPlaces(value, 2)
+  }
+  if (['inches', 'inch', 'in'].includes(normalized)) {
+    return truncateToDecimalPlaces(value * 2.54, 2)
+  }
+  if (['millimeters', 'millimetres', 'mm'].includes(normalized)) {
+    return truncateToDecimalPlaces(value / 10, 2)
+  }
+  return null
+}
+
+function weightToKg(value: number | null, unit: string | null): number | null {
+  if (value === null) return null
+  if (unit === null) return null
+  const normalized = unit.trim().toLowerCase()
+  if (['kilograms', 'kilogram', 'kg'].includes(normalized)) {
+    return truncateToDecimalPlaces(value, 2)
+  }
+  if (['grams', 'gram', 'g'].includes(normalized)) {
+    return truncateToDecimalPlaces(value / 1000, 2)
+  }
+  if (['pounds', 'pound', 'lb', 'lbs'].includes(normalized)) {
+    return truncateToDecimalPlaces(value * 0.453592, 2)
+  }
+  if (['ounces', 'ounce', 'oz'].includes(normalized)) {
+    return truncateToDecimalPlaces(value * 0.0283495, 2)
+  }
+  return null
+}
+
+function resolveColumn(headers: string[], name: string): number {
+  return headers.findIndex(header => header === name)
+}
+
+function getColumnValue(columns: string[], index: number): string | null {
+  if (index < 0) return null
+  const value = columns[index]
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+export function normalizeFbaFeePreviewSizeTier(
+  tenantCode: TenantCode,
+  rawSizeBand: string | null
+): string | null {
+  if (rawSizeBand === null) return null
+  const normalizedRaw = normalizeTierKey(rawSizeBand)
+  if (!normalizedRaw) return null
+
+  for (const option of getSizeTierOptionsForTenant(tenantCode)) {
+    if (normalizeTierKey(option) === normalizedRaw) {
+      return option
+    }
+  }
+
+  return null
+}
+
+export function parseFbaFeePreviewReport(
+  reportText: string,
+  tenantCode: TenantCode
+): FbaFeePreviewReportRow[] {
+  const lines = reportText.split(/\r?\n/).filter(line => line.trim())
+  const headerLine = lines[0]
+  if (!headerLine) return []
+
+  const headers = headerLine.split('\t').map(normalizeHeader)
+  const skuIndex = resolveColumn(headers, 'sku')
+  const asinIndex = resolveColumn(headers, 'asin')
+  const longestIndex = resolveColumn(headers, 'longest-side')
+  const medianIndex = resolveColumn(headers, 'median-side')
+  const shortestIndex = resolveColumn(headers, 'shortest-side')
+  const dimensionUnitIndex = resolveColumn(headers, 'unit-of-dimension')
+  const weightIndex = resolveColumn(headers, 'item-package-weight')
+  const weightUnitIndex = resolveColumn(headers, 'unit-of-weight')
+  const sizeBandIndex = resolveColumn(headers, 'product-size-weight-band')
+
+  const rows: FbaFeePreviewReportRow[] = []
+
+  for (const line of lines.slice(1)) {
+    const columns = line.split('\t')
+    const sku = getColumnValue(columns, skuIndex)
+    const asin = getColumnValue(columns, asinIndex)
+    if (sku === null && asin === null) continue
+
+    const dimensionUnit = getColumnValue(columns, dimensionUnitIndex)
+    const side1Cm = lengthToCm(parseFiniteNumber(getColumnValue(columns, shortestIndex)), dimensionUnit)
+    const side2Cm = lengthToCm(parseFiniteNumber(getColumnValue(columns, medianIndex)), dimensionUnit)
+    const side3Cm = lengthToCm(parseFiniteNumber(getColumnValue(columns, longestIndex)), dimensionUnit)
+    const packageTriplet = resolveDimensionTripletCm({ side1Cm, side2Cm, side3Cm })
+    const weightUnit = getColumnValue(columns, weightUnitIndex)
+
+    rows.push({
+      sku: sku ?? '',
+      asin,
+      packageTriplet: packageTriplet ? sortDimensionTripletCm(packageTriplet) : null,
+      packageWeightKg: weightToKg(parseFiniteNumber(getColumnValue(columns, weightIndex)), weightUnit),
+      sizeTier: normalizeFbaFeePreviewSizeTier(tenantCode, getColumnValue(columns, sizeBandIndex)),
+    })
+  }
+
+  return rows
+}
+
+export function resolveFbaFeePreviewRow(
+  rows: FbaFeePreviewReportRow[],
+  skuCode: string,
+  asin: string | null
+): FbaFeePreviewReportRow | null {
+  const normalizedSku = skuCode.trim().toUpperCase()
+  for (const row of rows) {
+    if (row.sku.trim().toUpperCase() === normalizedSku) return row
+  }
+
+  if (asin === null) return null
+  const normalizedAsin = asin.trim().toUpperCase()
+  if (!normalizedAsin) return null
+  for (const row of rows) {
+    if (row.asin && row.asin.trim().toUpperCase() === normalizedAsin) return row
+  }
+
+  return null
+}
+
+export async function loadLatestFbaFeePreviewReportRows(
+  tenantCode: TenantCode
+): Promise<FbaFeePreviewReportRow[]> {
+  const { getLatestAmazonReportDocumentText } = await import('@/lib/amazon/client')
+  const reportText = await getLatestAmazonReportDocumentText(
+    tenantCode,
+    FBA_FEE_PREVIEW_REPORT_TYPE
+  )
+  if (reportText === null) return []
+  return parseFbaFeePreviewReport(reportText, tenantCode)
+}

--- a/apps/talos/src/lib/amazon/reference-input.ts
+++ b/apps/talos/src/lib/amazon/reference-input.ts
@@ -4,6 +4,7 @@ import {
   getDefaultUnitSystem,
   type UnitSystem,
 } from '@/lib/measurements'
+import { truncateToDecimalPlaces } from '@/lib/number-precision'
 import {
   formatDimensionTripletCm,
   resolveDimensionTripletCm,
@@ -44,11 +45,17 @@ export function normalizeReferenceInputForStorage(
   input: ReferenceInputPayload
 ): NormalizedReferenceInput {
   const rawSide1Cm =
-    input.unitSide1 === null ? null : convertLengthToCm(input.unitSide1, input.inputUnitSystem)
+    input.unitSide1 === null
+      ? null
+      : truncateToDecimalPlaces(convertLengthToCm(input.unitSide1, input.inputUnitSystem), 2)
   const rawSide2Cm =
-    input.unitSide2 === null ? null : convertLengthToCm(input.unitSide2, input.inputUnitSystem)
+    input.unitSide2 === null
+      ? null
+      : truncateToDecimalPlaces(convertLengthToCm(input.unitSide2, input.inputUnitSystem), 2)
   const rawSide3Cm =
-    input.unitSide3 === null ? null : convertLengthToCm(input.unitSide3, input.inputUnitSystem)
+    input.unitSide3 === null
+      ? null
+      : truncateToDecimalPlaces(convertLengthToCm(input.unitSide3, input.inputUnitSystem), 2)
   const rawTriplet = resolveDimensionTripletCm({
     side1Cm: rawSide1Cm,
     side2Cm: rawSide2Cm,
@@ -56,7 +63,9 @@ export function normalizeReferenceInputForStorage(
   })
   const unitTriplet = rawTriplet ? sortDimensionTripletCm(rawTriplet) : null
   const unitWeightKg =
-    input.unitWeight === null ? null : convertWeightToKg(input.unitWeight, input.inputUnitSystem)
+    input.unitWeight === null
+      ? null
+      : truncateToDecimalPlaces(convertWeightToKg(input.unitWeight, input.inputUnitSystem), 2)
 
   return {
     unitTriplet,

--- a/apps/talos/src/lib/measurements.ts
+++ b/apps/talos/src/lib/measurements.ts
@@ -1,4 +1,5 @@
 import type { DimensionTriplet } from '@/lib/sku-dimensions'
+import { formatTruncatedDecimal } from '@/lib/number-precision'
 import type { TenantCode } from '@/lib/tenant/constants'
 
 export type UnitSystem = 'metric' | 'imperial'
@@ -21,12 +22,8 @@ export function getWeightUnitLabel(unitSystem: UnitSystem): 'kg' | 'lb' {
   return 'kg'
 }
 
-function stripTrailingZeros(value: string): string {
-  return value.includes('.') ? value.replace(/\.?0+$/, '') : value
-}
-
 function formatNumber(value: number, decimals: number): string {
-  return stripTrailingZeros(value.toFixed(decimals))
+  return formatTruncatedDecimal(value, decimals)
 }
 
 export function convertLengthFromCm(valueCm: number, unitSystem: UnitSystem): number {
@@ -65,7 +62,7 @@ export function formatLengthFromCm(valueCm: number, unitSystem: UnitSystem, deci
   return formatNumber(convertLengthFromCm(valueCm, unitSystem), decimals)
 }
 
-export function formatWeightFromKg(valueKg: number, unitSystem: UnitSystem, decimals: number = 3): string {
+export function formatWeightFromKg(valueKg: number, unitSystem: UnitSystem, decimals: number = 2): string {
   return formatNumber(convertWeightFromKg(valueKg, unitSystem), decimals)
 }
 

--- a/apps/talos/src/lib/number-precision.ts
+++ b/apps/talos/src/lib/number-precision.ts
@@ -1,0 +1,33 @@
+export function truncateToDecimalPlaces(value: number, decimals: number): number {
+  if (!Number.isFinite(value)) return value
+  if (!Number.isInteger(decimals)) {
+    throw new Error('Decimal places must be an integer')
+  }
+  if (decimals < 0) {
+    throw new Error('Decimal places must be non-negative')
+  }
+
+  const sign = value < 0 ? '-' : ''
+  const absoluteText = Math.abs(value).toString()
+  const exponentIndex = absoluteText.toLowerCase().indexOf('e')
+  if (exponentIndex >= 0) {
+    const factor = 10 ** decimals
+    const scaled = Math.trunc(Math.abs(value) * factor) / factor
+    return Number(`${sign}${scaled.toFixed(decimals)}`)
+  }
+
+  const decimalIndex = absoluteText.indexOf('.')
+  if (decimalIndex < 0) return Number(`${sign}${absoluteText}`)
+  const integerPart = absoluteText.slice(0, decimalIndex)
+  const decimalPart = absoluteText.slice(decimalIndex + 1, decimalIndex + 1 + decimals)
+  if (decimals === 0) return Number(`${sign}${integerPart}`)
+  return Number(`${sign}${integerPart}.${decimalPart.padEnd(decimals, '0')}`)
+}
+
+export function stripTrailingZeros(value: string): string {
+  return value.includes('.') ? value.replace(/\.?0+$/, '') : value
+}
+
+export function formatTruncatedDecimal(value: number, decimals: number): string {
+  return stripTrailingZeros(truncateToDecimalPlaces(value, decimals).toFixed(decimals))
+}

--- a/apps/talos/src/lib/sku-dimensions.ts
+++ b/apps/talos/src/lib/sku-dimensions.ts
@@ -1,15 +1,13 @@
+import { formatTruncatedDecimal } from '@/lib/number-precision'
+
 export type DimensionTriplet = {
   side1Cm: number
   side2Cm: number
   side3Cm: number
 }
 
-function stripTrailingZeros(value: string): string {
-  return value.includes('.') ? value.replace(/\.?0+$/, '') : value
-}
-
 function formatNumber(value: number, decimals: number): string {
-  return stripTrailingZeros(value.toFixed(decimals))
+  return formatTruncatedDecimal(value, decimals)
 }
 
 export function parseDimensionTriplet(value: string | null | undefined): DimensionTriplet | null {

--- a/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
 import test from 'node:test'
 
 import * as discrepancies from '../../src/lib/amazon/fba-fee-discrepancies'
@@ -8,8 +10,15 @@ import {
   isReferenceInputUnitSystemAllowedForTenant,
   normalizeReferenceInputForStorage,
 } from '../../src/lib/amazon/reference-input'
+import {
+  parseFbaFeePreviewReport,
+  resolveFbaFeePreviewRow,
+} from '../../src/lib/amazon/fba-fee-preview-report'
 import { getSizeTierOptionsForTenant, isAllowedSizeTierForTenant } from '../../src/lib/amazon/fees'
-import { formatDimensionTripletDisplayFromCm } from '../../src/lib/measurements'
+import {
+  formatDimensionTripletDisplayFromCm,
+  formatWeightDisplayFromKg,
+} from '../../src/lib/measurements'
 
 function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
   const referenceTriplet = {
@@ -247,6 +256,63 @@ test('Amazon catalog package dimensions normalize to shortest middle longest sid
   })
 })
 
+test('FBA fee preview report normalizes Seller Central size tier bands and package measurements', () => {
+  const report = [
+    'sku\tasin\tlongest-side\tmedian-side\tshortest-side\tunit-of-dimension\titem-package-weight\tunit-of-weight\tproduct-size-weight-band',
+    'CS 007\tB09HXC3NL8\t26.8\t21.0\t2.5\tcentimeters\t309.99\tgrams\tStandardEnvelope',
+  ].join('\n')
+  const rows = parseFbaFeePreviewReport(report, 'UK')
+  const row = resolveFbaFeePreviewRow(rows, 'CS 007', 'B09HXC3NL8')
+
+  assert.deepEqual(row, {
+    sku: 'CS 007',
+    asin: 'B09HXC3NL8',
+    packageTriplet: {
+      side1Cm: 2.5,
+      side2Cm: 21,
+      side3Cm: 26.8,
+    },
+    packageWeightKg: 0.3,
+    sizeTier: 'Standard Envelope',
+  })
+})
+
+test('Amazon report package measurements truncate down instead of rounding up', () => {
+  const report = [
+    'sku\tasin\tlongest-side\tmedian-side\tshortest-side\tunit-of-dimension\titem-package-weight\tunit-of-weight\tproduct-size-weight-band',
+    'ROUNDING\tB0ROUNDING\t26.899\t21.009\t2.599\tcentimeters\t309.99\tgrams\tStandardEnvelope',
+  ].join('\n')
+  const rows = parseFbaFeePreviewReport(report, 'UK')
+  const row = resolveFbaFeePreviewRow(rows, 'ROUNDING', 'B0ROUNDING')
+
+  assert.equal(row?.packageTriplet?.side1Cm, 2.59)
+  assert.equal(row?.packageTriplet?.side2Cm, 21)
+  assert.equal(row?.packageTriplet?.side3Cm, 26.89)
+  assert.equal(row?.packageWeightKg, 0.3)
+})
+
+test('SKU Info measurement display truncates down to two decimals instead of rounding', () => {
+  assert.equal(
+    formatDimensionTripletDisplayFromCm(
+      { side1Cm: 2.599, side2Cm: 21.009, side3Cm: 26.899 },
+      'metric'
+    ),
+    '2.59×21×26.89 cm'
+  )
+  assert.equal(formatWeightDisplayFromKg(0.30999, 'metric', 2), '0.3 kg')
+})
+
+test('SKU Info API does not calculate Amazon size tier from catalog dimensions', () => {
+  const talosRoot = path.resolve(__dirname, '..', '..')
+  const routeSource = readFileSync(
+    path.join(talosRoot, 'src/app/api/amazon/fba-fee-discrepancies/route.ts'),
+    'utf8'
+  )
+
+  assert.equal(routeSource.includes('calculateSizeTierForTenant'), false)
+  assert.equal(routeSource.includes('loadLatestFbaFeePreviewReportRows'), true)
+})
+
 test('assigned size tier option validation allows tenant options and rejects invalid names', () => {
   const ukSizeTiers = getSizeTierOptionsForTenant('UK')
   const firstUkTier = ukSizeTiers[0]
@@ -409,7 +475,7 @@ test('reference input normalizes US inches and pounds before database storage', 
   assert.equal(normalized.storage.unitSide1Cm, 2.54)
   assert.equal(normalized.storage.unitSide2Cm, 20.32)
   assert.equal(normalized.storage.unitSide3Cm, 25.4)
-  assert.equal(Math.abs(Number(normalized.storage.unitWeightKg) - 0.45359237) < 0.000001, true)
+  assert.equal(normalized.storage.unitWeightKg, 0.45)
 })
 
 test('reference input keeps UK centimeters and kilograms before database storage', () => {


### PR DESCRIPTION
## Summary
- Use the FBA Fee Preview report product-size-weight-band as the Amazon SKU Info size tier source.
- Stop deriving Amazon size tiers from Catalog Items package dimensions.
- Truncate SKU Info dimensions and weights down to two decimals across report parsing, import/sync normalization, reference input storage, and display.

## Verification
- pnpm --dir apps/talos test
- pnpm --dir apps/talos type-check
- pnpm --dir apps/talos lint
- Browser/API verified CS 007 uses raw SP-API StandardEnvelope -> Standard Envelope and package weight 309.99 g -> 0.30 kg.