### PR TITLE
fix(argus): standardize WPR week folder names

### DIFF
--- a/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
@@ -17,7 +17,9 @@ from market_config import wpr_market_config
 
 WPR_PATHS = resolve_wpr_paths()
 DATA_ROOT = WPR_PATHS.wpr_root
-WEEK_DIR_RE = re.compile(r"^Week (\d+) - (\d{4}-\d{2}-\d{2}) \(Sun\)(?: \(Partial\))?$")
+CANONICAL_WEEK_DIR_RE = re.compile(r"^W(\d{1,2})$")
+LEGACY_WEEK_DIR_RE = re.compile(r"^Week (\d+) - (\d{4}-\d{2}-\d{2}) \(Sun\)(?: \(Partial\))?$")
+BASE_WEEK_1_START = date(2025, 12, 28)
 ASIN_RE = re.compile(r"b0[a-z0-9]{8}$", re.IGNORECASE)
 MARKET_CONFIG = wpr_market_config()
 ARGUS_MARKET = MARKET_CONFIG.market
@@ -101,11 +103,18 @@ def mean_or_none(values: list[float]) -> float | None:
 
 def detect_week_folder(path: Path) -> tuple[int, str, str]:
     relative = path.relative_to(DATA_ROOT)
-    match = WEEK_DIR_RE.match(relative.parts[0])
-    if not match:
-        raise ValueError(f"Unrecognized week folder: {relative.parts[0]}")
-    week_number = int(match.group(1))
-    start_date = match.group(2)
+    folder_name = relative.parts[0]
+    canonical_match = CANONICAL_WEEK_DIR_RE.match(folder_name)
+    if canonical_match:
+        week_number = int(canonical_match.group(1))
+        start_date = (BASE_WEEK_1_START + timedelta(days=(week_number - 1) * 7)).isoformat()
+        return week_number, f"W{week_number:02d}", start_date
+
+    legacy_match = LEGACY_WEEK_DIR_RE.match(folder_name)
+    if not legacy_match:
+        raise ValueError(f"Unrecognized week folder: {folder_name}")
+    week_number = int(legacy_match.group(1))
+    start_date = legacy_match.group(2)
     return week_number, f"W{week_number:02d}", start_date
 
 
@@ -299,7 +308,7 @@ def assign_uk_cluster(term: str) -> tuple[str, str] | None:
     return None
 
 
-WEEK_FOLDER_GLOBS = ("Week * (Sun)", "Week * (Sun) (Partial)")
+WEEK_FOLDER_GLOBS = ("W[0-9]", "W[0-9][0-9]", "Week * (Sun)", "Week * (Sun) (Partial)")
 WEEK_FOLDER_PREFIX = "Week * (Sun)/"
 
 
@@ -311,7 +320,8 @@ def discover_week_folders_by_label() -> dict[str, Path]:
         candidates,
         key=lambda path: (
             detect_week_folder(path)[0],
-            1 if "(Partial)" in path.name else 0,
+            0 if CANONICAL_WEEK_DIR_RE.match(path.name) else 1,
+            1 if "Partial" in path.name else 0,
         ),
     )
     folders: dict[str, Path] = {}
@@ -584,12 +594,11 @@ def scan_sources(week_meta: dict[str, dict[str, object]]) -> dict[str, object]:
     complete_weeks_with_data: list[str] = []
 
     for folder in week_folders:
-        match = WEEK_DIR_RE.match(folder.name)
-        if not match:
+        try:
+            week_number, week_label, start_date_text = detect_week_folder(folder)
+        except ValueError:
             continue
-        week_number = int(match.group(1))
-        week_label = f"W{week_number:02d}"
-        is_partial = "(Partial)" in folder.name
+        is_complete = date.fromisoformat(start_date_text) + timedelta(days=7) <= date.today()
         week_labels.append(week_label)
         input_dir = folder / "input"
         has_any = False
@@ -618,7 +627,7 @@ def scan_sources(week_meta: dict[str, dict[str, object]]) -> dict[str, object]:
 
         if has_any:
             weeks_with_data.append(week_label)
-            if not is_partial:
+            if is_complete:
                 complete_weeks_with_data.append(week_label)
 
     latest_week = complete_weeks_with_data[-1] if complete_weeks_with_data else (weeks_with_data[-1] if weeks_with_data else "")

