### PR TITLE
fix(argus): support local WPR testing

### DIFF
--- a/apps/argus/middleware.test.ts
+++ b/apps/argus/middleware.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { NextRequest } from 'next/server'
+
+const ORIGINAL_ENV = { ...process.env }
+
+function resetEnv() {
+  for (const key of Object.keys(process.env)) {
+    delete process.env[key]
+  }
+  Object.assign(process.env, ORIGINAL_ENV)
+}
+
+function setSharedEnv() {
+  Object.assign(process.env, {
+    NODE_ENV: 'development',
+    BASE_PATH: '/argus',
+    NEXT_PUBLIC_BASE_PATH: '/argus',
+    NEXT_PUBLIC_APP_URL: 'http://localhost:3216/argus',
+    PORTAL_AUTH_URL: 'http://localhost:3200',
+    NEXT_PUBLIC_PORTAL_AUTH_URL: 'http://localhost:3200',
+    PORTAL_AUTH_SECRET: 'test-portal-auth-secret-000000000000',
+    NEXTAUTH_SECRET: 'test-portal-auth-secret-000000000000',
+  })
+}
+
+test.afterEach(() => {
+  resetEnv()
+})
+
+test('middleware allows localhost requests when dev auth session bypass is enabled', async () => {
+  setSharedEnv()
+  process.env.ALLOW_DEV_AUTH_SESSION_BYPASS = '1'
+
+  const mod = await import('./middleware')
+  const response = await mod.middleware(new NextRequest('http://localhost:3216/argus/api/wpr/weeks'))
+
+  assert.equal(response.status, 200)
+  assert.equal(response.headers.get('x-middleware-next'), '1')
+})
+
+test('middleware still rejects non-localhost requests when dev auth session bypass is enabled', async () => {
+  setSharedEnv()
+  process.env.ALLOW_DEV_AUTH_SESSION_BYPASS = '1'
+  process.env.NEXT_PUBLIC_APP_URL = 'https://dev-os.targonglobal.com/argus'
+  process.env.PORTAL_AUTH_URL = 'https://dev-os.targonglobal.com'
+  process.env.NEXT_PUBLIC_PORTAL_AUTH_URL = 'https://dev-os.targonglobal.com'
+
+  const mod = await import('./middleware')
+  const response = await mod.middleware(new NextRequest('https://dev-os.targonglobal.com/argus/api/wpr/weeks'))
+
+  assert.equal(response.status, 401)
+  assert.deepEqual(await response.json(), {
+    error: 'Authentication required',
+    reason: 'unauthenticated',
+  })
+})

--- a/apps/argus/middleware.ts
+++ b/apps/argus/middleware.ts
@@ -9,6 +9,36 @@ import {
   resolvePortalAuthOrigin,
 } from '@targon/auth'
 
+const truthyValues = new Set(['1', 'true', 'yes', 'on'])
+const loopbackHostnames = new Set(['localhost', '127.0.0.1', '::1', '[::1]', '0.0.0.0'])
+
+function isLoopbackHostname(rawHostname: string): boolean {
+  const hostname = rawHostname.trim().toLowerCase().replace(/\.$/, '')
+  if (hostname === '') {
+    return false
+  }
+
+  if (loopbackHostnames.has(hostname)) {
+    return true
+  }
+
+  return hostname.endsWith('.localhost')
+}
+
+function isLocalDevAuthBypassEnabled(request: NextRequest): boolean {
+  if (process.env.NODE_ENV === 'production') {
+    return false
+  }
+
+  const allowSessionBypass = truthyValues.has(String(process.env.ALLOW_DEV_AUTH_SESSION_BYPASS ?? '').toLowerCase())
+  const allowDefaults = truthyValues.has(String(process.env.ALLOW_DEV_AUTH_DEFAULTS ?? '').toLowerCase())
+  if (!allowSessionBypass && !allowDefaults) {
+    return false
+  }
+
+  return isLoopbackHostname(request.nextUrl.hostname)
+}
+
 export async function middleware(request: NextRequest) {
   const appBasePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH ?? process.env.BASE_PATH ?? '/argus')
   const pathname = request.nextUrl.pathname
