### PR TITLE
fix(plutus): stop deploying removed cashflow worker

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -1489,7 +1489,7 @@ if [[ "$app_key" == "hermes" ]]; then
 fi
 
 if [[ "$app_key" == "plutus" ]]; then
-  plutus_workers=("${PM2_PREFIX}-plutus-cashflow-refresh" "${PM2_PREFIX}-plutus-settlement-sync")
+  plutus_workers=("${PM2_PREFIX}-plutus-settlement-sync")
   for worker in "${plutus_workers[@]}"; do
     log "Step 7: Starting $worker"
     start_and_verify_pm2_process "$worker" "$app_dir" "$deploy_runtime_sha"

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -62,6 +62,14 @@ test('plutus deploy applies Prisma migrations instead of db push', () => {
   )
 })
 
+test('plutus deploy starts only active Plutus worker processes', () => {
+  assert.match(
+    deployScript,
+    /plutus_workers=\("\$\{PM2_PREFIX\}-plutus-settlement-sync"\)/,
+  )
+  assert.doesNotMatch(deployScript, /plutus-cashflow-refresh/)
+})
+
 test('shared-db deploys map apps onto deterministic owner roles and local owner URLs', () => {
   assert.match(
     deployScript,


### PR DESCRIPTION
## Summary
- remove the deleted Plutus cashflow refresh worker from deploy restarts
- keep only the active settlement sync worker in Plutus deploy
- add deploy test coverage for the worker list

## Test
- node --test scripts/deploy-app.test.cjs