### PR TITLE
fix(xplan): sync primary sellerboard draft strategies

### DIFF
--- a/apps/xplan/scripts/sellerboard-sync-worker.ts
+++ b/apps/xplan/scripts/sellerboard-sync-worker.ts
@@ -88,8 +88,8 @@ async function postSyncEndpoint(baseUrl: string, token: string, endpoint: string
 async function loadStrategies(): Promise<StrategyRow[]> {
   return prisma.strategy.findMany({
     where: {
-      status: 'ACTIVE',
       isPrimary: true,
+      status: { in: ['DRAFT', 'ACTIVE'] },
     },
     select: {
       id: true,
@@ -109,7 +109,7 @@ async function syncStrategy(baseUrl: string, token: string, strategy: StrategyRo
 
 async function runOnce(baseUrl: string, token: string): Promise<void> {
   const strategies = await loadStrategies();
-  console.log(`[xplan-sellerboard-sync] activePrimaryStrategies=${strategies.length}`);
+  console.log(`[xplan-sellerboard-sync] syncablePrimaryStrategies=${strategies.length}`);
 
   for (const strategy of strategies) {
     console.log(


### PR DESCRIPTION
## Summary
- allow the XPlan Sellerboard sync worker to process primary DRAFT strategies as well as ACTIVE strategies
- rename the worker count log from activePrimaryStrategies to syncablePrimaryStrategies

## Root Cause
The live US primary XPlan strategy is DRAFT, while the worker only selected ACTIVE primary strategies. The worker stayed healthy but skipped US.

## Validation
- pnpm --filter @targon/xplan type-check
- live PM2 worker posted US actual sales and dashboard successfully after the runtime patch
- worker stderr stayed at 0 bytes after the run
