### PR TITLE
fix(talos): promote metric carton dimensions

### DIFF
--- a/apps/talos/src/components/inbound/inbound-flow.tsx
+++ b/apps/talos/src/components/inbound/inbound-flow.tsx
@@ -58,6 +58,7 @@ import {
 } from '@/lib/inbound-line-costs'
 import { formatDimensionTripletCm, resolveDimensionTripletCm } from '@/lib/sku-dimensions'
 import {
+  CARTON_DIMENSION_UNIT_SYSTEM,
   convertLengthToCm,
   convertWeightFromKg,
   convertWeightToKg,
@@ -841,7 +842,8 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
   const { data: session, status } = useSession()
   const tenantRegion: TenantCode = session?.user?.region ?? 'US'
   const unitSystem = getDefaultUnitSystem(tenantRegion)
-  const lengthUnit = getLengthUnitLabel(unitSystem)
+  const cartonUnitSystem = CARTON_DIMENSION_UNIT_SYSTEM
+  const cartonLengthUnit = getLengthUnitLabel(cartonUnitSystem)
   const weightUnit = getWeightUnitLabel(unitSystem)
   const isCreate = props.mode === 'create'
   const orderId = props.orderId
@@ -1294,12 +1296,12 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
       }
 
       void patchOrderLine(lineId, {
-        cartonSide1Cm: convertLengthToCm(side1, unitSystem),
-        cartonSide2Cm: convertLengthToCm(side2, unitSystem),
-        cartonSide3Cm: convertLengthToCm(side3, unitSystem),
+        cartonSide1Cm: convertLengthToCm(side1, cartonUnitSystem),
+        cartonSide2Cm: convertLengthToCm(side2, cartonUnitSystem),
+        cartonSide3Cm: convertLengthToCm(side3, cartonUnitSystem),
       })
     },
-    [patchOrderLine, unitSystem]
+    [cartonUnitSystem, patchOrderLine]
   )
 
   const refreshForwardingCosts = useCallback(async () => {
@@ -3531,7 +3533,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                               Country
                             </th>
                             <th className="text-left font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[172px]">
-                              Carton Size ({lengthUnit})
+                              Carton Size ({cartonLengthUnit})
                             </th>
                             <th className="text-right font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[84px]">
                               Net ({weightUnit})
@@ -3732,7 +3734,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           placeholder="L"
                                           defaultValue={
                                             line.cartonSide1Cm != null
-                                              ? formatLengthFromCm(line.cartonSide1Cm, unitSystem)
+                                              ? formatLengthFromCm(line.cartonSide1Cm, cartonUnitSystem)
                                               : ''
                                           }
                                           data-carton-side-line={line.id}
@@ -3751,7 +3753,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           placeholder="W"
                                           defaultValue={
                                             line.cartonSide2Cm != null
-                                              ? formatLengthFromCm(line.cartonSide2Cm, unitSystem)
+                                              ? formatLengthFromCm(line.cartonSide2Cm, cartonUnitSystem)
                                               : ''
                                           }
                                           data-carton-side-line={line.id}
@@ -3770,7 +3772,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           placeholder="H"
                                           defaultValue={
                                             line.cartonSide3Cm != null
-                                              ? formatLengthFromCm(line.cartonSide3Cm, unitSystem)
+                                              ? formatLengthFromCm(line.cartonSide3Cm, cartonUnitSystem)
                                               : ''
                                           }
                                           data-carton-side-line={line.id}
@@ -3785,7 +3787,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                     ) : (
                                       <span className="text-xs text-slate-700 dark:text-slate-300">
                                         {cartonTriplet
-                                          ? `${formatLengthFromCm(cartonTriplet.side1Cm, unitSystem)}×${formatLengthFromCm(cartonTriplet.side2Cm, unitSystem)}×${formatLengthFromCm(cartonTriplet.side3Cm, unitSystem)}`
+                                          ? `${formatLengthFromCm(cartonTriplet.side1Cm, cartonUnitSystem)}×${formatLengthFromCm(cartonTriplet.side2Cm, cartonUnitSystem)}×${formatLengthFromCm(cartonTriplet.side3Cm, cartonUnitSystem)}`
                                           : '—'}
                                       </span>
                                     )}
