### PR TITLE
fix(talos): show master carton size on SKU Info

### DIFF
--- a/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
+++ b/apps/talos/src/app/amazon/fba-fee-discrepancies/page.tsx
@@ -10,6 +10,7 @@ import {
   type AlertStatus,
   type ApiSkuRow,
   computeComparison,
+  formatMasterCartonSizeCm,
   getComparisonStatusLabel,
   summarizeComparisonStatuses,
 } from '@/lib/amazon/fba-fee-discrepancies'
@@ -570,6 +571,24 @@ function AmazonFbaFeeDiscrepanciesPageContent() {
                             unitSystem
                           )}
                         </EditableReferenceValue>
+                      </td>
+                    ))}
+                  </tr>
+                  <tr className="bg-white dark:bg-slate-800">
+                    <td className="px-4 py-2 font-medium text-slate-700 dark:text-slate-300 sticky left-0 bg-white dark:bg-slate-800 z-10">
+                      Master Carton Size
+                    </td>
+                    {pageRows.map(row => (
+                      <td
+                        key={row.sku.id}
+                        className="px-4 py-2 text-center tabular-nums text-slate-700 dark:text-slate-300 text-xs"
+                      >
+                        <div>{formatMasterCartonSizeCm(row.sku)}</div>
+                        {row.sku.masterCartonSourceOrderNumber ? (
+                          <div className="mt-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-400 dark:text-slate-500">
+                            {row.sku.masterCartonSourceOrderNumber}
+                          </div>
+                        ) : null}
                       </td>
                     ))}
                   </tr>

