### PR TITLE
fix(argus): repair WPR route login loop

### DIFF
--- a/apps/argus/app/(app)/wpr/page.test.ts
+++ b/apps/argus/app/(app)/wpr/page.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+test('WPR root page keeps the Suspense boundary on the client side', () => {
+  const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8');
+
+  assert.match(source, /^'use client';/);
+  assert.match(source, /<Suspense fallback=\{<WprPageFallback \/>\}>/);
+  assert.match(source, /<WprDashboardShell \/>/);
+});

--- a/apps/argus/app/(app)/wpr/page.tsx
+++ b/apps/argus/app/(app)/wpr/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Suspense } from 'react';
 import { Box, CircularProgress } from '@mui/material';
 import WprDashboardShell from '@/components/wpr/wpr-dashboard-shell';

--- a/apps/sso/app/login/google/route.test.ts
+++ b/apps/sso/app/login/google/route.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('google login route starts provider sign-in without redirecting on stale auth state', () => {
+  const source = readFileSync(new URL('./route.ts', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(source, /auth\(\)/)
+  assert.doesNotMatch(source, /resolvePortalCallbackTarget/)
+  assert.match(source, /signIn\('google'/)
+})

--- a/apps/sso/app/login/google/route.ts
+++ b/apps/sso/app/login/google/route.ts
@@ -1,6 +1,5 @@
-import { auth, signIn } from '@/lib/auth'
+import { signIn } from '@/lib/auth'
 import { appendExpiredAuthCookieHeaders } from '@/lib/auth-cookie-clear'
-import { resolvePortalCallbackTarget } from '@/lib/callback-target'
 import { requireAuthEnv } from '@/lib/required-auth-env'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
@@ -24,20 +23,6 @@ function isRecoverableAuthError(error: unknown): boolean {
 export async function GET(request: NextRequest) {
   const callbackUrl = request.nextUrl.searchParams.get('callbackUrl') ?? '/'
   const hasRetried = request.nextUrl.searchParams.get('retry') === '1'
-  const session = await auth()
-
-  if (session) {
-    const target = resolvePortalCallbackTarget({
-      targetUrl: callbackUrl,
-      portalBaseUrl: requireAuthEnv('NEXTAUTH_URL'),
-    })
-
-    if (target) {
-      return NextResponse.redirect(target)
-    }
-
-    return NextResponse.redirect(new URL('/', request.url))
-  }
 
   try {
     const redirectUrl = await signIn('google', { redirect: false, redirectTo: callbackUrl })

--- a/apps/sso/app/login/page.test.ts
+++ b/apps/sso/app/login/page.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+
+test('login page always renders the sign-in form instead of preflight redirecting', () => {
+  const source = readFileSync(new URL('./page.tsx', import.meta.url), 'utf8')
+
+  assert.doesNotMatch(source, /from 'next\/navigation'/)
+  assert.doesNotMatch(source, /auth\(\)/)
+  assert.match(source, /<form action="\/login\/google" method="get"/)
+})

--- a/apps/sso/app/login/page.tsx
+++ b/apps/sso/app/login/page.tsx
@@ -1,8 +1,4 @@
 import './login.css'
-import { redirect } from 'next/navigation'
-import { auth } from '@/lib/auth'
-import { resolvePortalCallbackTarget } from '@/lib/callback-target'
-import { requireAuthEnv } from '@/lib/required-auth-env'
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>
 
@@ -35,20 +31,6 @@ export default async function LoginPage({ searchParams }: { searchParams?: Searc
   const error = typeof errorParam === 'string' ? errorParam : ''
   const errorMessage = error === '' ? '' : getErrorMessage(error)
   const loginSubtitle = 'Authenticate once to reach the TargonOS launcher and every workspace your role can open.'
-  const session = await auth()
-
-  if (session) {
-    const target = resolvePortalCallbackTarget({
-      targetUrl: callbackUrl,
-      portalBaseUrl: requireAuthEnv('NEXTAUTH_URL'),
-    })
-
-    if (target) {
-      redirect(target)
-    }
-
-    redirect('/')
-  }
 
   return (
     <div className="login-shell">

--- a/apps/sso/app/page.tsx
+++ b/apps/sso/app/page.tsx
@@ -2,6 +2,7 @@ import { filterAppsForUser, resolveAppUrl, ALL_APPS, type AppDef } from '@/lib/a
 import { getSafeServerSession } from '@/lib/safe-session'
 import PortalClient, { type PortalAppCard } from './PortalClient'
 import LoginPage from './login/page'
+import { hasSignedInUser } from '@/lib/session-state'
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>
 
@@ -21,7 +22,7 @@ function withLaunchUrl(app: AppDef): PortalAppCard {
 
 export default async function PortalHome({ searchParams }: { searchParams: SearchParams }) {
   const session = await getSafeServerSession()
-  if (!session) {
+  if (!hasSignedInUser(session)) {
     return <LoginPage />
   }
 

--- a/apps/sso/lib/session-state.test.ts
+++ b/apps/sso/lib/session-state.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import type { Session } from 'next-auth'
+import { hasSignedInUser } from './session-state'
+
+test('hasSignedInUser rejects null and empty session objects', () => {
+  assert.equal(hasSignedInUser(null), false)
+  assert.equal(hasSignedInUser({} as Session), false)
+  assert.equal(hasSignedInUser({ user: {} } as Session), false)
+  assert.equal(hasSignedInUser({ user: { email: '   ' } } as Session), false)
+})
+
+test('hasSignedInUser accepts a session with a real email', () => {
+  assert.equal(hasSignedInUser({ user: { email: 'jarrar@targonglobal.com' } } as Session), true)
+})

--- a/apps/sso/lib/session-state.ts
+++ b/apps/sso/lib/session-state.ts
@@ -1,0 +1,6 @@
+import type { Session } from 'next-auth'
+
+export function hasSignedInUser(session: Session | null): session is Session {
+  const email = session?.user?.email
+  return typeof email === 'string' && email.trim() !== ''
+}


### PR DESCRIPTION
## Summary
- keep Argus WPR root page on the client side so the MUI Suspense fallback is not serialized through RSC
- stop SSO /login and /login/google from preflight-redirecting back to Argus on stale or misleading auth state
- require a real signed-in user email before rendering the portal launcher

## Verification
- pnpm exec tsx --test apps/sso/app/login/page.test.ts apps/sso/app/login/google/route.test.ts apps/sso/lib/session-state.test.ts
- pnpm exec tsx --test apps/argus/app/'(app)'/wpr/page.test.ts
- pnpm --filter @targon/sso type-check
- pnpm --filter @targon/argus type-check
- pnpm --filter @targon/argus lint
- pnpm --filter @targon/sso build
- pnpm --filter @targon/argus build
- local smoke: /login returns 200 sign-in form, /login/google redirects to Google, /argus/wpr renders 200 and UK WPR API returns 200