### PR TITLE
fix(talos): keep inbound carton dimensions metric

### DIFF
--- a/apps/talos/src/components/inbound/inbound-flow.tsx
+++ b/apps/talos/src/components/inbound/inbound-flow.tsx
@@ -58,6 +58,7 @@ import {
 } from '@/lib/inbound-line-costs'
 import { formatDimensionTripletCm, resolveDimensionTripletCm } from '@/lib/sku-dimensions'
 import {
+  CARTON_DIMENSION_UNIT_SYSTEM,
   convertLengthToCm,
   convertWeightFromKg,
   convertWeightToKg,
@@ -841,7 +842,8 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
   const { data: session, status } = useSession()
   const tenantRegion: TenantCode = session?.user?.region ?? 'US'
   const unitSystem = getDefaultUnitSystem(tenantRegion)
-  const lengthUnit = getLengthUnitLabel(unitSystem)
+  const cartonUnitSystem = CARTON_DIMENSION_UNIT_SYSTEM
+  const cartonLengthUnit = getLengthUnitLabel(cartonUnitSystem)
   const weightUnit = getWeightUnitLabel(unitSystem)
   const isCreate = props.mode === 'create'
   const orderId = props.orderId
@@ -1294,12 +1296,12 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
       }
 
       void patchOrderLine(lineId, {
-        cartonSide1Cm: convertLengthToCm(side1, unitSystem),
-        cartonSide2Cm: convertLengthToCm(side2, unitSystem),
-        cartonSide3Cm: convertLengthToCm(side3, unitSystem),
+        cartonSide1Cm: convertLengthToCm(side1, cartonUnitSystem),
+        cartonSide2Cm: convertLengthToCm(side2, cartonUnitSystem),
+        cartonSide3Cm: convertLengthToCm(side3, cartonUnitSystem),
       })
     },
-    [patchOrderLine, unitSystem]
+    [cartonUnitSystem, patchOrderLine]
   )
 
   const refreshForwardingCosts = useCallback(async () => {
@@ -3531,7 +3533,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                               Country
                             </th>
                             <th className="text-left font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[172px]">
-                              Carton Size ({lengthUnit})
+                              Carton Size ({cartonLengthUnit})
                             </th>
                             <th className="text-right font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[84px]">
                               Net ({weightUnit})
@@ -3732,7 +3734,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           placeholder="L"
                                           defaultValue={
                                             line.cartonSide1Cm != null
-                                              ? formatLengthFromCm(line.cartonSide1Cm, unitSystem)
+                                              ? formatLengthFromCm(line.cartonSide1Cm, cartonUnitSystem)
                                               : ''
                                           }
                                           data-carton-side-line={line.id}
@@ -3751,7 +3753,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           placeholder="W"
                                           defaultValue={
                                             line.cartonSide2Cm != null
-                                              ? formatLengthFromCm(line.cartonSide2Cm, unitSystem)
+                                              ? formatLengthFromCm(line.cartonSide2Cm, cartonUnitSystem)
                                               : ''
                                           }
                                           data-carton-side-line={line.id}
@@ -3770,7 +3772,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           placeholder="H"
                                           defaultValue={
                                             line.cartonSide3Cm != null
-                                              ? formatLengthFromCm(line.cartonSide3Cm, unitSystem)
+                                              ? formatLengthFromCm(line.cartonSide3Cm, cartonUnitSystem)
                                               : ''
                                           }
                                           data-carton-side-line={line.id}
@@ -3785,7 +3787,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                     ) : (
                                       <span className="text-xs text-slate-700 dark:text-slate-300">
                                         {cartonTriplet
-                                          ? `${formatLengthFromCm(cartonTriplet.side1Cm, unitSystem)}×${formatLengthFromCm(cartonTriplet.side2Cm, unitSystem)}×${formatLengthFromCm(cartonTriplet.side3Cm, unitSystem)}`
+                                          ? `${formatLengthFromCm(cartonTriplet.side1Cm, cartonUnitSystem)}×${formatLengthFromCm(cartonTriplet.side2Cm, cartonUnitSystem)}×${formatLengthFromCm(cartonTriplet.side3Cm, cartonUnitSystem)}`
                                           : '—'}
                                       </span>
                                     )}
@@ -4310,7 +4312,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                               Country
                             </th>
                             <th className="text-left font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[172px]">
-                              Carton Size ({lengthUnit})
+                              Carton Size ({cartonLengthUnit})
                             </th>
                             <th className="text-right font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[84px]">
                               Net ({weightUnit})
