### PR TITLE
fix(argus): harden WPR monitoring backfill

### DIFF
--- a/apps/argus/scripts/api/weekly-sources/collect-datadive.mjs
+++ b/apps/argus/scripts/api/weekly-sources/collect-datadive.mjs
@@ -9,6 +9,7 @@ import {
   latestCompleteWeek,
   loadMonitoringEnv,
   requireEnv,
+  weekContextForRange,
   wprSourceConfigForMarket,
   writeCsv,
   writeTextFile,
@@ -68,8 +69,41 @@ const COMPETITOR_HEADERS = [
 ]
 
 function parseArgs() {
+  const argv = process.argv.slice(2)
+  let dryRun = false
+  let startDate = null
+  let endDate = null
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--dry-run') {
+      dryRun = true
+      continue
+    }
+    if (arg === '--market') {
+      index += 1
+      continue
+    }
+    if (arg === '--start-date') {
+      startDate = argv[index + 1] ?? null
+      index += 1
+      continue
+    }
+    if (arg === '--end-date') {
+      endDate = argv[index + 1] ?? null
+      index += 1
+      continue
+    }
+    throw new Error(`Unknown argument: ${arg}`)
+  }
+
+  if ((startDate && !endDate) || (!startDate && endDate)) {
+    throw new Error('Both --start-date and --end-date are required together.')
+  }
+
   return {
-    dryRun: process.argv.includes('--dry-run'),
+    dryRun,
+    week: startDate && endDate ? weekContextForRange(startDate, endDate) : latestCompleteWeek(),
   }
 }
 
@@ -222,8 +256,7 @@ function writeRankRadarCsv(file, week, sourceConfig, rankRadarId, rows) {
 }
 
 async function main() {
-  const { dryRun } = parseArgs()
-  const week = latestCompleteWeek()
+  const { dryRun, week } = parseArgs()
   const sourceConfig = wprSourceConfigForMarket()
   const weekPrefix = `${week.weekCode}_${week.weekEnd}`
   const scopeLabel = `${week.weekCode} ${week.weekStart}..${week.weekEnd}`

--- a/apps/argus/scripts/api/weekly-sources/collect-sp-ads.py
+++ b/apps/argus/scripts/api/weekly-sources/collect-sp-ads.py
@@ -3,6 +3,7 @@
 import argparse
 import csv
 import gzip
+import http.client
 import json
 import os
 import re
@@ -10,7 +11,7 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 ARGUS_APP_ROOT = Path(__file__).resolve().parents[3]
@@ -23,6 +24,8 @@ CURRENT_MARKET = None
 
 POLL_INTERVAL_SEC = 15
 MAX_WAIT_SECONDS = 40 * 60
+ACTIVE_REPORT_REUSE_MAX_SECONDS = 30 * 60
+ACTIVE_REPORT_STATUSES = {'PENDING', 'PROCESSING', 'IN_QUEUE', 'IN_PROGRESS'}
 
 SUBDIR = {
     'search_term': 'SP - Search Term Report (API)',
@@ -41,6 +44,8 @@ CODE_SUFFIX = {
     'placement': 'SP-Placement',
     'purchased': 'SP-Purchased',
 }
+
+SUPPORTED_REPORTS = set(CODE_SUFFIX.keys())
 
 
 def load_env(path: Path):
@@ -67,6 +72,24 @@ def parse_market(raw):
     if value in ('us', 'uk'):
         return value
     raise RuntimeError(f'Unsupported Argus market: {raw}')
+
+
+def parse_reports(raw):
+    if raw is None:
+        return set(SUPPORTED_REPORTS)
+
+    selected = set()
+    for item in raw.split(','):
+        value = item.strip().lower().replace('-', '_')
+        if not value:
+            continue
+        if value not in SUPPORTED_REPORTS:
+            raise RuntimeError(f'Unsupported SP Ads report: {item}')
+        selected.add(value)
+
+    if not selected:
+        raise RuntimeError('--reports must include at least one supported report.')
+    return selected
 
 
 def monitoring_base_for_market(env, market):
@@ -282,7 +305,7 @@ def get_report_status(base_url, headers, report_id):
     for attempt in range(1, 4):
         try:
             status, resp = http_json(endpoint, method='GET', headers=headers)
-        except urllib.error.URLError:
+        except (urllib.error.URLError, http.client.RemoteDisconnected, TimeoutError):
             if attempt == 3:
                 raise
             time.sleep(attempt)
@@ -366,6 +389,63 @@ def manifest_entry_for(reports, key, suffix):
     return None
 
 
+def reusable_manifest_entry(existing_manifest, key, suffix):
+    if not existing_manifest:
+        return None
+    reports = existing_manifest.get('reports') or {}
+    entry = manifest_entry_for(reports, key, suffix)
+    if not entry:
+        return None
+    if not str(entry.get('reportId') or '').strip():
+        return None
+    status = str(entry.get('status') or '').upper()
+    if status in ('FAILED', 'FAILURE', 'CANCELLED'):
+        return None
+    if status in ACTIVE_REPORT_STATUSES and active_manifest_entry_is_stale(existing_manifest, entry):
+        return None
+    return entry
+
+
+def parse_api_datetime(value):
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith('Z'):
+        text = text[:-1] + '+00:00'
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def active_manifest_entry_is_stale(existing_manifest, entry):
+    candidate_values = [
+        entry.get('updatedAt'),
+        entry.get('createdAt'),
+    ]
+    if existing_manifest:
+        candidate_values.append(existing_manifest.get('generatedAt'))
+
+    newest = None
+    for value in candidate_values:
+        parsed = parse_api_datetime(value)
+        if parsed is None:
+            continue
+        if newest is None or parsed > newest:
+            newest = parsed
+
+    if newest is None:
+        return False
+
+    age_seconds = (datetime.now(timezone.utc) - newest).total_seconds()
+    return age_seconds > ACTIVE_REPORT_REUSE_MAX_SECONDS
+
+
 def can_reuse_key_output(existing_manifest, week, key, entries, ads_metadata):
     if not existing_manifest:
         return False
@@ -393,6 +473,53 @@ def can_reuse_key_output(existing_manifest, week, key, entries, ads_metadata):
             return False
 
     return True
+
+
+def manifest_payload(existing_manifest, week, ads_metadata, skipped_keys, task_entries, outputs):
+    grouped = {}
+    for entry in task_entries:
+        grouped.setdefault(entry['key'], []).append(entry)
+
+    return {
+        'generatedAt': datetime.utcnow().isoformat() + 'Z',
+        'market': ads_metadata['market'],
+        'profileId': ads_metadata['profileId'],
+        'adsApiBaseUrl': ads_metadata['adsApiBaseUrl'],
+        'week': week,
+        'pollIntervalSec': POLL_INTERVAL_SEC,
+        'maxWaitSec': MAX_WAIT_SECONDS,
+        'reports': {
+            **{
+                key: (existing_manifest.get('reports') or {}).get(key, [])
+                for key in skipped_keys
+                if existing_manifest and (existing_manifest.get('reports') or {}).get(key)
+            },
+            **{
+                key: [
+                    {
+                        'suffix': entry['suffix'],
+                        'reportId': entry['reportId'],
+                        'status': entry['statusObj'].get('status') if entry.get('statusObj') else entry.get('status') or 'PENDING',
+                        'createdAt': entry['statusObj'].get('createdAt') if entry.get('statusObj') else entry.get('createdAt'),
+                        'updatedAt': entry['statusObj'].get('updatedAt') if entry.get('statusObj') else entry.get('updatedAt'),
+                        'reused': entry['reused'],
+                        'attempts': entry['attempts'],
+                        'outputColumns': entry['outputColumns'],
+                        'finalColumns': entry['columns'],
+                    }
+                    for entry in entries
+                ]
+                for key, entries in grouped.items()
+            },
+        },
+        'outputs': outputs,
+    }
+
+
+def write_manifest(manifest_path, payload):
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(payload, indent=2))
+    enqueue_drive_sync(manifest_path)
 
 
 def report_configs():
@@ -517,7 +644,7 @@ def report_configs():
     }
 
 
