### PR TITLE
fix(platform): harden auth and env setup

### DIFF
--- a/apps/argus/scripts/api/install.sh
+++ b/apps/argus/scripts/api/install.sh
@@ -77,6 +77,13 @@ TRACKING_FETCH_PLIST="$LAUNCH_AGENTS_DIR/$TRACKING_FETCH_LABEL.plist"
 HOURLY_LISTINGS_API_PLIST="$LAUNCH_AGENTS_DIR/$HOURLY_LISTINGS_API_LABEL.plist"
 DAILY_ACCOUNT_HEALTH_PLIST="$LAUNCH_AGENTS_DIR/$DAILY_ACCOUNT_HEALTH_LABEL.plist"
 WEEKLY_API_PLIST="$LAUNCH_AGENTS_DIR/$WEEKLY_API_LABEL.plist"
+if [ "$MARKET" = "us" ]; then
+  ARGUS_SALES_ROOT_ENV_KEY="ARGUS_SALES_ROOT_US"
+  ARGUS_SALES_ROOT="/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales"
+else
+  ARGUS_SALES_ROOT_ENV_KEY="ARGUS_SALES_ROOT_UK"
+  ARGUS_SALES_ROOT="/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - UK/Sales"
+fi
 
 if [ "$MARKET" = "us" ]; then
   ARGUS_SALES_ROOT_ENV_KEY="ARGUS_SALES_ROOT_US"

--- a/apps/argus/scripts/browser/install.sh
+++ b/apps/argus/scripts/browser/install.sh
@@ -71,6 +71,13 @@ WEEKLY_PLIST="$LAUNCH_AGENTS_DIR/$WEEKLY_LABEL.plist"
 DAILY_VISUALS_PLIST="$LAUNCH_AGENTS_DIR/$DAILY_VISUALS_LABEL.plist"
 LEGACY_DAILY_AH_PLIST="$LAUNCH_AGENTS_DIR/com.targon.daily-account-health.plist"
 BROWSER_DAILY_AH_SCRIPT="$SCRIPT_DIR/daily-account-health/collect.sh"
+if [ "$MARKET" = "us" ]; then
+  ARGUS_SALES_ROOT_ENV_KEY="ARGUS_SALES_ROOT_US"
+  ARGUS_SALES_ROOT="/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - US/Sales"
+else
+  ARGUS_SALES_ROOT_ENV_KEY="ARGUS_SALES_ROOT_UK"
+  ARGUS_SALES_ROOT="/Users/jarraramjad/Library/CloudStorage/GoogleDrive-jarrar@targonglobal.com/Shared drives/Dust Sheets - UK/Sales"
+fi
 
 bootout_if_loaded() {
   local label="$1"
@@ -123,6 +130,15 @@ cat > "$WEEKLY_PLIST" <<PLIST
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ARGUS_MARKET</key>
+    <string>${MARKET}</string>
+    <key>${ARGUS_SALES_ROOT_ENV_KEY}</key>
+    <string>${ARGUS_SALES_ROOT}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
   <key>Label</key>
   <string>${WEEKLY_LABEL}</string>
   <key>ProgramArguments</key>
@@ -157,6 +173,15 @@ cat > "$DAILY_VISUALS_PLIST" <<PLIST
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ARGUS_MARKET</key>
+    <string>${MARKET}</string>
+    <key>${ARGUS_SALES_ROOT_ENV_KEY}</key>
+    <string>${ARGUS_SALES_ROOT}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+  </dict>
   <key>Label</key>
   <string>${DAILY_VISUALS_LABEL}</string>
   <key>ProgramArguments</key>

--- a/scripts/setup-codex-env.mjs
+++ b/scripts/setup-codex-env.mjs
@@ -17,6 +17,7 @@ const GENERATED_DIR = path.join(ROOT_DIR, '.codex', 'generated')
 const PORTS_ENV_PATH = path.join(GENERATED_DIR, 'ports.env')
 const WORKTREE_APPS_PATH = path.join(GENERATED_DIR, 'dev.worktree.apps.json')
 const ENV_ASSIGNMENT = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/
+const WORKTREE_PRISMA_CONNECTION_LIMIT = '1'
 
 const APP_BASE_PATHS = {
   talos: '/talos',
@@ -90,12 +91,14 @@ function requireEnvValue(values, key, label) {
 function stripSchema(databaseUrl) {
   const url = new URL(databaseUrl)
   url.searchParams.delete('schema')
+  url.searchParams.set('connection_limit', WORKTREE_PRISMA_CONNECTION_LIMIT)
   return url.toString()
 }
 
 function withSchema(databaseUrl, schema) {
   const url = new URL(databaseUrl)
   url.searchParams.set('schema', schema)
+  url.searchParams.set('connection_limit', WORKTREE_PRISMA_CONNECTION_LIMIT)
   return url.toString()
 }
 


### PR DESCRIPTION
## Summary
- add launchd environment blocks for Argus API and browser collectors so US/UK Sales roots are explicit
- redirect already-authenticated SSO login requests through the registered callback target
- allow tenant-scoped Amazon SP-API app credentials in shared env validation
- cap generated Codex worktree Prisma URLs with connection_limit=1

## Verification
- /bin/bash -n apps/argus/scripts/api/install.sh
- /bin/bash -n apps/argus/scripts/browser/install.sh
- temp-HOME launchd install for US/UK browser and API plists, verified ARGUS_SALES_ROOT_US/UK values with PlistBuddy
- node --test scripts/lib/shared-env.test.cjs
- pnpm --filter @targon/sso run type-check
- pnpm --filter @targon/sso run test:auth-contracts
- git diff --check

## Note
- pnpm codex:env is blocked in this checkout because .codex/generated/ports.env is missing before the changed URL logic runs.