@@ -4310,7 +4312,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                               Country
                             </th>
                             <th className="text-left font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[172px]">
-                              Carton Size ({lengthUnit})
+                              Carton Size ({cartonLengthUnit})
                             </th>
                             <th className="text-right font-medium text-muted-foreground px-2 py-2 whitespace-nowrap text-xs w-[84px]">
                               Net ({weightUnit})
@@ -4488,7 +4490,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                         placeholder="L"
                                         value={
                                           line.cartonSide1Cm != null
-                                            ? formatLengthFromCm(line.cartonSide1Cm, unitSystem)
+                                            ? formatLengthFromCm(line.cartonSide1Cm, cartonUnitSystem)
                                             : ''
                                         }
                                         onChange={e => {
@@ -4498,7 +4500,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           const next =
                                             nextInput === null
                                               ? null
-                                              : convertLengthToCm(nextInput, unitSystem)
+                                              : convertLengthToCm(nextInput, cartonUnitSystem)
                                           updateLine(current => {
                                             const triplet = resolveDimensionTripletCm({
                                               side1Cm: next,
@@ -4525,7 +4527,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                         placeholder="W"
                                         value={
                                           line.cartonSide2Cm != null
-                                            ? formatLengthFromCm(line.cartonSide2Cm, unitSystem)
+                                            ? formatLengthFromCm(line.cartonSide2Cm, cartonUnitSystem)
                                             : ''
                                         }
                                         onChange={e => {
@@ -4535,7 +4537,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           const next =
                                             nextInput === null
                                               ? null
-                                              : convertLengthToCm(nextInput, unitSystem)
+                                              : convertLengthToCm(nextInput, cartonUnitSystem)
                                           updateLine(current => {
                                             const triplet = resolveDimensionTripletCm({
                                               side1Cm: current.cartonSide1Cm ?? null,
@@ -4562,7 +4564,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                         placeholder="H"
                                         value={
                                           line.cartonSide3Cm != null
-                                            ? formatLengthFromCm(line.cartonSide3Cm, unitSystem)
+                                            ? formatLengthFromCm(line.cartonSide3Cm, cartonUnitSystem)
                                             : ''
                                         }
                                         onChange={e => {
@@ -4572,7 +4574,7 @@ export function InboundOrderFlow(props: InboundOrderFlowProps) {
                                           const next =
                                             nextInput === null
                                               ? null
-                                              : convertLengthToCm(nextInput, unitSystem)
+                                              : convertLengthToCm(nextInput, cartonUnitSystem)
                                           updateLine(current => {
                                             const triplet = resolveDimensionTripletCm({
                                               side1Cm: current.cartonSide1Cm ?? null,

--- a/apps/talos/src/lib/measurements.ts
+++ b/apps/talos/src/lib/measurements.ts
@@ -6,6 +6,7 @@ export type UnitSystem = 'metric' | 'imperial'
 
 export const CM_PER_INCH = 2.54
 export const LB_PER_KG = 2.2046226218
+export const CARTON_DIMENSION_UNIT_SYSTEM: UnitSystem = 'metric'
 
 export function getDefaultUnitSystem(tenantCode: TenantCode): UnitSystem {
   if (tenantCode === 'UK') return 'metric'

--- a/apps/talos/tests/unit/carton-dimensions.test.ts
+++ b/apps/talos/tests/unit/carton-dimensions.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+import {
+  CARTON_DIMENSION_UNIT_SYSTEM,
+  convertLengthToCm,
+  formatLengthFromCm,
+  getDefaultUnitSystem,
+  getLengthUnitLabel,
+} from '../../src/lib/measurements'
+
+test('US carton dimensions stay metric for inbound entry', () => {
+  assert.equal(getDefaultUnitSystem('US'), 'imperial')
+  assert.equal(CARTON_DIMENSION_UNIT_SYSTEM, 'metric')
+  assert.equal(getLengthUnitLabel(CARTON_DIMENSION_UNIT_SYSTEM), 'cm')
+  assert.equal(convertLengthToCm(27.99, CARTON_DIMENSION_UNIT_SYSTEM), 27.99)
+  assert.equal(formatLengthFromCm(27.99, CARTON_DIMENSION_UNIT_SYSTEM), '27.99')
+})
+
+test('inbound carton size controls use metric carton units instead of tenant package units', () => {
+  const talosRoot = path.resolve(__dirname, '..', '..')
+  const source = readFileSync(
+    path.join(talosRoot, 'src/components/inbound/inbound-flow.tsx'),
+    'utf8'
+  )
+
+  assert.equal(source.includes('const cartonUnitSystem = CARTON_DIMENSION_UNIT_SYSTEM'), true)
+  assert.equal(source.includes('const cartonLengthUnit = getLengthUnitLabel(cartonUnitSystem)'), true)
+  assert.equal(source.includes('Carton Size ({cartonLengthUnit})'), true)
+  assert.equal(source.includes('Carton Size ({lengthUnit})'), false)
+  assert.equal(source.includes('cartonSide1Cm: convertLengthToCm(side1, unitSystem)'), false)
+  assert.equal(source.includes('formatLengthFromCm(line.cartonSide1Cm, unitSystem)'), false)
+  assert.equal(source.includes('cartonSide1Cm: convertLengthToCm(side1, cartonUnitSystem)'), true)
+  assert.equal(source.includes('formatLengthFromCm(line.cartonSide1Cm, cartonUnitSystem)'), true)
+})

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,43 +1,63 @@
 # Targon
 
-> Targon is an AI-driven manufacturing and design company. Its public website currently centers on Caelum Star extra large drop cloths and dust sheets, with region-specific pages for the United States and United Kingdom.
+> Targon builds protection products for decorating and renovation work. The current public product line is Caelum Star. Start with the market selector, then use United States pages for drop cloth terminology and United Kingdom pages for dust sheet terminology.
 
-Important notes:
-- Use region-specific pages, since the United States and United Kingdom assortments differ.
-- Targonglobal.com provides product information, comparisons, and support; checkout, payment, shipping, and returns are handled on Amazon.
-- Prices shown on Targon pages are reference prices and may vary by retailer or marketplace.
+This file is the high-signal index for Targon's public website and primary buying paths.
 
-## Start Here
+Preferred interpretation:
+- Use Targonglobal.com pages for brand context, product positioning, pack comparison, support guidance, and wholesale enquiries.
+- Use Amazon listings for live commercial facts such as current price, stock, delivery speed, buyer protection, shipping, returns, and customer reviews.
+- The public site currently focuses on Caelum Star, but Targon Home is the brand-level entry point for current and future Targon product lines.
+- The core Caelum Star plastic-sheet pages describe extra large 12 x 9 ft sheets made with 55% recycled plastic and GRS certification. Separate UK cotton dust sheet variants are listed under UK Amazon links.
+- Support and wholesale enquiries route through support@targonglobal.com and the market-specific support / where-to-buy pages.
 
-- [Targon Home](https://www.targonglobal.com/): Company overview, mission, values, and featured Caelum Star entry points.
-- [Caelum Star Region Selector](https://www.targonglobal.com/cs): Choose the United States or United Kingdom product experience.
+## Brand and Navigation
+- [Targon Home](https://www.targonglobal.com/): Brand overview, mission, values, and entry point to current and future Targon product lines.
+- [Caelum Star Region Selector](https://www.targonglobal.com/cs): Choose the correct market before interpreting pack options or retailer links.
+- [Privacy](https://www.targonglobal.com/legal/privacy): Explains analytics, support-email handling, and data practices.
+- [Terms](https://www.targonglobal.com/legal/terms): States that the site is for product information and support, while Amazon governs checkout, payment, shipping, returns, and live availability.
 
-## Product Collections
+## Caelum Star — Product Context
+- [US About](https://www.targonglobal.com/cs/us/about): Core product story for the US market, including clean-work positioning, four pack sizes, extra large sheet format, recycled-material emphasis, and Amazon-first retail model.
+- [UK About](https://www.targonglobal.com/cs/uk/about): Core product story for the UK market, including clean-work positioning, six pack options, extra large sheet format, recycled-material emphasis, and Amazon-first retail model.
 
-- [US Packs](https://www.targonglobal.com/cs/us/packs): Compare all four US pack options, coverage, durability, and core specifications.
-- [UK Packs](https://www.targonglobal.com/cs/uk/packs): Compare all six UK pack options, coverage, durability, and core specifications.
-- [US Where to Buy](https://www.targonglobal.com/cs/us/where-to-buy): Official buying routes, wholesale enquiry path, and direct pack navigation for US visitors.
-- [UK Where to Buy](https://www.targonglobal.com/cs/uk/where-to-buy): Official buying routes, wholesale enquiry path, and direct pack navigation for UK visitors.
+## United States — Compare, Choose, Buy
+- [US Packs](https://www.targonglobal.com/cs/us/packs): Main US comparison page for pack sizes, project fit, sheet size, material claims, and on-site reference pricing.
+- [US Where to Buy](https://www.targonglobal.com/cs/us/where-to-buy): Official US buying page with Amazon as retail partner, direct pack links, and wholesale information.
+- [US Support](https://www.targonglobal.com/cs/us/support): US help centre with email support, pack-selection help, usage steps, safety note, and FAQs.
+- [US 6 Pack Product Page](https://www.targonglobal.com/cs/us/packs/6pk-light): On-site detail page for the US 6 Pack.
+- [US 1 Pack Product Page](https://www.targonglobal.com/cs/us/packs/1pk-strong): On-site detail page for the US 1 Pack.
+- [US 3 Pack Product Page](https://www.targonglobal.com/cs/us/packs/3pk-standard): On-site detail page for the US 3 Pack.
+- [US 12 Pack Product Page](https://www.targonglobal.com/cs/us/packs/12pk-light): On-site detail page for the US 12 Pack.
 
-## United States Product Pages
+## United States — Amazon Listings
+- [US 6 Pack Amazon](https://www.amazon.com/dp/B09HXC3NL8): Direct Amazon US listing for the 6 Pack with live price, availability, delivery, reviews, and return handling.
+- [US 1 Pack Amazon](https://www.amazon.com/dp/B0FLKJ7WWM): Direct Amazon US listing for the 1 Pack with live transactional details.
+- [US 3 Pack Amazon](https://www.amazon.com/dp/B0CR1GSBQ9): Direct Amazon US listing for the 3 Pack with live transactional details.
+- [US 12 Pack Amazon](https://www.amazon.com/dp/B0FP66CWQ6): Direct Amazon US listing for the 12 Pack with live transactional details.
 
-- [US 6 Pack — Light](https://www.targonglobal.com/cs/us/packs/6pk-light): 6-sheet pack with 648 sq ft total coverage and light durability.
-- [US 1 Pack — Strong](https://www.targonglobal.com/cs/us/packs/1pk-strong): 1-sheet pack with 108 sq ft coverage and strong durability.
-- [US 3 Pack — Standard](https://www.targonglobal.com/cs/us/packs/3pk-standard): 3-sheet pack with 324 sq ft total coverage and standard durability.
-- [US 12 Pack — Light](https://www.targonglobal.com/cs/us/packs/12pk-light): 12-sheet pack with 1296 sq ft total coverage and light durability.
+## United Kingdom — Compare, Choose, Buy
+- [UK Packs](https://www.targonglobal.com/cs/uk/packs): Main UK comparison page for plastic dust sheet pack options, project fit, sheet size, material claims, and on-site reference pricing.
+- [UK Where to Buy](https://www.targonglobal.com/cs/uk/where-to-buy): Official UK buying page with Amazon as retail partner, direct pack links, and wholesale information.
+- [UK Support](https://www.targonglobal.com/cs/uk/support): UK help centre with email support, pack-selection help, usage steps, safety note, and FAQs.
 
-## Brand and Support
+## United Kingdom — Amazon Plastic Dust Sheets
+- [UK 6 Pack — Light Amazon](https://www.amazon.co.uk/dp/B09HXC3NL8): Direct Amazon UK listing for the 6 Pack light plastic dust sheet variant.
+- [UK 6 Pack — Strong Amazon](https://www.amazon.co.uk/dp/B0DHDTPGGP): Direct Amazon UK listing for the 6 Pack strong plastic dust sheet variant.
+- [UK 1 Pack — Strong Amazon](https://www.amazon.co.uk/dp/B0FLKJ7WWM): Direct Amazon UK listing for the 1 Pack strong plastic dust sheet variant.
+- [UK 3 Pack — Strong Amazon](https://www.amazon.co.uk/dp/B0CR1GSBQ9): Direct Amazon UK listing for the 3 Pack strong plastic dust sheet variant.
+- [UK 3 Pack — Light Amazon](https://www.amazon.co.uk/dp/B0C7ZQ3VZL): Direct Amazon UK listing for the 3 Pack light plastic dust sheet variant.
+- [UK 10 Pack — Light Amazon](https://www.amazon.co.uk/dp/B0CR1H3VSF): Direct Amazon UK listing for the 10 Pack light plastic dust sheet variant.
 
-- [US About](https://www.targonglobal.com/cs/us/about): Brand positioning, mission, materials, and buying model for US visitors.
-- [UK About](https://www.targonglobal.com/cs/uk/about): Brand positioning, mission, materials, and buying model for UK visitors.
-- [US Support](https://www.targonglobal.com/cs/us/support): Contact, usage guide, and FAQ for US visitors.
-- [UK Support](https://www.targonglobal.com/cs/uk/support): Contact, usage guide, and FAQ for UK visitors.
+## United Kingdom — Additional Amazon Variants
+- [UK Cotton Dust Sheet — 12 x 9 ft Amazon](https://www.amazon.co.uk/dp/B0CW3L6PQH): Direct Amazon UK listing for the cotton dust sheet 12 x 9 ft variant.
+- [UK Cotton Dust Sheet — 12 x 4 ft Amazon](https://www.amazon.co.uk/dp/B0CW3N48K1): Direct Amazon UK listing for the cotton dust sheet 12 x 4 ft variant.
 
-## Legal
-
-- [Privacy](https://www.targonglobal.com/legal/privacy): How Targon handles site analytics, support email, and personal data.
-- [Terms](https://www.targonglobal.com/legal/terms): Website terms and the note that purchases, payments, shipping, and returns are governed by Amazon.
+## Support and Wholesale
+- [US Support](https://www.targonglobal.com/cs/us/support): Contact route for product questions, pack choice, usage guidance, and FAQs in the US market.
+- [UK Support](https://www.targonglobal.com/cs/uk/support): Contact route for product questions, pack choice, usage guidance, and FAQs in the UK market.
+- [US Wholesale / Bulk Enquiries](https://www.targonglobal.com/cs/us/where-to-buy): Volume pricing and trade enquiries for the US market.
+- [UK Wholesale / Bulk Enquiries](https://www.targonglobal.com/cs/uk/where-to-buy): Volume pricing and trade enquiries for the UK market.
 
 ## Optional
-
-- [US Gallery](https://www.targonglobal.com/cs/us/gallery): Official US product imagery and pack visuals.
+- [US Gallery](https://www.targonglobal.com/cs/us/gallery): Official Caelum Star visuals for the US market.


### PR DESCRIPTION
## Summary
- promote current `dev` to `main`
- includes the Talos inbound carton dimension metric-only fix from #5331
- carries the already-green dev branch state forward to production

## Validation
- Dev PR #5331 CI passed before merge
- Local Talos validation passed: test, type-check, lint, build
