### PR TITLE
fix(talos): keep output freshness strict after mutations

### DIFF
--- a/apps/talos/src/lib/services/inbound-stage-service.ts
+++ b/apps/talos/src/lib/services/inbound-stage-service.ts
@@ -3985,15 +3985,18 @@ export function serializeInboundOrder(
   const inboundPdfGeneratedAt = order.inboundPdfGeneratedAt ?? null
   const shippingMarksGeneratedAt = order.shippingMarksGeneratedAt ?? null
   const generatedOutputDates = [rfqPdfGeneratedAt, inboundPdfGeneratedAt, shippingMarksGeneratedAt]
-  const orderUpdatedAt = isOrderUpdatedByGeneratedOutput(order.updatedAt, generatedOutputDates)
-    ? null
-    : order.updatedAt
+  const hasSourceChangedAtOption =
+    typeof _options === 'object' && _options !== null && 'sourceChangedAt' in _options
+  const orderUpdatedAt =
+    hasSourceChangedAtOption &&
+    isOrderUpdatedByGeneratedOutput(order.updatedAt, generatedOutputDates)
+      ? null
+      : order.updatedAt
+  const sourceChangedAt = hasSourceChangedAtOption
+    ? normalizeOptionalDate(_options.sourceChangedAt)
+    : null
   const lastChangedAt =
-    maxDateOrNull([
-      orderUpdatedAt,
-      lastLineUpdatedAt,
-      normalizeOptionalDate(_options?.sourceChangedAt),
-    ]) ?? order.createdAt
+    maxDateOrNull([orderUpdatedAt, lastLineUpdatedAt, sourceChangedAt]) ?? order.createdAt
 
   return {
     id: order.id,

--- a/apps/talos/tests/unit/inbound-detail-all-data-view.test.ts
+++ b/apps/talos/tests/unit/inbound-detail-all-data-view.test.ts
@@ -74,6 +74,11 @@ test('generated inbound outputs do not stale themselves', () => {
 
   assert.equal(serviceSource.includes('isOrderUpdatedByGeneratedOutput('), true)
   assert.equal(serviceSource.includes('sourceChangedAt?: Date | string | null'), true)
+  assert.equal(serviceSource.includes('const hasSourceChangedAtOption ='), true)
+  assert.match(
+    serviceSource,
+    /hasSourceChangedAtOption\s*&&\s*isOrderUpdatedByGeneratedOutput\(order\.updatedAt,\s*generatedOutputDates\)/
+  )
   assert.equal(detailRouteSource.includes('OUTPUT_SOURCE_AUDIT_ACTIONS'), true)
   assert.equal(detailRouteSource.includes('sourceChangedAt: latestSourceAudit'), true)
   assert.equal(pdfRouteSource.includes('updatedAt: order.updatedAt'), true)


### PR DESCRIPTION
## Summary
- Only suppress generated-output self-stale timestamps when the detail serializer is given source-audit context.
- Keeps mutation responses strict so immediate source edits after output generation mark outputs out of date.
- Adds a regression assertion for the guarded freshness path.

## Verification
- `pnpm --dir apps/talos exec tsx tests/unit/inbound-detail-all-data-view.test.ts`
- `pnpm --dir apps/talos type-check`
- `pnpm --dir apps/talos lint` (7 existing warnings, 0 errors)
- `pnpm --dir apps/talos exec prettier --check src/lib/services/inbound-stage-service.ts tests/unit/inbound-detail-all-data-view.test.ts && git diff --check`
- `pnpm --dir apps/talos test`