### PR TITLE
fix(plutus): clean settlement posting controls

### DIFF
--- a/apps/plutus/app/settlements/[region]/[settlementId]/page.tsx
+++ b/apps/plutus/app/settlements/[region]/[settlementId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSnackbar } from 'notistack';
 import Box from '@mui/material/Box';
@@ -12,8 +12,6 @@ import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import Skeleton from '@mui/material/Skeleton';
-import Tab from '@mui/material/Tab';
-import Tabs from '@mui/material/Tabs';
 import Typography from '@mui/material/Typography';
 
 import { BackButton } from '@/components/back-button';
@@ -144,14 +142,6 @@ type ParentPreviewResponse = {
   }>;
 };
 
-type DetailTab = 'review' | 'analysis';
-
-function readDetailTab(value: string | null): DetailTab {
-  if (value === 'analysis') return 'analysis';
-  if (value === 'history') return 'analysis';
-  return 'review';
-}
-
 function formatPeriod(start: string | null, end: string | null): string {
   if (start === null || end === null) return '—';
 
@@ -173,16 +163,6 @@ function formatPeriod(start: string | null, end: string | null): string {
   });
 
   return `${startText} – ${endText}`;
-}
-
-function formatMoney(amount: number, currency: string): string {
-  const formatted = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-  }).format(Math.abs(amount));
-
-  if (amount < 0) return `(${formatted})`;
-  return formatted;
 }
 
 function PlutusPill({ status }: { status: ParentSettlementDetailResponse['settlement']['plutusStatus'] }) {
@@ -244,8 +224,6 @@ export default function ParentSettlementDetailPage() {
   const { enqueueSnackbar } = useSnackbar();
   const params = useParams();
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const region = typeof params.region === 'string' ? params.region : '';
   const settlementId = typeof params.settlementId === 'string' ? decodeURIComponent(params.settlementId) : '';
@@ -254,7 +232,6 @@ export default function ParentSettlementDetailPage() {
     throw new Error('Settlement route params are required');
   }
 
-  const [tab, setTab] = useState<DetailTab>(() => readDetailTab(searchParams.get('tab')));
   const [preview, setPreview] = useState<ParentPreviewResponse | null>(null);
   const [isPreviewLoading, setIsPreviewLoading] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
@@ -275,10 +252,6 @@ export default function ParentSettlementDetailPage() {
     enabled: connection?.connected !== false,
     staleTime: 5 * 60 * 1000,
   });
-  useEffect(() => {
-    const nextTab = readDetailTab(searchParams.get('tab'));
-    setTab((current) => (current === nextTab ? current : nextTab));
-  }, [searchParams]);
   const settlementView = useMemo(
     () =>
       data
@@ -334,19 +307,6 @@ export default function ParentSettlementDetailPage() {
     () => (data ? data.children.filter((child) => child.invoiceResolution.status !== 'resolved') : []),
     [data],
   );
-
-  function handleTabChange(nextTab: DetailTab) {
-    setTab(nextTab);
-    const nextParams = new URLSearchParams(searchParams.toString());
-    if (nextTab === 'analysis') {
-      nextParams.set('tab', 'analysis');
-    } else {
-      nextParams.delete('tab');
-    }
-
-    const query = nextParams.toString();
-    router.replace(query === '' ? pathname : `${pathname}?${query}`, { scroll: false });
-  }
 
   if (!isCheckingConnection && connection?.connected === false) {
     return <NotConnectedScreen title="Settlement Details" canConnect={connection.canConnect} error={connection.error} />;
@@ -509,99 +469,55 @@ export default function ParentSettlementDetailPage() {
         )}
 
         {!isLoading && data && (
-          <Box sx={{ mt: 3, display: 'grid', gap: 2.5 }}>
-            <Box sx={{ borderBottom: '1px solid', borderColor: 'divider' }}>
-              <Tabs
-                value={tab}
-                onChange={(_, value: DetailTab) => handleTabChange(value)}
-                sx={{ minHeight: 42, '& .MuiTab-root': { minHeight: 42, textTransform: 'none' } }}
-              >
-                <Tab value="review" label="Ledger review" />
-                <Tab value="analysis" label="Analysis" />
-              </Tabs>
+          <Box sx={{ mt: 3, display: 'grid', gap: 1.5 }}>
+            {data.settlement.isSplit ? (
+              <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
+                {data.settlement.splitCount} month-end postings cover this settlement. Review them in order below.
+              </Typography>
+            ) : null}
+
+            {data.settlement.hasInconsistency ? (
+              <Typography color="warning.main" sx={{ fontSize: '0.8rem' }}>
+                Child posting states disagree. Treat this settlement as inconsistent until the backend state is repaired.
+              </Typography>
+            ) : null}
+
+            {unresolvedChildren.length > 0 ? (
+              <Typography color="warning.main" sx={{ fontSize: '0.8rem' }}>
+                Preview and processing stay blocked until every posting resolves to one audit invoice.
+              </Typography>
+            ) : null}
+
+            {actionError === null ? null : (
+              <Typography color="error.main" sx={{ fontSize: '0.8rem' }}>
+                {actionError}
+              </Typography>
+            )}
+
+            <Box component="section" sx={{ display: 'grid', gap: 0 }}>
+              {ledgerSections.map((section) => {
+                const child = childByJournalEntryId.get(section.qboJournalEntryId);
+                if (child === undefined) {
+                  throw new Error(`Missing child posting for ${section.qboJournalEntryId}`);
+                }
+
+                return (
+                  <SettlementLedgerSection
+                    key={section.qboJournalEntryId}
+                    section={section}
+                    currency={data.settlement.marketplace.currency}
+                    lines={child.lines}
+                  />
+                );
+              })}
             </Box>
 
-            {tab === 'review' ? (
-              <Box sx={{ display: 'grid', gap: 1.5 }}>
-                {data.settlement.isSplit ? (
-                  <Typography sx={{ fontSize: '0.875rem', color: 'text.secondary' }}>
-                    {data.settlement.splitCount} month-end postings cover this settlement. Review them in order below.
-                  </Typography>
-                ) : null}
-
-                {data.settlement.hasInconsistency ? (
-                  <Typography color="warning.main" sx={{ fontSize: '0.8rem' }}>
-                    Child posting states disagree. Treat this settlement as inconsistent until the backend state is repaired.
-                  </Typography>
-                ) : null}
-
-                {unresolvedChildren.length > 0 ? (
-                  <Typography color="warning.main" sx={{ fontSize: '0.8rem' }}>
-                    Preview and processing stay blocked until every posting resolves to one audit invoice.
-                  </Typography>
-                ) : null}
-
-                {actionError === null ? null : (
-                  <Typography color="error.main" sx={{ fontSize: '0.8rem' }}>
-                    {actionError}
-                  </Typography>
-                )}
-
-                <Box component="section" sx={{ display: 'grid', gap: 0 }}>
-                  {ledgerSections.map((section) => {
-                    const child = childByJournalEntryId.get(section.qboJournalEntryId);
-                    if (child === undefined) {
-                      throw new Error(`Missing child posting for ${section.qboJournalEntryId}`);
-                    }
-
-                    return (
-                      <SettlementLedgerSection
-                        key={section.qboJournalEntryId}
-                        section={section}
-                        currency={data.settlement.marketplace.currency}
-                        lines={child.lines}
-                      />
-                    );
-                  })}
-                </Box>
-
-                <Box component="section" sx={{ display: 'grid', gap: 0.5 }}>
-                  <Typography sx={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'text.secondary' }}>
-                    History
-                  </Typography>
-                  <SettlementHistoryList rows={historyRows} />
-                </Box>
-              </Box>
-            ) : (
-              <Box sx={{ display: 'grid', gap: 0.75 }}>
-                <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1.5, flexWrap: 'wrap' }}>
-                  <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
-                    {formatPeriod(data.settlement.periodStart, data.settlement.periodEnd)}
-                  </Typography>
-                  <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
-                    {data.settlement.marketplace.label}
-                  </Typography>
-                  <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
-                    Posted{' '}
-                    {new Date(`${data.settlement.postedDate}T00:00:00Z`).toLocaleDateString('en-US', {
-                      timeZone: 'UTC',
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                    })}
-                  </Typography>
-                  <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
-                    Total{' '}
-                    {data.settlement.settlementTotal === null
-                      ? '—'
-                      : formatMoney(data.settlement.settlementTotal, data.settlement.marketplace.currency)}
-                  </Typography>
-                </Box>
-                <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
-                  {data.settlement.childCount} posting{data.settlement.childCount === 1 ? '' : 's'} · {data.settlement.marketplace.region} settlement workspace
-                </Typography>
-              </Box>
-            )}
+            <Box component="section" sx={{ display: 'grid', gap: 0.5 }}>
+              <Typography sx={{ fontSize: '0.8rem', textTransform: 'uppercase', letterSpacing: '0.04em', color: 'text.secondary' }}>
+                History
+              </Typography>
+              <SettlementHistoryList rows={historyRows} />
+            </Box>
           </Box>
         )}
 

