### PR TITLE
fix(plutus): use migrate deploy in app deploy

### DIFF
--- a/apps/plutus/package.json
+++ b/apps/plutus/package.json
@@ -24,6 +24,7 @@
     "settlements:backfill-fx": "tsx scripts/backfill-settlement-exchange-rates.ts",
     "db:generate": "prisma generate --schema prisma/schema.prisma",
     "db:push": "prisma db push --schema prisma/schema.prisma",
+    "db:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
     "db:migrate": "prisma migrate dev --schema prisma/schema.prisma",
     "db:studio": "prisma studio --schema prisma/schema.prisma"
   },

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -324,7 +324,7 @@ case "$app_key" in
     app_dir="$REPO_DIR/apps/plutus"
     pm2_name="${PM2_PREFIX}-plutus"
     prisma_cmd=""
-    migrate_cmd="pnpm --filter $workspace db:push"
+    migrate_cmd="pnpm --filter $workspace db:migrate:deploy"
     build_cmd="pnpm --filter $workspace build"
     ;;
   hermes)

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -10,6 +10,7 @@ const talosDbCommon = fs.readFileSync(path.join(rootDir, 'scripts', 'db', 'talos
 const talosLoadEnv = fs.readFileSync(path.join(rootDir, 'apps', 'talos', 'scripts', 'load-env.ts'), 'utf8')
 const authPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'packages', 'auth', 'package.json'), 'utf8'))
 const talosPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps', 'talos', 'package.json'), 'utf8'))
+const plutusPackage = JSON.parse(fs.readFileSync(path.join(rootDir, 'apps', 'plutus', 'package.json'), 'utf8'))
 
 test('auth package exposes a deploy-safe prisma migrate command', () => {
   assert.equal(
@@ -21,6 +22,13 @@ test('auth package exposes a deploy-safe prisma migrate command', () => {
 test('talos package exposes a deploy-safe prisma migrate command', () => {
   assert.equal(
     talosPackage.scripts['db:migrate:deploy'],
+    'prisma migrate deploy --schema prisma/schema.prisma',
+  )
+})
+
+test('plutus package exposes a deploy-safe prisma migrate command', () => {
+  assert.equal(
+    plutusPackage.scripts['db:migrate:deploy'],
     'prisma migrate deploy --schema prisma/schema.prisma',
   )
 })
@@ -40,6 +48,17 @@ test('sso deploy uses PORTAL_DB_URL for migration readiness instead of app DATAB
   assert.match(
     deployScript,
     /error "PORTAL_DB_URL is not set and no env file found; cannot apply auth migrations"/,
+  )
+})
+
+test('plutus deploy applies Prisma migrations instead of db push', () => {
+  assert.match(
+    deployScript,
+    /plutus\)[\s\S]*?migrate_cmd="pnpm --filter \$workspace db:migrate:deploy"/,
+  )
+  assert.doesNotMatch(
+    deployScript,
+    /plutus\)[\s\S]*?migrate_cmd="pnpm --filter \$workspace db:push"/,
   )
 })
 


### PR DESCRIPTION
## Summary
- add a deploy-safe Plutus Prisma migrate command
- make the deploy script run Plutus migrations instead of db push
- cover the Plutus deploy migration path in deploy-app tests

## Test
- node --test scripts/deploy-app.test.cjs