### PR TITLE
fix(talos): promote tenant select fetch fix

### DIFF
--- a/apps/talos/src/lib/utils/patch-fetch.test.ts
+++ b/apps/talos/src/lib/utils/patch-fetch.test.ts
@@ -6,13 +6,18 @@ test('patched fetch rejects non-json Talos API responses before the JSON parser'
   const previousBasePath = process.env.BASE_PATH
   const previousPublicBasePath = process.env.NEXT_PUBLIC_BASE_PATH
   const apiPath = ['', 'api', 'dashboard', 'overview'].join('/')
-  let fetchedInput: RequestInfo | URL | undefined
+  const portalApiUrl = new URL('https://os.targonglobal.com/api/v1/session/active-tenant')
+  const fetchedInputs: Array<RequestInfo | URL> = []
 
   try {
     process.env.NEXT_PUBLIC_BASE_PATH = '/talos'
     delete process.env.BASE_PATH
     globalThis.fetch = (async (input: RequestInfo | URL) => {
-      fetchedInput = input
+      fetchedInputs.push(input)
+      if (input === portalApiUrl) {
+        return Response.json({ ok: true })
+      }
+
       return new Response('<!DOCTYPE html>', {
         status: 404,
         headers: { 'content-type': 'text/html; charset=utf-8' },
@@ -22,11 +27,14 @@ test('patched fetch rejects non-json Talos API responses before the JSON parser'
     await import(`./patch-fetch.ts?non-json-${Date.now()}`)
 
     const response = await fetch(apiPath)
-    assert.equal(fetchedInput, '/talos/api/dashboard/overview')
+    assert.equal(fetchedInputs[0], '/talos/api/dashboard/overview')
     await assert.rejects(
       () => response.json(),
       /Talos API expected JSON but received text\/html; charset=utf-8 from \/talos\/api\/dashboard\/overview \(404\)/,
     )
+
+    await fetch(portalApiUrl)
+    assert.equal(fetchedInputs[1], portalApiUrl)
   } finally {
     globalThis.fetch = previousFetch
     if (typeof previousBasePath === 'string') {

--- a/apps/talos/src/lib/utils/patch-fetch.ts
+++ b/apps/talos/src/lib/utils/patch-fetch.ts
@@ -21,6 +21,11 @@ function isJsonContentType(contentType: string): boolean {
  return lowerContentType.includes('+json')
 }
 
+function shouldRewriteAbsoluteRootApiUrl(input: URL): boolean {
+ if (typeof window === 'undefined') return false
+ return input.origin === window.location.origin
+}
+
 function guardJsonResponse(response: Response, requestPath: string): Response {
  const originalJson = response.json.bind(response)
  Object.defineProperty(response, 'json', {
@@ -59,9 +64,11 @@ function patchGlobalFetch() {
   }
  } else if (input instanceof URL) {
   if (isRootApiPath(input.pathname)) {
-   const resolvedPath = buildTalosApiPath(input.pathname)
-   input = new URL(resolvedPath + input.search + input.hash, input.origin)
-   apiRequestPath = `${resolvedPath}${input.search}`
+   if (shouldRewriteAbsoluteRootApiUrl(input)) {
+    const resolvedPath = buildTalosApiPath(input.pathname)
+    input = new URL(resolvedPath + input.search + input.hash, input.origin)
+    apiRequestPath = `${resolvedPath}${input.search}`
+   }
   } else if (isTalosApiPath(input.pathname)) {
    apiRequestPath = `${input.pathname}${input.search}`
   }


### PR DESCRIPTION
Promotes the Talos tenant-select fetch fix from dev to main.\n\nEvidence:\n- PR #5321 merged into dev at 7ed3e587.\n- dev CI run 25298533732 passed.\n- Targeted hosted Talos smoke on dev-os passed: talos region selection reaches dashboard.\n\nNote: the full dev hosted-auth-health suite is currently tripping on an unrelated dev Argus /argus/api/wpr/weeks 500 while checking the next route; the Talos-specific hosted smoke passes.