@@ -4488,7 +4490,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                         placeholder="L"
                                         value={
                                           line.cartonSide1Cm != null
-                                            ? formatLengthFromCm(line.cartonSide1Cm, unitSystem)
+                                            ? formatLengthFromCm(line.cartonSide1Cm, cartonUnitSystem)
                                             : ''
                                         }
                                         onChange={e => {
@@ -4498,7 +4500,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           const next =
                                             nextInput === null
                                               ? null
-                                              : convertLengthToCm(nextInput, unitSystem)
+                                              : convertLengthToCm(nextInput, cartonUnitSystem)
                                           updateLine(current => {
                                             const triplet = resolveDimensionTripletCm({
                                               side1Cm: next,
@@ -4525,7 +4527,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                         placeholder="W"
                                         value={
                                           line.cartonSide2Cm != null
-                                            ? formatLengthFromCm(line.cartonSide2Cm, unitSystem)
+                                            ? formatLengthFromCm(line.cartonSide2Cm, cartonUnitSystem)
                                             : ''
                                         }
                                         onChange={e => {
@@ -4535,7 +4537,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           const next =
                                             nextInput === null
                                               ? null
-                                              : convertLengthToCm(nextInput, unitSystem)
+                                              : convertLengthToCm(nextInput, cartonUnitSystem)
                                           updateLine(current => {
                                             const triplet = resolveDimensionTripletCm({
                                               side1Cm: current.cartonSide1Cm ?? null,
@@ -4562,7 +4564,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                         placeholder="H"
                                         value={
                                           line.cartonSide3Cm != null
-                                            ? formatLengthFromCm(line.cartonSide3Cm, unitSystem)
+                                            ? formatLengthFromCm(line.cartonSide3Cm, cartonUnitSystem)
                                             : ''
                                         }
                                         onChange={e => {
@@ -4572,7 +4574,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           const next =
                                             nextInput === null
                                               ? null
-                                              : convertLengthToCm(nextInput, unitSystem)
+                                              : convertLengthToCm(nextInput, cartonUnitSystem)
                                           updateLine(current => {
                                             const triplet = resolveDimensionTripletCm({
                                               side1Cm: current.cartonSide1Cm ?? null,

--- a/apps/talos/src/lib/measurements.ts
+++ b/apps/talos/src/lib/measurements.ts
@@ -6,6 +6,7 @@ export type UnitSystem = 'metric' | 'imperial'
 
 export const CM_PER_INCH = 2.54
 export const LB_PER_KG = 2.2046226218
+export const CARTON_DIMENSION_UNIT_SYSTEM: UnitSystem = 'metric'
 
 export function getDefaultUnitSystem(tenantCode: TenantCode): UnitSystem {
   if (tenantCode === 'UK') return 'metric'

--- a/apps/talos/tests/unit/carton-dimensions.test.ts
+++ b/apps/talos/tests/unit/carton-dimensions.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  CARTON_DIMENSION_UNIT_SYSTEM,
+  convertLengthToCm,
+  formatLengthFromCm,
+  getDefaultUnitSystem,
+  getLengthUnitLabel,
+} from '../../src/lib/measurements'
+
+test('US carton dimensions stay metric for inbound entry', () => {
+  assert.equal(getDefaultUnitSystem('US'), 'imperial')
+  assert.equal(CARTON_DIMENSION_UNIT_SYSTEM, 'metric')
+  assert.equal(getLengthUnitLabel(CARTON_DIMENSION_UNIT_SYSTEM), 'cm')
+  assert.equal(convertLengthToCm(27.99, CARTON_DIMENSION_UNIT_SYSTEM), 27.99)
+  assert.equal(formatLengthFromCm(27.99, CARTON_DIMENSION_UNIT_SYSTEM), '27.99')
+})
+
+test('inbound carton size controls use metric carton units instead of tenant package units', () => {
+  const talosRoot = path.resolve(__dirname, '..', '..')
+  const source = readFileSync(
+    path.join(talosRoot, 'src/components/inbound/inbound-flow.tsx'),
+    'utf8'
+  )
+
+  assert.equal(source.includes('const cartonUnitSystem = CARTON_DIMENSION_UNIT_SYSTEM'), true)
+  assert.equal(source.includes('const cartonLengthUnit = getLengthUnitLabel(cartonUnitSystem)'), true)
+  assert.equal(source.includes('Carton Size ({cartonLengthUnit})'), true)
+  assert.equal(source.includes('Carton Size ({lengthUnit})'), false)
+  assert.equal(source.includes('cartonSide1Cm: convertLengthToCm(side1, unitSystem)'), false)
+  assert.equal(source.includes('formatLengthFromCm(line.cartonSide1Cm, unitSystem)'), false)
+  assert.equal(source.includes('cartonSide1Cm: convertLengthToCm(side1, cartonUnitSystem)'), true)
+  assert.equal(source.includes('formatLengthFromCm(line.cartonSide1Cm, cartonUnitSystem)'), true)
+})


### PR DESCRIPTION
## Summary
- keep inbound carton size labels and inputs metric for every tenant
- prevent US inbound carton side edits from converting cm entries as inches
- add a regression test covering the metric-only carton dimension rule

## Root Cause
US inbound uses imperial tenant units for most measurements. Carton dimensions were reusing that tenant unit system, so US carton side inputs could be displayed and saved through inch/cm conversion even though supplier carton dimensions are sourced and maintained in cm.

## Validation
- `pnpm --filter @targon/talos exec tsx tests/unit/carton-dimensions.test.ts`
- `pnpm --filter @targon/talos exec tsx tests/unit/amazon-fba-fee-discrepancies.test.ts`
- `pnpm --filter @targon/talos exec tsx tests/unit/inbound-workflow.test.ts`
- `pnpm --filter @targon/talos type-check`
- `pnpm --filter @targon/talos lint` (passes with existing warnings)
- `pnpm --filter @targon/talos test`
- `pnpm --filter @targon/talos build`
