### PR TITLE
fix(argus): retry empty Bitwarden env reads

### DIFF
--- a/scripts/lib/shared-env.cjs
+++ b/scripts/lib/shared-env.cjs
@@ -158,24 +158,16 @@ function readCachedBitwardenSession(env) {
   return cachedSession
 }
 
-function createBitwardenResolver(env = process.env) {
+function createBitwardenResolver(env = process.env, options = {}) {
   const itemCache = new Map()
+  const readItemOutput = createBitwardenItemReader(options)
 
   return function resolveBitwardenRef(ref) {
     const parsed = parseBwRef(ref)
     let item = itemCache.get(parsed.itemName)
     if (!item) {
       const session = readCachedBitwardenSession(env)
-      const result = spawnSync('bw', ['get', 'item', parsed.itemName, '--session', session], {
-        encoding: 'utf8',
-      })
-      if (result.status !== 0) {
-        throw new Error(`Failed to read Bitwarden item "${parsed.itemName}": ${result.stderr.trim()}`)
-      }
-      const output = result.stdout.trim()
-      if (output.length === 0) {
-        throw new Error(`Failed to read Bitwarden item "${parsed.itemName}": empty response from bw`)
-      }
+      const output = readItemOutput(parsed.itemName, session)
       try {
         item = JSON.parse(output)
       } catch (error) {
@@ -204,6 +196,42 @@ function createBitwardenResolver(env = process.env) {
     }
     return field.value
   }
+}
+
+function createBitwardenItemReader(options = {}) {
+  const spawnSyncImpl = options.spawnSyncImpl ? options.spawnSyncImpl : spawnSync
+  const retryDelayMs = Number.isInteger(options.retryDelayMs) ? options.retryDelayMs : 250
+
+  return function readBitwardenItemOutput(itemName, session) {
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      const result = spawnSyncImpl('bw', ['get', 'item', itemName, '--session', session], {
+        encoding: 'utf8',
+      })
+      if (result.status !== 0) {
+        throw new Error(`Failed to read Bitwarden item "${itemName}": ${result.stderr.trim()}`)
+      }
+
+      const output = typeof result.stdout === 'string' ? result.stdout.trim() : ''
+      if (output.length > 0) {
+        return output
+      }
+
+      if (attempt < 3) {
+        waitForBitwardenRetry(retryDelayMs)
+      }
+    }
+
+    throw new Error(`Failed to read Bitwarden item "${itemName}": empty response from bw`)
+  }
+}
+
+function waitForBitwardenRetry(retryDelayMs) {
+  if (retryDelayMs <= 0) {
+    return
+  }
+  const retryBuffer = new SharedArrayBuffer(4)
+  const retryState = new Int32Array(retryBuffer)
+  Atomics.wait(retryState, 0, 0, retryDelayMs)
 }
 
 function resolveEnvEntries(entries, resolveBitwardenRef) {

--- a/scripts/lib/shared-env.test.cjs
+++ b/scripts/lib/shared-env.test.cjs
@@ -5,6 +5,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const {
+  createBitwardenResolver,
   getEnvFileSelection,
   loadEnvForApp,
   parseBwRef,
@@ -105,6 +106,54 @@ test('parseBwRef decodes Bitwarden item and field names', () => {
       fieldName: 'AMAZON_REFRESH_TOKEN_US',
     }
   )
+})
+
+test('createBitwardenResolver retries empty bw output', () => {
+  const home = tempRepo()
+  writeFile(path.join(home, '.config/codex/secrets/bitwarden-cli-session'), 'session-token\n')
+  const calls = []
+
+  const resolver = createBitwardenResolver(
+    { HOME: home },
+    {
+      retryDelayMs: 0,
+      spawnSyncImpl(command, args, options) {
+        calls.push({ command, args, options })
+        if (calls.length === 1) {
+          return { status: 0, stdout: '', stderr: '' }
+        }
+        return {
+          status: 0,
+          stdout: JSON.stringify({ fields: [{ name: 'FIELD', value: 'secret-value' }] }),
+          stderr: '',
+        }
+      },
+    },
+  )
+
+  assert.equal(resolver('bw://Item/FIELD'), 'secret-value')
+  assert.equal(calls.length, 2)
+  assert.deepEqual(calls[1].args, ['get', 'item', 'Item', '--session', 'session-token'])
+})
+
+test('createBitwardenResolver fails after repeated empty bw output', () => {
+  const home = tempRepo()
+  writeFile(path.join(home, '.config/codex/secrets/bitwarden-cli-session'), 'session-token\n')
+  let calls = 0
+
+  const resolver = createBitwardenResolver(
+    { HOME: home },
+    {
+      retryDelayMs: 0,
+      spawnSyncImpl() {
+        calls += 1
+        return { status: 0, stdout: '', stderr: '' }
+      },
+    },
+  )
+
+  assert.throws(() => resolver('bw://Item/FIELD'), /empty response from bw/)
+  assert.equal(calls, 3)
 })
 
 test('loadEnvForApp resolves bw refs before export', () => {


### PR DESCRIPTION
## Summary
- retry Bitwarden CLI reads when bw exits successfully with empty stdout
- keep hard failure after repeated empty responses
- add shared-env tests for retry and final failure behavior

## Tests
- node --test scripts/lib/shared-env.test.cjs scripts/deploy-app.test.cjs scripts/detect-cd-affected-apps.test.cjs
- git diff --check