### PR TITLE
fix(argus): remove missing Plutus deploy worker

### DIFF
--- a/scripts/deploy-app.sh
+++ b/scripts/deploy-app.sh
@@ -1489,7 +1489,7 @@ if [[ "$app_key" == "hermes" ]]; then
 fi
 
 if [[ "$app_key" == "plutus" ]]; then
-  plutus_workers=("${PM2_PREFIX}-plutus-cashflow-refresh" "${PM2_PREFIX}-plutus-settlement-sync")
+  plutus_workers=("${PM2_PREFIX}-plutus-settlement-sync")
   for worker in "${plutus_workers[@]}"; do
     log "Step 7: Starting $worker"
     start_and_verify_pm2_process "$worker" "$app_dir" "$deploy_runtime_sha"

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -137,6 +137,14 @@ test('plutus deploy skips migrations when prisma files did not change', () => {
   )
 })
 
+test('plutus deploy restarts only configured plutus workers', () => {
+  assert.match(
+    deployScript,
+    /plutus_workers=\("\$\{PM2_PREFIX\}-plutus-settlement-sync"\)/,
+  )
+  assert.doesNotMatch(deployScript, /plutus-cashflow-refresh/)
+})
+
 test('hosted deploys load exact shared and app env files without .env.local fallback', () => {
   assert.match(
     deployScript,


### PR DESCRIPTION
## Summary
- stop deploy-app from trying to start the undefined plutus cashflow PM2 worker
- keep Plutus deploy worker restarts aligned with ecosystem.config.js
- add deploy-script regression coverage

## Tests
- node --test scripts/deploy-app.test.cjs scripts/detect-cd-affected-apps.test.cjs
- bash -n scripts/deploy-app.sh
- git diff --check