--- a/apps/argus/scripts/wpr/rebuild_wpr.py
+++ b/apps/argus/scripts/wpr/rebuild_wpr.py
@@ -22,7 +22,8 @@ WPR_ROOT = WPR_PATHS.wpr_root
 SALES_ROOT = WPR_PATHS.sales_root
 MONITORING_ROOT = WPR_PATHS.monitoring_root
 
-EXISTING_WEEK_RE = re.compile(r"^Week (\d+) - (\d{4}-\d{2}-\d{2}) \(Sun\)(?: \(Partial\))?$")
+CANONICAL_WEEK_RE = re.compile(r"^W(\d{1,2})(?: Partial)?$")
+LEGACY_WEEK_RE = re.compile(r"^Week (\d+) - (\d{4}-\d{2}-\d{2}) \(Sun\)(?: \(Partial\))?$")
 PPC_WEEK_RE = re.compile(r"^Week (\d+) - (\d{4}-\d{2}-\d{2})$")
 WEEK_FILE_RE = re.compile(r"W(\d{2})_(\d{4}-\d{2}-\d{2})")
 WEEK_RANGE_RE = re.compile(r"W(\d{2})_W(\d{2})")
@@ -67,8 +68,7 @@ class WeekMeta:
 
     @property
     def folder_name(self) -> str:
-        suffix = " (Partial)" if self.partial else ""
-        return f"Week {self.week} - {self.start_date.isoformat()} (Sun){suffix}"
+        return f"W{self.week:02d}"
 
 
 def parse_iso_date(value: str) -> date:
@@ -184,15 +184,33 @@ def discover_anchor_week() -> WeekMeta:
     return WeekMeta(week=1, start_date=BASE_WEEK_1_START, end_date=BASE_WEEK_1_START + timedelta(days=6))
 
 
+def week_start_for_number(week: int) -> date:
+    return BASE_WEEK_1_START + timedelta(days=(week - 1) * 7)
+
+
+def parse_existing_week_dir_name(name: str) -> tuple[int, date] | None:
+    canonical_match = CANONICAL_WEEK_RE.match(name)
+    if canonical_match:
+        week = int(canonical_match.group(1))
+        return week, week_start_for_number(week)
+
+    legacy_match = LEGACY_WEEK_RE.match(name)
+    if legacy_match:
+        return int(legacy_match.group(1)), parse_iso_date(legacy_match.group(2))
+
+    return None
+
+
 def discover_existing_wpr_weeks() -> dict[int, date]:
     weeks: dict[int, date] = {}
     for path in WPR_ROOT.iterdir():
         if not path.is_dir():
             continue
-        match = EXISTING_WEEK_RE.match(path.name)
-        if not match:
+        parsed = parse_existing_week_dir_name(path.name)
+        if parsed is None:
             continue
-        weeks[int(match.group(1))] = parse_iso_date(match.group(2))
+        week, start = parsed
+        weeks[week] = start
     return weeks
 
 
@@ -201,10 +219,11 @@ def discover_existing_week_dirs() -> list[tuple[int, date, Path]]:
     for path in WPR_ROOT.iterdir():
         if not path.is_dir():
             continue
-        match = EXISTING_WEEK_RE.match(path.name)
-        if not match:
+        parsed = parse_existing_week_dir_name(path.name)
+        if parsed is None:
             continue
-        week_dirs.append((int(match.group(1)), parse_iso_date(match.group(2)), path))
+        week, start = parsed
+        week_dirs.append((week, start, path))
     return week_dirs
 
 
@@ -338,10 +357,13 @@ def canonicalize_existing_week_dirs(weeks: dict[int, WeekMeta]) -> None:
         canonical.mkdir(parents=True, exist_ok=True)
         if path == canonical:
             continue
-        for child in path.iterdir():
+        for child in list(path.iterdir()):
             if child.name in IGNORED_NAMES:
+                child.unlink(missing_ok=True)
                 continue
-            merge_copy(child, canonical / child.name)
+            merge_move(child, canonical / child.name)
+        if path.exists() and not any(path.iterdir()):
+            path.rmdir()
 
 
 def migrate_existing_week_payload(meta: WeekMeta) -> None:
@@ -583,7 +605,7 @@ def main() -> None:
         meta = weeks[week]
         if meta in removed_empty_weeks:
             continue