--- a/apps/plutus/app/settlements/page.tsx
+++ b/apps/plutus/app/settlements/page.tsx
@@ -859,7 +859,6 @@ export default function SettlementsPage() {
                               onClick={() => router.push(settlementHref)}
                               dropdownItems={[
                                 { label: 'Open settlement', onClick: () => router.push(settlementHref) },
-                                { label: 'History', onClick: () => router.push(`${settlementHref}?tab=history`) },
                                 {
                                   label: 'Sync from Amazon',
                                   onClick: () =>

--- a/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
@@ -173,6 +173,8 @@ function adjustmentMemo(event: SpApiAdjustmentEvent): string | null {
   if (type === 'MISSING_FROM_INBOUND') return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Missing From Inbound';
   if (type === 'REVERSAL_REIMBURSEMENT')
     return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Reversal Reimbursement';
+  if (type === 'COMPENSATED_CLAWBACK')
+    return 'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Compensated Clawback';
   return null;
 }
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -650,6 +650,20 @@ test('buildSettlementHistoryViewModel orders compact rows newest-first', () => {
   assert.equal(history[2]?.kind, 'posted');
 });
 
+test('settlement detail source does not expose the removed analysis tab', () => {
+  const source = readFileSync('app/settlements/[region]/[settlementId]/page.tsx', 'utf8');
+
+  assert.equal(source.includes('label="Analysis"'), false);
+  assert.equal(source.includes('value="analysis"'), false);
+  assert.equal(source.includes("tab', 'analysis'"), false);
+});
+
+test('settlements list no longer links to removed history tab alias', () => {
+  const source = readFileSync('app/settlements/page.tsx', 'utf8');
+
+  assert.equal(source.includes('?tab=history'), false);
+});
+
 test('normalizeSettlementMarketplaceQuery maps settlement route params to marketplace filters', () => {
   assert.equal(normalizeSettlementMarketplaceQuery('UK'), 'UK');
   assert.equal(normalizeSettlementMarketplaceQuery('us'), 'US');
@@ -1238,6 +1252,37 @@ test('buildUsSettlementDraftFromSpApiFinances maps compensated clawback adjustme
           PostedDate: '2026-04-04T08:00:00.000Z',
           AdjustmentType: 'COMPENSATED_CLAWBACK',
           AdjustmentAmount: { CurrencyCode: 'USD', CurrencyAmount: -4.26 },
+        },
+      ],
+    },
+    skuToBrandName: new Map(),
+  });
+
+  assert.equal(draft.segments.length, 1);
+  assert.equal(
+    draft.segments[0]?.memoTotalsCents.get(
+      'Amazon FBA Inventory Reimbursement - FBA Inventory Reimbursement - Compensated Clawback',
+    ),
+    -426,
+  );
+});
+
+test('buildUkSettlementDraftFromSpApiFinances maps compensated clawback adjustments', () => {
+  const draft = buildUkSettlementDraftFromSpApiFinances({
+    settlementId: 'SETTLEMENT-COMPENSATED-CLAWBACK-UK-1',
+    eventGroupId: 'GROUP-COMPENSATED-CLAWBACK-UK-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-01T08:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-10T08:00:00.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'GBP', CurrencyAmount: -4.26 },
+    },
+    events: {
+      AdjustmentEventList: [
+        {
+          PostedDate: '2026-04-04T08:00:00.000Z',
+          AdjustmentType: 'COMPENSATED_CLAWBACK',
+          AdjustmentAmount: { CurrencyCode: 'GBP', CurrencyAmount: -4.26 },
         },
       ],
     },


### PR DESCRIPTION
## Summary
- remove the dead Plutus settlement Analysis/History tab surface
- map UK SP-API COMPENSATED_CLAWBACK adjustments to FBA inventory reimbursement
- add source regressions for the removed tab and UK adjustment mapping

## Validation
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint
- git diff --check

## Operational proof
- live QBO Bank Feed Clearing accounts verified at 0
- live Plutus Settlement Control verified at 0 after posting the missing UK settlement JE and cleanup entries