### PR TITLE
fix(talos): clean up SKU info reference edits

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { toast } from 'react-hot-toast'
 import { useSession } from '@/hooks/usePortalSession'
@@ -160,6 +160,40 @@ function UnitNumberInput({
         {unit}
       </span>
     </div>
+  )
+}
+
+function ReferenceRowLabel({ children, editable = false }: { children: ReactNode; editable?: boolean }) {
+  return (
+    <div className="flex items-center gap-2">
+      {editable ? (
+        <Edit2 className="h-3.5 w-3.5 shrink-0 text-slate-400 dark:text-slate-500" aria-hidden="true" />
+      ) : null}
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function EditableReferenceValue({
+  row,
+  ariaLabelPrefix,
+  children,
+  onEdit,
+}: {
+  row: ComputedRow
+  ariaLabelPrefix: string
+  children: ReactNode
+  onEdit: (row: ComputedRow) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onEdit(row)}
+      className="inline-flex max-w-full items-center justify-center rounded-md px-2 py-1 text-center text-xs leading-tight text-slate-700 transition-colors hover:bg-slate-100 hover:text-cyan-700 focus:outline-none focus:ring-2 focus:ring-cyan-500 dark:text-slate-300 dark:hover:bg-slate-700 dark:hover:text-cyan-300"
+      aria-label={`${ariaLabelPrefix} ${row.sku.skuCode}`}
+    >
+      {children}
+    </button>
   )
 }
 
@@ -506,26 +540,6 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">
-                      Reference Input
-                    </td>
-                    {pageRows.map(row => (
-                      <td key={row.sku.id} className="px-4 py-2 text-center">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          onClick={() => openReferenceEditor(row)}
-                          className="h-7 px-2 text-xs"
-                          aria-label={`Edit reference data for ${row.sku.skuCode}`}
-                        >
-                          <Edit2 className="mr-1 h-3.5 w-3.5" />
-                          Edit
-                        </Button>
-                      </td>
-                    ))}
-                  </tr>
-                  <tr className="bg-white dark:bg-slate-800">
-                    <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">
                       ASIN
                     </td>
                     {pageRows.map(row => (
@@ -539,34 +553,46 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">
-                      Package Sides
+                      <ReferenceRowLabel editable>Package Sides</ReferenceRowLabel>
                     </td>
                     {pageRows.map(row => (
                       <td
                         key={row.sku.id}
                         className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs"
                       >
-                        {formatDimensionTripletDisplayFromCm(
-                          row.comparison.reference.triplet,
-                          unitSystem
-                        )}
+                        <EditableReferenceValue
+                          row={row}
+                          ariaLabelPrefix="Edit package sides for"
+                          onEdit={openReferenceEditor}
+                        >
+                          {formatDimensionTripletDisplayFromCm(
+                            row.comparison.reference.triplet,
+                            unitSystem
+                          )}
+                        </EditableReferenceValue>
                       </td>
                     ))}
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">
-                      Package Weight
+                      <ReferenceRowLabel editable>Package Weight</ReferenceRowLabel>
                     </td>
                     {pageRows.map(row => (
                       <td
                         key={row.sku.id}
                         className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs"
                       >
-                        {formatWeightDisplayFromKg(
-                          row.comparison.reference.shipping.unitWeightKg,
-                          unitSystem,
-                          2
-                        )}
+                        <EditableReferenceValue
+                          row={row}
+                          ariaLabelPrefix="Edit package weight for"
+                          onEdit={openReferenceEditor}
+                        >
+                          {formatWeightDisplayFromKg(
+                            row.comparison.reference.shipping.unitWeightKg,
+                            unitSystem,
+                            2
+                          )}
+                        </EditableReferenceValue>
                       </td>
                     ))}
                   </tr>
@@ -606,14 +632,20 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                   </tr>
                   <tr className="bg-white dark:bg-slate-800">
                     <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">
-                      Size Tier
+                      <ReferenceRowLabel editable>Size Tier</ReferenceRowLabel>
                     </td>
                     {pageRows.map(row => (
                       <td
                         key={row.sku.id}
                         className="px-4 py-2 text-center text-slate-700 dark:text-slate-300 text-xs"
                       >
-                        {row.comparison.reference.sizeTier ?? '—'}
+                        <EditableReferenceValue
+                          row={row}
+                          ariaLabelPrefix="Edit size tier for"
+                          onEdit={openReferenceEditor}
+                        >
+                          {row.comparison.reference.sizeTier ?? '—'}
+                        </EditableReferenceValue>
                       </td>
                     ))}
                   </tr>

--- a/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
@@ -165,6 +165,30 @@ test('computeComparison treats missing Amazon fee as match when assigned size ti
   assert.equal(comparison.hasSizeTierMismatch, false)
 })
 
+test('UK shipping weight uses package weight when it exceeds dimensional weight', () => {
+  const shipping = discrepancies.computeShippingWeights(
+    { side1Cm: 5, side2Cm: 10, side3Cm: 10 },
+    0.5,
+    null,
+    'UK'
+  )
+
+  assert.equal(shipping.dimensionalWeightKg, 0.1)
+  assert.equal(shipping.shippingWeightKg, 0.5)
+})
+
+test('UK shipping weight uses dimensional weight when it exceeds package weight', () => {
+  const shipping = discrepancies.computeShippingWeights(
+    { side1Cm: 10, side2Cm: 20, side3Cm: 30 },
+    0.5,
+    null,
+    'UK'
+  )
+
+  assert.equal(shipping.dimensionalWeightKg, 1.2)
+  assert.equal(shipping.shippingWeightKg, 1.2)
+})
+
 test('buildComparisonSkuRow does not expose stored reference FBA fulfillment fee', () => {
   assert.equal(typeof discrepancies.buildComparisonSkuRow, 'function')
   if (typeof discrepancies.buildComparisonSkuRow !== 'function') return
@@ -300,6 +324,22 @@ test('SKU Info measurement display truncates down to two decimals instead of rou
     '2.59×21×26.89 cm'
   )
   assert.equal(formatWeightDisplayFromKg(0.30999, 'metric', 2), '0.3 kg')
+})
+
+test('SKU Info reference table uses inline edit controls for editable reference values only', () => {
+  const talosRoot = path.resolve(__dirname, '..', '..')
+  const pageSource = readFileSync(
+    path.join(talosRoot, 'src/app/amazon/fba-fee-discrepancies/page.tsx'),
+    'utf8'
+  )
+
+  assert.equal(pageSource.includes('Reference Input'), false)
+  assert.equal(pageSource.includes('Edit reference data for'), false)
+  assert.equal(pageSource.includes('Edit package sides for'), true)
+  assert.equal(pageSource.includes('Edit package weight for'), true)
+  assert.equal(pageSource.includes('Edit size tier for'), true)
+  assert.equal(pageSource.includes('Edit dimensional weight for'), false)
+  assert.equal(pageSource.includes('Edit shipping weight for'), false)
 })
 
 test('SKU Info API does not calculate Amazon size tier from catalog dimensions', () => {


### PR DESCRIPTION
## Summary
- promotes the SKU Info reference edit cleanup from dev to main
- removes the separate Reference Input row
- keeps package sides, package weight, and size tier editable through the existing reference modal
- leaves dimensional and shipping weights calculated-only

## Checks
- PR #5305 build-test-github-hosted passed
- PR #5305 build-test passed
- local pnpm --dir apps/talos test passed
- local pnpm --dir apps/talos type-check passed
- local pnpm --dir apps/talos lint passed with existing warnings only
- browser verified /talos/amazon/fba-fee-discrepancies on localhost:41101