-        label = f"Week {week:02d}{' (Partial)' if meta.partial else ''}"
+        label = f"W{week:02d}{' (partial)' if meta.partial else ''}"
         print(
             f"  {label}: {meta.start_date.isoformat()} to {meta.end_date.isoformat()} "
             f"-> {input_file_counts.get(week, 0)} input files"

--- a/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
@@ -128,11 +128,11 @@ class DefaultWeekSelectionTest(unittest.TestCase):
             module = load_module(data_dir)
             week_meta = {
                 "W18": {"week_number": 18, "week_label": "W18", "start_date": "2026-04-26"},
-                "W19 Partial": {"week_number": 19, "week_label": "W19 Partial", "start_date": "2026-05-03"},
+                "W19": {"week_number": 19, "week_label": "W19", "start_date": "2026-05-03"},
             }
 
             self.assertEqual(
-                module.chart_week_order(["W18", "W19 Partial"], week_meta, module.date(2026, 5, 5)),
+                module.chart_week_order(["W18", "W19"], week_meta, module.date(2026, 5, 5)),
                 ["W18"],
             )
 
@@ -147,7 +147,7 @@ class SourceOverviewTest(unittest.TestCase):
             complete_source = (
                 sales_root
                 / "WPR"
-                / "Week 18 - 2026-04-26 (Sun)"
+                / "W18"
                 / "input"
                 / "Brand Analytics (API)"
                 / "SQP - Search Query Performance (API)"
@@ -159,7 +159,7 @@ class SourceOverviewTest(unittest.TestCase):
             partial_source = (
                 sales_root
                 / "WPR"
-                / "Week 19 - 2026-05-03 (Sun) (Partial)"
+                / "W19"
                 / "input"
                 / "Account Health Dashboard (API)"
                 / "account-health.csv"
@@ -179,7 +179,7 @@ class ListingChangeAggregationTest(unittest.TestCase):
             sales_root = Path(tmp_dir) / "Sales"
             data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
             data_dir.mkdir(parents=True, exist_ok=True)
-            week_input_dir = sales_root / "WPR" / "Week 1 - 2025-12-28 (Sun)" / "input" / "Listing Attributes (API)"
+            week_input_dir = sales_root / "WPR" / "W01" / "input" / "Listing Attributes (API)"
             week_input_dir.mkdir(parents=True, exist_ok=True)
             csv_path = week_input_dir / "Listings-Changes-History.csv"
             with csv_path.open("w", newline="", encoding="utf-8") as handle:
@@ -245,7 +245,7 @@ class ManualChangeLogParsingTest(unittest.TestCase):
             data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
             data_dir.mkdir(parents=True, exist_ok=True)
 
-            week_dir = sales_root / "WPR" / "Week 16 - 2026-04-12 (Sun)" / "output" / "Plans"
+            week_dir = sales_root / "WPR" / "W16" / "output" / "Plans"
             week_dir.mkdir(parents=True, exist_ok=True)
             log_path = week_dir / "W16_Content_update_across_2_ASINs_Log_2026-04-20.md"
             log_path.write_text(
@@ -302,7 +302,7 @@ class ManualChangeLogParsingTest(unittest.TestCase):
             data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
             data_dir.mkdir(parents=True, exist_ok=True)
 
-            week_dir = sales_root / "WPR" / "Week 12 - 2026-03-15 (Sun)" / "output" / "Plans"
+            week_dir = sales_root / "WPR" / "W12" / "output" / "Plans"
             week_dir.mkdir(parents=True, exist_ok=True)
             log_path = week_dir / "Week12_Legacy_EBC_Log_2026-03-21.md"
             log_path.write_text(
@@ -347,7 +347,7 @@ class SourceOverviewTest(unittest.TestCase):
             week_input_dir = (
                 sales_root
                 / "WPR"
-                / "Week 16 - 2026-04-12 (Sun)"
+                / "W16"
                 / "input"
                 / "Business Reports (API)"
                 / "Sales & Traffic (API)"

--- a/apps/argus/scripts/wpr/test_rebuild_wpr.py
+++ b/apps/argus/scripts/wpr/test_rebuild_wpr.py
@@ -94,14 +94,17 @@ class RebuildWprTest(unittest.TestCase):
             module = load_module(wpr_data_dir, monitoring_root)
             module.main()
 
-            week_one_input_dir = sales_root / "WPR" / "Week 1 - 2025-12-28 (Sun)" / "input" / "Listing Attributes (API)"
-            week_two_input_dir = sales_root / "WPR" / "Week 2 - 2026-01-04 (Sun) (Partial)" / "input" / "Listing Attributes (API)"
+            week_one_input_dir = sales_root / "WPR" / "W01" / "input" / "Listing Attributes (API)"
+            week_two_input_dir = sales_root / "WPR" / "W02" / "input" / "Listing Attributes (API)"
             self.assertTrue((week_one_input_dir / "Listings-Changes-History.csv").exists())
             self.assertTrue((week_two_input_dir / "Listings-Snapshot-History.csv").exists())
             self.assertFalse((week_one_input_dir / "latest_state.json").exists())
-            self.assertTrue(preserved_input.exists())
-            self.assertTrue(legacy_input.exists())
-            self.assertTrue(partial_input.exists())
+            self.assertTrue((sales_root / "WPR" / "W01" / "input" / "Manual Source" / "preserved.csv").exists())
+            self.assertTrue((sales_root / "WPR" / "W01" / "Daily" / "legacy.csv").exists())
+            self.assertTrue((sales_root / "WPR" / "W01" / "input" / "Manual Source" / "partial.csv").exists())
+            self.assertFalse(preserved_input.exists())
+            self.assertFalse(legacy_input.exists())
+            self.assertFalse(partial_input.exists())
 
     def test_copies_partial_week_payload_into_final_canonical_folder(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -144,13 +147,13 @@ class RebuildWprTest(unittest.TestCase):
             canonical_input = (
                 sales_root
                 / "WPR"
-                / "Week 2 - 2026-01-04 (Sun)"
+                / "W02"
                 / "input"
                 / "Manual Source"
                 / "manual.csv"
             )
             self.assertTrue(canonical_input.exists())
-            self.assertTrue(partial_input.exists())
+            self.assertFalse(partial_input.exists())
 
     def test_removes_generated_week_folders_without_source_payload(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -179,9 +182,9 @@ class RebuildWprTest(unittest.TestCase):
             module = load_module(wpr_data_dir, monitoring_root)
             module.main()
 
-            self.assertFalse((sales_root / "WPR" / "Week 1 - 2025-12-28 (Sun)").exists())
-            self.assertFalse((sales_root / "WPR" / "Week 2 - 2026-01-04 (Sun)").exists())
-            self.assertTrue((sales_root / "WPR" / "Week 3 - 2026-01-11 (Sun)").exists())
+            self.assertFalse((sales_root / "WPR" / "W01").exists())
+            self.assertFalse((sales_root / "WPR" / "W02").exists())
+            self.assertTrue((sales_root / "WPR" / "W03").exists())
 
     def test_routes_legacy_day_month_year_weekly_files(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -223,7 +226,7 @@ class RebuildWprTest(unittest.TestCase):
             routed_file = (
                 sales_root
                 / "WPR"
-                / "Week 17 - 2026-04-19 (Sun) (Partial)"
+                / "W17"
                 / "input"
                 / "Business Reports (API)"
                 / "Sales & Traffic (API)"
@@ -234,7 +237,7 @@ class RebuildWprTest(unittest.TestCase):
                 (
                     sales_root
                     / "WPR"
-                    / "Week 16 - 2026-04-12 (Sun) (Partial)"
+                    / "W16"
                     / "input"
                     / "Business Reports (API)"
                     / "Sales & Traffic (API)"
@@ -245,7 +248,7 @@ class RebuildWprTest(unittest.TestCase):
                 (
                     sales_root
                     / "WPR"
-                    / "Week 17 - 2026-04-19 (Sun) (Partial)"
+                    / "W17"
                     / "input"
                     / "Business Reports (API)"
                     / "Sales & Traffic (API)"
@@ -256,7 +259,7 @@ class RebuildWprTest(unittest.TestCase):
                 (
                     sales_root
                     / "WPR"
-                    / "Week 9 - 2026-02-22 (Sun) (Partial)"
+                    / "W09"
                     / "input"
                     / "Business Reports (API)"
                     / "Sales & Traffic (API)"


### PR DESCRIPTION
## Summary
- generate canonical compact WPR week folders as W01..W19
- migrate legacy verbose and partial local week folders into canonical folders instead of leaving duplicates
- teach dashboard discovery/source health to read compact folders while still tolerating legacy folders during migration

## Verification
- python3 apps/argus/scripts/wpr/test_rebuild_wpr.py
- python3 apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
- git diff --check -- apps/argus/scripts/wpr/rebuild_wpr.py apps/argus/scripts/wpr/build_intent_cluster_dashboard.py apps/argus/scripts/wpr/test_rebuild_wpr.py apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
- rebuilt US/UK local WPR roots; verified only W01..W19 week folders locally
- cleaned US/UK Shared Drive WPR roots through Drive API; verified 19 canonical WNN folders, no Week/Partial names, no duplicate WNN folders
