### PR TITLE
fix(argus): stream WPR payload reads

### DIFF
--- a/apps/argus/lib/wpr/reader-market.test.ts
+++ b/apps/argus/lib/wpr/reader-market.test.ts
@@ -1,9 +1,16 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { createWprWeekSummary, getWprWeekSummary } from './reader'
+
+test('WPR reader streams the latest payload from disk', () => {
+  const source = readFileSync(new URL('./reader.ts', import.meta.url), 'utf8')
+
+  assert.match(source, /createReadStream/)
+  assert.doesNotMatch(source, /import\s+\{\s*stat,\s*readFile\s*\}\s+from\s+'node:fs\/promises'/)
+})
 
 function buildScpMetrics() {
   return {
@@ -109,9 +116,9 @@ function buildWeekBundle(anchorWeek: string) {
 const weekStartDateByLabel: Record<string, string> = {
   W07: '2026-02-08',
   W08: '2026-02-15',
-  W16: '2026-04-12',
-  W17: '2026-04-19',
-  W18: '2026-04-26',
+  W16: '2026-04-19',
+  W17: '2026-04-26',
+  W18: '2026-05-03',
 }
 
 function writePayload(dataDir: string, stableWeek: string, latestCompletedWeek: string) {

--- a/apps/argus/lib/wpr/reader.ts
+++ b/apps/argus/lib/wpr/reader.ts
@@ -1,5 +1,7 @@
-import { stat, readFile } from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { text as readStreamAsText } from 'node:stream/consumers';
 import { DEFAULT_ARGUS_MARKET, getArgusMarketConfig, type ArgusMarket } from '@/lib/argus-market';
 import { assertWprPayloadContract } from './payload-contract';
 import type {
@@ -26,6 +28,10 @@ function resolveLatestJsonPath(market: ArgusMarket): string {
   return join(getArgusMarketConfig(market).wprDataDir, 'wpr-data-latest.json');
 }
 
+async function readPayloadFile(path: string): Promise<string> {
+  return readStreamAsText(createReadStream(path, { encoding: 'utf8' }));
+}
+
 async function loadPayload(market: ArgusMarket): Promise<WprPayload> {
   const path = resolveLatestJsonPath(market);
   const fileStats = await stat(path);
@@ -35,7 +41,7 @@ async function loadPayload(market: ArgusMarket): Promise<WprPayload> {
     return cacheState.payload;
   }
 
-  const raw = await readFile(path, 'utf8');
+  const raw = await readPayloadFile(path);
   const payload = JSON.parse(raw) as unknown;
   assertWprPayloadContract(payload);
   cacheByMarket.set(market, {


### PR DESCRIPTION
## Summary
- stream Argus WPR payload reads instead of using fs.promises.readFile on the large Google Drive JSON
- keep the WPR week summary test stable after W18 became completed

## Verification
- pnpm -C apps/argus exec tsx --test lib/wpr/reader-market.test.ts
- pnpm -C apps/argus type-check
- pnpm -C apps/argus lint
- git diff --check
- real WPR payload smoke: getWprWeekSummary('us') parsed the 100 MB wpr-data-latest.json