### PR TITLE
fix(host): drop removed Plutus worker check

### DIFF
--- a/scripts/verify-host-stack.mjs
+++ b/scripts/verify-host-stack.mjs
@@ -36,7 +36,6 @@ export const HOST_ENVIRONMENTS = {
       'main-argus',
     ],
     workerProcesses: [
-      'main-plutus-cashflow-refresh',
       'main-plutus-settlement-sync',
       'main-hermes-orders-sync',
       'main-hermes-request-review',
@@ -71,7 +70,6 @@ export const HOST_ENVIRONMENTS = {
       'dev-argus',
     ],
     workerProcesses: [
-      'dev-plutus-cashflow-refresh',
       'dev-plutus-settlement-sync',
       'dev-hermes-orders-sync',
       'dev-hermes-request-review',


### PR DESCRIPTION
## Summary
- remove `main-plutus-cashflow-refresh` and `dev-plutus-cashflow-refresh` from host-stack verification
- keep verification aligned with the PM2 config after the cashflow refresh worker was removed from Plutus

## Validation
- `pnpm test:host-stack`
- `node --check scripts/verify-host-stack.mjs`
