### PR TITLE
fix(argus): reject noncanonical WPR artifact names

### DIFF
--- a/apps/argus/scripts/lib/artifacts.mjs
+++ b/apps/argus/scripts/lib/artifacts.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 export const DRIVE_SYNC_QUEUE_RELATIVE_PATH = '.drive-sync/queue.jsonl'
 export const WPR_DRIVE_SYNC_QUEUE_RELATIVE_PATH = '.drive-sync/wpr-queue.jsonl'
 export const WPR_CANONICAL_WEEK_FOLDER_RE = /^W\d{2}$/
+export const WPR_NONCANONICAL_NAME_RE = / \(\d+\)(?=\.|$)|__(?:backup|wpr_recovery|legacy|dup\d+)\b/i
 
 export function parseArgusMarket(raw) {
   const value = String(raw).trim().toLowerCase()
@@ -124,6 +125,10 @@ export function enqueueWprDriveSync({ market, localPath }) {
   const [weekFolder] = relativePath.split('/')
   if (!WPR_CANONICAL_WEEK_FOLDER_RE.test(weekFolder)) {
     throw new Error(`WPR Drive sync path must start with a canonical WNN week folder: ${relativePath}`)
+  }
+  const badSegment = relativePath.split('/').find((segment) => WPR_NONCANONICAL_NAME_RE.test(segment))
+  if (badSegment !== undefined) {
+    throw new Error(`WPR Drive sync path contains a noncanonical artifact name: ${relativePath}`)
   }
 
   const stat = fs.statSync(localPath)

--- a/apps/argus/scripts/lib/artifacts.test.mjs
+++ b/apps/argus/scripts/lib/artifacts.test.mjs
@@ -70,6 +70,13 @@ test('Argus artifacts write to local monitoring roots and enqueue Drive sync', a
       () => enqueueWprDriveSync({ market: 'us', localPath: workspaceArtifactPath }),
       /WPR Drive sync path must start with a canonical WNN week folder: wpr-workspace\/output\/wpr-data-latest\.json/,
     )
+
+    const duplicateNamedArtifactPath = path.join(wprRoot, 'W01', 'input', 'source (1).csv')
+    fs.writeFileSync(duplicateNamedArtifactPath, 'wpr\n', 'utf8')
+    assert.throws(
+      () => enqueueWprDriveSync({ market: 'us', localPath: duplicateNamedArtifactPath }),
+      /WPR Drive sync path contains a noncanonical artifact name: W01\/input\/source \(1\)\.csv/,
+    )
   } finally {
     if (previousRoot === undefined) {
       delete process.env.ARGUS_MONITORING_ROOT_US

--- a/apps/argus/scripts/wpr/rebuild_wpr.py
+++ b/apps/argus/scripts/wpr/rebuild_wpr.py
@@ -37,6 +37,8 @@ MONTH_NAME_DATE_RE = re.compile(
     re.IGNORECASE,
 )
 LEGACY_WEEK_NUMBER_RE = re.compile(r"(?:^|[^A-Za-z0-9])Week[ _-](\d{1,2})(?!\d)", re.IGNORECASE)
+BROWSER_DUPLICATE_SUFFIX_RE = re.compile(r" \(\d+\)(?=\.|$)")
+NONCANONICAL_ARTIFACT_SUFFIX_RE = re.compile(r"__(?:backup|wpr_recovery|legacy|dup\d+)(?=\.|$)", re.IGNORECASE)
 
 IGNORED_NAMES = {".DS_Store"}
 LEGACY_INPUT_NAMES = {"Daily", "Hourly", "Weekly"}
@@ -124,20 +126,21 @@ def remove_empty_tree(path: Path) -> None:
     path.rmdir()
 
 
-def unique_path(path: Path) -> Path:
-    if not path.exists():
-        return path
-    stem = path.stem
-    suffix = path.suffix
-    counter = 2
-    while True:
-        candidate = path.with_name(f"{stem}__dup{counter}{suffix}")
-        if not candidate.exists():
-            return candidate
-        counter += 1
+def canonical_wpr_name(name: str) -> str:
+    cleaned = BROWSER_DUPLICATE_SUFFIX_RE.sub("", name)
+    if cleaned in {"", ".", ".."}:
+        raise ValueError(f"Invalid WPR artifact name: {name}")
+    if NONCANONICAL_ARTIFACT_SUFFIX_RE.search(cleaned):
+        raise ValueError(f"WPR artifact name contains a noncanonical suffix: {name}")
+    return cleaned
+
+
+def canonical_wpr_relative_path(path: Path) -> Path:
+    return Path(*(canonical_wpr_name(part) for part in path.parts))
 
 
 def merge_move(src: Path, dest: Path) -> None:
+    dest = dest.with_name(canonical_wpr_name(dest.name))
     dest.parent.mkdir(parents=True, exist_ok=True)
     if src.is_dir():
         if not dest.exists():
@@ -157,12 +160,12 @@ def merge_move(src: Path, dest: Path) -> None:
         if filecmp.cmp(src, dest, shallow=False):
             src.unlink()
             return
-        dest = unique_path(dest)
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        raise ValueError(f"WPR destination conflict after canonicalizing artifact name: {src} -> {dest}")
     shutil.move(str(src), str(dest))
 
 
 def merge_copy(src: Path, dest: Path) -> None:
+    dest = dest.with_name(canonical_wpr_name(dest.name))
     dest.parent.mkdir(parents=True, exist_ok=True)
     if src.is_dir():
         dest.mkdir(parents=True, exist_ok=True)
@@ -175,8 +178,7 @@ def merge_copy(src: Path, dest: Path) -> None:
             raise ValueError(f"Cannot copy file into directory: {src} -> {dest}")
         if filecmp.cmp(src, dest, shallow=False):
             return
-        dest = unique_path(dest)
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        raise ValueError(f"WPR destination conflict after canonicalizing artifact name: {src} -> {dest}")
     shutil.copy2(src, dest)
 
 
@@ -336,7 +338,7 @@ def create_input_scaffold(weeks: dict[int, WeekMeta]) -> None:
             continue
         for child in cadence_root.iterdir():
             if child.is_dir() and child.name not in IGNORED_NAMES and child.name not in EXCLUDED_INPUT_SOURCES:
-                sources.add(child.name)
+                sources.add(canonical_wpr_name(child.name))
 
     for meta in weeks.values():
         week_dir = WPR_ROOT / meta.folder_name
@@ -475,6 +477,12 @@ def resolve_week_for_weekly_file(path: Path, weeks: dict[int, WeekMeta]) -> int 
 
 def copy_file_into_week(src: Path, dest: Path, stats: dict[int, int], week: int) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists():
+        if dest.is_dir():
+            raise ValueError(f"Cannot copy file into directory: {src} -> {dest}")
+        if filecmp.cmp(src, dest, shallow=False):
+            return
+        raise ValueError(f"WPR destination conflict after canonicalizing artifact name: {src} -> {dest}")
     shutil.copy2(src, dest)
     stats[week] += 1
 
@@ -489,7 +497,7 @@ def populate_weekly_inputs(weeks: dict[int, WeekMeta], stats: dict[int, int]) ->
         if week is None:
             skipped.append(str(src.relative_to(MONITORING_ROOT)))
             continue
-        rel = src.relative_to(weekly_root)
+        rel = canonical_wpr_relative_path(src.relative_to(weekly_root))
         dest = WPR_ROOT / weeks[week].folder_name / "input" / rel
         copy_file_into_week(src, dest, stats, week)
     return skipped

--- a/apps/argus/scripts/wpr/test_rebuild_wpr.py
+++ b/apps/argus/scripts/wpr/test_rebuild_wpr.py
@@ -26,6 +26,21 @@ def load_module(data_dir: Path, monitoring_root: Path):
     return module
 
 
+def write_required_empty_sources(monitoring_root: Path) -> None:
+    account_health_root = monitoring_root / "Daily" / "Account Health Dashboard (API)"
+    account_health_root.mkdir(parents=True, exist_ok=True)
+    with (account_health_root / "account-health.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["date"])
+        writer.writeheader()
+
+    hourly_root = monitoring_root / "Hourly" / "Listing Attributes (API)"
+    hourly_root.mkdir(parents=True, exist_ok=True)
+    for name in ("Listings-Changes-History.csv", "Listings-Snapshot-History.csv"):
+        with (hourly_root / name).open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=["snapshot_timestamp_utc"])
+            writer.writeheader()
+
+
 class RebuildWprTest(unittest.TestCase):
     def test_slices_listing_attribute_history_and_preserves_existing_inputs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -278,6 +293,43 @@ class RebuildWprTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             with self.assertRaisesRegex(RuntimeError, "must be local"):
                 load_module(cloud_wpr_data_dir, Path(tmp_dir) / "Monitoring")
+
+    def test_canonicalizes_browser_duplicate_download_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            monitoring_root = Path(tmp_dir) / "Monitoring"
+            wpr_data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            wpr_data_dir.mkdir(parents=True, exist_ok=True)
+
+            weekly_root = monitoring_root / "Weekly" / "Business Reports (API)"
+            weekly_root.mkdir(parents=True, exist_ok=True)
+            (weekly_root / "report_W01_2026-01-03 (1).csv").write_text("header\nvalue\n", encoding="utf-8")
+            write_required_empty_sources(monitoring_root)
+
+            module = load_module(wpr_data_dir, monitoring_root)
+            module.main()
+
+            canonical = sales_root / "WPR" / "W01" / "input" / "Business Reports (API)" / "report_W01_2026-01-03.csv"
+            duplicate = sales_root / "WPR" / "W01" / "input" / "Business Reports (API)" / "report_W01_2026-01-03 (1).csv"
+            self.assertTrue(canonical.exists())
+            self.assertFalse(duplicate.exists())
+
+    def test_rejects_divergent_browser_duplicate_download_names(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            monitoring_root = Path(tmp_dir) / "Monitoring"
+            wpr_data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            wpr_data_dir.mkdir(parents=True, exist_ok=True)
+
+            weekly_root = monitoring_root / "Weekly" / "Business Reports (API)"
+            weekly_root.mkdir(parents=True, exist_ok=True)
+            (weekly_root / "report_W01_2026-01-03.csv").write_text("header\nvalue\n", encoding="utf-8")
+            (weekly_root / "report_W01_2026-01-03 (1).csv").write_text("header\nother\n", encoding="utf-8")
+            write_required_empty_sources(monitoring_root)
+
+            module = load_module(wpr_data_dir, monitoring_root)
+            with self.assertRaisesRegex(ValueError, "WPR destination conflict after canonicalizing artifact name"):
+                module.main()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- strip browser duplicate suffixes like `(1)` when rebuilding WPR inputs\n- fail on divergent canonicalized WPR artifact conflicts instead of creating duplicate names\n- reject noncanonical WPR artifact names before Drive publish\n\n## Tests\n- `node --test apps/argus/scripts/lib/artifacts.test.mjs apps/argus/scripts/lib/enqueue-wpr-drive-sync.test.mjs apps/argus/scripts/lib/drive-sync.test.mjs`\n- `python3 -m unittest apps.argus.scripts.wpr.test_rebuild_wpr`\n- `git diff --check`