### PR TITLE
fix(argus): align TST coverage table with SQP terms

### DIFF
--- a/apps/argus/components/wpr/tabs/tst-selection-table.tsx
+++ b/apps/argus/components/wpr/tabs/tst-selection-table.tsx
@@ -57,22 +57,27 @@ type Recommendation = {
 type TstColumn = {
   key: TstSortKey
   label: string
+  width: number
 }
 
+const TST_CHECKBOX_COLUMN_WIDTH = 48
+
 const TST_COLUMNS: TstColumn[] = [
-  { key: 'term', label: 'Term' },
-  { key: 'search_frequency_rank', label: 'SFR' },
-  { key: 'weeks_present', label: 'Weeks' },
-  { key: 'our_click_share', label: 'Our Click %' },
-  { key: 'competitor_click_share', label: 'Comp Click %' },
-  { key: 'click_gap', label: 'Click Gap' },
-  { key: 'our_purchase_share', label: 'Our Purch %' },
-  { key: 'competitor_purchase_share', label: 'Comp Purch %' },
-  { key: 'purchase_gap', label: 'Purch Gap' },
-  { key: 'issue', label: 'Issue' },
-  { key: 'priority', label: 'Priority' },
-  { key: 'tst_pool', label: 'TST Pool' },
+  { key: 'term', label: 'Term', width: 300 },
+  { key: 'search_frequency_rank', label: 'SFR', width: 50 },
+  { key: 'weeks_present', label: 'Wks', width: 48 },
+  { key: 'our_click_share', label: 'Our Clk', width: 62 },
+  { key: 'competitor_click_share', label: 'Comp Clk', width: 68 },
+  { key: 'click_gap', label: 'Clk Gap', width: 62 },
+  { key: 'our_purchase_share', label: 'Our Purch', width: 62 },
+  { key: 'competitor_purchase_share', label: 'Comp Purch', width: 68 },
+  { key: 'purchase_gap', label: 'Purch Gap', width: 62 },
+  { key: 'issue', label: 'Issue', width: 104 },
+  { key: 'priority', label: 'Prio', width: 72 },
+  { key: 'tst_pool', label: 'Pool', width: 74 },
 ]
+
+const TST_TABLE_WIDTH = TST_CHECKBOX_COLUMN_WIDTH + TST_COLUMNS.reduce((total, column) => total + column.width, 0)
 
 function toTstSortKey(value: string): TstSortKey {
   if (
@@ -380,6 +385,53 @@ function formatPctDelta(value: number): string {
   return `${sign}${formatPercent(value, 1)}`
 }
 
+function rootCoverageSummary(row: TstSelectionRootRow): string {
+  return `${row.coveredTermCount} / ${row.sqpTermCount} SQP terms covered · ${formatPercent(row.coverageRate, 1)}`
+}
+
+function selectedRootCount(viewModel: TstSelectionViewModel): number {
+  if (viewModel.rootIds.length > 0) {
+    return viewModel.rootIds.length
+  }
+
+  return viewModel.rootRows.length
+}
+
+function panelCoverageSummary(viewModel: TstSelectionViewModel): string {
+  return `${selectedRootCount(viewModel)} roots · ${viewModel.coveredTermCount} / ${viewModel.sqpTermCount} SQP terms covered · ${formatPercent(viewModel.coverageRate, 1)}`
+}
+
+function headerCellSx(width: number) {
+  return {
+    ...wprSelectionHeaderCellSx,
+    width,
+    px: 1,
+    py: 1.1,
+    fontSize: '0.67rem',
+    lineHeight: 1.18,
+    verticalAlign: 'middle',
+    overflow: 'hidden',
+  }
+}
+
+function sortLabelSx(align: 'left' | 'right') {
+  return {
+    width: '100%',
+    minWidth: 0,
+    justifyContent: align === 'left' ? 'flex-start' : 'flex-end',
+    color: textSecondary,
+    textAlign: align,
+    whiteSpace: 'normal',
+    wordBreak: 'normal',
+    lineHeight: 1.15,
+    '& .MuiTableSortLabel-icon': {
+      color: 'rgba(255,255,255,0.4) !important',
+      flexShrink: 0,
+      mx: 0.25,
+    },
+  }
+}
+
 function Pill({
   label,
   kind,
@@ -409,6 +461,8 @@ function Pill({
     background = 'rgba(52,211,153,0.1)'
   }
 
+  const visibleLabel = compactRecommendationLabel(label)
+
   return (
     <Box
       component="span"
@@ -421,20 +475,37 @@ function Pill({
         border: `1px solid ${borderColor}`,
         bgcolor: background,
         color,
+        display: 'inline-block',
+        maxWidth: '100%',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        verticalAlign: 'middle',
         whiteSpace: 'nowrap',
       }}
     >
-      {label}
+      {visibleLabel}
     </Box>
   )
+}
+
+function compactRecommendationLabel(label: string): string {
+  if (label === 'Low Confidence') return 'Low conf.'
+  if (label === 'Visibility / Traffic + Conversion / PDP') return 'Traffic + PDP'
+  if (label === 'Visibility / Traffic') return 'Traffic'
+  if (label === 'Conversion / PDP') return 'PDP'
+  if (label === 'Winning / Defend') return 'Defend'
+
+  return label
 }
 
 function MetricCell({
   align = 'right',
   children,
+  wrap = false,
 }: {
   align?: 'left' | 'right' | 'center'
   children: React.ReactNode
+  wrap?: boolean
 }) {
   return (
     <TableCell
@@ -442,6 +513,13 @@ function MetricCell({
       sx={{
         ...wprSelectionMetricCellSx,
         color: textSecondary,
+        px: 1,
+        py: 1.05,
+        lineHeight: 1.25,
+        whiteSpace: wrap ? 'normal' : 'nowrap',
+        overflow: wrap ? 'visible' : 'hidden',
+        textOverflow: wrap ? 'clip' : 'ellipsis',
+        verticalAlign: 'middle',
       }}
     >
       {children}
@@ -449,11 +527,27 @@ function MetricCell({
   )
 }
 
+function PoolCell({
+  clickShare,
+  purchaseShare,
+}: {
+  clickShare: number
+  purchaseShare: number
+}) {
+  return (
+    <MetricCell wrap>
+      <Stack spacing={0} sx={{ alignItems: 'flex-end', lineHeight: 1.2 }}>
+        <Box component="span">{`C ${formatPercent(clickShare, 1)}`}</Box>
+        <Box component="span">{`P ${formatPercent(purchaseShare, 1)}`}</Box>
+      </Stack>
+    </MetricCell>
+  )
+}
+
 export default function TstSelectionTable({
   selectedWeek,
   weeks,
   weekStartDates,
-  competitorBrand,
   familyOrder,
   viewModel,
   expandedRootIds,
@@ -490,11 +584,11 @@ export default function TstSelectionTable({
 
   const columns = TST_COLUMNS.map((column) => {
     if (column.key === 'competitor_click_share') {
-      return { ...column, label: `${competitorBrand} Click %` }
+      return { ...column, label: 'Comp Clk' }
     }
 
     if (column.key === 'competitor_purchase_share') {
-      return { ...column, label: `${competitorBrand} Purch %` }
+      return { ...column, label: 'Comp Purch' }
     }
 
     return column
@@ -503,7 +597,7 @@ export default function TstSelectionTable({
   return (
     <WprSelectionPanel
       title="TST Selection"
-      summary={`${viewModel.rootIds.length} roots · ${viewModel.selectedTermIds.length} terms`}
+      summary={panelCoverageSummary(viewModel)}
       toolbar={(
         <WprWeekSelect
           label="Table week"
@@ -514,10 +608,16 @@ export default function TstSelectionTable({
         />
       )}
     >
-        <Table stickyHeader size="small" sx={{ minWidth: 1320 }}>
+        <Table stickyHeader size="small" sx={{ minWidth: TST_TABLE_WIDTH, tableLayout: 'fixed' }}>
+          <colgroup>
+            <col style={{ width: TST_CHECKBOX_COLUMN_WIDTH }} />
+            {columns.map((column) => (
+              <col key={column.key} style={{ width: column.width }} />
+            ))}
+          </colgroup>
           <TableHead>
             <TableRow>
-              <TableCell padding="checkbox" sx={wprSelectionHeaderCellSx}>
+              <TableCell padding="checkbox" sx={headerCellSx(TST_CHECKBOX_COLUMN_WIDTH)}>
                 <Checkbox
                   size="small"
                   checked={allTermsChecked}
@@ -536,7 +636,7 @@ export default function TstSelectionTable({
                 <TableCell
                   key={column.key}
                   align={column.key === 'term' ? 'left' : 'right'}
-                  sx={wprSelectionHeaderCellSx}
+                  sx={headerCellSx(column.width)}
                 >
                   <TableSortLabel
                     active={sortState.key === column.key}
@@ -547,12 +647,7 @@ export default function TstSelectionTable({
                         dir: nextSortDirection(sortState, column.key),
                       })
                     }}
-                    sx={{
-                      color: textSecondary,
-                      '& .MuiTableSortLabel-icon': {
-                        color: 'rgba(255,255,255,0.4) !important',
-                      },
-                    }}
+                    sx={sortLabelSx(column.key === 'term' ? 'left' : 'right')}
                   >
                     {column.label}
                   </TableSortLabel>
@@ -625,8 +720,8 @@ export default function TstSelectionTable({
                               }}
                             />
                           </TableCell>
-                          <MetricCell align="left">
-                            <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                          <MetricCell align="left" wrap>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 0 }}>
                               <Box
                                 component="button"
                                 type="button"
@@ -635,9 +730,10 @@ export default function TstSelectionTable({
                                   onToggleExpanded(row.id)
                                 }}
                                 sx={{
-                                  mt: 0.35,
                                   width: 22,
+                                  minWidth: 22,
                                   height: 22,
+                                  flexShrink: 0,
                                   borderRadius: '50%',
                                   border: '1px solid rgba(255,255,255,0.12)',
                                   bgcolor: 'rgba(255,255,255,0.03)',
@@ -649,12 +745,12 @@ export default function TstSelectionTable({
                               >
                                 {rowIsExpanded ? '▾' : '▸'}
                               </Box>
-                              <Stack spacing={0.25}>
-                                <Typography sx={{ fontSize: '0.78rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)' }}>
+                              <Stack spacing={0.25} sx={{ minWidth: 0 }}>
+                                <Typography sx={{ fontSize: '0.78rem', fontWeight: 700, color: 'rgba(255,255,255,0.9)', lineHeight: 1.18 }}>
                                   {row.label}
                                 </Typography>
-                                <Typography sx={{ fontSize: '0.68rem', color: textMuted }}>
-                                  {`${row.selectedCount} / ${row.totalCount} terms selected`}
+                                <Typography sx={{ fontSize: '0.68rem', color: textMuted, lineHeight: 1.18, whiteSpace: 'nowrap' }}>
+                                  {rootCoverageSummary(row)}
                                 </Typography>
                               </Stack>
                             </Box>
@@ -673,9 +769,10 @@ export default function TstSelectionTable({
                           <MetricCell align="center">
                             <Pill label={recommendation.priority} kind={recommendation.priority_class} />
                           </MetricCell>
-                          <MetricCell>
-                            {`${formatPercent(row.current.coverage.avg_click_pool_share, 1)} click · ${formatPercent(row.current.coverage.avg_purchase_pool_share, 1)} purch`}
-                          </MetricCell>
+                          <PoolCell
+                            clickShare={row.current.coverage.avg_click_pool_share}
+                            purchaseShare={row.current.coverage.avg_purchase_pool_share}
+                          />
                         </TableRow>
 
                         {rowIsExpanded
@@ -705,9 +802,9 @@ export default function TstSelectionTable({
                                       }}
                                     />
                                   </TableCell>
-                                  <MetricCell align="left">
+                                  <MetricCell align="left" wrap>
                                     <Box sx={{ pl: 4 }}>
-                                      <Typography sx={{ fontSize: '0.74rem', color: 'rgba(255,255,255,0.84)' }}>
+                                      <Typography sx={{ fontSize: '0.74rem', color: 'rgba(255,255,255,0.84)', lineHeight: 1.2 }}>
                                         {termRow.label}
                                       </Typography>
                                     </Box>
@@ -728,9 +825,10 @@ export default function TstSelectionTable({
                                   <MetricCell align="center">
                                     <Pill label={termRecommendation.priority} kind={termRecommendation.priority_class} />
                                   </MetricCell>
-                                  <MetricCell>
-                                    {`${formatPercent(termRow.current.avg_click_pool_share, 1)} click · ${formatPercent(termRow.current.avg_purchase_pool_share, 1)} purch`}
-                                  </MetricCell>
+                                  <PoolCell
+                                    clickShare={termRow.current.avg_click_pool_share}
+                                    purchaseShare={termRow.current.avg_purchase_pool_share}
+                                  />
                                 </TableRow>
                               )
                             })

--- a/apps/argus/components/wpr/tabs/tst-tab.tsx
+++ b/apps/argus/components/wpr/tabs/tst-tab.tsx
@@ -46,7 +46,7 @@ export default function TstTab({
     const rootIdSet = new Set(bundle.clusters.map((cluster) => cluster.id))
     const allowedTermIds = new Set<string>()
     for (const cluster of bundle.clusters) {
-      for (const termId of competitorRootTermIds(bundle, cluster.id, selectedWeek)) {
+      for (const termId of competitorRootTermIds(bundle, cluster.id)) {
         allowedTermIds.add(termId)
       }
     }
@@ -114,7 +114,7 @@ export default function TstTab({
   const handleSetRootSelection = (rootId: string, shouldSelect: boolean) => {
     const nextRootIds = new Set(selectedCompetitorRootIds)
     const nextTermIds = new Set(selectedCompetitorTermIds)
-    const termIds = competitorRootTermIds(bundle, rootId, selectedWeek)
+    const termIds = competitorRootTermIds(bundle, rootId)
 
     if (shouldSelect) {
       nextRootIds.add(rootId)
@@ -144,7 +144,7 @@ export default function TstTab({
     }
 
     let rootStillSelected = false
-    for (const candidateTermId of competitorRootTermIds(bundle, rootId, selectedWeek)) {
+    for (const candidateTermId of competitorRootTermIds(bundle, rootId)) {
       if (nextTermIds.has(candidateTermId)) {
         rootStillSelected = true
         break
@@ -204,7 +204,7 @@ export default function TstTab({
           setSelectedCompetitorRootIds(bundle.clusters.map((cluster) => cluster.id))
           const allTermIds: string[] = []
           for (const cluster of bundle.clusters) {
-            allTermIds.push(...competitorRootTermIds(bundle, cluster.id, selectedWeek))
+            allTermIds.push(...competitorRootTermIds(bundle, cluster.id))
           }
           setSelectedCompetitorTermIds(allTermIds)
           setHasInitializedCompetitorSelection(true)

--- a/apps/argus/components/wpr/wpr-selection-panel.tsx
+++ b/apps/argus/components/wpr/wpr-selection-panel.tsx
@@ -62,7 +62,7 @@ export function WprSelectionPanel({
         {toolbar}
       </Box>
 
-      <TableContainer sx={{ maxHeight: tableMaxHeight }}>{children}</TableContainer>
+      <TableContainer sx={{ maxHeight: tableMaxHeight, overflowX: 'auto' }}>{children}</TableContainer>
     </Box>
   )
 }

--- a/apps/argus/lib/wpr/tst-view-model.test.ts
+++ b/apps/argus/lib/wpr/tst-view-model.test.ts
@@ -7,6 +7,7 @@ import type {
   WprCluster,
   WprCompetitorSummary,
   WprScpWindow,
+  WprSqpTerm,
   WprTstObserved,
   WprTstTermRow,
   WprTstWeeklyWindow,
@@ -108,6 +109,50 @@ function buildWeeklyWindow(weekLabel: 'W15' | 'W16', termRows: WprTstTermRow[], 
     week_label: weekLabel,
     week_number: weekLabel === 'W15' ? 15 : 16,
     start_date: weekLabel === 'W15' ? '2026-04-05' : '2026-04-12',
+  }
+}
+
+function buildSqpTerm(clusterId: string, cluster: string, family: string, term: string): WprSqpTerm {
+  return {
+    id: `${clusterId}-${term.replaceAll(' ', '-')}`,
+    term,
+    family,
+    cluster,
+    cluster_id: clusterId,
+    weekly: [],
+    selection_status: 'primary',
+    selection_reason: 'Selected-week SQP volume',
+    selection_volume_selected_week: 10,
+    selection_volume_baseline_13w: 10,
+    coverage: {
+      weeks_sqp: 1,
+      weeks_rank: 0,
+      weeks_ppc: 0,
+      has_sqp: true,
+      recent_4w: { weeks_sqp: 1, weeks_rank: 0, weeks_ppc: 0, has_sqp: true },
+      baseline_to_anchor: { weeks_sqp: 1, weeks_rank: 0, weeks_ppc: 0, has_sqp: true },
+    },
+    observed: {
+      current_week: buildEmptyObservedWindow(),
+      recent_4w: buildEmptyObservedWindow(),
+      baseline_13w: buildEmptyObservedWindow(),
+    },
+    benchmark: { competitor: buildCompetitor() },
+    search_volume: 0,
+    query_volume: 0,
+    query_volume_baseline: 0,
+    volume_score: 0,
+    market_ctr: 0,
+    market_cvr: 0,
+    asin_ctr: 0,
+    asin_cvr: 0,
+    impression_share: 0,
+    click_share: 0,
+    cart_add_share: 0,
+    asin_cart_add_rate: 0,
+    purchase_share: 0,
+    competitor_rank: null,
+    competitor_visibility: null,
   }
 }
 
@@ -290,6 +335,48 @@ function buildCluster(id: string, cluster: string, family: string, weekly: WprTs
   }
 }
 
+function buildEmptyObservedWindow() {
+  return {
+    week_label: 'W16' as const,
+    week_number: 16,
+    start_date: '2026-04-12',
+    market_impressions: 0,
+    asin_impressions: 0,
+    market_clicks: 0,
+    asin_clicks: 0,
+    market_cart_adds: 0,
+    asin_cart_adds: 0,
+    market_purchases: 0,
+    asin_purchases: 0,
+    query_volume: 0,
+    ppc_impressions: 0,
+    ppc_clicks: 0,
+    ppc_spend: 0,
+    ppc_sales: 0,
+    ppc_orders: 0,
+    rank_weight: 0,
+    rank_sum: 0,
+    rank_span_sum: 0,
+    rank_term_count: 0,
+    rank_weeks: 0,
+    weeks_in_window: 0,
+    avg_rank: null,
+    rank_volatility: null,
+    market_ctr: 0,
+    market_cvr: 0,
+    asin_ctr: 0,
+    asin_cvr: 0,
+    impression_share: 0,
+    click_share: 0,
+    cart_add_rate: 0,
+    asin_cart_add_rate: 0,
+    cart_add_share: 0,
+    purchase_share: 0,
+    ppc_acos: 0,
+    ppc_cvr: 0,
+  }
+}
+
 function buildBundle(): WprWeekBundle {
   const rootOneWeekly = [
     buildWeeklyWindow('W15', [
@@ -305,6 +392,13 @@ function buildBundle(): WprWeekBundle {
   const rootTwoWeekly = [
     buildWeeklyWindow('W15', [buildTermRow('term 3', { competitor_purchase_share: 0.2, our_purchase_share: 0.22, purchase_gap: 0.02 })]),
     buildWeeklyWindow('W16', [buildTermRow('term 3', { competitor_purchase_share: 0.18, our_purchase_share: 0.24, purchase_gap: 0.06 })]),
+  ]
+  const rootOneSqpTerms = [
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term 1'),
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term 2'),
+  ]
+  const rootTwoSqpTerms = [
+    buildSqpTerm('cluster-2', 'Root Two', 'Family B', 'term 3'),
   ]
 
   return {
@@ -334,8 +428,11 @@ function buildBundle(): WprWeekBundle {
     shareClusterIds: ['cluster-1'],
     ppcClusterIds: ['cluster-1', 'cluster-2'],
     defaultClusterIds: ['cluster-1'],
-    sqpTerms: [],
-    sqpClusterTerms: {},
+    sqpTerms: [...rootOneSqpTerms, ...rootTwoSqpTerms],
+    sqpClusterTerms: {
+      'cluster-1': rootOneSqpTerms.map((term) => term.id),
+      'cluster-2': rootTwoSqpTerms.map((term) => term.id),
+    },
     sqpGlobalTermIds: [],
     regression: { slope: 0, intercept: 0 },
     brandMetrics: {
@@ -458,7 +555,7 @@ test('createTstViewModel derives root and term table rows from the selected week
     selectedWeek: 'W15',
   })
 
-  assert.equal(weekFifteenVm.rootRows[0]?.current.observed.competitor_purchase_share, 0.28)
+  assert.equal(weekFifteenVm.rootRows[0]?.current.observed.competitor_purchase_share, 0.265)
 
   const weekSixteenVm = createTstViewModel({
     bundle: buildBundle(),
@@ -472,4 +569,55 @@ test('createTstViewModel derives root and term table rows from the selected week
   )
 
   assert.equal(selectedTermRow?.current.purchase_gap, -0.06)
+})
+
+test('createTstViewModel reports TST coverage against SQP-backed terms', () => {
+  const bundle = buildBundle()
+  const rootOneSqpTerms = [
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term 1'),
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term 2'),
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term missing from tst'),
+  ]
+  const rootTwoSqpTerms = bundle.sqpTerms.filter((term) => term.cluster_id === 'cluster-2')
+  bundle.sqpTerms = [...rootOneSqpTerms, ...rootTwoSqpTerms]
+  bundle.sqpClusterTerms = {
+    'cluster-1': rootOneSqpTerms.map((term) => term.id),
+    'cluster-2': rootTwoSqpTerms.map((term) => term.id),
+  }
+
+  const vm = createTstViewModel({
+    bundle,
+    selectedRootIds: new Set(['cluster-1']),
+    selectedTermIds: new Set(),
+    selectedWeek: 'W16',
+  })
+
+  assert.equal(vm.rootRows[0]?.coveredTermCount, 2)
+  assert.equal(vm.rootRows[0]?.sqpTermCount, 3)
+  assert.equal(vm.rootRows[0]?.coverageRate, 2 / 3)
+})
+
+test('createTstViewModel filters root TST metrics to SQP-backed terms', () => {
+  const bundle = buildBundle()
+  const rootOneSqpTerms = [
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term 1'),
+    buildSqpTerm('cluster-1', 'Root One', 'Family A', 'term missing from tst'),
+  ]
+  const rootTwoSqpTerms = bundle.sqpTerms.filter((term) => term.cluster_id === 'cluster-2')
+  bundle.sqpTerms = [...rootOneSqpTerms, ...rootTwoSqpTerms]
+  bundle.sqpClusterTerms = {
+    'cluster-1': rootOneSqpTerms.map((term) => term.id),
+    'cluster-2': rootTwoSqpTerms.map((term) => term.id),
+  }
+
+  const vm = createTstViewModel({
+    bundle,
+    selectedRootIds: new Set(['cluster-1']),
+    selectedTermIds: new Set(),
+    selectedWeek: 'W16',
+  })
+
+  assert.equal(vm.rootRows[0]?.coveredTermCount, 1)
+  assert.equal(vm.rootRows[0]?.current.coverage.terms_covered, 1)
+  assert.equal(vm.rootRows[0]?.current.term_rows.map((row) => row.term).join(','), 'term 1')
 })

--- a/apps/argus/lib/wpr/tst-view-model.ts
+++ b/apps/argus/lib/wpr/tst-view-model.ts
@@ -37,6 +37,9 @@ export interface TstSelectionRootRow {
   family: string
   selectedCount: number
   totalCount: number
+  coveredTermCount: number
+  sqpTermCount: number
+  coverageRate: number
   checked: boolean
   partial: boolean
   current: TstWeeklySelection
@@ -59,6 +62,9 @@ export interface TstSelectionViewModel {
   scopeType: TstSelectionScope
   allTermIds: string[]
   selectedTermIds: string[]
+  coveredTermCount: number
+  sqpTermCount: number
+  coverageRate: number
   rootRows: TstSelectionRootRow[]
   termRowsByRoot: Record<string, TstSelectionTermRow[]>
 }
@@ -199,28 +205,46 @@ function selectedWeekTermRows(cluster: WprCluster, selectedWeek: WeekLabel): Wpr
   return selectedWindow.term_rows
 }
 
+function sqpTermsById(bundle: WprWeekBundle) {
+  return new Map(bundle.sqpTerms.map((term) => [term.id, term]))
+}
+
+function clusterById(bundle: WprWeekBundle, clusterId: string): WprCluster {
+  const cluster = bundle.clusters.find((item) => item.id === clusterId)
+  if (cluster === undefined) {
+    throw new Error(`Missing TST cluster ${clusterId}`)
+  }
+
+  return cluster
+}
+
 export function competitorRootTermIds(
   bundle: WprWeekBundle,
   clusterId: string,
-  selectedWeek: WeekLabel,
 ): string[] {
-  const cluster = bundle.clusters.find((item) => item.id === clusterId)
-  if (cluster === undefined) {
-    return []
+  const cluster = clusterById(bundle, clusterId)
+  const sqpTermIds = bundle.sqpClusterTerms[cluster.id]
+  if (sqpTermIds === undefined) {
+    throw new Error(`Missing SQP term ids for TST root ${cluster.id}`)
   }
+  const terms = sqpTermsById(bundle)
 
-  return selectedWeekTermRows(cluster, selectedWeek).map((row) =>
-    competitorTermKey(cluster.cluster, row.term),
-  )
+  return sqpTermIds.map((termId) => {
+    const term = terms.get(termId)
+    if (term === undefined) {
+      throw new Error(`Missing SQP term ${termId} for TST root ${cluster.id}`)
+    }
+
+    return competitorTermKey(cluster.cluster, term.term)
+  })
 }
 
 function competitorSelectedTermsForRoot(
   bundle: WprWeekBundle,
   clusterId: string,
   selectedTermIds: Set<string>,
-  selectedWeek: WeekLabel,
 ): string[] {
-  return competitorRootTermIds(bundle, clusterId, selectedWeek).filter((termId) =>
+  return competitorRootTermIds(bundle, clusterId).filter((termId) =>
     selectedTermIds.has(termId),
   )
 }
@@ -237,8 +261,14 @@ function buildRootRows(
   selectedWeek: WeekLabel,
 ): TstSelectionRootRow[] {
   return bundle.clusters.map((cluster) => {
-    const allIds = competitorRootTermIds(bundle, cluster.id, selectedWeek)
-    const selectedIds = competitorSelectedTermsForRoot(bundle, cluster.id, selectedTermIds, selectedWeek)
+    const allIds = competitorRootTermIds(bundle, cluster.id)
+    const selectedIds = competitorSelectedTermsForRoot(bundle, cluster.id, selectedTermIds)
+    const coveredTermIds = new Set(
+      selectedWeekTermRows(cluster, selectedWeek)
+        .map((row) => competitorTermKey(cluster.cluster, row.term))
+        .filter((termId) => allIds.includes(termId)),
+    )
+    const coveredTermCount = coveredTermIds.size
 
     return {
       id: cluster.id,
@@ -246,9 +276,12 @@ function buildRootRows(
       family: cluster.family,
       selectedCount: selectedIds.length,
       totalCount: allIds.length,
+      coveredTermCount,
+      sqpTermCount: allIds.length,
+      coverageRate: safeDiv(coveredTermCount, allIds.length),
       checked: allIds.length > 0 && selectedIds.length === allIds.length,
       partial: selectedIds.length > 0 && selectedIds.length < allIds.length,
-      current: selectedWeekTstCompare(cluster.tstCompare.weekly, selectedWeek),
+      current: selectedWeekSqpTstCompare(bundle, cluster, selectedWeek),
     }
   })
 }
@@ -260,22 +293,27 @@ function buildTermRowsByRoot(
 ): Record<string, TstSelectionTermRow[]> {
   const rowsByRoot: Record<string, TstSelectionTermRow[]> = {}
   for (const cluster of bundle.clusters) {
-    const rows = selectedWeekTermRows(cluster, selectedWeek)
-      .map((row) => {
-        const id = competitorTermKey(cluster.cluster, row.term)
-        return {
-          id,
-          rootId: cluster.id,
-          label: row.term,
-          checked: selectedTermIds.has(id),
-          current: {
-            ...row,
-            root: cluster.cluster,
-            termId: id,
-          },
-        }
+    const allIds = new Set(competitorRootTermIds(bundle, cluster.id))
+    const rows: TstSelectionTermRow[] = []
+    for (const row of selectedWeekTermRows(cluster, selectedWeek)) {
+      const id = competitorTermKey(cluster.cluster, row.term)
+      if (!allIds.has(id)) {
+        continue
+      }
+
+      rows.push({
+        id,
+        rootId: cluster.id,
+        label: row.term,
+        checked: selectedTermIds.has(id),
+        current: {
+          ...row,
+          root: cluster.cluster,
+          termId: id,
+        },
       })
-      .sort((left, right) => compareByTstTermPriority(left.current, right.current))
+    }
+    rows.sort((left, right) => compareByTstTermPriority(left.current, right.current))
     rowsByRoot[cluster.id] = rows
   }
 
@@ -289,6 +327,22 @@ function firstCompetitor(bundle: WprWeekBundle): WprCompetitorSummary {
   }
 
   return competitor
+}
+
+function selectedWeekSqpTstCompare(
+  bundle: WprWeekBundle,
+  cluster: WprCluster,
+  selectedWeek: WeekLabel,
+): TstWeeklySelection {
+  const current = selectedWeekTstCompare(cluster.tstCompare.weekly, selectedWeek)
+  const selectedIds = new Set(competitorRootTermIds(bundle, cluster.id))
+  const filtered = filterTstCompareByTermIds(current, [cluster.cluster], selectedIds, selectedIds.size)
+  return {
+    ...filtered,
+    week_label: current.week_label,
+    week_number: current.week_number,
+    start_date: current.start_date,
+  }
 }
 
 function combineTstWindowCompare(
@@ -338,11 +392,12 @@ function filterTstCompareByTermIds(
   compare: TstCompareSelection | TstWeeklySelection,
   rootLabels: string[],
   selectedIds: Set<string>,
+  termsTotal: number,
 ): TstCompareSelection {
   const filtered = emptyTstSelectionBase()
   filtered.source = compare.source
   filtered.method = compare.method
-  filtered.coverage.terms_total = compare.coverage.terms_total
+  filtered.coverage.terms_total = termsTotal
   filtered.coverage.weeks_present = compare.coverage.weeks_present
 
   for (const row of compare.term_rows) {
@@ -453,7 +508,7 @@ function filterTstWeeklySeriesByTermIds(
   selectedIds: Set<string>,
 ): TstWeeklySelection[] {
   return weeklySeries.map((weekCompare) => {
-    const filtered = filterTstCompareByTermIds(weekCompare, rootLabels, selectedIds)
+    const filtered = filterTstCompareByTermIds(weekCompare, rootLabels, selectedIds, selectedIds.size)
     return {
       ...filtered,
       week_label: weekCompare.week_label,
@@ -488,6 +543,12 @@ export function createTstViewModel(input: {
   const rootIds = selectedCompetitorRootIdsList(bundle, selectedRootIds)
   const rootRows = buildRootRows(bundle, selectedTermIds, selectedWeek)
   const termRowsByRoot = buildTermRowsByRoot(bundle, selectedTermIds, selectedWeek)
+  const coverageRows = rootIds.length > 0
+    ? rootRows.filter((row) => rootIds.includes(row.id))
+    : rootRows
+  const coveredTermCount = coverageRows.reduce((sum, row) => sum + row.coveredTermCount, 0)
+  const sqpTermCount = coverageRows.reduce((sum, row) => sum + row.sqpTermCount, 0)
+  const coverageRate = safeDiv(coveredTermCount, sqpTermCount)
 
   if (rootIds.length === 0) {
     return {
@@ -499,6 +560,9 @@ export function createTstViewModel(input: {
       scopeType: 'empty',
       allTermIds: [],
       selectedTermIds: [],
+      coveredTermCount,
+      sqpTermCount,
+      coverageRate,
       rootRows,
       termRowsByRoot,
     }
@@ -506,13 +570,10 @@ export function createTstViewModel(input: {
 
   if (rootIds.length === 1) {
     const rootId = rootIds[0]
-    const cluster = bundle.clusters.find((item) => item.id === rootId)
-    if (cluster === undefined) {
-      throw new Error(`Missing TST root ${rootId}`)
-    }
+    const cluster = clusterById(bundle, rootId)
 
-    const allTermIds = competitorRootTermIds(bundle, rootId, selectedWeek)
-    const selectedIds = competitorSelectedTermsForRoot(bundle, rootId, selectedTermIds, selectedWeek)
+    const allTermIds = competitorRootTermIds(bundle, rootId)
+    const selectedIds = competitorSelectedTermsForRoot(bundle, rootId, selectedTermIds)
     if (selectedIds.length === 0) {
       return {
         rootIds,
@@ -523,16 +584,20 @@ export function createTstViewModel(input: {
         scopeType: 'no-terms',
         allTermIds,
         selectedTermIds: [],
+        coveredTermCount,
+        sqpTermCount,
+        coverageRate,
         rootRows,
         termRowsByRoot,
       }
     }
 
+    const weekly = filterTstWeeklySeriesByTermIds(
+      cluster.tstCompare.weekly.map(toWeeklySelection),
+      [cluster.cluster],
+      new Set(selectedIds),
+    )
     const fullSelection = selectedIds.length === allTermIds.length
-    let weekly = cluster.tstCompare.weekly.map(toWeeklySelection)
-    if (!fullSelection) {
-      weekly = filterTstWeeklySeriesByTermIds(weekly, [cluster.cluster], new Set(selectedIds))
-    }
 
     return {
       rootIds,
@@ -543,6 +608,9 @@ export function createTstViewModel(input: {
       scopeType: fullSelection ? 'root' : selectedIds.length === 1 ? 'term' : 'multi-term',
       allTermIds,
       selectedTermIds: selectedIds,
+      coveredTermCount,
+      sqpTermCount,
+      coverageRate,
       rootRows,
       termRowsByRoot,
     }
@@ -550,7 +618,7 @@ export function createTstViewModel(input: {
 
   const allTermIds: string[] = []
   for (const rootId of rootIds) {
-    allTermIds.push(...competitorRootTermIds(bundle, rootId, selectedWeek))
+    allTermIds.push(...competitorRootTermIds(bundle, rootId))
   }
 
   const selectedIds = allTermIds.filter((termId) => selectedTermIds.has(termId))
@@ -574,16 +642,20 @@ export function createTstViewModel(input: {
       scopeType: 'no-terms',
       allTermIds,
       selectedTermIds: [],
+      coveredTermCount,
+      sqpTermCount,
+      coverageRate,
       rootRows,
       termRowsByRoot,
     }
   }
 
+  const weekly = filterTstWeeklySeriesByTermIds(
+    combineTstWeeklySeries(bundle, rootIds),
+    rootLabels,
+    new Set(selectedIds),
+  )
   const fullSelection = selectedIds.length === allTermIds.length
-  let weekly = combineTstWeeklySeries(bundle, rootIds)
-  if (!fullSelection) {
-    weekly = filterTstWeeklySeriesByTermIds(weekly, rootLabels, new Set(selectedIds))
-  }
 
   return {
     rootIds,
@@ -594,6 +666,9 @@ export function createTstViewModel(input: {
     scopeType: fullSelection ? 'multi-root' : 'multi-root-term',
     allTermIds,
     selectedTermIds: selectedIds,
+    coveredTermCount,
+    sqpTermCount,
+    coverageRate,
     rootRows,
     termRowsByRoot,
   }
@@ -615,5 +690,5 @@ export function createTstWindowCompareSelection(input: {
     throw new Error('rootLabels are required when filtering TST terms')
   }
 
-  return filterTstCompareByTermIds(selection, input.rootLabels, input.selectedTermIds)
+  return filterTstCompareByTermIds(selection, input.rootLabels, input.selectedTermIds, input.selectedTermIds.size)
 }


### PR DESCRIPTION
## Summary
- Make TST coverage use SQP-backed terms as the denominator instead of only terms present in the selected TST export.
- Filter root and term TST metrics to the SQP-backed term set so coverage percentages and metric rows describe the same population.
- Tighten the TST selection table layout with fixed columns, compact labels, and overflow safety so headers and values line up in the WPR page.

## Verification
- `pnpm exec tsx --test apps/argus/lib/wpr/tst-view-model.test.ts`
- `pnpm --filter @targon/argus type-check`
- `pnpm --filter @targon/argus lint`
- Browser verified `http://localhost:41316/argus/wpr?tab=tst`: table showed `12 roots · 70 / 480 SQP terms covered · 14.6%`, aligned headers `Term SFR Wks Our Clk Comp Clk Clk Gap Our Purch Comp Purch Purch Gap Issue Prio Pool`, and no console errors.
