### PR TITLE
fix(argus): scope Plutus deploy migrations

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -194,6 +194,18 @@ build_talos_changed_migrate_cmd() {
   join_commands "${commands[@]}"
 }
 
+plutus_prisma_changed() {
+  if any_changed "apps/plutus/prisma/schema.prisma"; then
+    return 0
+  fi
+
+  if any_changed_under "apps/plutus/prisma/migrations/"; then
+    return 0
+  fi
+
+  return 1
+}
+
 skip_git="${DEPLOY_SKIP_GIT:-false}"
 skip_install="${DEPLOY_SKIP_INSTALL:-false}"
 skip_pm2_save="${DEPLOY_SKIP_PM2_SAVE:-false}"
@@ -1194,6 +1206,15 @@ if [[ "$app_key" == "talos" && "$changed_files_available" == "true" ]]; then
   if talos_changed_migrate_cmd="$(build_talos_changed_migrate_cmd)"; then
     migrate_cmd="$talos_changed_migrate_cmd"
   else
+    migrate_cmd=""
+  fi
+fi
+
+if [[ "$app_key" == "plutus" && "$changed_files_available" == "true" ]]; then
+  if plutus_prisma_changed; then
+    log "Plutus Prisma files changed; running db push"
+  else
+    log "Skipping Plutus db push (no Prisma changes in deploy range)"
     migrate_cmd=""
   fi
 fi

--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -1212,9 +1212,9 @@ fi
 
 if [[ "$app_key" == "plutus" && "$changed_files_available" == "true" ]]; then
   if plutus_prisma_changed; then
-    log "Plutus Prisma files changed; running db push"
+    log "Plutus Prisma files changed; running migrations"
   else
-    log "Skipping Plutus db push (no Prisma changes in deploy range)"
+    log "Skipping Plutus migrations (no Prisma changes in deploy range)"
     migrate_cmd=""
   fi
 fi

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -126,7 +126,7 @@ test('talos deploy always applies pending prisma migrations for both tenant sche
   )
 })
 
-test('plutus deploy skips db push when prisma files did not change', () => {
+test('plutus deploy skips migrations when prisma files did not change', () => {
   assert.match(
     deployScript,
     /plutus_prisma_changed\(\)[\s\S]*?any_changed "apps\/plutus\/prisma\/schema\.prisma"[\s\S]*?any_changed_under "apps\/plutus\/prisma\/migrations\/"/,

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -107,6 +107,17 @@ test('talos deploy always applies pending prisma migrations for both tenant sche
   )
 })
 
+test('plutus deploy skips db push when prisma files did not change', () => {
+  assert.match(
+    deployScript,
+    /plutus_prisma_changed\(\)[\s\S]*?any_changed "apps\/plutus\/prisma\/schema\.prisma"[\s\S]*?any_changed_under "apps\/plutus\/prisma\/migrations\/"/,
+  )
+  assert.match(
+    deployScript,
+    /if \[\[ "\$app_key" == "plutus" && "\$changed_files_available" == "true" \]\]; then[\s\S]*?if plutus_prisma_changed; then[\s\S]*?else[\s\S]*?migrate_cmd=""/,
+  )
+})
+
 test('hosted deploys load exact shared and app env files without .env.local fallback', () => {
   assert.match(
     deployScript,


### PR DESCRIPTION
## Summary
- skip Plutus db push when deploy range has no Plutus Prisma changes
- keep runtime config deploys from tripping Plutus data-loss guards
- add deploy-script coverage for the change-scoped behavior

## Tests
- node --test scripts/deploy-app.test.cjs scripts/detect-cd-affected-apps.test.cjs
- bash -n scripts/deploy-app.sh
- git diff --check