--- a/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
+++ b/apps/talos/src/app/api/amazon/fba-fee-discrepancies/route.ts
@@ -7,7 +7,9 @@ import {
 import {
   buildComparisonSkuRow,
   mergeAmazonCatalogPackageData,
+  resolveMasterCartonTripletCm,
   type AmazonCatalogPackageData,
+  type ApiSkuRow,
 } from '@/lib/amazon/fba-fee-discrepancies'
 import {
   loadLatestFbaFeePreviewReportRows,
@@ -26,7 +28,7 @@ import {
 } from '@/lib/amazon/reference-input'
 import type { TenantCode } from '@/lib/tenant/constants'
 import { getCurrentTenantCode, getTenantPrisma } from '@/lib/tenant/server'
-import { Prisma } from '@targon/prisma-talos'
+import { InboundOrderLineStatus, InboundOrderStatus, Prisma } from '@targon/prisma-talos'
 
 export const dynamic = 'force-dynamic'
 
@@ -86,8 +88,97 @@ type ComparisonSkuDatabaseRow = Prisma.SkuGetPayload<{
   select: typeof comparisonSkuSelect
 }>
 
+type MasterCartonFields = Pick<
+  ApiSkuRow,
+  | 'masterCartonDimensionsCm'
+  | 'masterCartonSide1Cm'
+  | 'masterCartonSide2Cm'
+  | 'masterCartonSide3Cm'
+  | 'masterCartonSourceOrderNumber'
+>
+
+const emptyMasterCartonFields: MasterCartonFields = {
+  masterCartonDimensionsCm: null,
+  masterCartonSide1Cm: null,
+  masterCartonSide2Cm: null,
+  masterCartonSide3Cm: null,
+  masterCartonSourceOrderNumber: null,
+}
+
+const latestMasterCartonLineSelect = {
+  skuCode: true,
+  cartonDimensionsCm: true,
+  cartonSide1Cm: true,
+  cartonSide2Cm: true,
+  cartonSide3Cm: true,
+  inboundOrder: {
+    select: {
+      orderNumber: true,
+      createdAt: true,
+    },
+  },
+} satisfies Prisma.InboundOrderLineSelect
+
+type LatestMasterCartonLine = Prisma.InboundOrderLineGetPayload<{
+  select: typeof latestMasterCartonLineSelect
+}>
+
+function buildMasterCartonFields(line: LatestMasterCartonLine): MasterCartonFields {
+  return {
+    masterCartonDimensionsCm: line.cartonDimensionsCm,
+    masterCartonSide1Cm: line.cartonSide1Cm,
+    masterCartonSide2Cm: line.cartonSide2Cm,
+    masterCartonSide3Cm: line.cartonSide3Cm,
+    masterCartonSourceOrderNumber: line.inboundOrder.orderNumber,
+  }
+}
+
+function attachMasterCartonFields<T extends ComparisonSkuDatabaseRow>(
+  sku: T,
+  masterCartonBySkuCode: Map<string, MasterCartonFields>
+): T & MasterCartonFields {
+  const masterCartonFields = masterCartonBySkuCode.get(sku.skuCode)
+  return {
+    ...sku,
+    ...(masterCartonFields === undefined ? emptyMasterCartonFields : masterCartonFields),
+  }
+}
+
+async function loadLatestMasterCartonBySkuCode(
+  prisma: Prisma.TransactionClient,
+  skuCodes: string[]
+): Promise<Map<string, MasterCartonFields>> {
+  if (skuCodes.length === 0) return new Map()
+
+  const lines = await prisma.inboundOrderLine.findMany({
+    where: {
+      skuCode: { in: skuCodes },
+      status: { not: InboundOrderLineStatus.CANCELLED },
+      inboundOrder: {
+        status: { not: InboundOrderStatus.CANCELLED },
+      },
+    },
+    orderBy: [
+      { inboundOrder: { createdAt: 'desc' } },
+      { createdAt: 'desc' },
+      { id: 'desc' },
+    ],
+    select: latestMasterCartonLineSelect,
+  })
+
+  const bySkuCode = new Map<string, MasterCartonFields>()
+  for (const line of lines) {
+    if (bySkuCode.has(line.skuCode)) continue
+    const masterCartonFields = buildMasterCartonFields(line)
+    if (resolveMasterCartonTripletCm(masterCartonFields) === null) continue
+    bySkuCode.set(line.skuCode, masterCartonFields)
+  }
+
+  return bySkuCode
+}
+
 async function buildLiveAmazonComparisonRow(
-  row: ComparisonSkuDatabaseRow,
+  row: ComparisonSkuDatabaseRow & MasterCartonFields,
   tenantCode: TenantCode,
   feePreviewRows: FbaFeePreviewReportRow[]
 ) {
@@ -154,8 +245,18 @@ export const GET = withRole(['admin', 'staff'], async (request, _session) => {
   })
 
   const feePreviewRows = await loadLatestFbaFeePreviewReportRows(tenantCode)
+  const masterCartonBySkuCode = await loadLatestMasterCartonBySkuCode(
+    prisma,
+    skus.map(sku => sku.skuCode)
+  )
   const comparisonSkus = await Promise.all(
-    skus.map(sku => buildLiveAmazonComparisonRow(sku, tenantCode, feePreviewRows))
+    skus.map(sku =>
+      buildLiveAmazonComparisonRow(
+        attachMasterCartonFields(sku, masterCartonBySkuCode),
+        tenantCode,
+        feePreviewRows
+      )
+    )
   )
 
   return ApiResponses.success({ skus: comparisonSkus, total, page, pageSize })
@@ -207,6 +308,11 @@ export const PATCH = withRole(['admin', 'staff'], async (request, _session) => {
   })
 
   const feePreviewRows = await loadLatestFbaFeePreviewReportRows(tenantCode)
-  const comparisonSku = await buildLiveAmazonComparisonRow(updatedSku, tenantCode, feePreviewRows)
+  const masterCartonBySkuCode = await loadLatestMasterCartonBySkuCode(prisma, [updatedSku.skuCode])
+  const comparisonSku = await buildLiveAmazonComparisonRow(
+    attachMasterCartonFields(updatedSku, masterCartonBySkuCode),
+    tenantCode,
+    feePreviewRows
+  )
   return ApiResponses.success(comparisonSku)
 })

--- a/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
+++ b/apps/talos/src/lib/amazon/fba-fee-discrepancies.ts
@@ -40,6 +40,11 @@ export type ApiSkuRow = {
   itemSide2Cm: ApiNumberValue
   itemSide3Cm: ApiNumberValue
   itemWeightKg: ApiNumberValue
+  masterCartonDimensionsCm: string | null
+  masterCartonSide1Cm: ApiNumberValue
+  masterCartonSide2Cm: ApiNumberValue
+  masterCartonSide3Cm: ApiNumberValue
+  masterCartonSourceOrderNumber: string | null
 }
 
 export type ComparisonSkuSourceRow = {
@@ -60,6 +65,11 @@ export type ComparisonSkuSourceRow = {
   itemSide2Cm: ApiNumberValue
   itemSide3Cm: ApiNumberValue
   itemWeightKg: ApiNumberValue
+  masterCartonDimensionsCm: string | null
+  masterCartonSide1Cm: ApiNumberValue
+  masterCartonSide2Cm: ApiNumberValue
+  masterCartonSide3Cm: ApiNumberValue
+  masterCartonSourceOrderNumber: string | null
   amazonItemPackageDimensionsCm: string | null
   amazonItemPackageSide1Cm: ApiNumberValue
   amazonItemPackageSide2Cm: ApiNumberValue
@@ -156,6 +166,33 @@ export function mergeAmazonCatalogPackageData(
   }
 
   return next
+}
+
+export function resolveMasterCartonTripletCm(row: Pick<
+  ApiSkuRow,
+  | 'masterCartonDimensionsCm'
+  | 'masterCartonSide1Cm'
+  | 'masterCartonSide2Cm'
+  | 'masterCartonSide3Cm'
+>): DimensionTriplet | null {
+  return resolveDimensionTripletCm({
+    side1Cm: row.masterCartonSide1Cm,
+    side2Cm: row.masterCartonSide2Cm,
+    side3Cm: row.masterCartonSide3Cm,
+    legacy: row.masterCartonDimensionsCm,
+  })
+}
+
+export function formatMasterCartonSizeCm(row: Pick<
+  ApiSkuRow,
+  | 'masterCartonDimensionsCm'
+  | 'masterCartonSide1Cm'
+  | 'masterCartonSide2Cm'
+  | 'masterCartonSide3Cm'
+>): string {
+  const triplet = resolveMasterCartonTripletCm(row)
+  if (triplet === null) return '—'
+  return `${formatDimensionTripletCm(triplet).replace(/x/g, '×')} cm`
 }
 
 export function parseDecimalNumber(value: unknown): number | null {

--- a/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
+++ b/apps/talos/tests/unit/amazon-fba-fee-discrepancies.test.ts
@@ -51,6 +51,11 @@ function createSkuRow(overrides: Partial<ApiSkuRow> = {}): ApiSkuRow {
     itemSide2Cm: null,
     itemSide3Cm: null,
     itemWeightKg: null,
+    masterCartonDimensionsCm: null,
+    masterCartonSide1Cm: null,
+    masterCartonSide2Cm: null,
+    masterCartonSide3Cm: null,
+    masterCartonSourceOrderNumber: null,
     ...overrides,
   }
 }
@@ -84,6 +89,11 @@ function createComparisonSkuSourceRow(
     itemSide2Cm: null,
     itemSide3Cm: null,
     itemWeightKg: null,
+    masterCartonDimensionsCm: null,
+    masterCartonSide1Cm: null,
+    masterCartonSide2Cm: null,
+    masterCartonSide3Cm: null,
+    masterCartonSourceOrderNumber: null,
     amazonItemPackageDimensionsCm: null,
     amazonItemPackageSide1Cm: referenceTriplet.side1Cm,
     amazonItemPackageSide2Cm: referenceTriplet.side2Cm,
@@ -262,6 +272,32 @@ test('SKU Info dimensions are side 1, side 2, side 3 ordered shortest to longest
   )
 })
 
+test('master carton size uses last PO carton dimensions in stored centimeters without regional conversion', () => {
+  const helpers = discrepancies as unknown as {
+    resolveMasterCartonTripletCm?: (row: ApiSkuRow) => discrepancies.DimensionTriplet | null
+    formatMasterCartonSizeCm?: (row: ApiSkuRow) => string
+  }
+  assert.equal(typeof helpers.resolveMasterCartonTripletCm, 'function')
+  assert.equal(typeof helpers.formatMasterCartonSizeCm, 'function')
+  if (typeof helpers.resolveMasterCartonTripletCm !== 'function') return
+  if (typeof helpers.formatMasterCartonSizeCm !== 'function') return
+
+  const row = createSkuRow({
+    masterCartonDimensionsCm: '50.8x25.4x2.54',
+    masterCartonSide1Cm: 50.8,
+    masterCartonSide2Cm: 25.4,
+    masterCartonSide3Cm: 2.54,
+    masterCartonSourceOrderNumber: 'PO-20-PDS',
+  })
+
+  assert.deepEqual(helpers.resolveMasterCartonTripletCm(row), {
+    side1Cm: 50.8,
+    side2Cm: 25.4,
+    side3Cm: 2.54,
+  })
+  assert.equal(helpers.formatMasterCartonSizeCm(row), '50.8×25.4×2.54 cm')
+})
+
 test('Amazon catalog package dimensions normalize to shortest middle longest sides', () => {
   const parsed = parseCatalogItemPackageDimensions({
     item_package_dimensions: [
@@ -351,6 +387,21 @@ test('SKU Info API does not calculate Amazon size tier from catalog dimensions',
 
   assert.equal(routeSource.includes('calculateSizeTierForTenant'), false)
   assert.equal(routeSource.includes('loadLatestFbaFeePreviewReportRows'), true)
+})
+
+test('SKU Info API loads master carton size from active tenant inbound order lines', () => {
+  const talosRoot = path.resolve(__dirname, '..', '..')
+  const routeSource = readFileSync(
+    path.join(talosRoot, 'src/app/api/amazon/fba-fee-discrepancies/route.ts'),
+    'utf8'
+  )
+
+  assert.equal(routeSource.includes('loadLatestMasterCartonBySkuCode'), true)
+  assert.equal(routeSource.includes('inboundOrderLine.findMany'), true)
+  assert.equal(routeSource.includes('resolveMasterCartonTripletCm(masterCartonFields) === null'), true)
+  assert.equal(routeSource.includes('cartonSide1Cm: { not: null }'), false)
+  assert.equal(routeSource.includes('DATABASE_URL_US'), false)
+  assert.equal(routeSource.includes('DATABASE_URL_UK'), false)
 })
 
 test('assigned size tier option validation allows tenant options and rejects invalid names', () => {


### PR DESCRIPTION
## Summary
- add last inbound PO master carton size to the SKU Info / FBA fee discrepancy reference table
- source the value from the active tenant inbound order lines only
- display stored carton dimensions in centimeters without US/UK unit conversion

## Verification
- pnpm --filter @targon/talos test
- pnpm --filter @targon/talos exec tsc --noEmit --skipLibCheck --project tsconfig.json
- pnpm --filter @targon/talos exec eslint src/lib/amazon/fba-fee-discrepancies.ts src/app/api/amazon/fba-fee-discrepancies/route.ts src/app/amazon/fba-fee-discrepancies/page.tsx tests/unit/amazon-fba-fee-discrepancies.test.ts
- pnpm --filter @targon/talos build
- local API/browser: US CS-010 -> PO-20-PDS 25.98x41.45x54.99 cm; UK CS 007 -> PO-17-PDS 38.5x44x52.5 cm