### PR TITLE
fix(argus): default WPR SQP selection

### DIFF
--- a/apps/argus/components/wpr/tabs/sqp-tab.tsx
+++ b/apps/argus/components/wpr/tabs/sqp-tab.tsx
@@ -6,7 +6,9 @@ import {
   allSelectableSqpRootIds,
   allSelectableSqpTermIds,
   createSqpSelectionViewModel,
+  defaultSqpRootIds,
   rootTermIds,
+  selectableSqpTermIdsForRoots,
 } from '@/lib/wpr/sqp-view-model'
 import type { WprChangeLogEntry, WprWeekBundle } from '@/lib/wpr/types'
 import { buildBundleWeekStartDateLookup } from '@/lib/wpr/week-display'
@@ -82,10 +84,11 @@ export default function SqpTab({
     const filteredExpandedIds = filterIds(expandedSqpRootIds, rootIdSet)
 
     if (!hasInitializedSqpSelection) {
+      const defaultRootIds = defaultSqpRootIds(bundle)
       replaceState({
-        selectedClusterId: null,
-        selectedSqpRootIds: new Set<string>(),
-        selectedSqpTermIds: new Set<string>(),
+        selectedClusterId: firstSetMember(new Set(defaultRootIds)),
+        selectedSqpRootIds: new Set(defaultRootIds),
+        selectedSqpTermIds: new Set(selectableSqpTermIdsForRoots(bundle, defaultRootIds)),
         expandedSqpRootIds: new Set<string>(),
         hasInitializedSqpSelection: true,
       })

--- a/apps/argus/components/wpr/wpr-change-props.test.ts
+++ b/apps/argus/components/wpr/wpr-change-props.test.ts
@@ -189,17 +189,13 @@ test('changelog owns its week selector once the top bar stops rendering one', ()
   assert.match(changelogTabSource, /onSelectWeek=\{onSelectWeek\}/)
 })
 
-test('SQP and TST do not auto-select the default cluster on first load', () => {
+test('SQP initializes default roots on first load while TST stays unselected', () => {
   const sqpSource = readFileSync(new URL('./tabs/sqp-tab.tsx', import.meta.url), 'utf8')
   const tstSource = readFileSync(new URL('./tabs/tst-tab.tsx', import.meta.url), 'utf8')
 
   assert.match(
     sqpSource,
-    /if \(!hasInitializedSqpSelection\) \{[\s\S]*selectedClusterId: null,[\s\S]*selectedSqpRootIds: new Set<string>\(\),[\s\S]*selectedSqpTermIds: new Set<string>\(\),[\s\S]*expandedSqpRootIds: new Set<string>\(\),[\s\S]*hasInitializedSqpSelection: true,[\s\S]*return/,
-  )
-  assert.doesNotMatch(
-    sqpSource,
-    /if \(!hasInitializedSqpSelection\) \{[\s\S]*selectedClusterId: defaultRootId,[\s\S]*selectedSqpRootIds: new Set\(\[defaultRootId\]\),[\s\S]*selectedSqpTermIds: new Set\(rootTermIds\(bundle, defaultRootId\)\)/,
+    /if \(!hasInitializedSqpSelection\) \{[\s\S]*const defaultRootIds = defaultSqpRootIds\(bundle\)[\s\S]*selectedClusterId: firstSetMember\(new Set\(defaultRootIds\)\),[\s\S]*selectedSqpRootIds: new Set\(defaultRootIds\),[\s\S]*selectedSqpTermIds: new Set\(selectableSqpTermIdsForRoots\(bundle, defaultRootIds\)\),[\s\S]*expandedSqpRootIds: new Set<string>\(\),[\s\S]*hasInitializedSqpSelection: true,[\s\S]*return/,
   )
 
   assert.match(

--- a/apps/argus/lib/wpr/dashboard-state.test.ts
+++ b/apps/argus/lib/wpr/dashboard-state.test.ts
@@ -159,6 +159,20 @@ test('WPR persisted state migration reopens initialized empty SQP selections', (
   assert.equal(migrated.weekStateByWeek.W16?.hasInitializedSqpSelection, false)
 })
 
+test('WPR persisted state migration reopens version 2 initialized empty SQP selections', () => {
+  const state = createInitialDashboardState('W16')
+  state.hasInitializedSqpSelection = true
+  state.weekStateByWeek.W16 = {
+    ...captureWeekScopedState(state),
+    hasInitializedSqpSelection: true,
+  }
+
+  const migrated = migrateWprDashboardState(state, 2) as typeof state
+
+  assert.equal(migrated.hasInitializedSqpSelection, false)
+  assert.equal(migrated.weekStateByWeek.W16?.hasInitializedSqpSelection, false)
+})
+
 test('WPR persisted state migration preserves non-empty SQP selections', () => {
   const state = createInitialDashboardState('W16')
   state.selectedSqpRootIds = new Set(['cluster-a'])

--- a/apps/argus/lib/wpr/dashboard-state.ts
+++ b/apps/argus/lib/wpr/dashboard-state.ts
@@ -226,7 +226,7 @@ function resetInitializedEmptySqpSelection<T extends Record<string, unknown>>(st
 }
 
 export function migrateWprDashboardState(persistedState: unknown, persistedVersion: number): unknown {
-  if (persistedVersion >= 2) {
+  if (persistedVersion >= 3) {
     return persistedState
   }
 

--- a/apps/argus/stores/wpr-store.ts
+++ b/apps/argus/stores/wpr-store.ts
@@ -190,7 +190,7 @@ export const useWprStore = create<WprStore>()(
     },
     {
       name: 'argus-wpr-dashboard',
-      version: 2,
+      version: 3,
       storage: createJSONStorage(() => localStorage, {
         replacer: wprStateReplacer,
         reviver: wprStateReviver,


### PR DESCRIPTION
Fix WPR SQP first-load behavior so the dashboard initializes from payload defaultClusterIds instead of rendering an empty chart/selection. Bumps the persisted WPR store version so existing empty saved selections reopen once.\n\nVerification:\n- pnpm exec tsx --test apps/argus/components/wpr/wpr-change-props.test.ts apps/argus/lib/wpr/dashboard-state.test.ts apps/argus/lib/wpr/sqp-view-model.test.ts\n- pnpm --filter @targon/argus type-check\n- pnpm --filter @targon/argus lint\n- pnpm --filter @targon/argus build\n- local browser: http://localhost:3317/argus/wpr renders US with 5 roots / 207 selected and UK with 3 roots / 34 selected