### PR TITLE
fix(plutus): guard QBO settlement posting

### DIFF
--- a/apps/plutus/app/api/plutus/settlements/spapi/uk/sync/route.ts
+++ b/apps/plutus/app/api/plutus/settlements/spapi/uk/sync/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createLogger } from '@targon/logger';
 
 import { QboAuthError } from '@/lib/qbo/api';
+import { ExplicitPostToQboError, requireExplicitPostToQbo } from '@/lib/amazon-finances/settlement-sync-post-mode';
 import { syncUkSettlementsFromSpApiFinances } from '@/lib/amazon-finances/uk-settlement-sync';
 
 export const runtime = 'nodejs';
@@ -15,7 +16,7 @@ export async function POST(req: Request) {
     const startDate = typeof body.startDate === 'string' ? body.startDate : '';
     const endDate = typeof body.endDate === 'string' ? body.endDate : undefined;
     const settlementIds = Array.isArray(body.settlementIds) ? (body.settlementIds as unknown[]).map((v) => String(v)) : undefined;
-    const postToQbo = body.postToQbo === undefined ? true : body.postToQbo === true;
+    const postToQbo = requireExplicitPostToQbo(body, 'UK SP-API settlement sync');
     const process = body.process === true;
 
     const result = await syncUkSettlementsFromSpApiFinances({
@@ -30,6 +31,9 @@ export async function POST(req: Request) {
   } catch (error) {
     if (error instanceof QboAuthError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    if (error instanceof ExplicitPostToQboError) {
+      return NextResponse.json({ error: 'Invalid settlement sync posting mode', details: error.message }, { status: 400 });
     }
 
     logger.error('UK SP-API settlement sync failed', { error });

--- a/apps/plutus/app/api/plutus/settlements/spapi/us/sync/route.ts
+++ b/apps/plutus/app/api/plutus/settlements/spapi/us/sync/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createLogger } from '@targon/logger';
 
 import { QboAuthError } from '@/lib/qbo/api';
+import { ExplicitPostToQboError, requireExplicitPostToQbo } from '@/lib/amazon-finances/settlement-sync-post-mode';
 import { syncUsSettlementsFromSpApiFinances } from '@/lib/amazon-finances/us-settlement-sync';
 
 export const runtime = 'nodejs';
@@ -15,7 +16,7 @@ export async function POST(req: Request) {
     const startDate = typeof body.startDate === 'string' ? body.startDate : '';
     const endDate = typeof body.endDate === 'string' ? body.endDate : undefined;
     const settlementIds = Array.isArray(body.settlementIds) ? (body.settlementIds as unknown[]).map((v) => String(v)) : undefined;
-    const postToQbo = body.postToQbo === undefined ? true : body.postToQbo === true;
+    const postToQbo = requireExplicitPostToQbo(body, 'US SP-API settlement sync');
     const process = body.process === true;
 
     const result = await syncUsSettlementsFromSpApiFinances({
@@ -31,6 +32,9 @@ export async function POST(req: Request) {
     if (error instanceof QboAuthError) {
       return NextResponse.json({ error: error.message }, { status: 401 });
     }
+    if (error instanceof ExplicitPostToQboError) {
+      return NextResponse.json({ error: 'Invalid settlement sync posting mode', details: error.message }, { status: 400 });
+    }
 
     logger.error('US SP-API settlement sync failed', { error });
     return NextResponse.json(
@@ -42,4 +46,3 @@ export async function POST(req: Request) {
     );
   }
 }
-

--- a/apps/plutus/app/settlements/page.tsx
+++ b/apps/plutus/app/settlements/page.tsx
@@ -479,7 +479,7 @@ export default function SettlementsPage() {
   const [syncRegion, setSyncRegion] = useState<Region>('US');
   const [syncEndDate, setSyncEndDate] = useState<string>('');
   const [syncSettlementIds, setSyncSettlementIds] = useState<string>('');
-  const [syncPostToQbo, setSyncPostToQbo] = useState(true);
+  const [syncPostToQbo, setSyncPostToQbo] = useState(false);
   const [syncProcess, setSyncProcess] = useState(false);
   const [syncResult, setSyncResult] = useState<SpApiSettlementSyncResult | null>(null);
 
@@ -531,7 +531,7 @@ export default function SettlementsPage() {
       setSyncEndDate('');
     }
 
-    setSyncPostToQbo(true);
+    setSyncPostToQbo(false);
     setSyncProcess(false);
     setSyncOpen(true);
   };

--- a/apps/plutus/lib/amazon-finances/settlement-sync-post-mode.ts
+++ b/apps/plutus/lib/amazon-finances/settlement-sync-post-mode.ts
@@ -1,0 +1,68 @@
+export const PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE = 'PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE';
+
+export class ExplicitPostToQboError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ExplicitPostToQboError';
+  }
+}
+
+export type SettlementSyncQboPostMode = 'read_only' | 'post_qbo';
+
+export function parseSettlementSyncWorkerPostMode(
+  rawMode: string | undefined,
+): { mode: SettlementSyncQboPostMode; postToQbo: boolean } {
+  const mode = rawMode === undefined ? '' : rawMode.trim();
+
+  if (mode === 'read_only') {
+    return { mode, postToQbo: false };
+  }
+
+  if (mode === 'post_qbo') {
+    return { mode, postToQbo: true };
+  }
+
+  throw new ExplicitPostToQboError(
+    `${PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE} must be set explicitly to "read_only" or "post_qbo".`,
+  );
+}
+
+export function parseSettlementSyncCliPostFlag(
+  argv: string[],
+  commandName: string,
+): { postToQbo: boolean; argv: string[] } {
+  let postToQbo: boolean | undefined;
+  const remainingArgs: string[] = [];
+
+  for (const arg of argv) {
+    if (arg !== '--post-qbo' && arg !== '--no-post') {
+      remainingArgs.push(arg);
+      continue;
+    }
+
+    if (postToQbo !== undefined) {
+      throw new ExplicitPostToQboError(`Only one QBO posting flag is allowed for ${commandName}.`);
+    }
+
+    postToQbo = arg === '--post-qbo';
+  }
+
+  if (postToQbo === undefined) {
+    throw new ExplicitPostToQboError(`${commandName} requires explicit --post-qbo or --no-post.`);
+  }
+
+  return { postToQbo, argv: remainingArgs };
+}
+
+export function requireExplicitPostToQbo(body: unknown, source: string): boolean {
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    throw new ExplicitPostToQboError(`${source} requires a JSON object with explicit postToQbo.`);
+  }
+
+  const value = (body as Record<string, unknown>).postToQbo;
+  if (value === true || value === false) {
+    return value;
+  }
+
+  throw new ExplicitPostToQboError(`${source} requires explicit boolean postToQbo.`);
+}

--- a/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
@@ -1008,28 +1008,14 @@ export function buildQboJournalEntriesFromUkSettlementDraft(input: {
       const abs = Math.abs(cents);
       const amount = abs / 100;
 
-      // Amazon uses FundTransferStatus to describe payout success for positive settlements.
-      // Negative settlements are charged to the payment method and typically show FundTransferStatus=Unknown,
-      // but still need a "Payment to Amazon" line so the charge can be matched in QBO.
-      const transferSucceeded = input.draft.fundTransferStatus === 'Succeeded';
-
       if (cents > 0) {
-        if (transferSucceeded) {
-          lines.push({
-            accountId: input.bankAccountId,
-            postingType: 'Debit',
-            amount,
-            description: 'Transfer to Bank',
-          });
-        } else {
-          const description = `Settlement Control (FundTransferStatus=${input.draft.fundTransferStatus})`;
-          lines.push({
-            accountId: input.settlementControlAccountId,
-            postingType: 'Debit',
-            amount,
-            description,
-          });
-        }
+        const description = `Settlement Control (FundTransferStatus=${input.draft.fundTransferStatus})`;
+        lines.push({
+          accountId: input.settlementControlAccountId,
+          postingType: 'Debit',
+          amount,
+          description,
+        });
       } else {
         lines.push({
           accountId: input.paymentAccountId,

--- a/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
@@ -548,7 +548,6 @@ export async function syncUkSettlementsFromSpApiFinances(input: UkSpApiSettlemen
       skuToBrandName,
     });
 
-    if (draft.originalTotalCents > 0 && draft.fundTransferStatus === 'Succeeded') needBankAccount = true;
     if (draft.originalTotalCents < 0) needPaymentAccount = true;
 
     for (const segment of draft.segments) {

--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -800,28 +800,14 @@ export function buildQboJournalEntriesFromUsSettlementDraft(input: {
       const abs = Math.abs(cents);
       const amount = abs / 100;
 
-      // Amazon uses FundTransferStatus to describe payout success for positive settlements.
-      // Negative settlements are charged to the payment method and typically show FundTransferStatus=Unknown,
-      // but still need a "Payment to Amazon" line so the charge can be matched in QBO.
-      const transferSucceeded = input.draft.fundTransferStatus === 'Succeeded';
-
       if (cents > 0) {
-        if (transferSucceeded) {
-          lines.push({
-            accountId: input.bankAccountId,
-            postingType: 'Debit',
-            amount,
-            description: 'Transfer to Bank',
-          });
-        } else {
-          const description = `Settlement Control (FundTransferStatus=${input.draft.fundTransferStatus})`;
-          lines.push({
-            accountId: input.settlementControlAccountId,
-            postingType: 'Debit',
-            amount,
-            description,
-          });
-        }
+        const description = `Settlement Control (FundTransferStatus=${input.draft.fundTransferStatus})`;
+        lines.push({
+          accountId: input.settlementControlAccountId,
+          postingType: 'Debit',
+          amount,
+          description,
+        });
       } else {
         lines.push({
           accountId: input.paymentAccountId,

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -522,7 +522,6 @@ export async function syncUsSettlementsFromSpApiFinances(input: UsSpApiSettlemen
       skuToBrandName,
     });
 
-    if (draft.originalTotalCents > 0 && draft.fundTransferStatus === 'Succeeded') needBankAccount = true;
     if (draft.originalTotalCents < 0) needPaymentAccount = true;
 
     for (const segment of draft.segments) {

--- a/apps/plutus/scripts/settlement-sync-worker.ts
+++ b/apps/plutus/scripts/settlement-sync-worker.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
 import { buildSyntheticUkSettlementId } from '@/lib/amazon-finances/uk-settlement-id';
+import { parseSettlementSyncWorkerPostMode } from '@/lib/amazon-finances/settlement-sync-post-mode';
 import {
   isSettlementDocNumber,
   normalizeSettlementDocNumber,
@@ -384,7 +385,7 @@ async function maybeRunAutopost() {
   return deps.runAutopostCheck();
 }
 
-async function runTick(input: { lookbackDays: number }): Promise<void> {
+async function runTick(input: { lookbackDays: number; postToQbo: boolean }): Promise<void> {
   const deps = await getWorkerDeps();
   const now = new Date();
   const startDate = buildLookbackStartDate({ now, lookbackDays: input.lookbackDays });
@@ -401,7 +402,7 @@ async function runTick(input: { lookbackDays: number }): Promise<void> {
       const result = await deps.syncUsSettlementsFromSpApiFinances({
         startDate,
         settlementIds: missingUsSettlementIds,
-        postToQbo: true,
+        postToQbo: input.postToQbo,
         process: false,
       });
 
@@ -429,7 +430,7 @@ async function runTick(input: { lookbackDays: number }): Promise<void> {
       const result = await deps.syncUkSettlementsFromSpApiFinances({
         startDate,
         settlementIds: missingUkSettlementIds,
-        postToQbo: true,
+        postToQbo: input.postToQbo,
         process: false,
       });
 
@@ -489,20 +490,23 @@ async function main(): Promise<void> {
     }
   }
 
+  const qboPostMode = parseSettlementSyncWorkerPostMode(process.env.PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE);
+
   log('info', 'Worker started', {
     intervalMinutes,
     lookbackDays,
+    qboPostMode: qboPostMode.mode,
     runOnce,
   });
 
   if (runOnce) {
-    await runTick({ lookbackDays });
+    await runTick({ lookbackDays, postToQbo: qboPostMode.postToQbo });
     return;
   }
 
   while (true) {
     try {
-      await runTick({ lookbackDays });
+      await runTick({ lookbackDays, postToQbo: qboPostMode.postToQbo });
     } catch (error) {
       log('error', 'Settlement sync tick failed', {
         error: error instanceof Error ? error.message : String(error),

--- a/apps/plutus/scripts/uk-settlement-reset-spapi.ts
+++ b/apps/plutus/scripts/uk-settlement-reset-spapi.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 
+import { parseSettlementSyncCliPostFlag } from '@/lib/amazon-finances/settlement-sync-post-mode';
 import { isSettlementDocNumber, parseSettlementDocNumber, stripPlutusDocPrefix } from '@/lib/plutus/settlement-doc-number';
 import { loadSharedPlutusEnv } from './shared-env';
 
@@ -10,6 +11,7 @@ type CliOptions = {
   plutusEnvPath: string;
   apply: boolean;
   resync: boolean;
+  postToQbo: boolean;
 };
 
 function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
@@ -73,6 +75,10 @@ function requireIsoDay(value: unknown, label: string): string {
 }
 
 function parseArgs(argv: string[]): CliOptions {
+  const willResync = !argv.includes('--no-resync');
+  const postFlag = willResync
+    ? parseSettlementSyncCliPostFlag(argv, 'UK SP-API settlement reset resync')
+    : { postToQbo: false, argv };
   let startDate = '2025-12-01';
   let endDate: string | undefined;
   let amazonEnvPath: string | null = null;
@@ -81,11 +87,11 @@ function parseArgs(argv: string[]): CliOptions {
   let resync = true;
 
   let i = 0;
-  while (i < argv.length) {
-    const arg = argv[i]!;
+  while (i < postFlag.argv.length) {
+    const arg = postFlag.argv[i]!;
 
     if (arg === '--start-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --start-date');
       startDate = next;
       i += 2;
@@ -93,7 +99,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--end-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --end-date');
       endDate = next;
       i += 2;
@@ -101,7 +107,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--amazon-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --amazon-env');
       amazonEnvPath = next;
       i += 2;
@@ -109,7 +115,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--plutus-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --plutus-env');
       plutusEnvPath = next;
       i += 2;
@@ -131,7 +137,7 @@ function parseArgs(argv: string[]): CliOptions {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  return { startDate, endDate, amazonEnvPath, plutusEnvPath, apply, resync };
+  return { startDate, endDate, amazonEnvPath, plutusEnvPath, apply, resync, postToQbo: postFlag.postToQbo };
 }
 
 function buildQboJournalHref(journalEntryId: string): string {
@@ -529,7 +535,7 @@ async function main(): Promise<void> {
     resyncResult = await syncUkSettlementsFromSpApiFinances({
       startDate,
       endDate,
-      postToQbo: true,
+      postToQbo: options.postToQbo,
       process: true,
     });
   }
@@ -538,7 +544,7 @@ async function main(): Promise<void> {
     JSON.stringify(
       {
         dryRun: false,
-        options: { startDate, endDate, resync: options.resync },
+        options: { startDate, endDate, resync: options.resync, postToQbo: options.postToQbo },
         totals: {
           deletedQboJournalEntries: deletedCount,
           skippedQboJournalEntries: skippedCount,

--- a/apps/plutus/scripts/uk-settlement-sync-spapi.ts
+++ b/apps/plutus/scripts/uk-settlement-sync-spapi.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { loadSharedPlutusEnv } from './shared-env';
+import { parseSettlementSyncCliPostFlag } from '@/lib/amazon-finances/settlement-sync-post-mode';
 
 type CliOptions = {
   startDate: string;
@@ -61,20 +62,21 @@ async function loadPlutusEnvFile(filePath: string): Promise<void> {
 }
 
 function parseArgs(argv: string[]): CliOptions {
+  const postFlag = parseSettlementSyncCliPostFlag(argv, 'UK SP-API settlement sync');
   let startDate = '2025-12-01';
   let endDate: string | undefined;
   let settlementIds: string[] | undefined;
   let amazonEnvPath: string | null = null;
   let plutusEnvPath = '.env.local';
-  let postToQbo = true;
+  const postToQbo = postFlag.postToQbo;
   let process = false;
 
   let i = 0;
-  while (i < argv.length) {
-    const arg = argv[i]!;
+  while (i < postFlag.argv.length) {
+    const arg = postFlag.argv[i]!;
 
     if (arg === '--start-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --start-date');
       startDate = next;
       i += 2;
@@ -82,7 +84,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--end-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --end-date');
       endDate = next;
       i += 2;
@@ -90,7 +92,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--settlement-ids') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --settlement-ids');
       settlementIds = next
         .split(',')
@@ -101,7 +103,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--amazon-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --amazon-env');
       amazonEnvPath = next;
       i += 2;
@@ -109,16 +111,10 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--plutus-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --plutus-env');
       plutusEnvPath = next;
       i += 2;
-      continue;
-    }
-
-    if (arg === '--no-post') {
-      postToQbo = false;
-      i += 1;
       continue;
     }
 

--- a/apps/plutus/scripts/us-settlement-reset-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reset-spapi.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { loadSharedPlutusEnv } from './shared-env';
 
+import { parseSettlementSyncCliPostFlag } from '@/lib/amazon-finances/settlement-sync-post-mode';
 import { isSettlementDocNumber, parseSettlementDocNumber, stripPlutusDocPrefix } from '@/lib/plutus/settlement-doc-number';
 
 type CliOptions = {
@@ -10,6 +11,7 @@ type CliOptions = {
   plutusEnvPath: string;
   apply: boolean;
   resync: boolean;
+  postToQbo: boolean;
 };
 
 function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
@@ -73,6 +75,10 @@ function requireIsoDay(value: unknown, label: string): string {
 }
 
 function parseArgs(argv: string[]): CliOptions {
+  const willResync = !argv.includes('--no-resync');
+  const postFlag = willResync
+    ? parseSettlementSyncCliPostFlag(argv, 'US SP-API settlement reset resync')
+    : { postToQbo: false, argv };
   let startDate = '2025-12-01';
   let endDate: string | undefined;
   let amazonEnvPath: string | null = null;
@@ -81,11 +87,11 @@ function parseArgs(argv: string[]): CliOptions {
   let resync = true;
 
   let i = 0;
-  while (i < argv.length) {
-    const arg = argv[i]!;
+  while (i < postFlag.argv.length) {
+    const arg = postFlag.argv[i]!;
 
     if (arg === '--start-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --start-date');
       startDate = next;
       i += 2;
@@ -93,7 +99,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--end-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --end-date');
       endDate = next;
       i += 2;
@@ -101,7 +107,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--amazon-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --amazon-env');
       amazonEnvPath = next;
       i += 2;
@@ -109,7 +115,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--plutus-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --plutus-env');
       plutusEnvPath = next;
       i += 2;
@@ -131,7 +137,7 @@ function parseArgs(argv: string[]): CliOptions {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  return { startDate, endDate, amazonEnvPath, plutusEnvPath, apply, resync };
+  return { startDate, endDate, amazonEnvPath, plutusEnvPath, apply, resync, postToQbo: postFlag.postToQbo };
 }
 
 function buildQboJournalHref(journalEntryId: string): string {
@@ -542,7 +548,7 @@ async function main(): Promise<void> {
     resyncResult = await syncUsSettlementsFromSpApiFinances({
       startDate,
       endDate,
-      postToQbo: true,
+      postToQbo: options.postToQbo,
       process: true,
     });
   }
@@ -551,7 +557,7 @@ async function main(): Promise<void> {
     JSON.stringify(
       {
         dryRun: false,
-        options: { startDate, endDate, resync: options.resync },
+        options: { startDate, endDate, resync: options.resync, postToQbo: options.postToQbo },
         totals: {
           deletedQboJournalEntries: deletedCount,
           skippedQboJournalEntries: skippedCount,

--- a/apps/plutus/scripts/us-settlement-sync-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-sync-spapi.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { loadSharedPlutusEnv } from './shared-env';
+import { parseSettlementSyncCliPostFlag } from '@/lib/amazon-finances/settlement-sync-post-mode';
 
 type CliOptions = {
   startDate: string;
@@ -61,20 +62,21 @@ async function loadPlutusEnvFile(filePath: string): Promise<void> {
 }
 
 function parseArgs(argv: string[]): CliOptions {
+  const postFlag = parseSettlementSyncCliPostFlag(argv, 'US SP-API settlement sync');
   let startDate = '2025-12-01';
   let endDate: string | undefined;
   let settlementIds: string[] | undefined;
   let amazonEnvPath: string | null = null;
   let plutusEnvPath = '.env.local';
-  let postToQbo = true;
+  const postToQbo = postFlag.postToQbo;
   let process = false;
 
   let i = 0;
-  while (i < argv.length) {
-    const arg = argv[i]!;
+  while (i < postFlag.argv.length) {
+    const arg = postFlag.argv[i]!;
 
     if (arg === '--start-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --start-date');
       startDate = next;
       i += 2;
@@ -82,7 +84,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--end-date') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --end-date');
       endDate = next;
       i += 2;
@@ -90,7 +92,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--settlement-ids') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --settlement-ids');
       settlementIds = next
         .split(',')
@@ -101,7 +103,7 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--amazon-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --amazon-env');
       amazonEnvPath = next;
       i += 2;
@@ -109,16 +111,10 @@ function parseArgs(argv: string[]): CliOptions {
     }
 
     if (arg === '--plutus-env') {
-      const next = argv[i + 1];
+      const next = postFlag.argv[i + 1];
       if (!next) throw new Error('Missing value for --plutus-env');
       plutusEnvPath = next;
       i += 2;
-      continue;
-    }
-
-    if (arg === '--no-post') {
-      postToQbo = false;
-      i += 1;
       continue;
     }
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -48,8 +48,20 @@ import {
 } from '../lib/plutus/shipment-fee-allocation';
 import { parseAmazonTransactionCsv } from '../lib/reconciliation/amazon-csv';
 import { parseAmazonUnifiedTransactionCsv } from '../lib/amazon-payments/unified-transaction-csv';
-import { buildUsSettlementDraftFromSpApiFinances } from '../lib/amazon-finances/us-settlement-builder';
-import { buildUkSettlementDraftFromSpApiFinances } from '../lib/amazon-finances/uk-settlement-builder';
+import {
+  buildQboJournalEntriesFromUsSettlementDraft,
+  buildUsSettlementDraftFromSpApiFinances,
+} from '../lib/amazon-finances/us-settlement-builder';
+import {
+  buildQboJournalEntriesFromUkSettlementDraft,
+  buildUkSettlementDraftFromSpApiFinances,
+} from '../lib/amazon-finances/uk-settlement-builder';
+import {
+  parseSettlementSyncCliPostFlag,
+  parseSettlementSyncWorkerPostMode,
+} from '../lib/amazon-finances/settlement-sync-post-mode';
+import { POST as postUsSpApiSettlementSync } from '../app/api/plutus/settlements/spapi/us/sync/route';
+import { POST as postUkSpApiSettlementSync } from '../app/api/plutus/settlements/spapi/uk/sync/route';
 import {
   buildSyntheticUkSettlementId,
   extractEventGroupIdFromSyntheticUkSettlementId,
@@ -3902,6 +3914,136 @@ test('fetchAuditSourceData queries purchases bills journal entries transfers and
     qboFullHistoryAuditDeps.fetch = originalFetch;
     qboFullHistoryAuditDeps.sleep = originalSleep;
   }
+});
+
+test('settlement sync worker post mode fails closed', () => {
+  assert.throws(() => parseSettlementSyncWorkerPostMode(undefined), /PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE/);
+  assert.throws(() => parseSettlementSyncWorkerPostMode(''), /PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE/);
+  assert.throws(() => parseSettlementSyncWorkerPostMode('true'), /PLUTUS_SETTLEMENT_SYNC_QBO_POST_MODE/);
+  assert.equal(parseSettlementSyncWorkerPostMode('read_only').postToQbo, false);
+  assert.equal(parseSettlementSyncWorkerPostMode('post_qbo').postToQbo, true);
+});
+
+test('settlement sync CLI post flag is explicit', () => {
+  assert.throws(() => parseSettlementSyncCliPostFlag([], 'US SP-API settlement sync'), /--post-qbo or --no-post/);
+  assert.throws(
+    () => parseSettlementSyncCliPostFlag(['--post-qbo', '--no-post'], 'US SP-API settlement sync'),
+    /Only one QBO posting flag/,
+  );
+  assert.deepEqual(parseSettlementSyncCliPostFlag(['--post-qbo', '--start-date', '2026-05-01'], 'US SP-API settlement sync'), {
+    postToQbo: true,
+    argv: ['--start-date', '2026-05-01'],
+  });
+  assert.deepEqual(parseSettlementSyncCliPostFlag(['--no-post', '--start-date', '2026-05-01'], 'US SP-API settlement sync'), {
+    postToQbo: false,
+    argv: ['--start-date', '2026-05-01'],
+  });
+});
+
+test('SP-API settlement sync routes require explicit postToQbo', async () => {
+  const request = new Request('https://plutus.test/api/plutus/settlements/spapi/us/sync', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ startDate: '2026-05-01' }),
+  });
+  const response = await postUsSpApiSettlementSync(request);
+  const payload = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.match(String(payload.details ?? payload.error), /postToQbo/);
+
+  const ukRequest = new Request('https://plutus.test/api/plutus/settlements/spapi/uk/sync', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ startDate: '2026-05-01' }),
+  });
+  const ukResponse = await postUkSpApiSettlementSync(ukRequest);
+  const ukPayload = await ukResponse.json();
+
+  assert.equal(ukResponse.status, 400);
+  assert.match(String(ukPayload.details ?? ukPayload.error), /postToQbo/);
+});
+
+test('successful US settlement payouts post to settlement control instead of bank account', () => {
+  const entries = buildQboJournalEntriesFromUsSettlementDraft({
+    draft: {
+      settlementId: '26189598301',
+      eventGroupId: 'group-us',
+      timeZone: 'America/Los_Angeles',
+      originalTotalCents: 11934,
+      fundTransferStatus: 'Succeeded',
+      segments: [
+        {
+          seq: 1,
+          yearMonth: '2026-05',
+          startIsoDay: '2026-04-16',
+          endIsoDay: '2026-04-30',
+          txnDate: '2026-04-30',
+          docNumber: 'US-260416-260430-S1',
+          memoTotalsCents: new Map([['Amazon Sales - Principal - US-PDS', 11934]]),
+          auditRows: [],
+        },
+      ],
+    } as any,
+    privateNote: 'test',
+    settlementControlAccountId: 'control',
+    bankAccountId: 'bank',
+    paymentAccountId: 'payment',
+    accountIdByMemo: new Map([['Amazon Sales - Principal - US-PDS', 'sales']]),
+  });
+
+  assert.equal(entries[0]!.lines.some((line) => line.accountId === 'bank'), false);
+  assert.equal(
+    entries[0]!.lines.some(
+      (line) =>
+        line.accountId === 'control' &&
+        line.postingType === 'Debit' &&
+        line.amount === 119.34 &&
+        line.description === 'Settlement Control (FundTransferStatus=Succeeded)',
+    ),
+    true,
+  );
+});
+
+test('successful UK settlement payouts post to settlement control instead of bank account', () => {
+  const entries = buildQboJournalEntriesFromUkSettlementDraft({
+    draft: {
+      settlementId: 'EG-group-uk',
+      eventGroupId: 'group-uk',
+      timeZone: 'Europe/London',
+      originalTotalCents: 1394696,
+      fundTransferStatus: 'Succeeded',
+      segments: [
+        {
+          seq: 1,
+          yearMonth: '2026-04',
+          startIsoDay: '2026-04-01',
+          endIsoDay: '2026-04-21',
+          txnDate: '2026-04-21',
+          docNumber: 'UK-260401-260421-S1',
+          memoTotalsCents: new Map([['Amazon Sales - Principal - UK-PDS', 1394696]]),
+          auditRows: [],
+        },
+      ],
+    } as any,
+    privateNote: 'test',
+    settlementControlAccountId: 'control',
+    bankAccountId: 'bank',
+    paymentAccountId: 'payment',
+    accountIdByMemo: new Map([['Amazon Sales - Principal - UK-PDS', 'sales']]),
+  });
+
+  assert.equal(entries[0]!.lines.some((line) => line.accountId === 'bank'), false);
+  assert.equal(
+    entries[0]!.lines.some(
+      (line) =>
+        line.accountId === 'control' &&
+        line.postingType === 'Debit' &&
+        line.amount === 13946.96 &&
+        line.description === 'Settlement Control (FundTransferStatus=Succeeded)',
+    ),
+    true,
+  );
 });
 
 


### PR DESCRIPTION
## Summary
- require explicit QBO posting mode for Plutus settlement sync worker, routes, and CLI flows
- route successful Amazon payout settlement JEs through Plutus Settlement Control instead of real bank accounts
- default the settlement sync UI to non-posting and add focused coverage for fail-closed posting guards

## Root cause
The settlement sync worker posted Amazon settlement JEs directly to real QBO bank accounts, while QBO bank-feed deposits also landed for the same payouts. That created bank-side double posting.

## Validation
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- git diff --check -- apps/plutus
- read-only QBO scan: duplicate Bills, BillPayment groups, payout Deposit/JE pairs, clearing balances, PM2 logs

## Notes
- main-plutus-settlement-sync was stopped before the guard work.
- Local fin-feed-ingest skill was updated outside the repo so matched Amazon payout feed rows are handled through Plutus Settlement Control.