-def run_week(base_url, headers, week, ads_metadata):
+def run_week(base_url, headers, week, ads_metadata, selected_reports):
     tasks = []
     configs = report_configs()
     manifest_path = MANIFEST_ROOT / f"{week['code']}_{week['endDate']}_SP-Manifest.json"
@@ -526,6 +653,8 @@ def run_week(base_url, headers, week, ads_metadata):
     skipped_keys = set()
 
     for key, entries in configs.items():
+        if key not in selected_reports:
+            continue
         if can_reuse_key_output(existing_manifest, week, key, entries, ads_metadata):
             outputs[key] = dict((existing_manifest.get('outputs') or {}).get(key) or {})
             print(f'[{week["code"]}] reuse existing {key} output file={output_path_for_week(week, key)}', flush=True)
@@ -533,12 +662,26 @@ def run_week(base_url, headers, week, ads_metadata):
             continue
 
         for suffix, cfg_base, request_columns, output_columns in entries:
-            created = create_with_adaptive_columns(base_url, headers, week, key, suffix, cfg_base, request_columns)
-            print(
-                f'[{week["code"]}] create {key}/{suffix} reportId={created["reportId"]} '
-                f'reused={created["reused"]} attempts={created["attempts"]} finalCols={len(created["columns"])}',
-                flush=True,
-            )
+            existing_entry = reusable_manifest_entry(existing_manifest, key, suffix)
+            if existing_entry:
+                created = {
+                    'reportId': existing_entry['reportId'],
+                    'columns': existing_entry.get('finalColumns') or request_columns,
+                    'reused': True,
+                    'attempts': existing_entry.get('attempts') or 0,
+                    'status': existing_entry.get('status') or 'PENDING',
+                    'createdAt': existing_entry.get('createdAt'),
+                    'updatedAt': existing_entry.get('updatedAt'),
+                }
+                print(f'[{week["code"]}] resume {key}/{suffix} reportId={created["reportId"]}', flush=True)
+            else:
+                created = create_with_adaptive_columns(base_url, headers, week, key, suffix, cfg_base, request_columns)
+                created['createdAt'] = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+                print(
+                    f'[{week["code"]}] create {key}/{suffix} reportId={created["reportId"]} '
+                    f'reused={created["reused"]} attempts={created["attempts"]} finalCols={len(created["columns"])}',
+                    flush=True,
+                )
             tasks.append({
                 'key': key,
                 'suffix': suffix,
@@ -547,12 +690,17 @@ def run_week(base_url, headers, week, ads_metadata):
                 'reportId': created['reportId'],
                 'reused': created['reused'],
                 'attempts': created['attempts'],
+                'status': created.get('status') or 'PENDING',
+                'createdAt': created.get('createdAt'),
+                'updatedAt': created.get('updatedAt'),
                 'statusObj': None,
             })
 
     if not tasks:
         print(f'[{week["code"]}] manifest {manifest_path} already current', flush=True)
         return
+
+    write_manifest(manifest_path, manifest_payload(existing_manifest, week, ads_metadata, skipped_keys, tasks, outputs))
 
     deadline = time.time() + MAX_WAIT_SECONDS
     pending = len(tasks)
@@ -608,44 +756,8 @@ def run_week(base_url, headers, week, ads_metadata):
         }
         print(f'[{week["code"]}] saved {key} rows={len(rows)} file={output_path}', flush=True)
 
-    manifest = {
-        'generatedAt': datetime.utcnow().isoformat() + 'Z',
-        'market': ads_metadata['market'],
-        'profileId': ads_metadata['profileId'],
-        'adsApiBaseUrl': ads_metadata['adsApiBaseUrl'],
-        'week': week,
-        'pollIntervalSec': POLL_INTERVAL_SEC,
-        'maxWaitSec': MAX_WAIT_SECONDS,
-        'reports': {
-            **{
-                key: (existing_manifest.get('reports') or {}).get(key, [])
-                for key in skipped_keys
-                if existing_manifest and (existing_manifest.get('reports') or {}).get(key)
-            },
-            **{
-                key: [
-                {
-                    'suffix': entry['suffix'],
-                    'reportId': entry['reportId'],
-                    'status': entry['statusObj'].get('status'),
-                    'createdAt': entry['statusObj'].get('createdAt'),
-                    'updatedAt': entry['statusObj'].get('updatedAt'),
-                    'reused': entry['reused'],
-                    'attempts': entry['attempts'],
-                    'outputColumns': entry['outputColumns'],
-                    'finalColumns': entry['columns'],
-                }
-                for entry in entries
-            ]
-            for key, entries in completed.items()
-            },
-        },
-        'outputs': outputs,
-    }
-
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps(manifest, indent=2))
-    enqueue_drive_sync(manifest_path)
+    manifest = manifest_payload(existing_manifest, week, ads_metadata, skipped_keys, tasks, outputs)
+    write_manifest(manifest_path, manifest)
     print(f'[{week["code"]}] manifest {manifest_path}', flush=True)
 
 
