### PR TITLE
fix(plutus): keep settlement cash legs in control

### DIFF
--- a/apps/plutus/lib/amazon-finances/settlement-cash-account-guardrails.ts
+++ b/apps/plutus/lib/amazon-finances/settlement-cash-account-guardrails.ts
@@ -1,0 +1,17 @@
+import type { QboAccount } from '@/lib/qbo/api';
+
+export type SettlementCashMappingRole = 'Transfer to Bank' | 'Payment to Amazon';
+
+const REAL_BANK_MOVEMENT_ACCOUNT_TYPES = new Set(['bank', 'credit card']);
+
+export function assertSettlementCashMappingDoesNotUseRealBankMovement(
+  account: QboAccount,
+  role: SettlementCashMappingRole,
+): void {
+  const accountType = account.AccountType.trim().toLowerCase();
+  if (!REAL_BANK_MOVEMENT_ACCOUNT_TYPES.has(accountType)) return;
+
+  throw new Error(
+    `Settlement mapping for ${role} cannot use real bank or card account: ${account.Name} / ${account.Id} (${account.AccountType})`,
+  );
+}

--- a/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
@@ -1027,7 +1027,7 @@ export function buildQboJournalEntriesFromUkSettlementDraft(input: {
         });
       } else {
         lines.push({
-          accountId: input.paymentAccountId,
+          accountId: input.settlementControlAccountId,
           postingType: 'Credit',
           amount,
           description: 'Payment to Amazon',

--- a/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
@@ -1,4 +1,5 @@
 import { buildQboJournalEntriesFromUkSettlementDraft, buildUkSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/uk-settlement-builder';
+import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '@/lib/amazon-finances/settlement-cash-account-guardrails';
 import {
   fetchAllFinancialEventsByGroupId,
   findFinancialEventGroupIdForSettlementId,
@@ -347,6 +348,7 @@ async function validateUkSettlementCashAccountCurrencies(input: {
     if (!account) {
       throw new Error(`Settlement mapping account not found in QBO for ${role}: ${accountId}`);
     }
+    assertSettlementCashMappingDoesNotUseRealBankMovement(account, role);
 
     const currency = account.CurrencyRef?.value ? account.CurrencyRef.value.trim().toUpperCase() : '';
     if (currency === '') {

--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -815,7 +815,7 @@ export function buildQboJournalEntriesFromUsSettlementDraft(input: {
         });
       } else {
         lines.push({
-          accountId: input.paymentAccountId,
+          accountId: input.settlementControlAccountId,
           postingType: 'Credit',
           amount,
           description: 'Payment to Amazon',

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -1,4 +1,5 @@
 import { buildQboJournalEntriesFromUsSettlementDraft, buildUsSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/us-settlement-builder';
+import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '@/lib/amazon-finances/settlement-cash-account-guardrails';
 import {
   fetchAllFinancialEventsByGroupId,
   findFinancialEventGroupIdForSettlementId,
@@ -338,6 +339,7 @@ async function validateUsSettlementCashAccountCurrencies(input: {
     if (!account) {
       throw new Error(`Settlement mapping account not found in QBO for ${role}: ${accountId}`);
     }
+    assertSettlementCashMappingDoesNotUseRealBankMovement(account, role);
 
     const currency = account.CurrencyRef?.value ? account.CurrencyRef.value.trim().toUpperCase() : '';
     if (currency === '') {

--- a/apps/plutus/scripts/create-settlement-je-from-audit.ts
+++ b/apps/plutus/scripts/create-settlement-je-from-audit.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 
 import { buildPlutusSettlementDocNumber, normalizeSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
 import type { QboConnection } from '@/lib/qbo/api';
-import { createJournalEntry, fetchExchangeRate, fetchJournalEntries, fetchPreferences } from '@/lib/qbo/api';
+import { createJournalEntry, fetchAccounts, fetchExchangeRate, fetchJournalEntries, fetchPreferences } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 
 type CliOptions = {
@@ -254,22 +254,9 @@ async function main(): Promise<void> {
     originalTotalCents += cents;
   }
 
-  const needBankAccount = originalTotalCents > 0;
-  const needPaymentAccount = originalTotalCents < 0;
-
   const postingConfig = await db.settlementPostingConfig.findUnique({ where: { marketplace: options.marketplace } });
   if (!postingConfig) {
     throw new Error(`Missing settlement posting config for marketplace=${options.marketplace}`);
-  }
-
-  const bankAccountId = postingConfig.bankAccountId ? postingConfig.bankAccountId.trim() : '';
-  const paymentAccountId = postingConfig.paymentAccountId ? postingConfig.paymentAccountId.trim() : '';
-
-  if (needBankAccount && bankAccountId === '') {
-    throw new Error("Missing 'Transfer to Bank' account id (configure it in Settlement Mapping)");
-  }
-  if (needPaymentAccount && paymentAccountId === '') {
-    throw new Error("Missing 'Payment to Amazon' account id (configure it in Settlement Mapping)");
   }
 
   const memoMapping = requireMemoMapping(postingConfig.accountIdByMemo);
@@ -292,6 +279,21 @@ async function main(): Promise<void> {
   if (fx.updatedConnection) {
     activeConnection = fx.updatedConnection;
   }
+
+  const accountsResult = await fetchAccounts(activeConnection, { includeInactive: true });
+  if (accountsResult.updatedConnection) {
+    activeConnection = accountsResult.updatedConnection;
+  }
+
+  const settlementControlMatches = accountsResult.accounts.filter(
+    (account) => account.Name.trim().toLowerCase() === 'plutus settlement control',
+  );
+  if (settlementControlMatches.length !== 1) {
+    throw new Error(
+      `Missing or ambiguous QBO account for settlement control (expected exactly one named "Plutus Settlement Control", found ${settlementControlMatches.length})`,
+    );
+  }
+  const settlementControlAccountId = settlementControlMatches[0]!.Id;
 
   const lines: Array<{
     amount: number;
@@ -318,14 +320,14 @@ async function main(): Promise<void> {
     const absAmount = Math.abs(originalTotalCents) / 100;
     if (originalTotalCents > 0) {
       lines.push({
-        accountId: bankAccountId,
+        accountId: settlementControlAccountId,
         postingType: 'Debit',
         amount: absAmount,
         description: 'Transfer to Bank',
       });
     } else {
       lines.push({
-        accountId: paymentAccountId,
+        accountId: settlementControlAccountId,
         postingType: 'Credit',
         amount: absAmount,
         description: 'Payment to Amazon',

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -67,6 +67,7 @@ import {
   buildSettlementMtdDailySummaryFilename,
 } from '../lib/amazon-finances/settlement-evidence';
 import { settlementJournalEntryMatchesSource } from '../lib/amazon-finances/settlement-sync-existing';
+import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '../lib/amazon-finances/settlement-cash-account-guardrails';
 import { isBlockingProcessingCode } from '../lib/plutus/settlement-types';
 import { buildPrincipalGroupsByDate, matchRefundsToSales } from '../lib/plutus/settlement-validation';
 import {
@@ -4035,6 +4036,41 @@ test('SP-API settlement sync routes require explicit postToQbo', async () => {
   assert.match(String(ukPayload.details ?? ukPayload.error), /postToQbo/);
 });
 
+test('settlement cash mapping guardrail rejects real bank and credit card accounts', () => {
+  assert.throws(
+    () =>
+      assertSettlementCashMappingDoesNotUseRealBankMovement(
+        { Id: '136', Name: 'Targon US Chase USD (9899)', AccountType: 'Bank' } as QboAccount,
+        'Transfer to Bank',
+      ),
+    /cannot use real bank or card account/,
+  );
+
+  assert.throws(
+    () =>
+      assertSettlementCashMappingDoesNotUseRealBankMovement(
+        { Id: '148', Name: 'Chase Ink CC (0922)', AccountType: 'Credit Card' } as QboAccount,
+        'Payment to Amazon',
+      ),
+    /cannot use real bank or card account/,
+  );
+
+  assert.doesNotThrow(() =>
+    assertSettlementCashMappingDoesNotUseRealBankMovement(
+      { Id: '178', Name: 'Plutus Settlement Control', AccountType: 'Other Current Asset' } as QboAccount,
+      'Payment to Amazon',
+    ),
+  );
+});
+
+test('audit settlement JE rebuild script posts cash legs to settlement control only', () => {
+  const source = readFileSync('scripts/create-settlement-je-from-audit.ts', 'utf8');
+
+  assert.equal(source.includes('accountId: bankAccountId,'), false);
+  assert.equal(source.includes('accountId: paymentAccountId,'), false);
+  assert.equal(source.includes('accountId: settlementControlAccountId,'), true);
+});
+
 test('successful US settlement payouts post to settlement control instead of bank account', () => {
   const entries = buildQboJournalEntriesFromUsSettlementDraft({
     draft: {
@@ -4112,6 +4148,88 @@ test('successful UK settlement payouts post to settlement control instead of ban
         line.postingType === 'Debit' &&
         line.amount === 13946.96 &&
         line.description === 'Settlement Control (FundTransferStatus=Succeeded)',
+    ),
+    true,
+  );
+});
+
+test('negative US settlement payments post to settlement control instead of payment account', () => {
+  const entries = buildQboJournalEntriesFromUsSettlementDraft({
+    draft: {
+      settlementId: '26189598302',
+      eventGroupId: 'group-us-negative',
+      timeZone: 'America/Los_Angeles',
+      originalTotalCents: -545378,
+      fundTransferStatus: 'Succeeded',
+      segments: [
+        {
+          seq: 1,
+          yearMonth: '2026-05',
+          startIsoDay: '2026-05-01',
+          endIsoDay: '2026-05-01',
+          txnDate: '2026-05-01',
+          docNumber: 'US-260501-260501-S1',
+          memoTotalsCents: new Map([['Amazon FBA Fees - Domestic Orders', -545378]]),
+          auditRows: [],
+        },
+      ],
+    } as any,
+    privateNote: 'test',
+    settlementControlAccountId: 'control',
+    bankAccountId: 'bank',
+    paymentAccountId: 'payment',
+    accountIdByMemo: new Map([['Amazon FBA Fees - Domestic Orders', 'fees']]),
+  });
+
+  assert.equal(entries[0]!.lines.some((line) => line.accountId === 'payment'), false);
+  assert.equal(
+    entries[0]!.lines.some(
+      (line) =>
+        line.accountId === 'control' &&
+        line.postingType === 'Credit' &&
+        line.amount === 5453.78 &&
+        line.description === 'Payment to Amazon',
+    ),
+    true,
+  );
+});
+
+test('negative UK settlement payments post to settlement control instead of payment account', () => {
+  const entries = buildQboJournalEntriesFromUkSettlementDraft({
+    draft: {
+      settlementId: 'EG-group-uk-negative',
+      eventGroupId: 'group-uk-negative',
+      timeZone: 'Europe/London',
+      originalTotalCents: -401753,
+      fundTransferStatus: 'Succeeded',
+      segments: [
+        {
+          seq: 1,
+          yearMonth: '2026-05',
+          startIsoDay: '2026-05-01',
+          endIsoDay: '2026-05-01',
+          txnDate: '2026-05-01',
+          docNumber: 'UK-260501-260501-S1',
+          memoTotalsCents: new Map([['Amazon FBA Fees - Domestic Orders', -401753]]),
+          auditRows: [],
+        },
+      ],
+    } as any,
+    privateNote: 'test',
+    settlementControlAccountId: 'control',
+    bankAccountId: 'bank',
+    paymentAccountId: 'payment',
+    accountIdByMemo: new Map([['Amazon FBA Fees - Domestic Orders', 'fees']]),
+  });
+
+  assert.equal(entries[0]!.lines.some((line) => line.accountId === 'payment'), false);
+  assert.equal(
+    entries[0]!.lines.some(
+      (line) =>
+        line.accountId === 'control' &&
+        line.postingType === 'Credit' &&
+        line.amount === 4017.53 &&
+        line.description === 'Payment to Amazon',
     ),
     true,
   );


### PR DESCRIPTION
## Summary
- route positive and negative Amazon settlement cash legs to Plutus Settlement Control instead of bank/card mapping accounts
- add a shared guardrail that rejects Bank/Credit Card settlement cash mappings before sync posting
- update the audit JE rebuild path and regression coverage for the same control-account rule

## Root cause
Plutus allowed settlement mapping cash legs such as Payment to Amazon to reference real QBO bank/card accounts. That made Plutus a second writer for bank/card movement instead of letting QBO bank feeds own those accounts.

## Checks
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint
- git diff --check