### PR TITLE
fix(argus): publish only canonical WPR weeks

### DIFF
--- a/apps/argus/scripts/lib/artifacts.mjs
+++ b/apps/argus/scripts/lib/artifacts.mjs
@@ -3,6 +3,7 @@ import path from 'node:path'
 
 export const DRIVE_SYNC_QUEUE_RELATIVE_PATH = '.drive-sync/queue.jsonl'
 export const WPR_DRIVE_SYNC_QUEUE_RELATIVE_PATH = '.drive-sync/wpr-queue.jsonl'
+export const WPR_CANONICAL_WEEK_FOLDER_RE = /^W\d{2}$/
 
 export function parseArgusMarket(raw) {
   const value = String(raw).trim().toLowerCase()
@@ -119,6 +120,10 @@ export function enqueueWprDriveSync({ market, localPath }) {
   const relativePath = normalizeArtifactRelativePath(path.relative(root, path.resolve(localPath)))
   if (relativePath === WPR_DRIVE_SYNC_QUEUE_RELATIVE_PATH) {
     return null
+  }
+  const [weekFolder] = relativePath.split('/')
+  if (!WPR_CANONICAL_WEEK_FOLDER_RE.test(weekFolder)) {
+    throw new Error(`WPR Drive sync path must start with a canonical WNN week folder: ${relativePath}`)
   }
 
   const stat = fs.statSync(localPath)

--- a/apps/argus/scripts/lib/artifacts.test.mjs
+++ b/apps/argus/scripts/lib/artifacts.test.mjs
@@ -55,13 +55,21 @@ test('Argus artifacts write to local monitoring roots and enqueue Drive sync', a
 
     const wprRoot = wprRootForMarket('us')
     assert.equal(wprRoot, path.join(tempRoot, 'wpr-us', 'WPR'))
-    const wprArtifactPath = path.join(wprRoot, 'Week 1 - 2025-12-28 (Sun)', 'input', 'source.csv')
+    const wprArtifactPath = path.join(wprRoot, 'W01', 'input', 'source.csv')
     fs.mkdirSync(path.dirname(wprArtifactPath), { recursive: true })
     fs.writeFileSync(wprArtifactPath, 'wpr\n', 'utf8')
     enqueueWprDriveSync({ market: 'us', localPath: wprArtifactPath })
     const wprQueuePath = path.join(root, '.drive-sync', 'wpr-queue.jsonl')
     const wprQueued = fs.readFileSync(wprQueuePath, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
-    assert.equal(wprQueued[0].relativePath, 'Week 1 - 2025-12-28 (Sun)/input/source.csv')
+    assert.equal(wprQueued[0].relativePath, 'W01/input/source.csv')
+
+    const workspaceArtifactPath = path.join(wprRoot, 'wpr-workspace', 'output', 'wpr-data-latest.json')
+    fs.mkdirSync(path.dirname(workspaceArtifactPath), { recursive: true })
+    fs.writeFileSync(workspaceArtifactPath, '{}\n', 'utf8')
+    assert.throws(
+      () => enqueueWprDriveSync({ market: 'us', localPath: workspaceArtifactPath }),
+      /WPR Drive sync path must start with a canonical WNN week folder: wpr-workspace\/output\/wpr-data-latest\.json/,
+    )
   } finally {
     if (previousRoot === undefined) {
       delete process.env.ARGUS_MONITORING_ROOT_US

--- a/apps/argus/scripts/lib/drive-sync.test.mjs
+++ b/apps/argus/scripts/lib/drive-sync.test.mjs
@@ -27,7 +27,7 @@ test('Drive sync planner targets Shared Drive folders with supportsAllDrives', a
 
     const wprPlan = buildDriveSyncPlan({
       market: 'us',
-      relativePath: 'Week 1 - 2025-12-28 (Sun)/input/source.csv',
+      relativePath: 'W01/input/source.csv',
       size: 10,
       scope: 'wpr',
     })

--- a/apps/argus/scripts/lib/enqueue-wpr-drive-sync.mjs
+++ b/apps/argus/scripts/lib/enqueue-wpr-drive-sync.mjs
@@ -2,7 +2,7 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { enqueueWprDriveSync, parseArgusMarket, wprRootForMarket } from './artifacts.mjs'
+import { WPR_CANONICAL_WEEK_FOLDER_RE, enqueueWprDriveSync, parseArgusMarket, wprRootForMarket } from './artifacts.mjs'
 
 function parseCliArgs(argv) {
   const args = { market: null }
@@ -51,10 +51,25 @@ function enqueueTree({ market, root }) {
   return count
 }
 
+export function enqueueWprWeekTrees({ market, root }) {
+  let count = 0
+  const entries = fs.readdirSync(root, { withFileTypes: true })
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    if (!WPR_CANONICAL_WEEK_FOLDER_RE.test(entry.name)) {
+      continue
+    }
+    count += enqueueTree({ market, root: path.join(root, entry.name) })
+  }
+  return count
+}
+
 function main() {
   const args = parseCliArgs(process.argv.slice(2))
   const root = wprRootForMarket(args.market)
-  const count = enqueueTree({ market: args.market, root })
+  const count = enqueueWprWeekTrees({ market: args.market, root })
   process.stdout.write(`Queued ${count} WPR artifact(s) for Drive sync from ${root}\n`)
 }
 

--- a/apps/argus/scripts/lib/enqueue-wpr-drive-sync.test.mjs
+++ b/apps/argus/scripts/lib/enqueue-wpr-drive-sync.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+
+const moduleUrl = new URL(`./enqueue-wpr-drive-sync.mjs?test=${Date.now()}`, import.meta.url)
+
+test('WPR Drive enqueue publishes canonical week folders only', async () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-wpr-enqueue-'))
+  const monitoringRoot = path.join(tempRoot, 'monitoring-us')
+  const wprRoot = path.join(tempRoot, 'wpr-us', 'WPR')
+  const previousEnv = {
+    ARGUS_MONITORING_ROOT_US: process.env.ARGUS_MONITORING_ROOT_US,
+    WPR_DATA_DIR_US: process.env.WPR_DATA_DIR_US,
+  }
+
+  process.env.ARGUS_MONITORING_ROOT_US = monitoringRoot
+  process.env.WPR_DATA_DIR_US = path.join(wprRoot, 'wpr-workspace', 'output')
+
+  const weekFile = path.join(wprRoot, 'W01', 'input', 'source.csv')
+  const workspaceFile = path.join(wprRoot, 'wpr-workspace', 'output', 'wpr-data-latest.json')
+  fs.mkdirSync(path.dirname(weekFile), { recursive: true })
+  fs.mkdirSync(path.dirname(workspaceFile), { recursive: true })
+  fs.writeFileSync(weekFile, 'wpr\n', 'utf8')
+  fs.writeFileSync(workspaceFile, '{}\n', 'utf8')
+
+  try {
+    const { enqueueWprWeekTrees } = await import(moduleUrl.href)
+    const count = enqueueWprWeekTrees({ market: 'us', root: wprRoot })
+    assert.equal(count, 1)
+
+    const queuePath = path.join(monitoringRoot, '.drive-sync', 'wpr-queue.jsonl')
+    const queued = fs.readFileSync(queuePath, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
+    assert.deepEqual(queued.map((entry) => entry.relativePath), ['W01/input/source.csv'])
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- restrict WPR Drive publishing to canonical WNN week folders
- hard-fail direct WPR sync entries outside canonical week folders
- add coverage so the local wpr-workspace is not queued to Drive

## Verification
- node --test apps/argus/scripts/lib/artifacts.test.mjs apps/argus/scripts/lib/enqueue-wpr-drive-sync.test.mjs apps/argus/scripts/lib/drive-sync.test.mjs
- git diff --check
- Drive API audit after cleanup: US rootWeeks=19 badRootFolders=0 suffixFolders=0 duplicateFolderGroups=0 duplicateFileGroups=0 emptyFolders=0 weeksWithoutFiles=0
- Drive API audit after cleanup: UK rootWeeks=19 badRootFolders=0 suffixFolders=0 duplicateFolderGroups=0 duplicateFileGroups=0 emptyFolders=0 weeksWithoutFiles=0