@@ -656,6 +768,7 @@ def main():
     parser.add_argument('--start-date')
     parser.add_argument('--end-date')
     parser.add_argument('--market', default=os.environ.get('ARGUS_MARKET', 'us'))
+    parser.add_argument('--reports')
     args = parser.parse_args()
 
     if bool(args.start_date) != bool(args.end_date):
@@ -664,6 +777,7 @@ def main():
     env = load_env(ENV_PATH)
     env.update(os.environ)
     market = parse_market(args.market)
+    selected_reports = parse_reports(args.reports)
     CURRENT_MARKET = market
     MONITORING_ROOT = monitoring_base_for_market(env, market)
     DEST_ROOT = MONITORING_ROOT / 'Weekly' / 'Ad Console' / 'SP - Sponsored Products (API)'
@@ -674,6 +788,8 @@ def main():
     if dry_run:
         print(f'[SP-Ads][dry-run] week={week["code"]} {week["startDate"]}..{week["endDate"]}')
         for key, subdir in SUBDIR.items():
+            if key not in selected_reports:
+                continue
             suffix = CODE_SUFFIX[key]
             file_name = f'{week["code"]}_{week["endDate"]}_{suffix}.csv'
             print(f'[SP-Ads][dry-run] {DEST_ROOT / subdir / file_name}')
@@ -696,7 +812,7 @@ def main():
     }
 
     print(f'=== {week["code"]} {week["startDate"]}..{week["endDate"]} ===', flush=True)
-    run_week(base_url, headers, week, ads_metadata)
+    run_week(base_url, headers, week, ads_metadata, selected_reports)
 
 
 if __name__ == '__main__':

--- a/apps/argus/scripts/api/weekly-sources/collect-spapi.mjs
+++ b/apps/argus/scripts/api/weekly-sources/collect-spapi.mjs
@@ -32,6 +32,7 @@ const TALOS_PACKAGE_JSON = path.join(REPO_ROOT, 'apps/talos/package.json')
 const ACTIVE_REPORT_STATUSES = new Set(['IN_QUEUE', 'IN_PROGRESS'])
 const DONE_REPORT_STATUSES = new Set(['DONE'])
 const REPORT_WAIT_TIMEOUT_MS = 120 * 60 * 1000
+const ACTIVE_REPORT_REUSE_MAX_AGE_MS = 30 * 60 * 1000
 
 const WEEKLY_ROOT = path.join(MONITORING_BASE, 'Weekly')
 const SPAPI_MANIFEST_DIR = path.join(MONITORING_BASE, 'Logs', 'weekly-api-sources', 'metadata')
@@ -226,6 +227,7 @@ function parseArgs() {
   let dryRun = false
   let startDate = null
   let endDate = null
+  let reports = ['scp', 'sqp', 'sales', 'tst']
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]
@@ -247,6 +249,25 @@ function parseArgs() {
       index += 1
       continue
     }
+    if (arg === '--reports') {
+      const rawReports = argv[index + 1] ?? ''
+      const parsedReports = rawReports
+        .split(',')
+        .map((value) => value.trim().toLowerCase())
+        .filter(Boolean)
+      const supportedReports = new Set(['scp', 'sqp', 'sales', 'tst'])
+      for (const report of parsedReports) {
+        if (!supportedReports.has(report)) {
+          throw new Error(`Unsupported SP-API report selector: ${report}`)
+        }
+      }
+      if (!parsedReports.length) {
+        throw new Error('--reports requires at least one report selector.')
+      }
+      reports = parsedReports
+      index += 1
+      continue
+    }
     throw new Error(`Unknown argument: ${arg}`)
   }
 
@@ -256,6 +277,7 @@ function parseArgs() {
 
   return {
     dryRun,
+    reports,
     week: startDate && endDate ? weekContextForRange(startDate, endDate) : latestCompleteWeek(),
   }
 }
@@ -363,6 +385,16 @@ function canBlindlyReuseReport(report, reportOptions) {
   return sameReportOptions(report.reportOptions, reportOptions)
 }
 