@@ -34,6 +64,10 @@ export async function middleware(request: NextRequest) {
     normalizedPath === '/favicon.svg'
 
   if (isPublic) {
+    return NextResponse.next()
+  }
+
+  if (isLocalDevAuthBypassEnabled(request)) {
     return NextResponse.next()
   }
 

--- a/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/build_intent_cluster_dashboard.py
@@ -331,6 +331,34 @@ def discover_week_folders_by_label() -> dict[str, Path]:
     return folders
 
 
+def normalize_week_meta_with_discovered_folders(
+    week_meta: dict[str, dict[str, object]],
+) -> dict[str, dict[str, object]]:
+    normalized = {
+        week_label: dict(meta)
+        for week_label, meta in week_meta.items()
+    }
+    for week_label, folder in discover_week_folders_by_label().items():
+        week_number, _, start_date = detect_week_folder(folder)
+        existing = normalized.get(week_label)
+        if existing is None:
+            normalized[week_label] = {
+                "week_number": week_number,
+                "week_label": week_label,
+                "start_date": start_date,
+            }
+            continue
+        if existing.get("week_number") != week_number:
+            existing["week_number"] = week_number
+        if existing.get("week_label") != week_label:
+            existing["week_label"] = week_label
+        if existing.get("start_date") == "":
+            existing["start_date"] = start_date
+    return dict(
+        sorted(normalized.items(), key=lambda item: int(item[1]["week_number"]))
+    )
+
+
 def discover_files(pattern: str) -> list[Path]:
     if pattern.startswith(WEEK_FOLDER_PREFIX):
         suffix = pattern[len(WEEK_FOLDER_PREFIX) :]
@@ -10302,6 +10330,7 @@ def main() -> None:
     tst_term_week = load_tst(week_meta, cluster_terms, target_asin, term_info)
     load_rank_radar(cluster_week, cluster_terms, term_rollup, week_meta, term_info, rank_term_week_detail)
     load_ppc(cluster_week, cluster_terms, term_rollup, week_meta, term_info, ppc_term_week)
+    week_meta = normalize_week_meta_with_discovered_folders(week_meta)
 
     if not week_meta:
         raise SystemExit("No weekly data found.")

--- a/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
+++ b/apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
@@ -238,6 +238,39 @@ class ListingChangeAggregationTest(unittest.TestCase):
             self.assertEqual(entries[0]["summary"], "Listing price")
 
 
+class WeekFolderInclusionTest(unittest.TestCase):
+    def test_includes_discovered_week_without_metric_week_meta(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            sales_root = Path(tmp_dir) / "Sales"
+            data_dir = sales_root / "WPR" / "wpr-workspace" / "output"
+            data_dir.mkdir(parents=True, exist_ok=True)
+
+            week_input = (
+                sales_root
+                / "WPR"
+                / "W02"
+                / "input"
+                / "Listing Attributes (API)"
+            )
+            week_input.mkdir(parents=True, exist_ok=True)
+            module = load_module(data_dir)
+
+            resolved = module.normalize_week_meta_with_discovered_folders(
+                {
+                    "W01": {
+                        "week_number": 1,
+                        "week_label": "W01",
+                        "start_date": "2025-12-28",
+                    }
+                }
+            )
+
+            self.assertEqual(list(resolved.keys()), ["W01", "W02"])
+            self.assertEqual(resolved["W02"]["week_number"], 2)
+            self.assertEqual(resolved["W02"]["week_label"], "W02")
+            self.assertEqual(resolved["W02"]["start_date"], "2026-01-04")
+
+
 class ManualChangeLogParsingTest(unittest.TestCase):
     def test_parses_standardized_plan_log_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- allow Argus local loopback requests through middleware when explicit dev auth bypass flags are enabled
- keep non-localhost Argus requests protected even with the dev bypass flag
- include discovered WPR week folders in dashboard week metadata when metric payloads do not create a week entry

## Validation
- python3 -m unittest apps/argus/scripts/wpr/test_build_intent_cluster_dashboard.py
- pnpm --dir apps/argus exec tsx --test middleware.test.ts
- git diff --check