+function isStaleActiveReport(report) {
+  if (!ACTIVE_REPORT_STATUSES.has(report?.processingStatus)) return false
+  if (!report?.createdTime) return false
+
+  const createdAt = new Date(report.createdTime).getTime()
+  if (Number.isNaN(createdAt)) return false
+
+  return Date.now() - createdAt > ACTIVE_REPORT_REUSE_MAX_AGE_MS
+}
+
 async function findReusableReport(client, { reportType, marketplaceId, dataStartTime, dataEndTime, reportOptions = null, statuses }) {
   const response = await client.callAPI({
     operation: 'getReports',
@@ -381,6 +413,7 @@ async function findReusableReport(client, { reportType, marketplaceId, dataStart
       .filter((report) => sameInstant(report?.dataEndTime, dataEndTime))
       .filter((report) => canBlindlyReuseReport(report, reportOptions))
       .filter((report) => statuses.has(report?.processingStatus))
+      .filter((report) => !isStaleActiveReport(report))
       .sort((left, right) => String(right?.createdTime ?? '').localeCompare(String(left?.createdTime ?? '')))[0] ?? null
   )
 }
@@ -430,15 +463,19 @@ async function resolveReportId(client, { reportType, reportWindow, label, report
     return manifestReport.reportId
   }
 
-  if (ACTIVE_REPORT_STATUSES.has(manifestStatus)) {
-    console.log(`[SP-API] ${label} reusing manifest active reportId=${manifestReport.reportId}`)
-    return waitForReport(client, manifestReport.reportId, label)
-  }
-
   const completedReport = await findReusableReport(client, { ...criteria, statuses: DONE_REPORT_STATUSES })
   if (completedReport?.reportId) {
     console.log(`[SP-API] ${label} reusing DONE reportId=${completedReport.reportId}`)
     return completedReport.reportId
+  }
+
+  if (ACTIVE_REPORT_STATUSES.has(manifestStatus) && !isStaleActiveReport(manifestReport)) {
+    console.log(`[SP-API] ${label} reusing manifest active reportId=${manifestReport.reportId}`)
+    return waitForReport(client, manifestReport.reportId, label)
+  }
+
+  if (ACTIVE_REPORT_STATUSES.has(manifestStatus) && isStaleActiveReport(manifestReport)) {
+    console.log(`[SP-API] ${label} ignoring stale manifest active reportId=${manifestReport.reportId}`)
   }
 
   const activeReport = await findReusableReport(client, { ...criteria, statuses: ACTIVE_REPORT_STATUSES })
@@ -565,7 +602,8 @@ function runTstFilter(rawPath, outputPath, targetAsins) {
 }
 
 async function main() {
-  const { dryRun, week } = parseArgs()
+  const { dryRun, week, reports } = parseArgs()
+  const selectedReports = new Set(reports)
   const { weekCode, weekStart, weekEnd } = week
 
   const weekPrefix = `${weekCode}_${weekEnd}`
@@ -595,11 +633,13 @@ async function main() {
 
   if (dryRun) {
     console.log(`[SP-API][dry-run] scope=${scopeLabel}`)
-    console.log(`[SP-API][dry-run] ${scpPath}`)
-    console.log(`[SP-API][dry-run] ${sqpPath}`)
-    console.log(`[SP-API][dry-run] ${filteredTstPath}`)
-    console.log(`[SP-API][dry-run] ${salesByDatePath}`)
-    console.log(`[SP-API][dry-run] ${salesByAsinPath}`)
+    if (selectedReports.has('scp')) console.log(`[SP-API][dry-run] ${scpPath}`)
+    if (selectedReports.has('sqp')) console.log(`[SP-API][dry-run] ${sqpPath}`)
+    if (selectedReports.has('tst')) console.log(`[SP-API][dry-run] ${filteredTstPath}`)
+    if (selectedReports.has('sales')) {
+      console.log(`[SP-API][dry-run] ${salesByDatePath}`)
+      console.log(`[SP-API][dry-run] ${salesByAsinPath}`)
+    }
     return
   }
 
@@ -639,87 +679,95 @@ async function main() {
   manifestState.competitorBrand = sourceConfig.competitorBrand
   manifestState.targetAsins = tstTargetAsins
 
-  const scpReportId = await resolveReportId(client, {
-    reportType: 'GET_BRAND_ANALYTICS_SEARCH_CATALOG_PERFORMANCE_REPORT',
-    reportWindow,
-    label: `${scopeLabel} SCP`,
-    reportOptions: { reportPeriod: 'WEEK' },
-    manifestReportId: existingManifest?.reports?.scpReportId,
-    onReportCreated: rememberReportId('scpReportId'),
-  })
-  rememberReportId('scpReportId')(scpReportId)
-  const canReuseScpOutput = existingManifest?.reports?.scpReportId === scpReportId && fs.existsSync(scpPath)
-  if (canReuseScpOutput) {
-    console.log(`[SP-API] ${scopeLabel} SCP output already current for reportId=${scpReportId}`)
-  } else {
-    const scpData = await downloadJsonReport(client, scpReportId)
-    rowsToCsv(scpPath, scpData.parsed?.dataByAsin || [], SCP_HEADERS)
+  if (selectedReports.has('scp')) {
+    const scpReportId = await resolveReportId(client, {
+      reportType: 'GET_BRAND_ANALYTICS_SEARCH_CATALOG_PERFORMANCE_REPORT',
+      reportWindow,
+      label: `${scopeLabel} SCP`,
+      reportOptions: { reportPeriod: 'WEEK' },
+      manifestReportId: existingManifest?.reports?.scpReportId,
+      onReportCreated: rememberReportId('scpReportId'),
+    })
+    rememberReportId('scpReportId')(scpReportId)
+    const canReuseScpOutput = existingManifest?.reports?.scpReportId === scpReportId && fs.existsSync(scpPath)
+    if (canReuseScpOutput) {
+      console.log(`[SP-API] ${scopeLabel} SCP output already current for reportId=${scpReportId}`)
+    } else {
+      const scpData = await downloadJsonReport(client, scpReportId)
+      rowsToCsv(scpPath, scpData.parsed?.dataByAsin || [], SCP_HEADERS)
+    }
   }
 
-  const sqpReportId = await resolveReportId(client, {
-    reportType: 'GET_BRAND_ANALYTICS_SEARCH_QUERY_PERFORMANCE_REPORT',
-    reportWindow,
-    label: `${scopeLabel} SQP`,
-    reportOptions: { reportPeriod: 'WEEK', asin: sourceConfig.heroAsin },
-    manifestReportId: existingManifest?.reports?.sqpReportId,
-    onReportCreated: rememberReportId('sqpReportId'),
-  })
-  rememberReportId('sqpReportId')(sqpReportId)
-  const canReuseSqpOutput = existingManifest?.reports?.sqpReportId === sqpReportId && fs.existsSync(sqpPath)
-  if (canReuseSqpOutput) {
-    console.log(`[SP-API] ${scopeLabel} SQP output already current for reportId=${sqpReportId}`)
-  } else {
-    const sqpData = await downloadJsonReport(client, sqpReportId)
-    rowsToCsv(sqpPath, sqpData.parsed?.dataByAsin || [], SQP_HEADERS)
+  if (selectedReports.has('sqp')) {
+    const sqpReportId = await resolveReportId(client, {
+      reportType: 'GET_BRAND_ANALYTICS_SEARCH_QUERY_PERFORMANCE_REPORT',
+      reportWindow,
+      label: `${scopeLabel} SQP`,
+      reportOptions: { reportPeriod: 'WEEK', asin: sourceConfig.heroAsin },
+      manifestReportId: existingManifest?.reports?.sqpReportId,
+      onReportCreated: rememberReportId('sqpReportId'),
+    })
+    rememberReportId('sqpReportId')(sqpReportId)
+    const canReuseSqpOutput = existingManifest?.reports?.sqpReportId === sqpReportId && fs.existsSync(sqpPath)
+    if (canReuseSqpOutput) {
+      console.log(`[SP-API] ${scopeLabel} SQP output already current for reportId=${sqpReportId}`)
+    } else {
+      const sqpData = await downloadJsonReport(client, sqpReportId)
+      rowsToCsv(sqpPath, sqpData.parsed?.dataByAsin || [], SQP_HEADERS)
+    }
   }
 
-  const salesReportId = await resolveReportId(client, {
-    reportType: 'GET_SALES_AND_TRAFFIC_REPORT',
-    reportWindow,
-    label: `${scopeLabel} SalesTraffic`,
-    reportOptions: { dateGranularity: 'DAY', asinGranularity: 'CHILD' },
-    manifestReportId: existingManifest?.reports?.salesReportId,
-    onReportCreated: rememberReportId('salesReportId'),
-  })
-  rememberReportId('salesReportId')(salesReportId)
-  const canReuseSalesOutput =
-    existingManifest?.reports?.salesReportId === salesReportId &&
-    fs.existsSync(salesByDatePath) &&
-    fs.existsSync(salesByAsinPath)
-  if (canReuseSalesOutput) {
-    console.log(`[SP-API] ${scopeLabel} SalesTraffic output already current for reportId=${salesReportId}`)
-  } else {
-    const salesData = await downloadJsonReport(client, salesReportId)
-    rowsToCsv(salesByDatePath, salesData.parsed?.salesAndTrafficByDate || [], SALES_BY_DATE_HEADERS)
-    rowsToCsv(salesByAsinPath, salesData.parsed?.salesAndTrafficByAsin || [], SALES_BY_ASIN_HEADERS)
+  if (selectedReports.has('sales')) {
+    const salesReportId = await resolveReportId(client, {
+      reportType: 'GET_SALES_AND_TRAFFIC_REPORT',
+      reportWindow,
+      label: `${scopeLabel} SalesTraffic`,
+      reportOptions: { dateGranularity: 'DAY', asinGranularity: 'CHILD' },
+      manifestReportId: existingManifest?.reports?.salesReportId,
+      onReportCreated: rememberReportId('salesReportId'),
+    })
+    rememberReportId('salesReportId')(salesReportId)
+    const canReuseSalesOutput =
+      existingManifest?.reports?.salesReportId === salesReportId &&
+      fs.existsSync(salesByDatePath) &&
+      fs.existsSync(salesByAsinPath)
+    if (canReuseSalesOutput) {
+      console.log(`[SP-API] ${scopeLabel} SalesTraffic output already current for reportId=${salesReportId}`)
+    } else {
+      const salesData = await downloadJsonReport(client, salesReportId)
+      rowsToCsv(salesByDatePath, salesData.parsed?.salesAndTrafficByDate || [], SALES_BY_DATE_HEADERS)
+      rowsToCsv(salesByAsinPath, salesData.parsed?.salesAndTrafficByAsin || [], SALES_BY_ASIN_HEADERS)
+    }
   }
 
-  const tstReportId = await resolveReportId(client, {
-    reportType: TST_REPORT_TYPE,
-    reportWindow,
-    label: `${scopeLabel} TST`,
-    reportOptions: { reportPeriod: 'WEEK' },
-    manifestReportId: existingManifest?.reports?.tstReportId,
-    onReportCreated: rememberReportId('tstReportId'),
-  })
-  rememberReportId('tstReportId')(tstReportId)
+  if (selectedReports.has('tst')) {
+    const tstReportId = await resolveReportId(client, {
+      reportType: TST_REPORT_TYPE,
+      reportWindow,
+      label: `${scopeLabel} TST`,
+      reportOptions: { reportPeriod: 'WEEK' },
+      manifestReportId: existingManifest?.reports?.tstReportId,
+      onReportCreated: rememberReportId('tstReportId'),
+    })
+    rememberReportId('tstReportId')(tstReportId)
 
-  const canReuseFilteredTst =
-    existingManifest?.reports?.tstReportId === tstReportId &&
-    existingManifest?.filterMode === 'clickedAsinAny' &&
-    sameStringArray(existingManifest?.targetAsins, tstTargetAsins) &&
-    fs.existsSync(filteredTstPath)
+    const canReuseFilteredTst =
+      existingManifest?.reports?.tstReportId === tstReportId &&
+      existingManifest?.filterMode === 'clickedAsinAny' &&
+      sameStringArray(existingManifest?.targetAsins, tstTargetAsins) &&
+      fs.existsSync(filteredTstPath)
 
-  if (canReuseFilteredTst) {
-    console.log(`[SP-API] ${scopeLabel} TST output already current for reportId=${tstReportId}`)
-  } else {
-    const tstDoc = await reportDocumentInfo(client, tstReportId)
-    const rawTstPath = path.join('/tmp', `${weekPrefix}_TST.raw.json${String(tstDoc?.compressionAlgorithm || '').toUpperCase() === 'GZIP' ? '.gz' : ''}`)
+    if (canReuseFilteredTst) {
+      console.log(`[SP-API] ${scopeLabel} TST output already current for reportId=${tstReportId}`)
+    } else {
+      const tstDoc = await reportDocumentInfo(client, tstReportId)
+      const rawTstPath = path.join('/tmp', `${weekPrefix}_TST.raw.json${String(tstDoc?.compressionAlgorithm || '').toUpperCase() === 'GZIP' ? '.gz' : ''}`)
 
-    await downloadUrlToFile(tstDoc.url, rawTstPath)
-    runTstFilter(rawTstPath, filteredTstPath, tstTargetAsins)
-    enqueueOutputFile(filteredTstPath)
-    fs.rmSync(rawTstPath, { force: true })
+      await downloadUrlToFile(tstDoc.url, rawTstPath)
+      runTstFilter(rawTstPath, filteredTstPath, tstTargetAsins)
+      enqueueOutputFile(filteredTstPath)
+      fs.rmSync(rawTstPath, { force: true })
+    }
   }
 
   writeManifest(manifestPath, manifestState)

--- a/apps/argus/scripts/api/weekly-sources/run.sh
+++ b/apps/argus/scripts/api/weekly-sources/run.sh
@@ -160,7 +160,7 @@ run_optional_step() {
 
 run_step "SP-API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-spapi.mjs\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
 run_step "SP Ads API" "python3 \"$SCRIPT_DIR/collect-sp-ads.py\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
-run_step "Datadive API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-datadive.mjs\" $MARKET_FLAG $DRY_FLAG"
+run_step "Datadive API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-datadive.mjs\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
 run_step "Datadive format repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-datadive-formats.mjs\" $MARKET_FLAG $DRY_FLAG"
 run_step "Sellerboard API" "\"$NODE_BIN\" \"$SCRIPT_DIR/collect-sellerboard.mjs\" $MARKET_FLAG $DRY_FLAG $DATE_FLAGS"
 run_step "Weekly label repair" "\"$NODE_BIN\" \"$SCRIPT_DIR/repair-week-labels.mjs\" $MARKET_FLAG $DRY_FLAG"

--- a/apps/argus/scripts/api/weekly-sources/test_collect_sp_ads.py
+++ b/apps/argus/scripts/api/weekly-sources/test_collect_sp_ads.py
@@ -1,6 +1,7 @@
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 
@@ -86,6 +87,33 @@ class CollectSpAdsTest(unittest.TestCase):
 
         self.assertEqual(module.get_report_status("https://ads.example", {}, "report-id"), {"status": "PENDING"})
         self.assertEqual(len(calls), 2)
+
+    def test_parse_reports_rejects_unsupported_values(self) -> None:
+        module = load_module()
+        with self.assertRaisesRegex(RuntimeError, "Unsupported SP Ads report"):
+            module.parse_reports("campaign,nope")
+
+    def test_parse_reports_accepts_dash_alias(self) -> None:
+        module = load_module()
+        self.assertEqual(module.parse_reports("search-term,campaign"), {"search_term", "campaign"})
+
+    def test_active_pending_manifest_entry_expires(self) -> None:
+        module = load_module()
+        old = datetime.now(timezone.utc) - timedelta(seconds=module.ACTIVE_REPORT_REUSE_MAX_SECONDS + 60)
+        manifest = {
+            "generatedAt": old.isoformat().replace("+00:00", "Z"),
+            "reports": {
+                "campaign": [
+                    {
+                        "suffix": "main",
+                        "reportId": "abc-123",
+                        "status": "PENDING",
+                    }
+                ]
+            },
+        }
+
+        self.assertIsNone(module.reusable_manifest_entry(manifest, "campaign", "main"))
 
 
 if __name__ == "__main__":

--- a/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
@@ -581,6 +581,7 @@ def scan_sources(week_meta: dict[str, dict[str, object]]) -> dict[str, object]:
     week_folders = list(discover_week_folders_by_label().values())
     week_labels: list[str] = []
     weeks_with_data: list[str] = []
+    complete_weeks_with_data: list[str] = []
 
     for folder in week_folders:
         match = WEEK_DIR_RE.match(folder.name)
@@ -588,6 +589,7 @@ def scan_sources(week_meta: dict[str, dict[str, object]]) -> dict[str, object]:
             continue
         week_number = int(match.group(1))
         week_label = f"W{week_number:02d}"
+        is_partial = "(Partial)" in folder.name
         week_labels.append(week_label)
         input_dir = folder / "input"
         has_any = False
@@ -616,8 +618,10 @@ def scan_sources(week_meta: dict[str, dict[str, object]]) -> dict[str, object]:
 
         if has_any:
             weeks_with_data.append(week_label)
+            if not is_partial:
+                complete_weeks_with_data.append(week_label)
 
-    latest_week = weeks_with_data[-1] if weeks_with_data else ""
+    latest_week = complete_weeks_with_data[-1] if complete_weeks_with_data else (weeks_with_data[-1] if weeks_with_data else "")
     latest_present = 0
     latest_total = len(SOURCE_TYPES)
     critical_gaps: list[str] = []

--- a/apps/argus/scripts/wpr/rebuild_wpr.py
+++ b/apps/argus/scripts/wpr/rebuild_wpr.py
@@ -27,12 +27,35 @@ PPC_WEEK_RE = re.compile(r"^Week (\d+) - (\d{4}-\d{2}-\d{2})$")
 WEEK_FILE_RE = re.compile(r"W(\d{2})_(\d{4}-\d{2}-\d{2})")
 WEEK_RANGE_RE = re.compile(r"W(\d{2})_W(\d{2})")
 ISO_DATE_RE = re.compile(r"(?<!\d)(\d{4}-\d{2}-\d{2})(?!\d)")
+YMD_UNDERSCORE_DATE_RE = re.compile(r"(?<!\d)(\d{4})_(\d{2})_(\d{2})(?!\d)")
 MDY_DATE_RE = re.compile(r"(?<!\d)(\d{1,2})[ _-](\d{1,2})[ _-](\d{4})(?!\d)")
+MONTH_NAME_DATE_RE = re.compile(
+    r"(?<![A-Za-z])"
+    r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec)"
+    r"[ _-](\d{1,2})[ _-](\d{4})(?!\d)",
+    re.IGNORECASE,
+)
+LEGACY_WEEK_NUMBER_RE = re.compile(r"(?:^|[^A-Za-z0-9])Week[ _-](\d{1,2})(?!\d)", re.IGNORECASE)
 
 IGNORED_NAMES = {".DS_Store"}
 LEGACY_INPUT_NAMES = {"Daily", "Hourly", "Weekly"}
 EXCLUDED_INPUT_SOURCES = {"Visuals (Browser)"}
 BASE_WEEK_1_START = date(2025, 12, 28)
+MONTH_NAME_TO_NUMBER = {
+    "jan": 1,
+    "feb": 2,
+    "mar": 3,
+    "apr": 4,
+    "may": 5,
+    "jun": 6,
+    "jul": 7,
+    "aug": 8,
+    "sep": 9,
+    "sept": 9,
+    "oct": 10,
+    "nov": 11,
+    "dec": 12,
+}
 
 
 @dataclass(frozen=True)
@@ -57,6 +80,23 @@ def parse_timestamp(value: str) -> date:
     if cleaned.endswith("Z"):
         cleaned = cleaned[:-1] + "+00:00"
     return datetime.fromisoformat(cleaned).date()
+
+
+def parse_legacy_file_date(first: int, second: int, year: int, weeks: dict[int, WeekMeta]) -> int | None:
+    candidates: list[date] = []
+    for month, day in ((first, second), (second, first)):
+        try:
+            candidate = date(year, month, day)
+        except ValueError:
+            continue
+        if candidate not in candidates:
+            candidates.append(candidate)
+
+    for candidate in candidates:
+        week = week_for_date(candidate, weeks)
+        if week is not None:
+            return week
+    return None
 
 
 def payload_exists(path: Path) -> bool:
@@ -362,6 +402,19 @@ def remove_legacy_output_snapshots(weeks: dict[int, WeekMeta]) -> None:
             shutil.rmtree(legacy_dir)
 
 
+def remove_empty_week_scaffolds(weeks: dict[int, WeekMeta]) -> list[WeekMeta]:
+    removed: list[WeekMeta] = []
+    for meta in weeks.values():
+        week_dir = WPR_ROOT / meta.folder_name
+        if not week_dir.exists():
+            continue
+        if payload_exists(week_dir):
+            continue
+        remove_empty_tree(week_dir)
+        removed.append(meta)
+    return removed
+
+
 def resolve_week_for_weekly_file(path: Path, weeks: dict[int, WeekMeta]) -> int | None:
     match = WEEK_FILE_RE.search(path.name)
     if match:
@@ -375,10 +428,25 @@ def resolve_week_for_weekly_file(path: Path, weeks: dict[int, WeekMeta]) -> int 
     if iso_match:
         return week_for_date(parse_iso_date(iso_match.group(1)), weeks)
 
+    ymd_match = YMD_UNDERSCORE_DATE_RE.search(path.stem)
+    if ymd_match:
+        year, month, day = map(int, ymd_match.groups())
+        return week_for_date(date(year, month, day), weeks)
+
+    month_name_match = MONTH_NAME_DATE_RE.search(path.stem)
+    if month_name_match:
+        month_name, day, year = month_name_match.groups()
+        month = MONTH_NAME_TO_NUMBER[month_name.lower()]
+        return week_for_date(date(int(year), month, int(day)), weeks)
+
+    legacy_week_match = LEGACY_WEEK_NUMBER_RE.search(path.stem)
+    if legacy_week_match:
+        return int(legacy_week_match.group(1))
+
     mdy_match = MDY_DATE_RE.search(path.stem)
     if mdy_match:
-        month, day, year = map(int, mdy_match.groups())
-        return week_for_date(date(year, month, day), weeks)
+        first, second, year = map(int, mdy_match.groups())
+        return parse_legacy_file_date(first, second, year, weeks)
 
     return None
 
@@ -508,15 +576,23 @@ def main() -> None:
     skipped_weekly_files = populate_weekly_inputs(weeks, input_file_counts)
     populate_daily_inputs(weeks, input_file_counts)
     populate_hourly_inputs(weeks, input_file_counts)
+    removed_empty_weeks = remove_empty_week_scaffolds(weeks)
 
     print("Rebuilt WPR week folders:")
     for week in sorted(weeks):
         meta = weeks[week]
+        if meta in removed_empty_weeks:
+            continue
         label = f"Week {week:02d}{' (Partial)' if meta.partial else ''}"
         print(
             f"  {label}: {meta.start_date.isoformat()} to {meta.end_date.isoformat()} "
             f"-> {input_file_counts.get(week, 0)} input files"
         )
+
+    if removed_empty_weeks:
+        print("\nRemoved generated week folders without source payload:")
+        for meta in removed_empty_weeks:
+            print(f"  {meta.folder_name}")
 
     if skipped_weekly_files:
         print("\nSkipped monitoring files without a resolvable week:")

--- a/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
@@ -137,6 +137,42 @@ class DefaultWeekSelectionTest(unittest.TestCase):
             )
 
 
+class SourceOverviewTest(unittest.TestCase):
+    def test_latest_source_week_ignores_partial_week(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            data_dir.mkdir(parents=True, exist_ok=True)
+
+            complete_source = (
+                sales_root
+                / "WPR"
+                / "Week 18 - 2026-04-26 (Sun)"
+                / "input"
+                / "Brand Analytics (API)"
+                / "SQP - Search Query Performance (API)"
+                / "W18_2026-05-02_SQP.csv"
+            )
+            complete_source.parent.mkdir(parents=True, exist_ok=True)
+            complete_source.write_text("header\nvalue\n", encoding="utf-8")
+
+            partial_source = (
+                sales_root
+                / "WPR"
+                / "Week 19 - 2026-05-03 (Sun) (Partial)"
+                / "input"
+                / "Account Health Dashboard (API)"
+                / "account-health.csv"
+            )
+            partial_source.parent.mkdir(parents=True, exist_ok=True)
+            partial_source.write_text("header\nvalue\n", encoding="utf-8")
+
+            module = load_module(data_dir)
+            overview = module.scan_sources({})
+
+            self.assertEqual(overview["latest_week"], "W18")
+
+
 class ListingChangeAggregationTest(unittest.TestCase):
     def test_groups_changes_by_timestamp_and_fields(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/apps/argus/scripts/wpr/test_rebuild_wpr.py
+++ b/apps/argus/scripts/wpr/test_rebuild_wpr.py
@@ -152,6 +152,118 @@ class RebuildWprTest(unittest.TestCase):
             self.assertTrue(canonical_input.exists())
             self.assertTrue(partial_input.exists())
 
+    def test_removes_generated_week_folders_without_source_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            monitoring_root = Path(tmp_dir) / "Monitoring"
+            wpr_data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            wpr_data_dir.mkdir(parents=True, exist_ok=True)
+
+            weekly_root = monitoring_root / "Weekly" / "Dummy Source"
+            weekly_root.mkdir(parents=True, exist_ok=True)
+            (weekly_root / "report_W03_2026-01-17.csv").write_text("header\nvalue\n", encoding="utf-8")
+
+            account_health_root = monitoring_root / "Daily" / "Account Health Dashboard (API)"
+            account_health_root.mkdir(parents=True, exist_ok=True)
+            with (account_health_root / "account-health.csv").open("w", newline="", encoding="utf-8") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["date"])
+                writer.writeheader()
+
+            hourly_root = monitoring_root / "Hourly" / "Listing Attributes (API)"
+            hourly_root.mkdir(parents=True, exist_ok=True)
+            for name in ("Listings-Changes-History.csv", "Listings-Snapshot-History.csv"):
+                with (hourly_root / name).open("w", newline="", encoding="utf-8") as handle:
+                    writer = csv.DictWriter(handle, fieldnames=["snapshot_timestamp_utc"])
+                    writer.writeheader()
+
+            module = load_module(wpr_data_dir, monitoring_root)
+            module.main()
+
+            self.assertFalse((sales_root / "WPR" / "Week 1 - 2025-12-28 (Sun)").exists())
+            self.assertFalse((sales_root / "WPR" / "Week 2 - 2026-01-04 (Sun)").exists())
+            self.assertTrue((sales_root / "WPR" / "Week 3 - 2026-01-11 (Sun)").exists())
+
+    def test_routes_legacy_day_month_year_weekly_files(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            monitoring_root = Path(tmp_dir) / "Monitoring"
+            wpr_data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            wpr_data_dir.mkdir(parents=True, exist_ok=True)
+
+            weekly_root = monitoring_root / "Weekly" / "Business Reports (API)" / "Sales & Traffic (API)"
+            weekly_root.mkdir(parents=True, exist_ok=True)
+            (weekly_root / "BusinessReport-21-04-2026.csv").write_text("header\nvalue\n", encoding="utf-8")
+            (weekly_root / "GB_Search_catalogue_performance_Simple_Week_2026_04_18.csv").write_text(
+                "header\nvalue\n",
+                encoding="utf-8",
+            )
+            (weekly_root / "Products_Apr_21_2026.csv").write_text("header\nvalue\n", encoding="utf-8")
+            (weekly_root / "Sponsored_Products_Search_term_report_-_Week_9.xlsx").write_text(
+                "binary-ish\n",
+                encoding="utf-8",
+            )
+
+            account_health_root = monitoring_root / "Daily" / "Account Health Dashboard (API)"
+            account_health_root.mkdir(parents=True, exist_ok=True)
+            with (account_health_root / "account-health.csv").open("w", newline="", encoding="utf-8") as handle:
+                writer = csv.DictWriter(handle, fieldnames=["date"])
+                writer.writeheader()
+                writer.writerow({"date": "2026-04-21"})
+
+            hourly_root = monitoring_root / "Hourly" / "Listing Attributes (API)"
+            hourly_root.mkdir(parents=True, exist_ok=True)
+            for name in ("Listings-Changes-History.csv", "Listings-Snapshot-History.csv"):
+                with (hourly_root / name).open("w", newline="", encoding="utf-8") as handle:
+                    writer = csv.DictWriter(handle, fieldnames=["snapshot_timestamp_utc"])
+                    writer.writeheader()
+
+            module = load_module(wpr_data_dir, monitoring_root)
+            module.main()
+
+            routed_file = (
+                sales_root
+                / "WPR"
+                / "Week 17 - 2026-04-19 (Sun) (Partial)"
+                / "input"
+                / "Business Reports (API)"
+                / "Sales & Traffic (API)"
+                / "BusinessReport-21-04-2026.csv"
+            )
+            self.assertTrue(routed_file.exists())
+            self.assertTrue(
+                (
+                    sales_root
+                    / "WPR"
+                    / "Week 16 - 2026-04-12 (Sun) (Partial)"
+                    / "input"
+                    / "Business Reports (API)"
+                    / "Sales & Traffic (API)"
+                    / "GB_Search_catalogue_performance_Simple_Week_2026_04_18.csv"
+                ).exists()
+            )
+            self.assertTrue(
+                (
+                    sales_root
+                    / "WPR"
+                    / "Week 17 - 2026-04-19 (Sun) (Partial)"
+                    / "input"
+                    / "Business Reports (API)"
+                    / "Sales & Traffic (API)"
+                    / "Products_Apr_21_2026.csv"
+                ).exists()
+            )
+            self.assertTrue(
+                (
+                    sales_root
+                    / "WPR"
+                    / "Week 9 - 2026-02-22 (Sun) (Partial)"
+                    / "input"
+                    / "Business Reports (API)"
+                    / "Sales & Traffic (API)"
+                    / "Sponsored_Products_Search_term_report_-_Week_9.xlsx"
+                ).exists()
+            )
+
     def test_rejects_google_drive_mount_paths(self) -> None:
         cloud_wpr_data_dir = (
             Path("/Users/test/Library/CloudStorage/GoogleDrive-test@example.com/Shared drives/Dust Sheets - US")


### PR DESCRIPTION
## Summary
- route legacy WPR inputs into canonical week folders and drop empty generated scaffolds
- make WPR source health use the latest completed week instead of partial current-week folders
- harden weekly-source collectors for explicit report/date selection and resumable pending reports

## Verification
- python3 apps/argus/scripts/wpr/test_rebuild_wpr.py
- python3 apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
- python3 -m unittest apps.argus.scripts.api.weekly-sources.test_collect_sp_ads
- python3 -m py_compile apps/argus/scripts/api/weekly-sources/collect-sp-ads.py
- node --test apps/argus/scripts/api/weekly-sources/run.test.mjs apps/argus/scripts/api/weekly-sources/collect-spapi.test.mjs apps/argus/scripts/api/weekly-sources/weekly-source-config.test.mjs apps/argus/scripts/lib/drive-sync.test.mjs apps/argus/scripts/lib/artifacts.test.mjs
- live US/UK WPR rebuild and Drive API publish verified: canonical W01-W19 folders populated from real landed Monitoring inputs and sync queues drained
