### PR TITLE
fix(talos): resolve US UK audit issues

### DIFF
--- a/apps/talos/package.json
+++ b/apps/talos/package.json
@@ -46,7 +46,7 @@
     "db:migrate:erd-v10-views": "tsx scripts/migrations/ensure-erd-v10-views.ts",
     "db:migrate:inbound-line-packaging-snapshots": "tsx scripts/migrations/backfill-inbound-line-packaging-snapshots.ts",
     "db:migrate:inbound-base-currency": "tsx scripts/migrations/normalize-inbound-base-currency.ts",
-    "db:migrate:sku-description-42": "tsx scripts/migrations/truncate-sku-description-42.ts",
+    "db:migrate:sku-description-255": "tsx scripts/migrations/expand-sku-description-255.ts",
     "db:studio": "prisma studio",
     "demo": "tsx scripts/demo.ts",
     "demo:headed": "tsx scripts/demo.ts --headed",

--- a/apps/talos/prisma/migrations/20260508120000_expand_sku_description_255/migration.sql
+++ b/apps/talos/prisma/migrations/20260508120000_expand_sku_description_255/migration.sql
@@ -1,0 +1,84 @@
+DROP VIEW IF EXISTS "sku";
+
+ALTER TABLE skus ALTER COLUMN description TYPE VARCHAR(255);
+
+CREATE OR REPLACE VIEW "sku" AS
+SELECT
+  s."id" AS "sku_id",
+  s."sku_code",
+  s."sku_group",
+  s."asin",
+  s."description",
+  s."is_active",
+  s."default_supplier_id",
+  s."secondary_supplier_id",
+  CASE
+    WHEN s."carton_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."carton_side1_cm" / 2.54)::numeric, 4)
+  END AS "ref_pkg_length_in",
+  CASE
+    WHEN s."carton_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."carton_side2_cm" / 2.54)::numeric, 4)
+  END AS "ref_pkg_width_in",
+  CASE
+    WHEN s."carton_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."carton_side3_cm" / 2.54)::numeric, 4)
+  END AS "ref_pkg_height_in",
+  CASE
+    WHEN s."carton_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."carton_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "ref_pkg_weight_lb",
+  CASE
+    WHEN s."item_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."item_side1_cm" / 2.54)::numeric, 4)
+  END AS "ref_item_length_in",
+  CASE
+    WHEN s."item_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."item_side2_cm" / 2.54)::numeric, 4)
+  END AS "ref_item_width_in",
+  CASE
+    WHEN s."item_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."item_side3_cm" / 2.54)::numeric, 4)
+  END AS "ref_item_height_in",
+  CASE
+    WHEN s."item_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."item_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "ref_item_weight_lb",
+  CASE
+    WHEN s."amazon_item_package_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_package_side1_cm" / 2.54)::numeric, 4)
+  END AS "amz_pkg_length_in",
+  CASE
+    WHEN s."amazon_item_package_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_package_side2_cm" / 2.54)::numeric, 4)
+  END AS "amz_pkg_width_in",
+  CASE
+    WHEN s."amazon_item_package_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_package_side3_cm" / 2.54)::numeric, 4)
+  END AS "amz_pkg_height_in",
+  CASE
+    WHEN s."amazon_reference_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_reference_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "amz_pkg_weight_lb",
+  CASE
+    WHEN s."amazon_item_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_side1_cm" / 2.54)::numeric, 4)
+  END AS "amz_item_length_in",
+  CASE
+    WHEN s."amazon_item_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_side2_cm" / 2.54)::numeric, 4)
+  END AS "amz_item_width_in",
+  CASE
+    WHEN s."amazon_item_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_side3_cm" / 2.54)::numeric, 4)
+  END AS "amz_item_height_in",
+  CASE
+    WHEN s."amazon_item_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "amz_item_weight_lb",
+  s."category",
+  s."subcategory",
+  s."size_tier",
+  s."referral_fee_percent" AS "referral_fee_pct",
+  s."fba_fulfillment_fee"
+FROM "skus" s;

--- a/apps/talos/prisma/schema.prisma
+++ b/apps/talos/prisma/schema.prisma
@@ -115,7 +115,7 @@ model Sku {
   amazonReferralFeePercent Decimal? @map("amazon_referral_fee_percent") @db.Decimal(5, 2)
   amazonListingPrice   Decimal?   @map("amazon_listing_price") @db.Decimal(12, 2)
   amazonReferenceWeightKg Decimal? @map("amazon_reference_weight_kg") @db.Decimal(8, 3)
-  description         String     @db.VarChar(42)
+  description         String     @db.VarChar(255)
   packSize            Int?       @map("pack_size")
   defaultSupplierId   String?    @map("default_supplier_id")
   secondarySupplierId String?    @map("secondary_supplier_id")

--- a/apps/talos/scripts/migrations/expand-sku-description-255.ts
+++ b/apps/talos/scripts/migrations/expand-sku-description-255.ts
@@ -1,0 +1,197 @@
+#!/usr/bin/env tsx
+
+import { getTenantPrismaClient } from '../../src/lib/tenant/prisma-factory'
+import type { TenantCode } from '../../src/lib/tenant/constants'
+
+import { loadTalosScriptEnv } from '../load-env'
+
+type ScriptOptions = {
+  tenants: TenantCode[]
+  dryRun: boolean
+  help?: boolean
+}
+
+const SKU_VIEW_SQL = `CREATE OR REPLACE VIEW "sku" AS
+SELECT
+  s."id" AS "sku_id",
+  s."sku_code",
+  s."sku_group",
+  s."asin",
+  s."description",
+  s."is_active",
+  s."default_supplier_id",
+  s."secondary_supplier_id",
+  CASE
+    WHEN s."carton_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."carton_side1_cm" / 2.54)::numeric, 4)
+  END AS "ref_pkg_length_in",
+  CASE
+    WHEN s."carton_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."carton_side2_cm" / 2.54)::numeric, 4)
+  END AS "ref_pkg_width_in",
+  CASE
+    WHEN s."carton_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."carton_side3_cm" / 2.54)::numeric, 4)
+  END AS "ref_pkg_height_in",
+  CASE
+    WHEN s."carton_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."carton_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "ref_pkg_weight_lb",
+  CASE
+    WHEN s."item_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."item_side1_cm" / 2.54)::numeric, 4)
+  END AS "ref_item_length_in",
+  CASE
+    WHEN s."item_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."item_side2_cm" / 2.54)::numeric, 4)
+  END AS "ref_item_width_in",
+  CASE
+    WHEN s."item_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."item_side3_cm" / 2.54)::numeric, 4)
+  END AS "ref_item_height_in",
+  CASE
+    WHEN s."item_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."item_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "ref_item_weight_lb",
+  CASE
+    WHEN s."amazon_item_package_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_package_side1_cm" / 2.54)::numeric, 4)
+  END AS "amz_pkg_length_in",
+  CASE
+    WHEN s."amazon_item_package_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_package_side2_cm" / 2.54)::numeric, 4)
+  END AS "amz_pkg_width_in",
+  CASE
+    WHEN s."amazon_item_package_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_package_side3_cm" / 2.54)::numeric, 4)
+  END AS "amz_pkg_height_in",
+  CASE
+    WHEN s."amazon_reference_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_reference_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "amz_pkg_weight_lb",
+  CASE
+    WHEN s."amazon_item_side1_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_side1_cm" / 2.54)::numeric, 4)
+  END AS "amz_item_length_in",
+  CASE
+    WHEN s."amazon_item_side2_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_side2_cm" / 2.54)::numeric, 4)
+  END AS "amz_item_width_in",
+  CASE
+    WHEN s."amazon_item_side3_cm" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_side3_cm" / 2.54)::numeric, 4)
+  END AS "amz_item_height_in",
+  CASE
+    WHEN s."amazon_item_weight_kg" IS NULL THEN NULL
+    ELSE ROUND((s."amazon_item_weight_kg" * 2.2046226218)::numeric, 4)
+  END AS "amz_item_weight_lb",
+  s."category",
+  s."subcategory",
+  s."size_tier",
+  s."referral_fee_percent" AS "referral_fee_pct",
+  s."fba_fulfillment_fee"
+FROM "skus" s`
+
+function parseArgs(): ScriptOptions {
+  const options: ScriptOptions = {
+    tenants: ['US', 'UK'],
+    dryRun: false,
+  }
+
+  for (const raw of process.argv.slice(2)) {
+    const arg = raw.trim()
+    if (arg === '--') continue
+    if (arg === '--help' || arg === '-h') {
+      options.help = true
+      continue
+    }
+    if (arg === '--dry-run') {
+      options.dryRun = true
+      continue
+    }
+    if (arg.startsWith('--tenant=')) {
+      const value = arg.split('=')[1]?.toUpperCase()
+      if (value === 'US' || value === 'UK') {
+        options.tenants = [value]
+        continue
+      }
+      if (value === 'ALL') {
+        options.tenants = ['US', 'UK']
+        continue
+      }
+      throw new Error(`Invalid --tenant value: ${value ?? ''} (expected US, UK, or ALL)`)
+    }
+
+    throw new Error(`Unknown arg: ${arg}`)
+  }
+
+  return options
+}
+
+function showHelp() {
+  console.log(`
+Expand SKU Description to 255 Characters
+
+Alters skus.description to VARCHAR(255), matching the app validation limit.
+
+Usage:
+  pnpm --filter @targon/talos tsx scripts/migrations/expand-sku-description-255.ts [options]
+
+Options:
+  --tenant=US|UK|ALL        Which tenant(s) to process (default: ALL)
+  --dry-run                Print actions without applying changes
+  --help, -h               Show this help
+`)
+}
+
+async function applyForTenant(tenant: TenantCode, options: ScriptOptions) {
+  const prisma = await getTenantPrismaClient(tenant)
+
+  const rows = await prisma.$queryRaw<{ character_maximum_length: number | null }[]>`
+    SELECT character_maximum_length
+    FROM information_schema.columns
+    WHERE table_schema = current_schema()
+      AND table_name = 'skus'
+      AND column_name = 'description'
+  `
+
+  if (rows.length !== 1) {
+    throw new Error(`[${tenant}] Expected one skus.description column, found ${rows.length}`)
+  }
+
+  const currentLength = rows[0].character_maximum_length
+  console.log(`[${tenant}] skus.description current limit: ${currentLength}`)
+
+  const dropViewStatement = 'DROP VIEW IF EXISTS "sku"'
+  const alterColumnStatement = 'ALTER TABLE skus ALTER COLUMN description TYPE VARCHAR(255)'
+  if (options.dryRun) {
+    console.log(`[${tenant}] DRY RUN: ${dropViewStatement}`)
+    console.log(`[${tenant}] DRY RUN: ${alterColumnStatement}`)
+    console.log(`[${tenant}] DRY RUN: ${SKU_VIEW_SQL}`)
+    return
+  }
+
+  await prisma.$executeRawUnsafe(dropViewStatement)
+  await prisma.$executeRawUnsafe(alterColumnStatement)
+  await prisma.$executeRawUnsafe(SKU_VIEW_SQL)
+  console.log(`[${tenant}] skus.description expanded to VARCHAR(255)`)
+}
+
+async function main() {
+  loadTalosScriptEnv()
+  const options = parseArgs()
+
+  if (options.help) {
+    showHelp()
+    return
+  }
+
+  for (const tenant of options.tenants) {
+    await applyForTenant(tenant, options)
+  }
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/apps/talos/src/app/api/finance/storage-ledger/route.ts
+++ b/apps/talos/src/app/api/finance/storage-ledger/route.ts
@@ -4,145 +4,155 @@ import { getTenantPrisma } from '@/lib/tenant/server'
 import { checkRateLimit, rateLimitConfigs } from '@/lib/security/rate-limiter'
 import { getWarehouseFilter } from '@/lib/auth-utils'
 import { Prisma } from '@targon/prisma-talos'
+import { endOfWeek, startOfWeek } from 'date-fns'
+import { materializeStorageLedgerEntriesForRange } from '@/services/storageCost.service'
 
 export const dynamic = 'force-dynamic'
 
 export const GET = withAuth(async (request, session) => {
- try {
- // Rate limiting
- const rateLimitResponse = await checkRateLimit(request, rateLimitConfigs.api)
- if (rateLimitResponse) return rateLimitResponse
+  try {
+    // Rate limiting
+    const rateLimitResponse = await checkRateLimit(request, rateLimitConfigs.api)
+    if (rateLimitResponse) return rateLimitResponse
 
- // Only staff and admin can access storage ledger
- if (!['staff', 'admin'].includes(session.user.role)) {
- return NextResponse.json({ error: 'Access denied' }, { status: 403 })
- }
+    // Only staff and admin can access storage ledger
+    if (!['staff', 'admin'].includes(session.user.role)) {
+      return NextResponse.json({ error: 'Access denied' }, { status: 403 })
+    }
 
- const prisma = await getTenantPrisma()
- const { searchParams } = request.nextUrl
- const warehouseCode = searchParams.get('warehouseCode')
- const startDate = searchParams.get('startDate')
- const endDate = searchParams.get('endDate')
- const includeCosts = searchParams.get('includeCosts') === 'true'
- const page = parseInt(searchParams.get('page') || '1')
- const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100)
- const search = searchParams.get('search')
+    const prisma = await getTenantPrisma()
+    const { searchParams } = request.nextUrl
+    const warehouseCode = searchParams.get('warehouseCode')
+    const startDate = searchParams.get('startDate')
+    const endDate = searchParams.get('endDate')
+    const includeCosts = searchParams.get('includeCosts') === 'true'
+    const page = parseInt(searchParams.get('page') ?? '1')
+    const limit = Math.min(parseInt(searchParams.get('limit') ?? '50'), 100)
+    const search = searchParams.get('search')
 
- // Apply warehouse filter based on user role
- const warehouseFilter = getWarehouseFilter(session, undefined)
- const where: Prisma.StorageLedgerWhereInput = {}
+    // Apply warehouse filter based on user role
+    const warehouseFilter = getWarehouseFilter(session, undefined)
+    const where: Prisma.StorageLedgerWhereInput = {}
+    let resolvedWarehouseCode: string | undefined = undefined
 
- if (warehouseFilter?.warehouseId) {
- // Staff user - filter to their warehouse
- const warehouse = await prisma.warehouse.findUnique({
- where: { id: warehouseFilter.warehouseId },
- select: { code: true }
- })
- if (warehouse) {
- where.warehouseCode = warehouse.code
- }
- } else if (warehouseCode) {
- // Admin user with warehouse filter
- where.warehouseCode = warehouseCode
- }
+    if (warehouseFilter?.warehouseId) {
+      // Staff user - filter to their warehouse
+      const warehouse = await prisma.warehouse.findUnique({
+        where: { id: warehouseFilter.warehouseId },
+        select: { code: true },
+      })
+      if (warehouse) {
+        where.warehouseCode = warehouse.code
+        resolvedWarehouseCode = warehouse.code
+      }
+    } else if (warehouseCode) {
+      // Admin user with warehouse filter
+      where.warehouseCode = warehouseCode
+      resolvedWarehouseCode = warehouseCode
+    }
 
- // Date range filter
- if (startDate && endDate) {
- where.weekEndingDate = {
- gte: new Date(startDate),
- lte: new Date(endDate)
- }
- }
+    // Date range filter
+    if (startDate && endDate) {
+      const parsedStartDate = new Date(startDate)
+      const parsedEndDate = new Date(endDate)
+      if (Number.isNaN(parsedStartDate.getTime()) || Number.isNaN(parsedEndDate.getTime())) {
+        return NextResponse.json({ error: 'Invalid date range' }, { status: 400 })
+      }
+      const weekStartDate = startOfWeek(parsedStartDate, { weekStartsOn: 1 })
+      const weekEndDate = endOfWeek(parsedEndDate, { weekStartsOn: 1 })
+      await materializeStorageLedgerEntriesForRange(
+        weekStartDate,
+        weekEndDate,
+        resolvedWarehouseCode
+      )
+      where.weekEndingDate = {
+        gte: weekStartDate,
+        lte: weekEndDate,
+      }
+    }
 
- // Search filter
- if (search) {
- where.OR = [
- { skuCode: { contains: search, mode: 'insensitive' } },
- { skuDescription: { contains: search, mode: 'insensitive' } },
- { lotRef: { contains: search, mode: 'insensitive' } },
- { warehouseName: { contains: search, mode: 'insensitive' } }
- ]
- }
+    // Search filter
+    if (search) {
+      where.OR = [
+        { skuCode: { contains: search, mode: 'insensitive' } },
+        { skuDescription: { contains: search, mode: 'insensitive' } },
+        { lotRef: { contains: search, mode: 'insensitive' } },
+        { warehouseName: { contains: search, mode: 'insensitive' } },
+      ]
+    }
 
- const totalCount = await prisma.storageLedger.count({ where })
+    const totalCount = await prisma.storageLedger.count({ where })
 
- // Get paginated results
- const entries = await prisma.storageLedger.findMany({
- where,
- select: {
- id: true,
- warehouseCode: true,
- warehouseName: true,
- skuCode: true,
- skuDescription: true,
- lotRef: true,
- weekEndingDate: true,
- closingBalance: true,
- averageBalance: true,
- closingPallets: true,
- palletDays: true,
- createdAt: true,
- ...(includeCosts && {
- storageRatePerPalletDay: true,
- totalStorageCost: true,
- isCostCalculated: true,
- rateEffectiveDate: true,
- costRateId: true
- })
- },
- orderBy: [
- { weekEndingDate: 'desc' },
- { warehouseCode: 'asc' },
- { skuCode: 'asc' }
- ],
- skip: (page - 1) * limit,
- take: limit
- })
+    // Get paginated results
+    const entries = await prisma.storageLedger.findMany({
+      where,
+      select: {
+        id: true,
+        warehouseCode: true,
+        warehouseName: true,
+        skuCode: true,
+        skuDescription: true,
+        lotRef: true,
+        weekEndingDate: true,
+        closingBalance: true,
+        averageBalance: true,
+        closingPallets: true,
+        palletDays: true,
+        createdAt: true,
+        ...(includeCosts && {
+          storageRatePerPalletDay: true,
+          totalStorageCost: true,
+          isCostCalculated: true,
+          rateEffectiveDate: true,
+          costRateId: true,
+        }),
+      },
+      orderBy: [{ weekEndingDate: 'desc' }, { warehouseCode: 'asc' }, { skuCode: 'asc' }],
+      skip: (page - 1) * limit,
+      take: limit,
+    })
 
- // Build summary from the filtered set
- let summary = null
- if (includeCosts) {
- const aggregated = await prisma.storageLedger.aggregate({
- where,
- _count: { id: true, totalStorageCost: true },
- _sum: { palletDays: true, totalStorageCost: true },
- })
+    // Build summary from the filtered set
+    let summary = null
+    if (includeCosts) {
+      const aggregated = await prisma.storageLedger.aggregate({
+        where,
+        _count: { id: true, totalStorageCost: true },
+        _sum: { palletDays: true, totalStorageCost: true },
+      })
 
- const totalEntries = aggregated._count.id || 0
- const entriesWithCosts = aggregated._count.totalStorageCost || 0
- const totalPalletDays = Number(aggregated._sum.palletDays || 0)
- const totalStorageCost = Number(aggregated._sum.totalStorageCost || 0)
- const costCalculationRate =
- totalEntries > 0 ? ((entriesWithCosts / totalEntries) * 100).toFixed(1) : '0'
+      const totalEntries = aggregated._count.id ?? 0
+      const entriesWithCosts = aggregated._count.totalStorageCost ?? 0
+      const totalPalletDays = Number(aggregated._sum.palletDays ?? 0)
+      const totalStorageCost = Number(aggregated._sum.totalStorageCost ?? 0)
+      const costCalculationRate =
+        totalEntries > 0 ? ((entriesWithCosts / totalEntries) * 100).toFixed(1) : '0'
 
- summary = {
- totalEntries,
- entriesWithCosts,
- totalPalletDays,
- totalStorageCost,
- costCalculationRate,
- }
- }
+      summary = {
+        totalEntries,
+        entriesWithCosts,
+        totalPalletDays,
+        totalStorageCost,
+        costCalculationRate,
+      }
+    }
 
- const response = {
- entries,
- pagination: {
- page,
- limit,
- totalCount,
- totalPages: Math.ceil(totalCount / limit),
- hasNext: page < Math.ceil(totalCount / limit),
- hasPrev: page > 1
- },
- ...(summary && { summary })
- }
+    const response = {
+      entries,
+      pagination: {
+        page,
+        limit,
+        totalCount,
+        totalPages: Math.ceil(totalCount / limit),
+        hasNext: page < Math.ceil(totalCount / limit),
+        hasPrev: page > 1,
+      },
+      ...(summary && { summary }),
+    }
 
- return NextResponse.json(response)
- } catch (error) {
- console.error('Storage ledger API error:', error)
- return NextResponse.json(
- { error: 'Failed to fetch storage ledger' },
- { status: 500 }
- )
- }
+    return NextResponse.json(response)
+  } catch (error) {
+    console.error('Storage ledger API error:', error)
+    return NextResponse.json({ error: 'Failed to fetch storage ledger' }, { status: 500 })
+  }
 })

--- a/apps/talos/src/app/api/transactions/[id]/route.ts
+++ b/apps/talos/src/app/api/transactions/[id]/route.ts
@@ -8,365 +8,395 @@ import { TransactionValidationError, validateTransactionDelete } from './validat
 export const dynamic = 'force-dynamic'
 
 type ApiAttachment = {
- fileName?: string
- name?: string
- contentType?: string
- type?: string
- size?: number
- s3Key?: string
- s3Url?: string
- uploadedAt?: string
- uploadedBy?: string
+  fileName?: string
+  name?: string
+  contentType?: string
+  type?: string
+  size?: number
+  s3Key?: string
+  s3Url?: string
+  uploadedAt?: string
+  uploadedBy?: string
 }
 
 const toOptionalString = (value: unknown): string | undefined => {
- return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined
 }
 
 const toOptionalNumber = (value: unknown): number | undefined => {
- return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
 }
 
 function normalizeAttachmentRecord(value: unknown): Record<string, ApiAttachment> {
- const result: Record<string, ApiAttachment> = {}
+  const result: Record<string, ApiAttachment> = {}
 
- if (!value) {
- return result
- }
+  if (!value) {
+    return result
+  }
 
- if (Array.isArray(value)) {
- for (const entry of value) {
- if (!entry || typeof entry !== 'object') continue
- const record = entry as Record<string, unknown>
- const category = toOptionalString(record.type)
- if (!category || category === 'notes') continue
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (!entry || typeof entry !== 'object') continue
+      const record = entry as Record<string, unknown>
+      const category = toOptionalString(record.type)
+      if (!category || category === 'notes') continue
 
- const attachment: ApiAttachment = {}
- const s3Key = toOptionalString(record.s3Key)
- if (s3Key) {
- attachment.s3Key = s3Key
- }
- const name = toOptionalString(record.name)
- if (name) {
- attachment.fileName = name
- attachment.name = name
- }
- const uploadedAt = toOptionalString(record.uploadedAt)
- if (uploadedAt) {
- attachment.uploadedAt = uploadedAt
- }
- const uploadedBy = toOptionalString(record.uploadedBy)
- if (uploadedBy) {
- attachment.uploadedBy = uploadedBy
- }
+      const attachment: ApiAttachment = {}
+      const s3Key = toOptionalString(record.s3Key)
+      if (s3Key) {
+        attachment.s3Key = s3Key
+      }
+      const name = toOptionalString(record.name)
+      if (name) {
+        attachment.fileName = name
+        attachment.name = name
+      }
+      const uploadedAt = toOptionalString(record.uploadedAt)
+      if (uploadedAt) {
+        attachment.uploadedAt = uploadedAt
+      }
+      const uploadedBy = toOptionalString(record.uploadedBy)
+      if (uploadedBy) {
+        attachment.uploadedBy = uploadedBy
+      }
 
- result[category] = attachment
- }
+      result[category] = attachment
+    }
 
- return result
- }
+    return result
+  }
 
- if (typeof value === 'object') {
- const record = value as Record<string, unknown>
- for (const [key, entry] of Object.entries(record)) {
- if (!entry || typeof entry !== 'object') continue
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    for (const [key, entry] of Object.entries(record)) {
+      if (!entry || typeof entry !== 'object') continue
 
- const entryRecord = entry as Record<string, unknown>
- const s3Key = toOptionalString(entryRecord.s3Key)
- if (!s3Key) continue
+      const entryRecord = entry as Record<string, unknown>
+      const s3Key = toOptionalString(entryRecord.s3Key)
+      if (!s3Key) continue
 
- const attachment: ApiAttachment = {}
- attachment.s3Key = s3Key
+      const attachment: ApiAttachment = {}
+      attachment.s3Key = s3Key
 
- const fileName = toOptionalString(entryRecord.fileName)
- if (fileName) {
- attachment.fileName = fileName
- }
- const name = toOptionalString(entryRecord.name)
- if (name) {
- attachment.name = name
- }
- const contentType = toOptionalString(entryRecord.contentType)
- if (contentType) {
- attachment.contentType = contentType
- }
- const type = toOptionalString(entryRecord.type)
- if (type) {
- attachment.type = type
- }
- const size = toOptionalNumber(entryRecord.size)
- if (size !== undefined) {
- attachment.size = size
- }
- const uploadedAt = toOptionalString(entryRecord.uploadedAt)
- if (uploadedAt) {
- attachment.uploadedAt = uploadedAt
- }
- const uploadedBy = toOptionalString(entryRecord.uploadedBy)
- if (uploadedBy) {
- attachment.uploadedBy = uploadedBy
- }
+      const fileName = toOptionalString(entryRecord.fileName)
+      if (fileName) {
+        attachment.fileName = fileName
+      }
+      const name = toOptionalString(entryRecord.name)
+      if (name) {
+        attachment.name = name
+      }
+      const contentType = toOptionalString(entryRecord.contentType)
+      if (contentType) {
+        attachment.contentType = contentType
+      }
+      const type = toOptionalString(entryRecord.type)
+      if (type) {
+        attachment.type = type
+      }
+      const size = toOptionalNumber(entryRecord.size)
+      if (size !== undefined) {
+        attachment.size = size
+      }
+      const uploadedAt = toOptionalString(entryRecord.uploadedAt)
+      if (uploadedAt) {
+        attachment.uploadedAt = uploadedAt
+      }
+      const uploadedBy = toOptionalString(entryRecord.uploadedBy)
+      if (uploadedBy) {
+        attachment.uploadedBy = uploadedBy
+      }
 
- result[key] = attachment
- }
- }
+      result[key] = attachment
+    }
+  }
 
- return result
+  return result
 }
 
 async function addPresignedUrls(
- attachments: Record<string, ApiAttachment>
+  attachments: Record<string, ApiAttachment>
 ): Promise<Record<string, ApiAttachment>> {
- const entries = Object.entries(attachments)
- if (entries.length === 0) {
- return attachments
- }
+  const entries = Object.entries(attachments)
+  if (entries.length === 0) {
+    return attachments
+  }
 
- const s3Service = getS3Service()
+  const s3Service = getS3Service()
 
- const processed = await Promise.all(
- entries.map(async ([category, attachment]) => {
- if (!attachment.s3Key) {
- return [category, attachment] as const
- }
+  const processed = await Promise.all(
+    entries.map(async ([category, attachment]) => {
+      if (!attachment.s3Key) {
+        return [category, attachment] as const
+      }
 
- let filename = attachment.fileName
- if (!filename) {
- filename = attachment.name
- }
- if (!filename) {
- filename = attachment.s3Key
- }
+      let filename = attachment.fileName
+      if (!filename) {
+        filename = attachment.name
+      }
+      if (!filename) {
+        filename = attachment.s3Key
+      }
 
- try {
- const s3Url = await s3Service.getPresignedUrl(attachment.s3Key, 'get', {
- responseContentDisposition: `attachment; filename="${filename}"`,
- expiresIn: 3600,
- })
- return [category, { ...attachment, s3Url }] as const
- } catch (_error) {
- return [category, attachment] as const
- }
- })
- )
+      try {
+        const s3Url = await s3Service.getPresignedUrl(attachment.s3Key, 'get', {
+          responseContentDisposition: `attachment; filename="${filename}"`,
+          expiresIn: 3600,
+        })
+        return [category, { ...attachment, s3Url }] as const
+      } catch (_error) {
+        return [category, attachment] as const
+      }
+    })
+  )
 
- return Object.fromEntries(processed)
+  return Object.fromEntries(processed)
 }
 
 export const GET = withAuthAndParams(async (request, params, _session) => {
- try {
- const { id } = params as { id: string }
+  try {
+    const { id } = params as { id: string }
 
- const prisma = await getTenantPrisma()
- const transaction = await prisma.inventoryTransaction.findUnique({
- where: { id },
- select: {
- id: true,
- transactionDate: true,
- transactionType: true,
- lotRef: true,
- referenceId: true,
- cartonsIn: true,
- cartonsOut: true,
- storagePalletsIn: true,
- shippingPalletsOut: true,
- createdAt: true,
- shipName: true,
- trackingNumber: true,
- pickupDate: true,
- attachments: true,
- storageCartonsPerPallet: true,
- shippingCartonsPerPallet: true,
- unitsPerCarton: true,
- supplier: true,
- // Use snapshot data instead of relations
- warehouseCode: true,
- warehouseName: true,
- warehouseAddress: true,
- skuCode: true,
- skuDescription: true,
- unitDimensionsCm: true,
- unitWeightKg: true,
- cartonDimensionsCm: true,
- cartonWeightKg: true,
- packagingType: true,
- createdById: true,
- createdByName: true
- }
- })
+    const prisma = await getTenantPrisma()
+    const transaction = await prisma.inventoryTransaction.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        transactionDate: true,
+        transactionType: true,
+        lotRef: true,
+        referenceId: true,
+        cartonsIn: true,
+        cartonsOut: true,
+        storagePalletsIn: true,
+        shippingPalletsOut: true,
+        createdAt: true,
+        shipName: true,
+        trackingNumber: true,
+        pickupDate: true,
+        attachments: true,
+        storageCartonsPerPallet: true,
+        shippingCartonsPerPallet: true,
+        unitsPerCarton: true,
+        supplier: true,
+        // Use snapshot data instead of relations
+        warehouseCode: true,
+        warehouseName: true,
+        warehouseAddress: true,
+        skuCode: true,
+        skuDescription: true,
+        unitDimensionsCm: true,
+        unitWeightKg: true,
+        cartonDimensionsCm: true,
+        cartonWeightKg: true,
+        packagingType: true,
+        createdById: true,
+        createdByName: true,
+      },
+    })
 
- if (!transaction) {
- return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
- }
+    if (!transaction) {
+      return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+    }
 
- // Fetch costs from CostLedger for this transaction
- const costLedger = await prisma.costLedger.findMany({
- where: {
- transactionId: id // Use the UUID directly
- },
- select: {
- costCategory: true,
- quantity: true,
- unitRate: true,
- totalCost: true
- }
- })
+    // Fetch costs from CostLedger for this transaction
+    const costLedger = await prisma.costLedger.findMany({
+      where: {
+        transactionId: id, // Use the UUID directly
+      },
+      select: {
+        costCategory: true,
+        quantity: true,
+        unitRate: true,
+        totalCost: true,
+      },
+    })
 
-  // Process attachments to add presigned URLs
-  const attachmentRecord = normalizeAttachmentRecord(transaction.attachments)
-  const processedAttachments = await addPresignedUrls(attachmentRecord)
+    // Process attachments to add presigned URLs
+    const attachmentRecord = normalizeAttachmentRecord(transaction.attachments)
+    const processedAttachments = await addPresignedUrls(attachmentRecord)
 
- // Create response object with transaction and costs
- // Transform to match expected format with nested objects
- const response = {
- ...transaction,
- attachments: processedAttachments,
- costLedger: costLedger,
- calculatedCosts: costLedger, // For backward compatibility
- // Add nested objects for backward compatibility
- warehouse: {
- id: '', // No longer have warehouse ID
- code: transaction.warehouseCode,
- name: transaction.warehouseName
- },
- sku: {
- id: '', // No longer have SKU ID
- skuCode: transaction.skuCode,
- description: transaction.skuDescription,
- unitsPerCarton: transaction.unitsPerCarton
- },
- createdBy: {
- id: transaction.createdById,
- fullName: transaction.createdByName
- }
- }
+    // Create response object with transaction and costs
+    // Transform to match expected format with nested objects
+    const response = {
+      ...transaction,
+      attachments: processedAttachments,
+      costLedger: costLedger,
+      calculatedCosts: costLedger, // For backward compatibility
+      lineItems: [
+        {
+          id: transaction.id,
+          skuId: transaction.skuCode,
+          sku: {
+            id: transaction.skuCode,
+            skuCode: transaction.skuCode,
+            description: transaction.skuDescription,
+            unitsPerCarton: transaction.unitsPerCarton,
+          },
+          lotRef: transaction.lotRef,
+          cartonsIn: transaction.cartonsIn,
+          cartonsOut: transaction.cartonsOut,
+          storagePalletsIn: transaction.storagePalletsIn,
+          shippingPalletsOut: transaction.shippingPalletsOut,
+          storageCartonsPerPallet: transaction.storageCartonsPerPallet,
+          shippingCartonsPerPallet: transaction.shippingCartonsPerPallet,
+          unitsPerCarton: transaction.unitsPerCarton,
+        },
+      ],
+      // Add nested objects for backward compatibility
+      warehouse: {
+        id: '', // No longer have warehouse ID
+        code: transaction.warehouseCode,
+        name: transaction.warehouseName,
+      },
+      sku: {
+        id: '', // No longer have SKU ID
+        skuCode: transaction.skuCode,
+        description: transaction.skuDescription,
+        unitsPerCarton: transaction.unitsPerCarton,
+      },
+      createdBy: {
+        id: transaction.createdById,
+        fullName: transaction.createdByName,
+      },
+    }
 
- return NextResponse.json(response)
- } catch (_error) {
- // console.error('Failed to fetch transaction:', _error)
- return NextResponse.json({ 
- error: 'Failed to fetch transaction'
- }, { status: 500 })
- }
+    return NextResponse.json(response)
+  } catch (_error) {
+    // console.error('Failed to fetch transaction:', _error)
+    return NextResponse.json(
+      {
+        error: 'Failed to fetch transaction',
+      },
+      { status: 500 }
+    )
+  }
 })
 
 export const PUT = withAuthAndParams(async (request, params, session) => {
- try {
- const { id } = params as { id: string }
+  try {
+    const { id } = params as { id: string }
 
- const prisma = await getTenantPrisma()
- const body = await request.json()
+    const prisma = await getTenantPrisma()
+    const body = await request.json()
 
- // Get the existing transaction
- const existingTransaction = await prisma.inventoryTransaction.findUnique({
- where: { id }
- })
+    // Get the existing transaction
+    const existingTransaction = await prisma.inventoryTransaction.findUnique({
+      where: { id },
+    })
 
- if (!existingTransaction) {
- return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
- }
+    if (!existingTransaction) {
+      return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+    }
 
- // Check if user has permission to edit this warehouse's transactions
- // Since we don't have warehouseId anymore, we need to check by warehouse code
- if (session.user.role === 'staff' && session.user.warehouseId) {
- const userWarehouse = await prisma.warehouse.findUnique({
- where: { id: session.user.warehouseId },
- select: { code: true }
- })
- if (userWarehouse && userWarehouse.code !== existingTransaction.warehouseCode) {
- return NextResponse.json({ error: 'Access denied' }, { status: 403 })
- }
- }
+    // Check if user has permission to edit this warehouse's transactions
+    // Since we don't have warehouseId anymore, we need to check by warehouse code
+    if (session.user.role === 'staff' && session.user.warehouseId) {
+      const userWarehouse = await prisma.warehouse.findUnique({
+        where: { id: session.user.warehouseId },
+        select: { code: true },
+      })
+      if (userWarehouse && userWarehouse.code !== existingTransaction.warehouseCode) {
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 })
+      }
+    }
 
- // Only allow updating reference fields, NOT quantities or costs
- const allowedFields = [
- 'referenceId',
- 'shipName',
- 'trackingNumber',
- 'supplier'
- ]
+    // Only allow updating reference fields, NOT quantities or costs
+    const allowedFields = ['referenceId', 'shipName', 'trackingNumber', 'supplier']
 
- const updateData: Record<string, unknown> = {}
- for (const field of allowedFields) {
- if (body[field] !== undefined) {
- updateData[field] = body[field]
- }
- }
+    const updateData: Record<string, unknown> = {}
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        updateData[field] = body[field]
+      }
+    }
 
- // Update the transaction
- const updatedTransaction = await prisma.inventoryTransaction.update({
- where: { id },
- data: updateData as Prisma.InventoryTransactionUpdateInput
- })
+    // Update the transaction
+    const updatedTransaction = await prisma.inventoryTransaction.update({
+      where: { id },
+      data: updateData as Prisma.InventoryTransactionUpdateInput,
+    })
 
- return NextResponse.json(updatedTransaction)
- } catch (_error) {
- // console.error('Failed to update transaction:', _error)
- return NextResponse.json({ 
- error: 'Failed to update transaction'
- }, { status: 500 })
- }
+    return NextResponse.json(updatedTransaction)
+  } catch (_error) {
+    // console.error('Failed to update transaction:', _error)
+    return NextResponse.json(
+      {
+        error: 'Failed to update transaction',
+      },
+      { status: 500 }
+    )
+  }
 })
 
 export const DELETE = withAuthAndParams(async (request, params, session) => {
- try {
- const { id } = params as { id: string }
+  try {
+    const { id } = params as { id: string }
 
- const prisma = await getTenantPrisma()
- const validation = await validateTransactionDelete(prisma, session.user, id)
+    const prisma = await getTenantPrisma()
+    const validation = await validateTransactionDelete(prisma, session.user, id)
 
- if (!validation.canDelete) {
- return NextResponse.json({ 
- error: validation.reason ?? 'Cannot delete this transaction' 
- }, { status: 400 })
- }
+    if (!validation.canDelete) {
+      return NextResponse.json(
+        {
+          error: validation.reason ?? 'Cannot delete this transaction',
+        },
+        { status: 400 }
+      )
+    }
 
- // Get transaction details before deletion for logging
- const transaction = await prisma.inventoryTransaction.findUnique({
- where: { id }
- })
+    // Get transaction details before deletion for logging
+    const transaction = await prisma.inventoryTransaction.findUnique({
+      where: { id },
+    })
 
- if (!transaction) {
- return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
- }
+    if (!transaction) {
+      return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+    }
 
- // Check user permissions
- if (session.user.role === 'staff' && session.user.warehouseId) {
- const userWarehouse = await prisma.warehouse.findUnique({
- where: { id: session.user.warehouseId },
- select: { code: true }
- })
- if (userWarehouse && userWarehouse.code !== transaction.warehouseCode) {
- return NextResponse.json({ error: 'Access denied' }, { status: 403 })
- }
- }
+    // Check user permissions
+    if (session.user.role === 'staff' && session.user.warehouseId) {
+      const userWarehouse = await prisma.warehouse.findUnique({
+        where: { id: session.user.warehouseId },
+        select: { code: true },
+      })
+      if (userWarehouse && userWarehouse.code !== transaction.warehouseCode) {
+        return NextResponse.json({ error: 'Access denied' }, { status: 403 })
+      }
+    }
 
- // Delete the transaction (cascade deletion will handle related cost ledger entries)
- await prisma.inventoryTransaction.delete({
- where: { id }
- })
+    // Delete the transaction (cascade deletion will handle related cost ledger entries)
+    await prisma.inventoryTransaction.delete({
+      where: { id },
+    })
 
- // Log the deletion
- // console.log(`Transaction ${transaction.id} deleted by ${session.user.email}`)
+    // Log the deletion
+    // console.log(`Transaction ${transaction.id} deleted by ${session.user.email}`)
 
- return NextResponse.json({ 
- success: true, 
- message: 'Transaction deleted successfully',
- deletedTransaction: {
- id: transaction.id,
- type: transaction.transactionType,
- sku: transaction.skuCode,
- lotRef: transaction.lotRef,
- quantity: transaction.cartonsIn || transaction.cartonsOut
- }
- })
- } catch (_error) {
- if (_error instanceof TransactionValidationError) {
- return NextResponse.json({ error: _error.message }, { status: _error.status })
- }
- // console.error('Failed to delete transaction:', _error)
- return NextResponse.json({ 
- error: 'Failed to delete transaction'
- }, { status: 500 })
- }
+    return NextResponse.json({
+      success: true,
+      message: 'Transaction deleted successfully',
+      deletedTransaction: {
+        id: transaction.id,
+        type: transaction.transactionType,
+        sku: transaction.skuCode,
+        lotRef: transaction.lotRef,
+        quantity:
+          transaction.transactionType === 'RECEIVE'
+            ? transaction.cartonsIn
+            : transaction.cartonsOut,
+      },
+    })
+  } catch (_error) {
+    if (_error instanceof TransactionValidationError) {
+      return NextResponse.json({ error: _error.message }, { status: _error.status })
+    }
+    // console.error('Failed to delete transaction:', _error)
+    return NextResponse.json(
+      {
+        error: 'Failed to delete transaction',
+      },
+      { status: 500 }
+    )
+  }
 })

--- a/apps/talos/src/app/config/suppliers/suppliers-panel.tsx
+++ b/apps/talos/src/app/config/suppliers/suppliers-panel.tsx
@@ -265,9 +265,13 @@ export default function SuppliersPanel({
           <div className="space-y-1.5">
             <div className="flex items-center gap-2">
               <Users className="h-5 w-5 text-cyan-600 dark:text-cyan-400" />
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Supplier Directory</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                Supplier Directory
+              </h2>
             </div>
-            <p className="text-sm text-slate-600 dark:text-slate-400">Manage supplier information and contacts</p>
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              Manage supplier information and contacts
+            </p>
           </div>
           <Badge className="bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 border-cyan-200 dark:border-cyan-800 font-medium">
             {suppliers.length} suppliers
@@ -317,17 +321,32 @@ export default function SuppliersPanel({
             <table className="min-w-[980px] w-full table-auto text-sm">
               <thead>
                 <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Name</th>
-                  <th className="min-w-[120px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Contact</th>
-                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Email</th>
-                  <th className="min-w-[140px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Phone</th>
-                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Default Terms</th>
-                  <th className="w-[72px] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Actions</th>
+                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Name
+                  </th>
+                  <th className="min-w-[120px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Contact
+                  </th>
+                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Email
+                  </th>
+                  <th className="min-w-[140px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Phone
+                  </th>
+                  <th className="min-w-[220px] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Default Terms
+                  </th>
+                  <th className="w-[72px] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {filteredSuppliers.map(supplier => (
-                  <tr key={supplier.id} className="border-t border-slate-200 align-top dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
+                  <tr
+                    key={supplier.id}
+                    className="border-t border-slate-200 align-top dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50"
+                  >
                     <td className="px-3 py-2 font-medium text-foreground">
                       <button
                         type="button"
@@ -338,7 +357,10 @@ export default function SuppliersPanel({
                         {supplier.name}
                       </button>
                     </td>
-                    <td className="px-3 py-2 text-muted-foreground whitespace-normal break-words leading-5" title={supplier.contactName ?? undefined}>
+                    <td
+                      className="px-3 py-2 text-muted-foreground whitespace-normal break-words leading-5"
+                      title={supplier.contactName ?? undefined}
+                    >
                       {supplier.contactName ?? '—'}
                     </td>
                     <td className="px-3 py-2 text-muted-foreground break-all leading-5">
@@ -347,9 +369,18 @@ export default function SuppliersPanel({
                     <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">
                       {supplier.phone ?? '—'}
                     </td>
-                    <td className="px-3 py-2 text-sm text-muted-foreground whitespace-normal break-words leading-5" title={[supplier.defaultIncoterms, supplier.defaultPaymentTerms].filter(Boolean).join(' · ') || undefined}>
+                    <td
+                      className="px-3 py-2 text-sm text-muted-foreground whitespace-normal break-words leading-5"
+                      title={
+                        [supplier.defaultIncoterms, supplier.defaultPaymentTerms]
+                          .filter(Boolean)
+                          .join(' · ') || undefined
+                      }
+                    >
                       {supplier.defaultPaymentTerms || supplier.defaultIncoterms ? (
-                        [supplier.defaultIncoterms, supplier.defaultPaymentTerms].filter(Boolean).join(' · ')
+                        [supplier.defaultIncoterms, supplier.defaultPaymentTerms]
+                          .filter(Boolean)
+                          .join(' · ')
                       ) : (
                         <span className="text-muted-foreground">—</span>
                       )}
@@ -360,6 +391,7 @@ export default function SuppliersPanel({
                         size="sm"
                         onClick={() => setConfirmDelete(supplier)}
                         className="border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 hover:text-red-800 dark:hover:text-red-300"
+                        aria-label={`Delete supplier ${supplier.name}`}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
@@ -489,7 +521,9 @@ export default function SuppliersPanel({
                     placeholder="e.g., Net 30, 50% deposit"
                     className="w-full rounded-lg border border-slate-200 dark:border-slate-700 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-2.5 text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-500 dark:placeholder:text-slate-400 focus:border-cyan-500 dark:focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-100 dark:focus:ring-cyan-900 transition-shadow"
                   />
-                  <p className="text-xs text-slate-500 dark:text-slate-400">Auto-filled when creating new Inbound</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Auto-filled when creating new Inbound
+                  </p>
                 </div>
 
                 <div className="space-y-1">
@@ -509,7 +543,9 @@ export default function SuppliersPanel({
                       </option>
                     ))}
                   </select>
-                  <p className="text-xs text-slate-500 dark:text-slate-400">Auto-filled when creating new Inbound</p>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Auto-filled when creating new Inbound
+                  </p>
                 </div>
               </div>
             </div>

--- a/apps/talos/src/app/config/warehouses/[id]/rates/page.tsx
+++ b/apps/talos/src/app/config/warehouses/[id]/rates/page.tsx
@@ -4,13 +4,23 @@ import { use, useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import { DashboardLayout } from '@/components/layout/dashboard-layout'
 import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
-import { DollarSign, Loader2, Upload, Download, Trash2, ChevronRight, Home } from '@/lib/lucide-icons'
+import {
+  DollarSign,
+  Loader2,
+  Upload,
+  Download,
+  Trash2,
+  ChevronRight,
+  Home,
+} from '@/lib/lucide-icons'
 import { Button } from '@/components/ui/button'
 import { fetchWithCSRF } from '@/lib/fetch-with-csrf'
 import { toast } from 'react-hot-toast'
 import { WarehouseRatesPanel } from '../../warehouse-rates-panel'
 import { useRef, ChangeEvent } from 'react'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
+import { useSession } from '@/hooks/usePortalSession'
+import { getTenantConfig } from '@/lib/tenant/constants'
 
 interface Warehouse {
   id: string
@@ -25,11 +35,7 @@ interface Warehouse {
   } | null
 }
 
-export default function WarehouseRatesPage({
-  params
-}: {
-  params: Promise<{ id: string }>
-}) {
+export default function WarehouseRatesPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params)
   const [warehouse, setWarehouse] = useState<Warehouse | null>(null)
   const [loading, setLoading] = useState(true)
@@ -37,6 +43,7 @@ export default function WarehouseRatesPage({
   const [downloading, setDownloading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false)
+  const { data: session, status } = useSession()
 
   const loadWarehouse = useCallback(async () => {
     try {
@@ -132,15 +139,25 @@ export default function WarehouseRatesPage({
 
   const customBreadcrumb = warehouse ? (
     <nav className="flex items-center space-x-1 text-sm text-slate-600 dark:text-slate-400 mb-4">
-      <Link href="/dashboard" className="flex items-center hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
+      <Link
+        href="/dashboard"
+        aria-label="Go to dashboard"
+        className="flex items-center hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+      >
         <Home className="h-4 w-4" />
       </Link>
       <ChevronRight className="h-4 w-4 mx-1 text-slate-400 dark:text-slate-500" />
-      <Link href="/config/warehouses" className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
+      <Link
+        href="/config/warehouses"
+        className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+      >
         Configuration
       </Link>
       <ChevronRight className="h-4 w-4 mx-1 text-slate-400 dark:text-slate-500" />
-      <Link href="/config/warehouses" className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors">
+      <Link
+        href="/config/warehouses"
+        className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+      >
         Warehouses
       </Link>
       <ChevronRight className="h-4 w-4 mx-1 text-slate-400 dark:text-slate-500" />
@@ -148,7 +165,7 @@ export default function WarehouseRatesPage({
     </nav>
   ) : null
 
-  if (loading) {
+  if (loading || status === 'loading') {
     return (
       <DashboardLayout hideBreadcrumb>
         <div className="flex h-64 items-center justify-center">
@@ -179,12 +196,18 @@ export default function WarehouseRatesPage({
     )
   }
 
+  if (!session) {
+    return null
+  }
+
+  const tenantCurrency = getTenantConfig(session.user.region).currency
+
   return (
     <DashboardLayout customBreadcrumb={customBreadcrumb}>
       <PageContainer>
         <PageHeaderSection
           title={warehouse.name}
-          description={`Template Rates • ${warehouse.code}`}
+          description={`Template Rates • ${warehouse.code} • ${tenantCurrency}`}
           icon={DollarSign}
           backHref="/config/warehouses"
           backLabel="Back"
@@ -204,6 +227,7 @@ export default function WarehouseRatesPage({
                       onClick={handleDownload}
                       disabled={downloading}
                       className="h-7 px-2"
+                      aria-label={`Download rate list for ${warehouse.code}`}
                     >
                       <Download className="h-3.5 w-3.5" />
                     </Button>
@@ -212,6 +236,7 @@ export default function WarehouseRatesPage({
                       size="sm"
                       onClick={handleRemoveAttachment}
                       className="h-7 px-2 text-red-600 hover:text-red-700 hover:bg-red-50"
+                      aria-label={`Remove rate list for ${warehouse.code}`}
                     >
                       <Trash2 className="h-3.5 w-3.5" />
                     </Button>
@@ -225,6 +250,7 @@ export default function WarehouseRatesPage({
                   onClick={() => fileInputRef.current?.click()}
                   disabled={uploading}
                   className="h-7 px-2"
+                  aria-label={`Upload rate list for ${warehouse.code}`}
                 >
                   <Upload className="h-3.5 w-3.5" />
                 </Button>
@@ -246,6 +272,7 @@ export default function WarehouseRatesPage({
               warehouseId={warehouse.id}
               warehouseName={warehouse.name}
               warehouseCode={warehouse.code}
+              currency={tenantCurrency}
             />
           </div>
         </PageContent>

--- a/apps/talos/src/app/config/warehouses/warehouse-rates-panel.tsx
+++ b/apps/talos/src/app/config/warehouses/warehouse-rates-panel.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/components/ui/badge'
 import { fetchWithCSRF } from '@/lib/fetch-with-csrf'
 import { usePageState } from '@/lib/store/page-state'
 import { toast } from 'react-hot-toast'
+import { formatCurrencyForCode } from '@/lib/dashboard/currency'
 
 interface CostRate {
   id: string
@@ -29,6 +30,7 @@ interface WarehouseRatesPanelProps {
   warehouseId: string
   warehouseName: string
   warehouseCode: string
+  currency: string
 }
 
 type TabKey = 'inbound' | 'storage' | 'outbound' | 'forwarding'
@@ -103,7 +105,7 @@ const RATE_TEMPLATES = {
       costName: 'Pallets Putaway',
       costCategory: 'Inbound',
       unitOfMeasure: 'per_pallet',
-      defaultValue: 2.10,
+      defaultValue: 2.1,
     },
     {
       costName: 'Pallets Supplied',
@@ -209,6 +211,7 @@ export function WarehouseRatesPanel({
   warehouseId,
   warehouseName,
   warehouseCode,
+  currency,
 }: WarehouseRatesPanelProps) {
   const pageState = usePageState(`/config/warehouses/${warehouseId}/rates`)
   const activeTab = (pageState.activeTab as TabKey) ?? 'inbound'
@@ -233,7 +236,7 @@ export function WarehouseRatesPanel({
       const response = await fetchWithCSRF(`/api/warehouses/${warehouseId}/cost-rates`)
       if (response.ok) {
         const data = await response.json()
-        setRates(data.costRates || [])
+        setRates(Array.isArray(data.costRates) ? data.costRates : [])
       }
     } catch (error) {
       console.error('Failed to load rates:', error)
@@ -293,7 +296,7 @@ export function WarehouseRatesPanel({
         cancelEditing()
       } else {
         const error = await response.json().catch(() => null)
-        toast.error(error?.error || 'Failed to update rate')
+        toast.error(error?.error ?? 'Failed to update rate')
       }
     } catch (_error) {
       toast.error('Failed to update rate')
@@ -332,7 +335,7 @@ export function WarehouseRatesPanel({
         cancelEditing()
       } else {
         const error = await response.json().catch(() => null)
-        toast.error(error?.error || 'Failed to create rate')
+        toast.error(error?.error ?? 'Failed to create rate')
       }
     } catch (_error) {
       toast.error('Failed to create rate')
@@ -348,7 +351,10 @@ export function WarehouseRatesPanel({
     const isAddingNew = isEditingThis && editState?.field === 'new'
 
     return (
-      <tr key={template.costName} className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
+      <tr
+        key={template.costName}
+        className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50"
+      >
         <td className="px-3 py-2 text-foreground whitespace-nowrap w-[55%]">
           {template.costName}
           {showCategory && (
@@ -359,11 +365,11 @@ export function WarehouseRatesPanel({
           {rate ? (
             isEditingRate ? (
               <div className="flex items-center justify-end gap-2">
-                <span className="text-muted-foreground">$</span>
+                <span className="text-muted-foreground">{currency}</span>
                 <input
                   type="number"
                   step="0.01"
-                  value={editState?.value || ''}
+                  value={editState?.value ?? ''}
                   onChange={e =>
                     setEditState(prev => (prev ? { ...prev, value: e.target.value } : null))
                   }
@@ -371,28 +377,36 @@ export function WarehouseRatesPanel({
                   autoFocus
                 />
                 <button
+                  type="button"
                   onClick={() => saveRate(rate)}
                   disabled={saving}
                   className="p-1 text-green-600 hover:bg-green-50 rounded"
                   title="Save"
+                  aria-label={`Save ${template.costName} rate`}
                 >
                   <Save className="h-4 w-4" />
                 </button>
                 <button
+                  type="button"
                   onClick={cancelEditing}
                   className="p-1 text-muted-foreground hover:bg-muted rounded"
                   title="Cancel"
+                  aria-label={`Cancel ${template.costName} rate edit`}
                 >
                   <X className="h-4 w-4" />
                 </button>
               </div>
             ) : (
               <div className="flex items-center justify-end gap-2">
-                <span className="font-semibold text-foreground">${rate.costValue.toFixed(2)}</span>
+                <span className="font-semibold text-foreground">
+                  {formatCurrencyForCode(rate.costValue, currency)}
+                </span>
                 <button
+                  type="button"
                   onClick={() => startEditingRate(rate)}
                   className="p-1 text-muted-foreground/50 hover:text-primary hover:bg-primary/10 rounded transition-colors"
                   title="Edit rate"
+                  aria-label={`Edit ${template.costName} rate`}
                 >
                   <Edit className="h-3.5 w-3.5" />
                 </button>
@@ -400,11 +414,11 @@ export function WarehouseRatesPanel({
             )
           ) : isAddingNew ? (
             <div className="flex items-center justify-end gap-2">
-              <span className="text-muted-foreground">$</span>
+              <span className="text-muted-foreground">{currency}</span>
               <input
                 type="number"
                 step="0.01"
-                value={editState?.value || ''}
+                value={editState?.value ?? ''}
                 onChange={e =>
                   setEditState(prev => (prev ? { ...prev, value: e.target.value } : null))
                 }
@@ -412,17 +426,21 @@ export function WarehouseRatesPanel({
                 autoFocus
               />
               <button
+                type="button"
                 onClick={() => createRate(template)}
                 disabled={saving}
                 className="p-1 text-green-600 hover:bg-green-50 rounded"
                 title="Save"
+                aria-label={`Save ${template.costName} rate`}
               >
                 <Save className="h-4 w-4" />
               </button>
               <button
+                type="button"
                 onClick={cancelEditing}
                 className="p-1 text-muted-foreground hover:bg-muted rounded"
                 title="Cancel"
+                aria-label={`Cancel ${template.costName} rate add`}
               >
                 <X className="h-4 w-4" />
               </button>
@@ -438,8 +456,10 @@ export function WarehouseRatesPanel({
             formatUnit(template.unitOfMeasure)
           ) : (
             <button
+              type="button"
               onClick={() => startAddingRate(template)}
               className="inline-flex items-center gap-1 text-sm text-primary hover:text-primary/80 font-medium transition-colors"
+              aria-label={`Add ${template.costName} rate`}
             >
               <Plus className="h-3.5 w-3.5" />
               Add
@@ -462,7 +482,7 @@ export function WarehouseRatesPanel({
       per_shipment: 'per shipment',
       flat: 'flat',
     }
-    return unitLabels[unit] || unit
+    return unitLabels[unit] ?? unit
   }
 
   if (loading) {
@@ -479,7 +499,9 @@ export function WarehouseRatesPanel({
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold text-foreground">{warehouseName}</h2>
-          <p className="text-sm text-muted-foreground">Template Rates • {warehouseCode} • USD</p>
+          <p className="text-sm text-muted-foreground">
+            Template Rates • {warehouseCode} • {currency}
+          </p>
           <p className="text-xs text-muted-foreground mt-1">
             Used to prefill warehouse-stage costs in the Inbound workflow.
           </p>
@@ -494,6 +516,7 @@ export function WarehouseRatesPanel({
         <nav className="flex gap-1 -mb-px">
           {tabs.map(tab => (
             <button
+              type="button"
               key={tab.key}
               onClick={() => setActiveTab(tab.key)}
               className={`
@@ -518,10 +541,7 @@ export function WarehouseRatesPanel({
           <InboundTab templates={RATE_TEMPLATES.inbound} renderRateRow={renderRateRow} />
         )}
         {activeTab === 'storage' && (
-          <StorageTab
-            templates={RATE_TEMPLATES.storage}
-            renderRateRow={renderRateRow}
-          />
+          <StorageTab templates={RATE_TEMPLATES.storage} renderRateRow={renderRateRow} />
         )}
         {activeTab === 'outbound' && (
           <OutboundTab templates={RATE_TEMPLATES.outbound} renderRateRow={renderRateRow} />
@@ -569,9 +589,15 @@ function InboundTab({ templates, renderRateRow }: TabProps) {
         <table className="w-full table-fixed text-sm">
           <thead>
             <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">Container Type</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">Rate</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">Unit</th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">
+                Container Type
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">
+                Rate
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">
+                Unit
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -620,9 +646,15 @@ function StorageTab({ templates, renderRateRow }: StorageTabProps) {
         <table className="w-full table-fixed text-sm">
           <thead>
             <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">Description</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">Rate</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">Unit</th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">
+                Description
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">
+                Rate
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">
+                Unit
+              </th>
             </tr>
           </thead>
           <tbody>{templates.map(t => renderRateRow(t))}</tbody>
@@ -652,9 +684,15 @@ function OutboundTab({ templates, renderRateRow }: TabProps) {
         <table className="w-full table-fixed text-sm">
           <thead>
             <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">Pallet Range</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">Rate</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">Unit</th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">
+                Pallet Range
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">
+                Rate
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">
+                Unit
+              </th>
             </tr>
           </thead>
           <tbody>{truckingRates.map(t => renderRateRow(t))}</tbody>
@@ -697,9 +735,15 @@ function ForwardingTab({ templates, renderRateRow }: TabProps) {
         <table className="w-full table-fixed text-sm">
           <thead>
             <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">Service</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">Rate</th>
-              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">Unit</th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[55%]">
+                Service
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right w-[25%]">
+                Rate
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left w-[20%]">
+                Unit
+              </th>
             </tr>
           </thead>
           <tbody>{templates.map(t => renderRateRow(t))}</tbody>

--- a/apps/talos/src/app/config/warehouses/warehouses-panel.tsx
+++ b/apps/talos/src/app/config/warehouses/warehouses-panel.tsx
@@ -2,11 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import Link from 'next/link'
-import {
-  Building2,
-  Edit,
-  Search,
-} from '@/lib/lucide-icons'
+import { Building2, Edit, Search } from '@/lib/lucide-icons'
 import { fetchWithCSRF } from '@/lib/fetch-with-csrf'
 import { usePageState } from '@/lib/store/page-state'
 import { toast } from 'react-hot-toast'
@@ -54,7 +50,7 @@ export default function WarehousesPanel() {
 
       const payload = await response.json()
       const data: Warehouse[] = Array.isArray(payload) ? payload : []
-      const normalized = data.map((warehouse) => ({
+      const normalized = data.map(warehouse => ({
         ...warehouse,
         name: warehouse.name || 'Unnamed warehouse',
         code: warehouse.code || '—',
@@ -83,7 +79,7 @@ export default function WarehousesPanel() {
 
   const filteredWarehouses = useMemo(() => {
     const term = searchTerm.trim().toLowerCase()
-    return warehouses.filter((warehouse) => {
+    return warehouses.filter(warehouse => {
       if (!term) return true
 
       const haystack = [
@@ -125,9 +121,13 @@ export default function WarehousesPanel() {
           <div className="space-y-1.5">
             <div className="flex items-center gap-2">
               <Building2 className="h-5 w-5 text-cyan-600 dark:text-cyan-400" />
-              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Warehouse Network</h2>
+              <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+                Warehouse Network
+              </h2>
             </div>
-            <p className="text-sm text-slate-600 dark:text-slate-400">Manage warehouses and configure cost rates</p>
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              Manage warehouses and configure cost rates
+            </p>
           </div>
           <Badge className="bg-cyan-50 dark:bg-cyan-900/30 text-cyan-700 dark:text-cyan-300 border-cyan-200 dark:border-cyan-800 font-medium">
             {warehouses.length} warehouses · {totals.costRates} rates
@@ -140,7 +140,7 @@ export default function WarehousesPanel() {
               <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400 dark:text-slate-500" />
               <input
                 value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
+                onChange={event => setSearchTerm(event.target.value)}
                 placeholder="Search warehouses..."
                 className="w-full rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 pl-10 pr-4 py-2.5 text-sm text-slate-900 dark:text-slate-100 placeholder:text-slate-500 dark:placeholder:text-slate-400 focus:border-cyan-500 dark:focus:border-cyan-400 focus:outline-none focus:ring-2 focus:ring-cyan-100 dark:focus:ring-cyan-900 transition-shadow"
               />
@@ -156,7 +156,9 @@ export default function WarehousesPanel() {
           <div className="flex flex-col items-center justify-center gap-3 px-6 py-16 text-center">
             <Building2 className="h-10 w-10 text-slate-300 dark:text-slate-600" />
             <div>
-              <p className="text-base font-semibold text-slate-900 dark:text-slate-100">No warehouses to show</p>
+              <p className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                No warehouses to show
+              </p>
               <p className="text-sm text-slate-500 dark:text-slate-400">
                 Contact an administrator to configure warehouses.
               </p>
@@ -167,18 +169,35 @@ export default function WarehousesPanel() {
             <table className="w-full table-fixed text-sm">
               <thead>
                 <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
-                  <th className="w-[12%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Code</th>
-                  <th className="w-[22%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Name</th>
-                  <th className="w-[10%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Type</th>
-                  <th className="w-[26%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Address</th>
-                  <th className="w-[14%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Phone</th>
-                  <th className="w-[8%] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Rates</th>
-                  <th className="w-[8%] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">Actions</th>
+                  <th className="w-[12%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Code
+                  </th>
+                  <th className="w-[22%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Name
+                  </th>
+                  <th className="w-[10%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Type
+                  </th>
+                  <th className="w-[26%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Address
+                  </th>
+                  <th className="w-[14%] text-left font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Phone
+                  </th>
+                  <th className="w-[8%] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Rates
+                  </th>
+                  <th className="w-[8%] text-right font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs">
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {filteredWarehouses.map(warehouse => (
-                  <tr key={warehouse.id} className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
+                  <tr
+                    key={warehouse.id}
+                    className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50"
+                  >
                     <td className="px-3 py-2 font-medium text-foreground">
                       <Link
                         href={`/config/warehouses/${warehouse.id}/rates`}
@@ -193,7 +212,10 @@ export default function WarehousesPanel() {
                     <td className="px-3 py-2 text-muted-foreground">
                       {getKindLabel(warehouse.kind)}
                     </td>
-                    <td className="px-3 py-2 text-muted-foreground truncate" title={warehouse.address || undefined}>
+                    <td
+                      className="px-3 py-2 text-muted-foreground truncate"
+                      title={warehouse.address || undefined}
+                    >
                       {warehouse.address || '—'}
                     </td>
                     <td className="px-3 py-2 text-muted-foreground whitespace-nowrap">
@@ -203,12 +225,11 @@ export default function WarehousesPanel() {
                       {warehouse._count.costRates}
                     </td>
                     <td className="px-3 py-2 text-right">
-                      <Button
-                        asChild
-                        variant="outline"
-                        size="sm"
-                      >
-                        <Link href={`/config/warehouses/${warehouse.id}/edit`}>
+                      <Button asChild variant="outline" size="sm">
+                        <Link
+                          href={`/config/warehouses/${warehouse.id}/edit`}
+                          aria-label={`Edit warehouse ${warehouse.code}`}
+                        >
                           <Edit className="h-4 w-4" />
                         </Link>
                       </Button>

--- a/apps/talos/src/app/operations/cost-ledger/page.tsx
+++ b/apps/talos/src/app/operations/cost-ledger/page.tsx
@@ -4,28 +4,21 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { format } from 'date-fns'
 import { useSession } from '@/hooks/usePortalSession'
 import { useRouter } from 'next/navigation'
-import {
-  DollarSign,
-  BarChart3,
-  Filter,
-  Download,
-  Truck,
-  Box,
-  Package,
-} from '@/lib/lucide-icons'
+import { DollarSign, BarChart3, Filter, Download, Truck, Box, Package } from '@/lib/lucide-icons'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { cn } from '@/lib/utils'
 import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
 import { StatsCard, StatsCardGrid } from '@/components/ui/stats-card'
 import { Button } from '@/components/ui/button'
 import { PageLoading } from '@/components/ui/loading-spinner'
-import { formatCurrency } from '@/lib/utils'
+import { formatCurrencyForCode } from '@/lib/dashboard/currency'
 import { toast } from 'react-hot-toast'
 import type { CostLedgerBucketTotals, CostLedgerGroupResult } from '@targon/ledger'
 import { buildAppCallbackUrl, redirectToPortal } from '@/lib/portal'
 import { withBasePath } from '@/lib/utils/base-path'
 import { parseCostLedgerExportResponse } from './export'
 import { usePageState } from '@/lib/store'
+import { getTenantConfig } from '@/lib/tenant/constants'
 
 const baseFilterInputClass =
   'w-full rounded-md border border-muted px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary'
@@ -81,6 +74,11 @@ export default function CostLedgerPage() {
 
   // Initialize column filters from persisted state after hydration
   const [columnFilters, setColumnFilters] = useState(defaultColumnFilters)
+  const tenantCurrency = session ? getTenantConfig(session.user.region).currency : 'USD'
+  const formatAmount = useCallback(
+    (amount: number) => formatCurrencyForCode(amount, tenantCurrency),
+    [tenantCurrency]
+  )
 
   useEffect(() => {
     setHydrated(true)
@@ -126,12 +124,8 @@ export default function CostLedgerPage() {
         credentials: 'include',
       })
       if (!response.ok) {
-        const errorData = await response
-          .json()
-          .catch(() => ({ error: 'Unknown error' }))
-        toast.error(
-          `Failed to load cost ledger: ${errorData.error || response.statusText}`,
-        )
+        const errorData = await response.json().catch(() => ({ error: 'Unknown error' }))
+        toast.error(`Failed to load cost ledger: ${errorData.error ?? response.statusText}`)
         return
       }
 
@@ -154,7 +148,7 @@ export default function CostLedgerPage() {
   const renderNumericFilter = (
     label: string,
     minKey: keyof typeof columnFilters,
-    maxKey: keyof typeof columnFilters,
+    maxKey: keyof typeof columnFilters
   ) => (
     <Popover>
       <PopoverTrigger asChild>
@@ -168,9 +162,7 @@ export default function CostLedgerPage() {
       </PopoverTrigger>
       <PopoverContent align="end" className="w-56 space-y-2">
         <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-foreground">
-            {label} range
-          </span>
+          <span className="text-sm font-medium text-foreground">{label} range</span>
           <button
             type="button"
             className="text-xs font-medium text-primary hover:underline"
@@ -184,7 +176,7 @@ export default function CostLedgerPage() {
             type="number"
             inputMode="numeric"
             value={columnFilters[minKey] as string}
-            onChange={(event) =>
+            onChange={event =>
               setColumnFilters(prev => ({ ...prev, [minKey]: event.target.value }))
             }
             placeholder="Min"
@@ -194,7 +186,7 @@ export default function CostLedgerPage() {
             type="number"
             inputMode="numeric"
             value={columnFilters[maxKey] as string}
-            onChange={(event) =>
+            onChange={event =>
               setColumnFilters(prev => ({ ...prev, [maxKey]: event.target.value }))
             }
             placeholder="Max"
@@ -229,7 +221,7 @@ export default function CostLedgerPage() {
     const matchesRange = (
       value: number | null | undefined,
       min: number | null,
-      max: number | null,
+      max: number | null
     ) => {
       const actual = value ?? 0
       if (min !== null && actual < min) return false
@@ -301,34 +293,34 @@ export default function CostLedgerPage() {
     return [
       {
         title: 'Total',
-        value: formatCurrency(totals.total ?? 0),
+        value: formatAmount(totals.total ?? 0),
         subtitle: 'All cost buckets',
         icon: DollarSign,
         variant: 'default' as const,
       },
       {
         title: 'Inbound',
-        value: formatCurrency(totals.inbound ?? 0),
+        value: formatAmount(totals.inbound ?? 0),
         subtitle: 'Inbound handling',
         icon: Package,
         variant: 'default' as const,
       },
       {
         title: 'Outbound',
-        value: formatCurrency(totals.outbound ?? 0),
+        value: formatAmount(totals.outbound ?? 0),
         subtitle: 'Outbound handling',
         icon: Truck,
         variant: 'default' as const,
       },
       {
         title: 'Storage',
-        value: formatCurrency(totals.storage ?? 0),
+        value: formatAmount(totals.storage ?? 0),
         subtitle: 'Storage fees',
         icon: Box,
         variant: 'default' as const,
       },
     ]
-  }, [totals])
+  }, [formatAmount, totals])
 
   if (status === 'loading') {
     return (
@@ -389,7 +381,7 @@ export default function CostLedgerPage() {
                                 'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
                                 columnFilters.weekEnding
                                   ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
-                                  : 'hover:bg-muted/30 hover:text-primary',
+                                  : 'hover:bg-muted/30 hover:text-primary'
                               )}
                             >
                               <Filter className="h-3.5 w-3.5" />
@@ -441,11 +433,7 @@ export default function CostLedgerPage() {
                     <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
                       <div className="flex items-center justify-end gap-1">
                         <span>Forwarding</span>
-                        {renderNumericFilter(
-                          'Forwarding',
-                          'forwardingMin',
-                          'forwardingMax',
-                        )}
+                        {renderNumericFilter('Forwarding', 'forwardingMin', 'forwardingMax')}
                       </div>
                     </th>
                     <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
@@ -474,9 +462,7 @@ export default function CostLedgerPage() {
                       <td colSpan={7} className="px-6 py-10 text-center">
                         <div className="mx-auto flex max-w-sm flex-col items-center gap-2">
                           <Package className="h-10 w-10 text-muted-foreground/60" />
-                          <h3 className="text-sm font-semibold text-foreground">
-                            No results
-                          </h3>
+                          <h3 className="text-sm font-semibold text-foreground">No results</h3>
                           <p className="text-xs text-muted-foreground">
                             Adjust your filters to see cost ledger activity.
                           </p>
@@ -490,22 +476,22 @@ export default function CostLedgerPage() {
                           {format(new Date(group.rangeEnd), 'PP')}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
-                          {formatCurrency(group.costs.inbound ?? 0)}
+                          {formatAmount(group.costs.inbound ?? 0)}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
-                          {formatCurrency(group.costs.outbound ?? 0)}
+                          {formatAmount(group.costs.outbound ?? 0)}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
-                          {formatCurrency(group.costs.forwarding ?? 0)}
+                          {formatAmount(group.costs.forwarding ?? 0)}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
-                          {formatCurrency(group.costs.storage ?? 0)}
+                          {formatAmount(group.costs.storage ?? 0)}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums">
-                          {formatCurrency(group.costs.other ?? 0)}
+                          {formatAmount(group.costs.other ?? 0)}
                         </td>
                         <td className="px-3 py-2 text-right tabular-nums font-medium text-foreground">
-                          {formatCurrency(group.costs.total ?? 0)}
+                          {formatAmount(group.costs.total ?? 0)}
                         </td>
                       </tr>
                     ))

--- a/apps/talos/src/app/operations/inventory/page.tsx
+++ b/apps/talos/src/app/operations/inventory/page.tsx
@@ -20,6 +20,7 @@ import {
   type SortKey,
 } from '@/hooks/useInventoryFilters'
 import { getMovementTypeFromTransaction } from '@/lib/utils/movement-types'
+import { isAmazonWarehouseCode } from '@/lib/warehouses/amazon-warehouse'
 
 const LEDGER_TIME_FORMAT = 'MMM d, yyyy h:mm a'
 
@@ -138,7 +139,7 @@ function InventoryPage() {
     return processedBalances.reduce(
       (acc, balance) => {
         acc.cartons += balance.currentCartons
-        acc.pallets += balance.currentPallets
+        acc.pallets += isAmazonWarehouseCode(balance.warehouse.code) ? 0 : balance.currentPallets
         acc.units += balance.currentUnits
         return acc
       },
@@ -624,8 +625,8 @@ function InventoryPage() {
 
                     const sourceNumber =
                       movementType === 'negative'
-                        ? balance.lastTransactionReference ?? null
-                        : balance.inboundOrderNumber ?? null
+                        ? (balance.lastTransactionReference ?? null)
+                        : (balance.inboundOrderNumber ?? null)
                     const sourceHref =
                       movementType === 'negative'
                         ? balance.lastTransactionId
@@ -646,6 +647,7 @@ function InventoryPage() {
                     if (warehouseDisplay.length === 0) {
                       warehouseDisplay = '—'
                     }
+                    const carriesPallets = !isAmazonWarehouseCode(balance.warehouse.code)
 
                     return (
                       <tr
@@ -668,14 +670,14 @@ function InventoryPage() {
                             sourceDisplay
                           )}
                         </td>
-                        <td className="px-2 py-2 text-sm font-medium text-foreground truncate">
+                        <td className="px-2 py-2 text-sm font-medium text-foreground whitespace-normal break-words leading-5">
                           {warehouseDisplay}
                         </td>
-                        <td className="px-2 py-2 text-sm font-semibold text-foreground truncate">
+                        <td className="px-2 py-2 text-sm font-semibold text-foreground whitespace-nowrap">
                           {balance.sku.skuCode}
                         </td>
                         <td
-                          className="px-2 py-2 text-sm text-muted-foreground truncate"
+                          className="px-2 py-2 text-sm text-muted-foreground whitespace-normal break-words leading-5"
                           title={balance.sku.description || undefined}
                         >
                           {balance.sku.description || '—'}
@@ -710,7 +712,7 @@ function InventoryPage() {
                           {balance.currentCartons.toLocaleString()}
                         </td>
                         <td className="px-2 py-2 text-right text-sm whitespace-nowrap">
-                          {balance.currentPallets.toLocaleString()}
+                          {carriesPallets ? balance.currentPallets.toLocaleString() : '—'}
                         </td>
                         <td className="px-2 py-2 text-right text-sm whitespace-nowrap">
                           {balance.currentUnits.toLocaleString()}

--- a/apps/talos/src/app/operations/outbound/outbound-panel.tsx
+++ b/apps/talos/src/app/operations/outbound/outbound-panel.tsx
@@ -191,7 +191,7 @@ export function OutboundPanel() {
             <h2 className="text-lg font-semibold text-foreground">Outbound</h2>
           </div>
           <p className="mt-1 text-sm text-muted-foreground">
-            Shipments returned by Amazon inbound SP-API for the active tenant.
+            Shipments returned by Amazon FBA shipment data for the active tenant.
           </p>
         </div>
 

--- a/apps/talos/src/app/operations/storage-ledger/page.tsx
+++ b/apps/talos/src/app/operations/storage-ledger/page.tsx
@@ -4,11 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useSession } from '@/hooks/usePortalSession'
 import { useRouter } from 'next/navigation'
 import { Package, Calendar } from '@/lib/lucide-icons'
-import {
-  PageContainer,
-  PageHeaderSection,
-  PageContent,
-} from '@/components/layout/page-container'
+import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
 import { EmptyState } from '@/components/ui/empty-state'
 import { PageLoading, ContentLoading } from '@/components/ui/loading-spinner'
 import { StorageLedgerHeader } from '@/components/finance/storage-ledger/StorageLedgerHeader'
@@ -21,7 +17,7 @@ import { useStorageLedger } from '@/hooks/useStorageLedger'
 import { usePageState } from '@/lib/store/page-state'
 import { format } from 'date-fns'
 import { buildAppCallbackUrl, redirectToPortal } from '@/lib/portal'
-import { withBasePath } from '@/lib/utils/base-path'
+import { getTenantConfig } from '@/lib/tenant/constants'
 
 const PAGE_KEY = '/operations/storage-ledger'
 
@@ -49,50 +45,53 @@ export default function StorageLedgerPage() {
     )
   }
 
+  if (!session || !['staff', 'admin'].includes(session.user.role)) {
+    return null
+  }
+
   return (
     <PageContainer>
-      <StorageLedgerContent />
+      <StorageLedgerContent currency={getTenantConfig(session.user.region).currency} />
     </PageContainer>
   )
 }
 
-function StorageLedgerContent() {
+function StorageLedgerContent({ currency }: { currency: string }) {
   const pageState = usePageState(PAGE_KEY)
-  
+
   const aggregationView = (pageState.custom?.aggregationView as 'weekly' | 'monthly') ?? 'weekly'
-  const setAggregationView = (value: 'weekly' | 'monthly') => pageState.setCustom('aggregationView', value)
-  
+  const setAggregationView = (value: 'weekly' | 'monthly') =>
+    pageState.setCustom('aggregationView', value)
+
   const storedFilters = pageState.custom?.filters as StorageLedgerColumnFilters | undefined
   const [filters, setFiltersState] = useState<StorageLedgerColumnFilters>(
-    () => storedFilters ?? createDefaultFilters(),
+    () => storedFilters ?? createDefaultFilters()
   )
-  
-  const setFilters = (newFilters: StorageLedgerColumnFilters | ((prev: StorageLedgerColumnFilters) => StorageLedgerColumnFilters)) => {
+
+  const setFilters = (
+    newFilters:
+      | StorageLedgerColumnFilters
+      | ((prev: StorageLedgerColumnFilters) => StorageLedgerColumnFilters)
+  ) => {
     setFiltersState(prev => {
       const resolved = typeof newFilters === 'function' ? newFilters(prev) : newFilters
       pageState.setCustom('filters', resolved)
       return resolved
     })
   }
-  
+
   const [dateRange] = useState({
-    start: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
-      .toISOString()
-      .split('T')[0],
+    start: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
     end: new Date().toISOString().split('T')[0],
   })
 
-  const { entries, summary, loading, error, exportData, refetch } =
-    useStorageLedger({
-      startDate: dateRange.start,
-      endDate: dateRange.end,
-      includeCosts: true,
-    })
+  const { entries, summary, loading, error, exportData, refetch } = useStorageLedger({
+    startDate: dateRange.start,
+    endDate: dateRange.end,
+    includeCosts: true,
+  })
 
-  const filteredEntries = useMemo(
-    () => filterEntries(entries, filters),
-    [entries, filters],
-  )
+  const filteredEntries = useMemo(() => filterEntries(entries, filters), [entries, filters])
 
   const headerActions = (
     <StorageLedgerHeader
@@ -118,12 +117,13 @@ function StorageLedgerContent() {
           <EmptyState icon={Package} title="Error Loading Data" description={error} />
         ) : (
           <div className="space-y-6">
-            {summary && <StorageLedgerStats summary={summary} />}
+            {summary && <StorageLedgerStats summary={summary} currency={currency} />}
             <StorageLedgerTable
               entries={filteredEntries}
               aggregationView={aggregationView}
               filters={filters}
               onFilterChange={setFilters}
+              currency={currency}
             />
           </div>
         )}
@@ -151,7 +151,7 @@ function createDefaultFilters(): StorageLedgerColumnFilters {
 
 function filterEntries(
   entries: ReturnType<typeof useStorageLedger>['entries'],
-  filters: StorageLedgerColumnFilters,
+  filters: StorageLedgerColumnFilters
 ) {
   const parseNumber = (value: string) => {
     const trimmed = value.trim()
@@ -213,9 +213,7 @@ function filterEntries(
       return false
     }
 
-    const rate = entry.storageRatePerPalletDay
-      ? Number(entry.storageRatePerPalletDay)
-      : null
+    const rate = entry.storageRatePerPalletDay ? Number(entry.storageRatePerPalletDay) : null
     if (rateMin !== null && (rate ?? 0) < rateMin) {
       return false
     }

--- a/apps/talos/src/app/operations/transactions/[id]/page.tsx
+++ b/apps/talos/src/app/operations/transactions/[id]/page.tsx
@@ -5,19 +5,12 @@ import { useParams, useRouter } from 'next/navigation'
 import { toast } from 'react-hot-toast'
 import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
 import { Button } from '@/components/ui/button'
-import {
-  Package2,
-  Truck,
-  Loader2,
-  FileText,
-  DollarSign,
-  Paperclip,
-} from '@/lib/lucide-icons'
+import { Package2, Truck, Loader2, FileText, DollarSign, Paperclip } from '@/lib/lucide-icons'
 import { TabbedContainer, TabPanel } from '@/components/ui/tabbed-container'
 import { type ApiAttachment } from '@/components/operations/edit-attachments-tab'
 import { withBasePath } from '@/lib/utils/base-path'
 
-const INVENTORY_LEDGER_PATH = '/operations/inventory'
+const TRANSACTION_LEDGER_PATH = '/operations/transactions'
 
 interface TransactionData {
   id: string
@@ -107,6 +100,9 @@ export default function TransactionDetailPage() {
       }
 
       const data = await response.json()
+      if (!Array.isArray(data.lineItems)) {
+        throw new Error('Transaction line items missing')
+      }
 
       // Transform the transaction data to match the expected format
       // Since the API returns a single transaction, we need to create lineItems array
@@ -117,20 +113,20 @@ export default function TransactionDetailPage() {
 
       const transformedData: TransactionData = {
         ...data,
-        transactionId: data.transactionId || data.referenceId || data.id,
-        warehouseId: data.warehouse?.id || data.warehouseId,
-        skuCode: data.skuCode || data.sku?.skuCode || '',
-        cartonsIn: data.cartonsIn ?? 0,
-        cartonsOut: data.cartonsOut ?? 0,
-        lineItems: data.lineItems || data.transactionLines || [],
-        costs: data.costs || [],
+        transactionId: data.id,
+        warehouseId: data.warehouse?.id ?? data.warehouseId,
+        skuCode: data.skuCode,
+        cartonsIn: data.cartonsIn,
+        cartonsOut: data.cartonsOut,
+        lineItems: data.lineItems,
+        costs: Array.isArray(data.costs) ? data.costs : [],
         attachments: attachmentsRecord,
-        createdBy: data.createdBy || { fullName: 'System User', email: 'system@warehouse.com' },
-        history: data.history || [],
-        referenceId: data.referenceId || '',
-        shipName: data.shipName || '',
-        trackingNumber: data.trackingNumber || '',
-        supplier: data.supplier || '',
+        createdBy: data.createdBy,
+        history: Array.isArray(data.history) ? data.history : [],
+        referenceId: data.referenceId ?? '',
+        shipName: data.shipName ?? '',
+        trackingNumber: data.trackingNumber ?? '',
+        supplier: data.supplier ?? '',
       }
 
       setTransaction(transformedData)
@@ -142,14 +138,14 @@ export default function TransactionDetailPage() {
     }
   }
 
-	  const loadSkus = async () => {
-	    try {
-	      const response = await fetch(withBasePath('/api/skus'), {
-	        credentials: 'include',
-	      })
+  const loadSkus = async () => {
+    try {
+      const response = await fetch(withBasePath('/api/skus'), {
+        credentials: 'include',
+      })
       if (response.ok) {
         const data = await response.json()
-        setSkus(data.skus || [])
+        setSkus(Array.isArray(data.skus) ? data.skus : [])
       }
     } catch (_error) {
       // Failed to load SKUs
@@ -163,7 +159,7 @@ export default function TransactionDetailPage() {
           title="Transaction Details"
           description="Operations"
           icon={FileText}
-          backHref={INVENTORY_LEDGER_PATH}
+          backHref={TRANSACTION_LEDGER_PATH}
           backLabel="Back"
         />
         <PageContent className="flex items-center justify-center">
@@ -180,7 +176,7 @@ export default function TransactionDetailPage() {
           title="Transaction Details"
           description="Operations"
           icon={FileText}
-          backHref={INVENTORY_LEDGER_PATH}
+          backHref={TRANSACTION_LEDGER_PATH}
           backLabel="Back"
         />
         <PageContent>
@@ -194,23 +190,28 @@ export default function TransactionDetailPage() {
 
   const isReceive = transaction.transactionType === 'RECEIVE'
   const isShip = transaction.transactionType === 'SHIP'
+  const calculatedCosts = transaction.calculatedCosts ?? []
+  const attachments = transaction.attachments ?? {}
 
   // Convert line items to the format expected by cargo tabs
-  const cargoItems = transaction.lineItems.map(item => ({
-    id: item.id,
-    skuCode: item.sku?.skuCode ?? '',
-    skuId: item.skuId,
-    lotRef: item.lotRef,
-    cartons: isReceive ? item.cartonsIn : item.cartonsOut,
-    units: (isReceive ? item.cartonsIn : item.cartonsOut) * (item.unitsPerCarton ?? 0),
-    unitsPerCarton: item.unitsPerCarton ?? item.sku?.unitsPerCarton ?? 0,
-    storagePalletsIn: item.storagePalletsIn ?? 0,
-    shippingPalletsOut: item.shippingPalletsOut ?? 0,
-    storageCartonsPerPallet: item.storageCartonsPerPallet ?? 0,
-    shippingCartonsPerPallet: item.shippingCartonsPerPallet ?? 0,
-    configLoaded: true,
-    loadingLot: false,
-  }))
+  const cargoItems = transaction.lineItems.map(item => {
+    const unitsPerCarton = item.unitsPerCarton ?? item.sku?.unitsPerCarton ?? 0
+    return {
+      id: item.id,
+      skuCode: item.sku?.skuCode ?? '',
+      skuId: item.skuId,
+      lotRef: item.lotRef,
+      cartons: isReceive ? item.cartonsIn : item.cartonsOut,
+      units: (isReceive ? item.cartonsIn : item.cartonsOut) * unitsPerCarton,
+      unitsPerCarton,
+      storagePalletsIn: item.storagePalletsIn ?? 0,
+      shippingPalletsOut: item.shippingPalletsOut ?? 0,
+      storageCartonsPerPallet: item.storageCartonsPerPallet ?? 0,
+      shippingCartonsPerPallet: item.shippingCartonsPerPallet ?? 0,
+      configLoaded: true,
+      loadingLot: false,
+    }
+  })
 
   // Tab configuration based on transaction type
   const tabConfig = [
@@ -226,14 +227,14 @@ export default function TransactionDetailPage() {
         title="Transaction Details"
         description="Operations"
         icon={isReceive ? Package2 : Truck}
-        backHref={INVENTORY_LEDGER_PATH}
+        backHref={TRANSACTION_LEDGER_PATH}
         backLabel="Back"
         actions={
           <Button
             type="button"
             variant="outline"
             size="sm"
-            onClick={() => router.push(INVENTORY_LEDGER_PATH)}
+            onClick={() => router.push(TRANSACTION_LEDGER_PATH)}
           >
             Close
           </Button>
@@ -242,7 +243,9 @@ export default function TransactionDetailPage() {
           <div className="flex flex-wrap items-center gap-2">
             <span
               className={`px-2 py-1 text-xs font-medium rounded-full ${
-                isReceive ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300' : 'bg-cyan-100 dark:bg-cyan-900/30 text-cyan-800 dark:text-cyan-300'
+                isReceive
+                  ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
+                  : 'bg-cyan-100 dark:bg-cyan-900/30 text-cyan-800 dark:text-cyan-300'
               }`}
             >
               {transaction.transactionType}
@@ -255,286 +258,178 @@ export default function TransactionDetailPage() {
       />
       <PageContent>
         <TabbedContainer tabs={tabConfig} defaultTab={activeTab} onChange={setActiveTab}>
-        {/* Transaction Details Tab */}
-        <TabPanel>
-          <div className="space-y-2">
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1">
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
-                  Transaction Date
-                </label>
-                <input
-                  type="date"
-                  value={transaction.transactionDate?.split('T')[0] || ''}
-                  className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                  readOnly
-                />
+          {/* Transaction Details Tab */}
+          <TabPanel>
+            <div className="space-y-2">
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-1">
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    Transaction Date
+                  </label>
+                  <input
+                    type="date"
+                    value={transaction.transactionDate?.split('T')[0] ?? ''}
+                    className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                    readOnly
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    {isReceive ? 'PI/CI Number' : 'CI/PI Number'}
+                  </label>
+                  <input
+                    type="text"
+                    value={transaction.referenceId ?? ''}
+                    className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                    readOnly
+                  />
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-foreground mb-1">
+                    Warehouse
+                  </label>
+                  <input
+                    type="text"
+                    value={transaction.warehouse?.name ?? ''}
+                    className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                    readOnly
+                  />
+                </div>
+
+                {isReceive && (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Ship Name
+                      </label>
+                      <input
+                        type="text"
+                        value={transaction.shipName ?? ''}
+                        className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                        readOnly
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Container Number
+                      </label>
+                      <input
+                        type="text"
+                        value={transaction.trackingNumber ?? ''}
+                        className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                        readOnly
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Supplier
+                      </label>
+                      <input
+                        type="text"
+                        value={transaction.supplier ?? ''}
+                        className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                        readOnly
+                      />
+                    </div>
+                  </>
+                )}
+
+                {isShip && (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Pickup Date
+                      </label>
+                      <input
+                        type="date"
+                        value={transaction.pickupDate?.split('T')[0] ?? ''}
+                        className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                        readOnly
+                      />
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium text-foreground mb-1">
+                        Tracking Number
+                      </label>
+                      <input
+                        type="text"
+                        value={transaction.trackingNumber ?? ''}
+                        className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                        readOnly
+                      />
+                    </div>
+                  </>
+                )}
               </div>
-
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
-                  {isReceive ? 'PI/CI Number' : 'CI/PI Number'}
-                </label>
-                <input
-                  type="text"
-                  value={transaction.referenceId || ''}
-                  className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                  readOnly
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1">Warehouse</label>
-                <input
-                  type="text"
-                  value={transaction.warehouse?.name || ''}
-                  className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                  readOnly
-                />
-              </div>
-
-              {isReceive && (
-                <>
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Ship Name
-                    </label>
-                    <input
-                      type="text"
-                      value={transaction.shipName || ''}
-                      className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                      readOnly
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Container Number
-                    </label>
-                    <input
-                      type="text"
-                      value={transaction.trackingNumber || ''}
-                      className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                      readOnly
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Supplier
-                    </label>
-                    <input
-                      type="text"
-                      value={transaction.supplier || ''}
-                      className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                      readOnly
-                    />
-                  </div>
-                </>
-              )}
-
-              {isShip && (
-                <>
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Pickup Date
-                    </label>
-                    <input
-                      type="date"
-                      value={transaction.pickupDate?.split('T')[0] || ''}
-                      className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                      readOnly
-                    />
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-medium text-foreground mb-1">
-                      Tracking Number
-                    </label>
-                    <input
-                      type="text"
-                      value={transaction.trackingNumber || ''}
-                      className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                      readOnly
-                    />
-                  </div>
-                </>
-              )}
             </div>
-          </div>
-        </TabPanel>
+          </TabPanel>
 
-        {/* Cargo Tab - Using actual CargoTab component structure */}
-        <TabPanel>
-          <div className="space-y-4">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-slate-50 dark:bg-slate-900">
-                  <tr>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                      SKU
-                    </th>
-	                    <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-	                      Lot
-	                    </th>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                      Cartons
-                    </th>
-                    <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                      Units
-                    </th>
-                    {isReceive && (
-                      <>
-                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                          Storage Pallets In
-                        </th>
-                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                          Storage Cartons/Pallet
-                        </th>
-                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                          Shipping Cartons/Pallet
-                        </th>
-                      </>
-                    )}
-                    {isShip && (
-                      <>
-                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                          Shipping Pallets Out
-                        </th>
-                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                          Shipping Cartons/Pallet
-                        </th>
-                      </>
-                    )}
-                  </tr>
-                </thead>
-                <tbody className="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
-                  {cargoItems.map((item, _index) => (
-                    <tr key={item.id}>
-                      <td className="px-4 py-3 whitespace-nowrap">
-                        <div className="flex items-center gap-2">
-                          <input
-                            type="text"
-                            value={item.skuCode}
-                            className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                            readOnly
-                          />
-                        </div>
-                      </td>
-	                      <td className="px-4 py-3 whitespace-nowrap">
-	                        <input
-	                          type="text"
-	                          value={item.lotRef}
-	                          className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-	                          readOnly
-	                        />
-	                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap">
-                        <input
-                          type="number"
-                          value={item.cartons}
-                          className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                          readOnly
-                        />
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap">
-                        <input
-                          type="number"
-                          value={item.units}
-                          className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                          readOnly
-                        />
-                      </td>
-                      {isReceive && (
-                        <>
-                          <td className="px-4 py-3 whitespace-nowrap">
-                            <input
-                              type="number"
-                              value={item.storagePalletsIn}
-                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                              readOnly
-                            />
-                          </td>
-                          <td className="px-4 py-3 whitespace-nowrap">
-                            <input
-                              type="number"
-                              value={item.storageCartonsPerPallet}
-                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                              readOnly
-                            />
-                          </td>
-                          <td className="px-4 py-3 whitespace-nowrap">
-                            <input
-                              type="number"
-                              value={item.shippingCartonsPerPallet}
-                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                              readOnly
-                            />
-                          </td>
-                        </>
-                      )}
-                      {isShip && (
-                        <>
-                          <td className="px-4 py-3 whitespace-nowrap">
-                            <input
-                              type="number"
-                              value={item.shippingPalletsOut}
-                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                              readOnly
-                            />
-                          </td>
-                          <td className="px-4 py-3 whitespace-nowrap">
-                            <input
-                              type="number"
-                              value={item.shippingCartonsPerPallet}
-                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                              readOnly
-                            />
-                          </td>
-                        </>
-                      )}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </TabPanel>
-
-        {/* Costs Tab */}
-        <TabPanel>
-          <div className="space-y-6">
-            {!transaction.calculatedCosts || transaction.calculatedCosts.length === 0 ? (
-              <div className="text-center py-12 text-muted-foreground">
-                <p>No costs recorded for this transaction</p>
-                <p className="text-sm mt-2">Costs need to be saved when creating the transaction</p>
-              </div>
-            ) : (
+          {/* Cargo Tab - Using actual CargoTab component structure */}
+          <TabPanel>
+            <div className="space-y-4">
               <div className="overflow-x-auto">
                 <table className="min-w-full divide-y divide-gray-200">
                   <thead className="bg-slate-50 dark:bg-slate-900">
                     <tr>
                       <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Cost Category
+                        SKU
                       </th>
                       <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Quantity
+                        Lot
                       </th>
                       <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Unit Rate
+                        Cartons
                       </th>
                       <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Total Cost
+                        Units
                       </th>
+                      {isReceive && (
+                        <>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            Storage Pallets In
+                          </th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            Storage Cartons/Pallet
+                          </th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            Shipping Cartons/Pallet
+                          </th>
+                        </>
+                      )}
+                      {isShip && (
+                        <>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            Shipping Pallets Out
+                          </th>
+                          <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                            Shipping Cartons/Pallet
+                          </th>
+                        </>
+                      )}
                     </tr>
                   </thead>
                   <tbody className="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
-                    {transaction.calculatedCosts.map((cost, index) => (
-                      <tr key={index}>
+                    {cargoItems.map((item, _index) => (
+                      <tr key={item.id}>
+                        <td className="px-4 py-3 whitespace-nowrap">
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="text"
+                              value={item.skuCode}
+                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                              readOnly
+                            />
+                          </div>
+                        </td>
                         <td className="px-4 py-3 whitespace-nowrap">
                           <input
                             type="text"
-                            value={cost.costCategory ?? cost.category ?? ''}
+                            value={item.lotRef}
                             className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
                             readOnly
                           />
@@ -542,7 +437,7 @@ export default function TransactionDetailPage() {
                         <td className="px-4 py-3 whitespace-nowrap">
                           <input
                             type="number"
-                            value={cost.quantity ?? 0}
+                            value={item.cartons}
                             className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
                             readOnly
                           />
@@ -550,112 +445,229 @@ export default function TransactionDetailPage() {
                         <td className="px-4 py-3 whitespace-nowrap">
                           <input
                             type="number"
-                            value={cost.unitRate ?? cost.rate ?? 0}
+                            value={item.units}
                             className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
                             readOnly
                           />
                         </td>
-                        <td className="px-4 py-3 whitespace-nowrap">
-                          <input
-                            type="number"
-                            value={cost.totalCost ?? cost.amount ?? 0}
-                            className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
-                            readOnly
-                          />
-                        </td>
+                        {isReceive && (
+                          <>
+                            <td className="px-4 py-3 whitespace-nowrap">
+                              <input
+                                type="number"
+                                value={item.storagePalletsIn}
+                                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                                readOnly
+                              />
+                            </td>
+                            <td className="px-4 py-3 whitespace-nowrap">
+                              <input
+                                type="number"
+                                value={item.storageCartonsPerPallet}
+                                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                                readOnly
+                              />
+                            </td>
+                            <td className="px-4 py-3 whitespace-nowrap">
+                              <input
+                                type="number"
+                                value={item.shippingCartonsPerPallet}
+                                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                                readOnly
+                              />
+                            </td>
+                          </>
+                        )}
+                        {isShip && (
+                          <>
+                            <td className="px-4 py-3 whitespace-nowrap">
+                              <input
+                                type="number"
+                                value={item.shippingPalletsOut}
+                                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                                readOnly
+                              />
+                            </td>
+                            <td className="px-4 py-3 whitespace-nowrap">
+                              <input
+                                type="number"
+                                value={item.shippingCartonsPerPallet}
+                                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                                readOnly
+                              />
+                            </td>
+                          </>
+                        )}
                       </tr>
                     ))}
                   </tbody>
                 </table>
               </div>
-            )}
-          </div>
-        </TabPanel>
+            </div>
+          </TabPanel>
 
-        {/* Attachments Tab */}
-        <TabPanel>
-          <div className="space-y-4">
-            {!transaction.attachments || Object.keys(transaction.attachments).length === 0 ? (
-              <div className="text-center py-12 text-muted-foreground">
-                <Paperclip className="h-12 w-12 mx-auto mb-4 text-slate-400 dark:text-slate-600" />
-                <p className="text-lg font-medium text-foreground">No attachments</p>
-                <p className="text-sm mt-2">No documents have been attached to this transaction</p>
-              </div>
-            ) : (
-              <div className="bg-white dark:bg-slate-800 rounded-xl border">
-                <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
-                  <h3 className="text-lg font-semibold text-foreground">Transaction Documents</h3>
+          {/* Costs Tab */}
+          <TabPanel>
+            <div className="space-y-6">
+              {calculatedCosts.length === 0 ? (
+                <div className="text-center py-12 text-muted-foreground">
+                  <p>No costs recorded for this transaction</p>
+                  <p className="text-sm mt-2">
+                    Costs need to be saved when creating the transaction
+                  </p>
                 </div>
-                <div className="p-6">
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    {Object.entries(
-                      transaction.attachments as Record<string, ApiAttachment | null>
-                    ).map(([category, attachment]) => {
-                      if (!attachment) return null
+              ) : (
+                <div className="overflow-x-auto">
+                  <table className="min-w-full divide-y divide-gray-200">
+                    <thead className="bg-slate-50 dark:bg-slate-900">
+                      <tr>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                          Cost Category
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                          Quantity
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                          Unit Rate
+                        </th>
+                        <th className="px-4 py-2 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                          Total Cost
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody className="bg-white dark:bg-slate-800 divide-y divide-gray-200 dark:divide-slate-700">
+                      {calculatedCosts.map((cost, index) => (
+                        <tr key={index}>
+                          <td className="px-4 py-3 whitespace-nowrap">
+                            <input
+                              type="text"
+                              value={cost.costCategory ?? cost.category ?? ''}
+                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                              readOnly
+                            />
+                          </td>
+                          <td className="px-4 py-3 whitespace-nowrap">
+                            <input
+                              type="number"
+                              value={cost.quantity ?? 0}
+                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                              readOnly
+                            />
+                          </td>
+                          <td className="px-4 py-3 whitespace-nowrap">
+                            <input
+                              type="number"
+                              value={cost.unitRate ?? cost.rate ?? 0}
+                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                              readOnly
+                            />
+                          </td>
+                          <td className="px-4 py-3 whitespace-nowrap">
+                            <input
+                              type="number"
+                              value={cost.totalCost ?? cost.amount ?? 0}
+                              className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md bg-slate-50 dark:bg-slate-900 text-foreground"
+                              readOnly
+                            />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          </TabPanel>
 
-	                      const categoryLabels: Record<string, string> = {
-	                        commercial_invoice: 'Commercial Invoice',
-	                        bill_of_lading: 'Bill of Lading',
-	                        packing_list: 'Packing List',
-	                        grn: 'GRN',
-	                        cube_master: 'Cube Master',
-	                        transaction_certificate: 'TC GRS',
-	                        custom_declaration: 'CDS',
-	                        proof_of_pickup: 'Proof of Pickup',
-	                      }
+          {/* Attachments Tab */}
+          <TabPanel>
+            <div className="space-y-4">
+              {Object.keys(attachments).length === 0 ? (
+                <div className="text-center py-12 text-muted-foreground">
+                  <Paperclip className="h-12 w-12 mx-auto mb-4 text-slate-400 dark:text-slate-600" />
+                  <p className="text-lg font-medium text-foreground">No attachments</p>
+                  <p className="text-sm mt-2">
+                    No documents have been attached to this transaction
+                  </p>
+                </div>
+              ) : (
+                <div className="bg-white dark:bg-slate-800 rounded-xl border">
+                  <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900">
+                    <h3 className="text-lg font-semibold text-foreground">Transaction Documents</h3>
+                  </div>
+                  <div className="p-6">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {Object.entries(attachments as Record<string, ApiAttachment | null>).map(
+                        ([category, attachment]) => {
+                          if (!attachment) return null
 
-                      return (
-                        <div key={category} className="border border-slate-200 dark:border-slate-700 rounded-lg p-4 bg-slate-50 dark:bg-slate-900">
-                          <div className="flex items-start justify-between">
-                            <div className="flex-1 min-w-0">
-                              <h4 className="font-medium text-sm text-foreground">
-                                {categoryLabels[category] || category}
-                              </h4>
-                              <div className="flex items-center gap-2 mt-2">
-                                <Paperclip className="h-4 w-4 text-slate-400 dark:text-slate-500 flex-shrink-0" />
-                                <p className="text-sm text-foreground truncate">
-                                  {attachment.fileName || attachment.name || 'Document'}
-                                </p>
+                          const categoryLabels: Record<string, string> = {
+                            commercial_invoice: 'Commercial Invoice',
+                            bill_of_lading: 'Bill of Lading',
+                            packing_list: 'Packing List',
+                            grn: 'GRN',
+                            cube_master: 'Cube Master',
+                            transaction_certificate: 'TC GRS',
+                            custom_declaration: 'CDS',
+                            proof_of_pickup: 'Proof of Pickup',
+                          }
+
+                          return (
+                            <div
+                              key={category}
+                              className="border border-slate-200 dark:border-slate-700 rounded-lg p-4 bg-slate-50 dark:bg-slate-900"
+                            >
+                              <div className="flex items-start justify-between">
+                                <div className="flex-1 min-w-0">
+                                  <h4 className="font-medium text-sm text-foreground">
+                                    {categoryLabels[category] ?? category}
+                                  </h4>
+                                  <div className="flex items-center gap-2 mt-2">
+                                    <Paperclip className="h-4 w-4 text-slate-400 dark:text-slate-500 flex-shrink-0" />
+                                    <p className="text-sm text-foreground truncate">
+                                      {attachment.fileName ?? attachment.name ?? 'Document'}
+                                    </p>
+                                  </div>
+                                  {attachment.size && (
+                                    <p className="text-xs text-muted-foreground mt-1">
+                                      {(attachment.size / 1024).toFixed(1)} KB
+                                    </p>
+                                  )}
+                                </div>
+                                {attachment.s3Url && (
+                                  <a
+                                    href={attachment.s3Url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="ml-2 p-2 text-cyan-600 dark:text-cyan-400 hover:text-cyan-800 dark:hover:text-cyan-300 hover:bg-cyan-50 dark:hover:bg-cyan-900/30 rounded"
+                                    title="Download"
+                                  >
+                                    <svg
+                                      className="h-5 w-5"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      viewBox="0 0 24 24"
+                                    >
+                                      <path
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                        strokeWidth={2}
+                                        d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+                                      />
+                                    </svg>
+                                  </a>
+                                )}
                               </div>
-                              {attachment.size && (
-                                <p className="text-xs text-muted-foreground mt-1">
-                                  {(attachment.size / 1024).toFixed(1)} KB
-                                </p>
-                              )}
                             </div>
-                            {attachment.s3Url && (
-                              <a
-                                href={attachment.s3Url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="ml-2 p-2 text-cyan-600 dark:text-cyan-400 hover:text-cyan-800 dark:hover:text-cyan-300 hover:bg-cyan-50 dark:hover:bg-cyan-900/30 rounded"
-                                title="Download"
-                              >
-                                <svg
-                                  className="h-5 w-5"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
-                                  />
-                                </svg>
-                              </a>
-                            )}
-                          </div>
-                        </div>
-                      )
-                    })}
+                          )
+                        }
+                      )}
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
-          </div>
-        </TabPanel>
+              )}
+            </div>
+          </TabPanel>
         </TabbedContainer>
       </PageContent>
     </PageContainer>

--- a/apps/talos/src/app/operations/transactions/page.tsx
+++ b/apps/talos/src/app/operations/transactions/page.tsx
@@ -1,6 +1,307 @@
-import { redirect } from 'next/navigation'
+'use client'
+
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { format } from 'date-fns'
+import { useSession } from '@/hooks/usePortalSession'
+import { PageContainer, PageHeaderSection, PageContent } from '@/components/layout/page-container'
+import { PageLoading } from '@/components/ui/loading-spinner'
+import { Badge } from '@/components/ui/badge'
+import { FileText, Search } from '@/lib/lucide-icons'
+import { buildAppCallbackUrl, redirectToPortal } from '@/lib/portal'
+import { withBasePath } from '@/lib/utils/base-path'
+import { getMovementTypeFromTransaction } from '@/lib/utils/movement-types'
+
+type TransactionRow = {
+  id: string
+  transactionDate: string
+  transactionType: string
+  referenceId: string | null
+  warehouseCode: string
+  warehouseName: string
+  skuCode: string
+  skuDescription: string
+  lotRef: string
+  cartonsIn: number
+  cartonsOut: number
+  storagePalletsIn: number
+  shippingPalletsOut: number
+  unitsPerCarton: number
+  createdBy?: {
+    fullName?: string | null
+  }
+}
+
+type TransactionsResponse = {
+  transactions: TransactionRow[]
+}
+
+const TRANSACTION_DATE_FORMAT = 'MMM d, yyyy h:mm a'
+
+function formatTransactionDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return 'Invalid date'
+  }
+  return format(date, TRANSACTION_DATE_FORMAT)
+}
+
+function getTransactionCartons(row: TransactionRow) {
+  const movementType = getMovementTypeFromTransaction(row.transactionType)
+  if (movementType === 'negative') {
+    return row.cartonsOut
+  }
+  return row.cartonsIn
+}
+
+function getTransactionPallets(row: TransactionRow) {
+  const movementType = getMovementTypeFromTransaction(row.transactionType)
+  if (movementType === 'negative') {
+    return row.shippingPalletsOut
+  }
+  return row.storagePalletsIn
+}
+
+function getMovementBadge(row: TransactionRow) {
+  const movementType = getMovementTypeFromTransaction(row.transactionType)
+  if (movementType === 'positive') {
+    return { label: 'Inbound', variant: 'success' as const }
+  }
+  if (movementType === 'negative') {
+    return { label: 'Outbound', variant: 'danger' as const }
+  }
+  return { label: 'Flat', variant: 'neutral' as const }
+}
 
 export default function TransactionsIndexPage() {
- // Redirect to inventory page as transactions are viewed there
- redirect('/operations/inventory')
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [transactions, setTransactions] = useState<TransactionRow[]>([])
+  const [searchTerm, setSearchTerm] = useState('')
+  const [loadError, setLoadError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    if (status === 'loading') return
+    if (!session) {
+      redirectToPortal('/login', buildAppCallbackUrl('/operations/transactions'))
+      return
+    }
+    if (!['staff', 'admin'].includes(session.user.role)) {
+      router.push('/dashboard')
+      return
+    }
+  }, [router, session, status])
+
+  const fetchTransactions = useCallback(async () => {
+    try {
+      setLoading(true)
+      setLoadError(null)
+
+      const response = await fetch(withBasePath('/api/transactions?limit=1000'), {
+        credentials: 'include',
+      })
+      const payload = (await response.json()) as TransactionsResponse | { error: string }
+
+      if (!response.ok) {
+        if ('error' in payload && typeof payload.error === 'string') {
+          throw new Error(payload.error)
+        }
+        throw new Error('Transactions request failed')
+      }
+
+      if (!('transactions' in payload) || !Array.isArray(payload.transactions)) {
+        throw new Error('Transactions payload missing rows')
+      }
+
+      setTransactions(payload.transactions)
+    } catch (error) {
+      setLoadError(error instanceof Error ? error : new Error('Failed to load transactions'))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (status === 'authenticated') {
+      fetchTransactions()
+    }
+  }, [fetchTransactions, status])
+
+  const filteredTransactions = useMemo(() => {
+    const query = searchTerm.trim().toLowerCase()
+    if (query.length === 0) {
+      return transactions
+    }
+
+    return transactions.filter(row => {
+      const fields = [
+        row.referenceId,
+        row.transactionType,
+        row.warehouseCode,
+        row.warehouseName,
+        row.skuCode,
+        row.skuDescription,
+        row.lotRef,
+        row.createdBy?.fullName,
+      ]
+
+      return fields.some(value => {
+        if (typeof value !== 'string') {
+          return false
+        }
+        return value.toLowerCase().includes(query)
+      })
+    })
+  }, [searchTerm, transactions])
+
+  if (status === 'loading') {
+    return (
+      <PageContainer>
+        <PageLoading />
+      </PageContainer>
+    )
+  }
+
+  if (!session || !['staff', 'admin'].includes(session.user.role)) {
+    return null
+  }
+
+  if (loadError !== null) {
+    throw loadError
+  }
+
+  if (loading) {
+    return (
+      <PageContainer>
+        <PageLoading />
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeaderSection title="Transactions" description="Operations" icon={FileText} />
+      <PageContent className="flex-1 overflow-hidden px-4 py-6 sm:px-6 lg:px-8 flex flex-col">
+        <div className="flex min-h-0 flex-1 flex-col rounded-xl border bg-white shadow-soft dark:bg-slate-800">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b px-4 py-3">
+            <div className="text-sm text-muted-foreground">
+              Showing {filteredTransactions.length.toLocaleString()} of{' '}
+              {transactions.length.toLocaleString()} transactions
+            </div>
+            <div className="relative w-full max-w-sm">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={searchTerm}
+                onChange={event => setSearchTerm(event.target.value)}
+                placeholder="Search transactions"
+                className="h-9 w-full rounded-md border border-slate-200 bg-white pl-9 pr-3 text-sm text-foreground outline-none transition-shadow focus:border-primary focus:ring-2 focus:ring-primary/20 dark:border-slate-700 dark:bg-slate-900"
+              />
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-auto scrollbar-gutter-stable">
+            <table className="w-full min-w-[1220px] table-auto text-sm">
+              <thead>
+                <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
+                  <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    Date
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    Ref ID
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    Type
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    Warehouse
+                  </th>
+                  <th className="px-3 py-2 text-left text-xs font-medium text-muted-foreground">
+                    SKU / Lot
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-muted-foreground">
+                    Cartons
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-muted-foreground">
+                    Pallets
+                  </th>
+                  <th className="px-3 py-2 text-right text-xs font-medium text-muted-foreground">
+                    Units
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {!loading && filteredTransactions.length === 0 && (
+                  <tr>
+                    <td colSpan={8} className="px-3 py-10 text-center text-muted-foreground">
+                      No transactions found.
+                    </td>
+                  </tr>
+                )}
+
+                {filteredTransactions.map(row => {
+                  const movement = getMovementBadge(row)
+                  const cartons = getTransactionCartons(row)
+                  const units = cartons * row.unitsPerCarton
+                  const pallets = getTransactionPallets(row)
+
+                  return (
+                    <tr
+                      key={row.id}
+                      className="border-t border-slate-200 align-top hover:bg-slate-50/50 dark:border-slate-700 dark:hover:bg-slate-700/50"
+                    >
+                      <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                        {formatTransactionDate(row.transactionDate)}
+                      </td>
+                      <td className="px-3 py-2 font-medium">
+                        <Link
+                          href={`/operations/transactions/${row.id}`}
+                          className="text-primary hover:underline"
+                          prefetch={false}
+                        >
+                          {row.referenceId ?? row.id.slice(0, 8)}
+                        </Link>
+                      </td>
+                      <td className="px-3 py-2 whitespace-nowrap">
+                        <Badge variant={movement.variant} className="uppercase text-[10px]">
+                          {movement.label}
+                        </Badge>
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="font-medium text-foreground">{row.warehouseCode}</div>
+                        <div className="text-xs text-muted-foreground whitespace-normal break-words leading-5">
+                          {row.warehouseName}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2">
+                        <div className="font-semibold text-foreground">
+                          {row.skuCode}
+                          <span className="ml-2 font-normal text-muted-foreground">
+                            {row.lotRef}
+                          </span>
+                        </div>
+                        <div className="text-xs text-muted-foreground whitespace-normal break-words leading-5">
+                          {row.skuDescription}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 text-right font-semibold tabular-nums">
+                        {cartons.toLocaleString()}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {pallets.toLocaleString()}
+                      </td>
+                      <td className="px-3 py-2 text-right tabular-nums">
+                        {units.toLocaleString()}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </PageContent>
+    </PageContainer>
+  )
 }

--- a/apps/talos/src/components/finance/storage-ledger/StorageCostSummary.tsx
+++ b/apps/talos/src/components/finance/storage-ledger/StorageCostSummary.tsx
@@ -2,44 +2,45 @@
 
 import { Package, Archive, DollarSign, Calculator } from '@/lib/lucide-icons'
 import { StatsCard, StatsCardGrid } from '@/components/ui/stats-card'
-import { formatCurrency } from '@/lib/utils'
+import { formatCurrencyForCode } from '@/lib/dashboard/currency'
 import type { StorageSummary } from '@/hooks/useStorageLedger'
 
 interface StorageCostSummaryProps {
- summary: StorageSummary
+  summary: StorageSummary
+  currency: string
 }
 
-export function StorageCostSummary({ summary }: StorageCostSummaryProps) {
- return (
- <StatsCardGrid cols={4}>
- <StatsCard
- title="Total Entries"
- value={summary.totalEntries}
- subtitle="Storage records"
- icon={Package}
- variant="default"
- />
- <StatsCard
- title="Total Pallet Days"
- value={summary.totalPalletDays}
- subtitle="Billed in period"
- icon={Archive}
- variant="info"
- />
- <StatsCard
- title="Total Storage Cost"
- value={formatCurrency(summary.totalStorageCost)}
- subtitle="All entries"
- icon={DollarSign}
- variant="default"
- />
- <StatsCard
- title="Costs Calculated"
- value={`${summary.entriesWithCosts}/${summary.totalEntries}`}
- subtitle={`${summary.costCalculationRate}% complete`}
- icon={Calculator}
- variant="default"
- />
- </StatsCardGrid>
- )
+export function StorageCostSummary({ summary, currency }: StorageCostSummaryProps) {
+  return (
+    <StatsCardGrid cols={4}>
+      <StatsCard
+        title="Total Entries"
+        value={summary.totalEntries}
+        subtitle="Storage records"
+        icon={Package}
+        variant="default"
+      />
+      <StatsCard
+        title="Total Pallet Days"
+        value={summary.totalPalletDays}
+        subtitle="Billed in period"
+        icon={Archive}
+        variant="info"
+      />
+      <StatsCard
+        title="Total Storage Cost"
+        value={formatCurrencyForCode(summary.totalStorageCost, currency)}
+        subtitle="All entries"
+        icon={DollarSign}
+        variant="default"
+      />
+      <StatsCard
+        title="Costs Calculated"
+        value={`${summary.entriesWithCosts}/${summary.totalEntries}`}
+        subtitle={`${summary.costCalculationRate}% complete`}
+        icon={Calculator}
+        variant="default"
+      />
+    </StatsCardGrid>
+  )
 }

--- a/apps/talos/src/components/finance/storage-ledger/StorageLedgerStats.tsx
+++ b/apps/talos/src/components/finance/storage-ledger/StorageLedgerStats.tsx
@@ -2,9 +2,10 @@ import { StorageCostSummary } from './StorageCostSummary'
 import type { StorageSummary } from '@/hooks/useStorageLedger'
 
 interface StorageLedgerStatsProps {
- summary: StorageSummary
+  summary: StorageSummary
+  currency: string
 }
 
-export function StorageLedgerStats({ summary }: StorageLedgerStatsProps) {
- return <StorageCostSummary summary={summary} />
+export function StorageLedgerStats({ summary, currency }: StorageLedgerStatsProps) {
+  return <StorageCostSummary summary={summary} currency={currency} />
 }

--- a/apps/talos/src/components/finance/storage-ledger/StorageLedgerTable.tsx
+++ b/apps/talos/src/components/finance/storage-ledger/StorageLedgerTable.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client'
 
 import { useMemo } from 'react'
 import { format } from 'date-fns'
@@ -6,36 +6,40 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { Badge } from '@/components/ui/badge'
 import { Filter } from '@/lib/lucide-icons'
 import { cn } from '@/lib/utils'
+import { formatCurrencyForCode } from '@/lib/dashboard/currency'
 import type { StorageEntry } from '@/hooks/useStorageLedger'
 export interface StorageLedgerColumnFilters {
- warehouseCodes: string[]
- skuCodes: string[]
- weekEnding: string
- description: string
- lot: string
- status: Array<'CALCULATED' | 'PENDING'>
- palletDaysMin: string
- palletDaysMax: string
- rateMin: string
- rateMax: string
- totalCostMin: string
- totalCostMax: string
+  warehouseCodes: string[]
+  skuCodes: string[]
+  weekEnding: string
+  description: string
+  lot: string
+  status: Array<'CALCULATED' | 'PENDING'>
+  palletDaysMin: string
+  palletDaysMax: string
+  rateMin: string
+  rateMax: string
+  totalCostMin: string
+  totalCostMax: string
 }
 
 interface StorageLedgerTableProps {
- entries: StorageEntry[]
- aggregationView: 'weekly' | 'monthly'
- filters: StorageLedgerColumnFilters
- onFilterChange: (filters: StorageLedgerColumnFilters) => void
+  entries: StorageEntry[]
+  aggregationView: 'weekly' | 'monthly'
+  filters: StorageLedgerColumnFilters
+  onFilterChange: (filters: StorageLedgerColumnFilters) => void
+  currency: string
 }
 
-const baseFilterInputClass = 'w-full rounded-md border border-muted px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary'
+const baseFilterInputClass =
+  'w-full rounded-md border border-muted px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary'
 
 export function StorageLedgerTable({
- entries,
- aggregationView: _aggregationView,
- filters,
- onFilterChange,
+  entries,
+  aggregationView: _aggregationView,
+  filters,
+  onFilterChange,
+  currency,
 }: StorageLedgerTableProps) {
   const uniqueWarehouses = useMemo(() => {
     const set = new Set<string>()
@@ -43,364 +47,395 @@ export function StorageLedgerTable({
       set.add(entry.warehouseCode)
     })
     return Array.from(set.values())
-      .map((value) => ({ value, label: value }))
+      .map(value => ({ value, label: value }))
       .sort((a, b) => a.label.localeCompare(b.label))
   }, [entries])
 
- const uniqueSkus = useMemo(() => {
- const set = new Set<string>()
- entries.forEach(entry => {
- set.add(entry.skuCode)
- })
- return Array.from(set.values()).sort().map(value => ({ value, label: value }))
- }, [entries])
+  const uniqueSkus = useMemo(() => {
+    const set = new Set<string>()
+    entries.forEach(entry => {
+      set.add(entry.skuCode)
+    })
+    return Array.from(set.values())
+      .sort()
+      .map(value => ({ value, label: value }))
+  }, [entries])
 
- const uniqueStatuses = useMemo(() => [
- { value: 'CALCULATED', label: 'Calculated' },
- { value: 'PENDING', label: 'Pending' },
- ], [])
+  const uniqueStatuses = useMemo(
+    () => [
+      { value: 'CALCULATED', label: 'Calculated' },
+      { value: 'PENDING', label: 'Pending' },
+    ],
+    []
+  )
 
- const updateFilters = (partial: Partial<StorageLedgerColumnFilters>) => {
- onFilterChange({ ...filters, ...partial })
- }
+  const updateFilters = (partial: Partial<StorageLedgerColumnFilters>) => {
+    onFilterChange({ ...filters, ...partial })
+  }
 
- const toggleSelection = (key: 'warehouseCodes' | 'skuCodes' | 'status', value: string) => {
- const current = filters[key]
- const exists = current.includes(value as never)
- const next = exists
- ? current.filter(item => item !== value)
- : [...current, value] as typeof current
- onFilterChange({ ...filters, [key]: next })
- }
+  const toggleSelection = (key: 'warehouseCodes' | 'skuCodes' | 'status', value: string) => {
+    const current = filters[key]
+    const exists = current.includes(value as never)
+    const next = exists
+      ? current.filter(item => item !== value)
+      : ([...current, value] as typeof current)
+    onFilterChange({ ...filters, [key]: next })
+  }
 
- const renderNumericFilter = (
- label: string,
- minKey: keyof StorageLedgerColumnFilters,
- maxKey: keyof StorageLedgerColumnFilters,
- ) => (
- <Popover>
- <PopoverTrigger asChild>
- <button
- type="button"
- aria-label={`Filter ${label}`}
- className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted/30 hover:text-primary"
- >
- <Filter className="h-3.5 w-3.5" />
- </button>
- </PopoverTrigger>
- <PopoverContent align="end" className="w-56 space-y-2">
- <div className="flex items-center justify-between">
- <span className="text-sm font-medium text-foreground">{label} range</span>
- <button
- type="button"
- className="text-xs font-medium text-primary hover:underline"
- onClick={() => updateFilters({ [minKey]: '', [maxKey]: '' } as Partial<StorageLedgerColumnFilters>)}
- >
- Clear
- </button>
- </div>
- <div className="flex gap-2">
- <input
- type="number"
- inputMode="numeric"
- value={filters[minKey] as string}
- onChange={(event) => updateFilters({ [minKey]: event.target.value } as Partial<StorageLedgerColumnFilters>)}
- placeholder="Min"
- className={`${baseFilterInputClass} text-right`}
- />
- <input
- type="number"
- inputMode="numeric"
- value={filters[maxKey] as string}
- onChange={(event) => updateFilters({ [maxKey]: event.target.value } as Partial<StorageLedgerColumnFilters>)}
- placeholder="Max"
- className={`${baseFilterInputClass} text-right`}
- />
- </div>
- </PopoverContent>
- </Popover>
- )
-
- const renderTextFilter = (label: string, key: keyof StorageLedgerColumnFilters) => (
- <Popover>
- <PopoverTrigger asChild>
- <button
- type="button"
- aria-label={`Filter ${label}`}
- className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted/30 hover:text-primary"
- >
- <Filter className="h-3.5 w-3.5" />
- </button>
- </PopoverTrigger>
- <PopoverContent align="start" className="w-64 space-y-2">
- <div className="flex items-center justify-between">
- <span className="text-sm font-medium text-foreground">{label} filter</span>
- <button
- type="button"
- className="text-xs font-medium text-primary hover:underline"
- onClick={() => updateFilters({ [key]: '' } as Partial<StorageLedgerColumnFilters>)}
- >
- Clear
- </button>
- </div>
- <input
- type="text"
- value={filters[key] as string}
- onChange={(event) => updateFilters({ [key]: event.target.value } as Partial<StorageLedgerColumnFilters>)}
- placeholder={`Search ${label.toLowerCase()}`}
- className={baseFilterInputClass}
- />
- </PopoverContent>
- </Popover>
- )
-
-
- return (
- <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-soft">
- <div className="flex flex-wrap items-center gap-3 px-4 py-3 border-b">
- <div className="flex items-center gap-2 text-sm text-muted-foreground">
- <Filter className="h-4 w-4" />
- <span>
- Showing {entries.length} storage {entries.length === 1 ? 'entry' : 'entries'}
- </span>
- </div>
- </div>
-
- <div className="overflow-x-auto">
- <table className="w-full table-auto text-sm">
- <thead>
- <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
- <div className="flex items-center justify-between gap-1">
- <span>Week Ending</span>
- {renderTextFilter('Week ending', 'weekEnding')}
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
- <div className="flex items-center justify-between gap-1">
- <span>Warehouse</span>
- <Popover>
- <PopoverTrigger asChild>
- <button
- type="button"
- aria-label="Filter warehouses"
- className={cn(
- 'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
- filters.warehouseCodes.length > 0
- ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
- : 'hover:bg-muted/30 hover:text-primary'
- )}
- >
- <Filter className="h-3.5 w-3.5" />
- </button>
- </PopoverTrigger>
- <PopoverContent align="start" className="w-64 space-y-2">
- <div className="flex items-center justify-between">
- <span className="text-sm font-medium text-foreground">Warehouse filter</span>
- <button
- type="button"
- className="text-xs font-medium text-primary hover:underline"
- onClick={() => updateFilters({ warehouseCodes: [] })}
- >
- Clear
- </button>
- </div>
- <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
- {uniqueWarehouses.map(option => (
- <label key={option.value} className="flex items-center gap-2 text-sm text-foreground">
- <input
- type="checkbox"
- checked={filters.warehouseCodes.includes(option.value)}
- onChange={() => toggleSelection('warehouseCodes', option.value)}
- className="h-4 w-4 rounded border-muted text-primary focus:ring-primary"
- />
- <span>{option.label}</span>
- </label>
- ))}
- </div>
-        </PopoverContent>
-      </Popover>
-    </div>
-  </th>
-          
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
- <div className="flex items-center justify-between gap-1">
- <span>SKU</span>
- <Popover>
- <PopoverTrigger asChild>
- <button
- type="button"
- aria-label="Filter SKUs"
- className={cn(
- 'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
- filters.skuCodes.length > 0
- ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
- : 'hover:bg-muted/30 hover:text-primary'
- )}
- >
- <Filter className="h-3.5 w-3.5" />
- </button>
- </PopoverTrigger>
- <PopoverContent align="start" className="w-64 space-y-2">
- <div className="flex items-center justify-between">
- <span className="text-sm font-medium text-foreground">SKU filter</span>
- <button
- type="button"
- className="text-xs font-medium text-primary hover:underline"
- onClick={() => updateFilters({ skuCodes: [] })}
- >
- Clear
- </button>
- </div>
- <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
- {uniqueSkus.map(option => (
- <label key={option.value} className="flex items-center gap-2 text-sm text-foreground">
- <input
- type="checkbox"
- checked={filters.skuCodes.includes(option.value)}
- onChange={() => toggleSelection('skuCodes', option.value)}
- className="h-4 w-4 rounded border-muted text-primary focus:ring-primary"
- />
- <span>{option.label}</span>
- </label>
- ))}
- </div>
- </PopoverContent>
- </Popover>
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
- <div className="flex items-center justify-between gap-1">
- <span>Description</span>
- {renderTextFilter('Description', 'description')}
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
- <div className="flex items-center justify-between gap-1">
- <span>Lot</span>
- {renderTextFilter('Lot', 'lot')}
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
- <div className="flex items-center justify-end gap-1">
- <span>Pallet Days</span>
- {renderNumericFilter('Pallet days', 'palletDaysMin', 'palletDaysMax')}
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
- <div className="flex items-center justify-end gap-1">
- <span>Rate</span>
- {renderNumericFilter('Rate', 'rateMin', 'rateMax')}
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
- <div className="flex items-center justify-end gap-1">
- <span>Total Cost</span>
- {renderNumericFilter('Total cost', 'totalCostMin', 'totalCostMax')}
- </div>
- </th>
- <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
- <div className="flex items-center justify-between gap-1">
- <span>Status</span>
- <Popover>
- <PopoverTrigger asChild>
- <button
- type="button"
- aria-label="Filter statuses"
- className={cn(
- 'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
- filters.status.length > 0
- ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
- : 'hover:bg-muted/30 hover:text-primary'
- )}
- >
- <Filter className="h-3.5 w-3.5" />
- </button>
- </PopoverTrigger>
- <PopoverContent align="start" className="w-48 space-y-2">
- <div className="flex items-center justify-between">
- <span className="text-sm font-medium text-foreground">Status filter</span>
- <button
- type="button"
- className="text-xs font-medium text-primary hover:underline"
- onClick={() => updateFilters({ status: [] })}
- >
- Clear
- </button>
- </div>
- <div className="space-y-2">
- {uniqueStatuses.map(option => (
- <label key={option.value} className="flex items-center gap-2 text-sm text-foreground">
- <input
- type="checkbox"
- checked={filters.status.includes(option.value as 'CALCULATED' | 'PENDING')}
- onChange={() => toggleSelection('status', option.value)}
- className="h-4 w-4 rounded border-muted text-primary focus:ring-primary"
- />
- <span>{option.label}</span>
- </label>
- ))}
- </div>
- </PopoverContent>
- </Popover>
- </div>
- </th>
- </tr>
- </thead>
- <tbody>
- {entries.length === 0 && (
- <tr>
-          <td
-            colSpan={9}
-            className="px-4 py-10 text-center text-muted-foreground"
+  const renderNumericFilter = (
+    label: string,
+    minKey: keyof StorageLedgerColumnFilters,
+    maxKey: keyof StorageLedgerColumnFilters
+  ) => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Filter ${label}`}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted/30 hover:text-primary"
+        >
+          <Filter className="h-3.5 w-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-foreground">{label} range</span>
+          <button
+            type="button"
+            className="text-xs font-medium text-primary hover:underline"
+            onClick={() =>
+              updateFilters({ [minKey]: '', [maxKey]: '' } as Partial<StorageLedgerColumnFilters>)
+            }
           >
- No storage entries found. Adjust filters to see results.
- </td>
- </tr>
- )}
+            Clear
+          </button>
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="number"
+            inputMode="numeric"
+            value={filters[minKey] as string}
+            onChange={event =>
+              updateFilters({ [minKey]: event.target.value } as Partial<StorageLedgerColumnFilters>)
+            }
+            placeholder="Min"
+            className={`${baseFilterInputClass} text-right`}
+          />
+          <input
+            type="number"
+            inputMode="numeric"
+            value={filters[maxKey] as string}
+            onChange={event =>
+              updateFilters({ [maxKey]: event.target.value } as Partial<StorageLedgerColumnFilters>)
+            }
+            placeholder="Max"
+            className={`${baseFilterInputClass} text-right`}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
 
-      {entries.map(entry => (
-        <tr key={entry.id} className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50">
-          <td className="px-3 py-2 text-sm text-foreground whitespace-nowrap">
-            {format(new Date(entry.weekEndingDate), 'PP')}
-          </td>
-          <td className="px-3 py-2 text-sm font-medium text-foreground whitespace-nowrap">
-            {entry.warehouseCode}
-          </td>
- <td className="px-3 py-2 text-sm font-medium text-foreground whitespace-nowrap">
- {entry.skuCode}
- </td>
- <td className="px-3 py-2 text-sm text-muted-foreground max-w-xs truncate" title={entry.skuDescription}>
- {entry.skuDescription}
- </td>
- <td className="px-3 py-2 text-sm text-muted-foreground font-mono whitespace-nowrap">
- {entry.lotRef}
- </td>
- <td className="px-3 py-2 text-sm font-semibold text-foreground text-right whitespace-nowrap">
- {entry.palletDays.toLocaleString()}
- </td>
- <td className="px-3 py-2 text-sm text-right text-foreground whitespace-nowrap">
- {entry.storageRatePerPalletDay
- ? `$${Number(entry.storageRatePerPalletDay).toFixed(4)}`
- : <span className="text-muted-foreground">—</span>
- }
- </td>
- <td className="px-3 py-2 text-sm text-right font-semibold text-foreground whitespace-nowrap">
- {entry.totalStorageCost
- ? `$${Number(entry.totalStorageCost).toFixed(2)}`
- : <span className="text-muted-foreground">—</span>
- }
- </td>
- <td className="px-3 py-2 text-sm">
-              <Badge variant={entry.isCostCalculated ? 'success' : 'warning'}>
-                {entry.isCostCalculated ? 'Calculated' : 'Pending'}
-              </Badge>
- </td>
- </tr>
- ))}
- </tbody>
- </table>
- </div>
- </div>
- )
+  const renderTextFilter = (label: string, key: keyof StorageLedgerColumnFilters) => (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={`Filter ${label}`}
+          className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:bg-muted/30 hover:text-primary"
+        >
+          <Filter className="h-3.5 w-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-foreground">{label} filter</span>
+          <button
+            type="button"
+            className="text-xs font-medium text-primary hover:underline"
+            onClick={() => updateFilters({ [key]: '' } as Partial<StorageLedgerColumnFilters>)}
+          >
+            Clear
+          </button>
+        </div>
+        <input
+          type="text"
+          value={filters[key] as string}
+          onChange={event =>
+            updateFilters({ [key]: event.target.value } as Partial<StorageLedgerColumnFilters>)
+          }
+          placeholder={`Search ${label.toLowerCase()}`}
+          className={baseFilterInputClass}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+
+  return (
+    <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 shadow-soft">
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3 border-b">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Filter className="h-4 w-4" />
+          <span>
+            Showing {entries.length} storage {entries.length === 1 ? 'entry' : 'entries'}
+          </span>
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full table-auto text-sm">
+          <thead>
+            <tr className="border-b bg-slate-50/50 dark:bg-slate-700/50">
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
+                <div className="flex items-center justify-between gap-1">
+                  <span>Week Ending</span>
+                  {renderTextFilter('Week ending', 'weekEnding')}
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
+                <div className="flex items-center justify-between gap-1">
+                  <span>Warehouse</span>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Filter warehouses"
+                        className={cn(
+                          'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                          filters.warehouseCodes.length > 0
+                            ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                            : 'hover:bg-muted/30 hover:text-primary'
+                        )}
+                      >
+                        <Filter className="h-3.5 w-3.5" />
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-64 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-foreground">
+                          Warehouse filter
+                        </span>
+                        <button
+                          type="button"
+                          className="text-xs font-medium text-primary hover:underline"
+                          onClick={() => updateFilters({ warehouseCodes: [] })}
+                        >
+                          Clear
+                        </button>
+                      </div>
+                      <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
+                        {uniqueWarehouses.map(option => (
+                          <label
+                            key={option.value}
+                            className="flex items-center gap-2 text-sm text-foreground"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={filters.warehouseCodes.includes(option.value)}
+                              onChange={() => toggleSelection('warehouseCodes', option.value)}
+                              className="h-4 w-4 rounded border-muted text-primary focus:ring-primary"
+                            />
+                            <span>{option.label}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </th>
+
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
+                <div className="flex items-center justify-between gap-1">
+                  <span>SKU</span>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Filter SKUs"
+                        className={cn(
+                          'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                          filters.skuCodes.length > 0
+                            ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                            : 'hover:bg-muted/30 hover:text-primary'
+                        )}
+                      >
+                        <Filter className="h-3.5 w-3.5" />
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-64 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-foreground">SKU filter</span>
+                        <button
+                          type="button"
+                          className="text-xs font-medium text-primary hover:underline"
+                          onClick={() => updateFilters({ skuCodes: [] })}
+                        >
+                          Clear
+                        </button>
+                      </div>
+                      <div className="max-h-60 space-y-2 overflow-y-auto pr-1">
+                        {uniqueSkus.map(option => (
+                          <label
+                            key={option.value}
+                            className="flex items-center gap-2 text-sm text-foreground"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={filters.skuCodes.includes(option.value)}
+                              onChange={() => toggleSelection('skuCodes', option.value)}
+                              className="h-4 w-4 rounded border-muted text-primary focus:ring-primary"
+                            />
+                            <span>{option.label}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
+                <div className="flex items-center justify-between gap-1">
+                  <span>Description</span>
+                  {renderTextFilter('Description', 'description')}
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
+                <div className="flex items-center justify-between gap-1">
+                  <span>Lot</span>
+                  {renderTextFilter('Lot', 'lot')}
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
+                <div className="flex items-center justify-end gap-1">
+                  <span>Pallet Days</span>
+                  {renderNumericFilter('Pallet days', 'palletDaysMin', 'palletDaysMax')}
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
+                <div className="flex items-center justify-end gap-1">
+                  <span>Rate</span>
+                  {renderNumericFilter('Rate', 'rateMin', 'rateMax')}
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-right">
+                <div className="flex items-center justify-end gap-1">
+                  <span>Total Cost</span>
+                  {renderNumericFilter('Total cost', 'totalCostMin', 'totalCostMax')}
+                </div>
+              </th>
+              <th className="font-medium text-muted-foreground px-3 py-2 whitespace-nowrap text-xs text-left">
+                <div className="flex items-center justify-between gap-1">
+                  <span>Status</span>
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Filter statuses"
+                        className={cn(
+                          'inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors',
+                          filters.status.length > 0
+                            ? 'border-primary/50 bg-primary/10 text-primary hover:bg-primary/20'
+                            : 'hover:bg-muted/30 hover:text-primary'
+                        )}
+                      >
+                        <Filter className="h-3.5 w-3.5" />
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="w-48 space-y-2">
+                      <div className="flex items-center justify-between">
+                        <span className="text-sm font-medium text-foreground">Status filter</span>
+                        <button
+                          type="button"
+                          className="text-xs font-medium text-primary hover:underline"
+                          onClick={() => updateFilters({ status: [] })}
+                        >
+                          Clear
+                        </button>
+                      </div>
+                      <div className="space-y-2">
+                        {uniqueStatuses.map(option => (
+                          <label
+                            key={option.value}
+                            className="flex items-center gap-2 text-sm text-foreground"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={filters.status.includes(
+                                option.value as 'CALCULATED' | 'PENDING'
+                              )}
+                              onChange={() => toggleSelection('status', option.value)}
+                              className="h-4 w-4 rounded border-muted text-primary focus:ring-primary"
+                            />
+                            <span>{option.label}</span>
+                          </label>
+                        ))}
+                      </div>
+                    </PopoverContent>
+                  </Popover>
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 && (
+              <tr>
+                <td colSpan={9} className="px-4 py-10 text-center text-muted-foreground">
+                  No storage entries found. Adjust filters to see results.
+                </td>
+              </tr>
+            )}
+
+            {entries.map(entry => (
+              <tr
+                key={entry.id}
+                className="border-t border-slate-200 dark:border-slate-700 hover:bg-slate-50/50 dark:hover:bg-slate-700/50"
+              >
+                <td className="px-3 py-2 text-sm text-foreground whitespace-nowrap">
+                  {format(new Date(entry.weekEndingDate), 'PP')}
+                </td>
+                <td className="px-3 py-2 text-sm font-medium text-foreground whitespace-nowrap">
+                  {entry.warehouseCode}
+                </td>
+                <td className="px-3 py-2 text-sm font-medium text-foreground whitespace-nowrap">
+                  {entry.skuCode}
+                </td>
+                <td
+                  className="px-3 py-2 text-sm text-muted-foreground whitespace-normal break-words leading-5"
+                  title={entry.skuDescription}
+                >
+                  {entry.skuDescription}
+                </td>
+                <td className="px-3 py-2 text-sm text-muted-foreground font-mono whitespace-nowrap">
+                  {entry.lotRef}
+                </td>
+                <td className="px-3 py-2 text-sm font-semibold text-foreground text-right whitespace-nowrap">
+                  {entry.palletDays.toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-sm text-right text-foreground whitespace-nowrap">
+                  {entry.storageRatePerPalletDay !== undefined &&
+                  entry.storageRatePerPalletDay !== null ? (
+                    formatCurrencyForCode(Number(entry.storageRatePerPalletDay), currency, 4)
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-sm text-right font-semibold text-foreground whitespace-nowrap">
+                  {entry.totalStorageCost !== undefined && entry.totalStorageCost !== null ? (
+                    formatCurrencyForCode(Number(entry.totalStorageCost), currency)
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2 text-sm">
+                  <Badge variant={entry.isCostCalculated ? 'success' : 'warning'}>
+                    {entry.isCostCalculated ? 'Calculated' : 'Pending'}
+                  </Badge>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
 }

--- a/apps/talos/src/components/ui/breadcrumb.tsx
+++ b/apps/talos/src/components/ui/breadcrumb.tsx
@@ -6,110 +6,116 @@ import { ChevronRight, Home } from '@/lib/lucide-icons'
 import { withoutBasePath } from '@/lib/utils/base-path'
 
 type BreadcrumbItem = {
- href: string
- label: string
- skip: boolean
+  href: string
+  label: string
+  skip: boolean
 }
 
 const ROUTE_LABELS = new Map<string, string>([
- ['/amazon/fba-fee-discrepancies', 'SKU Info'],
- ['/operations/inbound', 'Inbound'],
- ['/operations/outbound', 'Outbound'],
+  ['/amazon/fba-fee-discrepancies', 'SKU Info'],
+  ['/operations/inbound', 'Inbound'],
+  ['/operations/outbound', 'Outbound'],
 ])
 
 function formatSegmentLabel(segment: string): string {
- switch (segment) {
- case 'operations':
- return 'Operations'
- case 'finance':
- return 'Ledgers'
- case 'config':
- return 'Configuration'
- case 'integrations':
- return 'Integrations'
- case 'transactions':
- return 'Transactions'
- case 'inventory':
- return 'Inventory'
- default:
- // For IDs and other segments, format them nicely
- if (segment.match(/^[a-f0-9-]+$/i) && segment.length > 20) {
- // Looks like an ID, truncate it
- return segment.substring(0, 8) + '...'
- }
+  switch (segment) {
+    case 'operations':
+      return 'Operations'
+    case 'finance':
+      return 'Ledgers'
+    case 'config':
+      return 'Configuration'
+    case 'integrations':
+      return 'Integrations'
+    case 'transactions':
+      return 'Transactions'
+    case 'inventory':
+      return 'Inventory'
+    default:
+      // For IDs and other segments, format them nicely
+      if (segment.match(/^[a-f0-9-]+$/i) && segment.length > 20) {
+        // Looks like an ID, truncate it
+        return segment.substring(0, 8) + '...'
+      }
 
- return segment
- .split('-')
- .map(word => word.charAt(0).toUpperCase() + word.slice(1))
- .join(' ')
- }
+      return segment
+        .split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ')
+  }
 }
 
 export function buildBreadcrumbItems(pathname: string): BreadcrumbItem[] {
- const normalizedPathname = withoutBasePath(pathname, pathname)
+  const normalizedPathname = withoutBasePath(pathname, pathname)
 
- // Parse the pathname into segments
- const segments = normalizedPathname.split('/').filter(Boolean)
+  // Parse the pathname into segments
+  const segments = normalizedPathname.split('/').filter(Boolean)
 
- // Create breadcrumb items
- const breadcrumbs = segments.map((segment, index) => {
- const href = '/' + segments.slice(0, index + 1).join('/')
- const previousSegment = index > 0 ? segments[index - 1] : null
- const nextSegment = index < segments.length - 1 ? segments[index + 1] : null
+  // Create breadcrumb items
+  const breadcrumbs = segments
+    .map((segment, index) => {
+      const href = '/' + segments.slice(0, index + 1).join('/')
+      const previousSegment = index > 0 ? segments[index - 1] : null
+      const nextSegment = index < segments.length - 1 ? segments[index + 1] : null
 
- // Skip warehouse IDs in breadcrumbs (they don't have their own page)
- // Warehouse IDs appear after 'warehouses' and before 'rates' or 'edit'
- const isWarehouseId = previousSegment === 'warehouses' && nextSegment !== null && ['edit', 'rates'].includes(nextSegment)
- const isOperationsRoot = segment === 'operations'
+      // Skip warehouse IDs in breadcrumbs (they don't have their own page)
+      // Warehouse IDs appear after 'warehouses' and before 'rates' or 'edit'
+      const isWarehouseId =
+        previousSegment === 'warehouses' &&
+        nextSegment !== null &&
+        ['edit', 'rates'].includes(nextSegment)
+      const isOperationsRoot = segment === 'operations'
 
- const routeLabel = ROUTE_LABELS.get(href)
- const label = typeof routeLabel === 'string' ? routeLabel : formatSegmentLabel(segment)
+      const routeLabel = ROUTE_LABELS.get(href)
+      const label = typeof routeLabel === 'string' ? routeLabel : formatSegmentLabel(segment)
 
- return { href, label, skip: isWarehouseId || isOperationsRoot }
- }).filter(item => !item.skip)
+      return { href, label, skip: isWarehouseId || isOperationsRoot }
+    })
+    .filter(item => !item.skip)
 
- return breadcrumbs
+  return breadcrumbs
 }
 
 export function Breadcrumb() {
- const pathname = usePathname()
- const normalizedPathname = withoutBasePath(pathname, pathname)
+  const pathname = usePathname()
+  const normalizedPathname = withoutBasePath(pathname, pathname)
 
- // Don't show breadcrumbs on home or login pages
- if (normalizedPathname === '/' || normalizedPathname === '/auth/login') {
- return null
- }
+  // Don't show breadcrumbs on home or login pages
+  if (normalizedPathname === '/' || normalizedPathname === '/auth/login') {
+    return null
+  }
 
- const breadcrumbs = buildBreadcrumbItems(normalizedPathname)
+  const breadcrumbs = buildBreadcrumbItems(normalizedPathname)
 
- const homeLink = '/dashboard'
+  const homeLink = '/dashboard'
 
   return (
-  <nav className="flex items-center space-x-1 text-sm text-slate-600 dark:text-slate-400 mb-4">
-  <Link
-  href={homeLink}
-  className="flex items-center hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
-  >
-  <Home className="h-4 w-4" />
-  </Link>
-  
-  {breadcrumbs.map((breadcrumb, index) => (
-  <div key={breadcrumb.href} className="flex items-center">
-  <ChevronRight className="h-4 w-4 mx-1 text-slate-400 dark:text-slate-500" />
-  {index === breadcrumbs.length - 1 ? (
-  <span className="font-medium text-slate-900 dark:text-slate-100">
-  {breadcrumb.label}
-  </span>
-  ) : (
-  <Link
-  href={breadcrumb.href}
-  className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
-  >
-  {breadcrumb.label}
-  </Link>
-  )}
-  </div>
-  ))}
-  </nav>
+    <nav className="flex items-center space-x-1 text-sm text-slate-600 dark:text-slate-400 mb-4">
+      <Link
+        href={homeLink}
+        aria-label="Go to dashboard"
+        className="flex items-center hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+      >
+        <Home className="h-4 w-4" />
+      </Link>
+
+      {breadcrumbs.map((breadcrumb, index) => (
+        <div key={breadcrumb.href} className="flex items-center">
+          <ChevronRight className="h-4 w-4 mx-1 text-slate-400 dark:text-slate-500" />
+          {index === breadcrumbs.length - 1 ? (
+            <span className="font-medium text-slate-900 dark:text-slate-100">
+              {breadcrumb.label}
+            </span>
+          ) : (
+            <Link
+              href={breadcrumb.href}
+              className="hover:text-slate-900 dark:hover:text-slate-100 transition-colors"
+            >
+              {breadcrumb.label}
+            </Link>
+          )}
+        </div>
+      ))}
+    </nav>
   )
 }

--- a/apps/talos/src/lib/dashboard/currency.test.ts
+++ b/apps/talos/src/lib/dashboard/currency.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { formatDashboardCurrency } from './currency'
+import { formatCurrencyForCode, formatDashboardCurrency } from './currency'
 
 test('formatDashboardCurrency uses USD for the US tenant', () => {
   assert.equal(formatDashboardCurrency(0, 'US'), '$0.00')
@@ -16,4 +16,8 @@ test('formatDashboardCurrency rejects unknown tenant codes', () => {
     () => formatDashboardCurrency(10, 'CA'),
     /Invalid tenant code for dashboard currency/
   )
+})
+
+test('formatCurrencyForCode supports rate precision for tenant-scoped rates', () => {
+  assert.equal(formatCurrencyForCode(0.6925, 'GBP', 4), '£0.6925')
 })

--- a/apps/talos/src/lib/dashboard/currency.ts
+++ b/apps/talos/src/lib/dashboard/currency.ts
@@ -1,5 +1,18 @@
 import { getTenantConfig, isValidTenantCode } from '@/lib/tenant/constants'
 
+export function formatCurrencyForCode(
+  amount: number,
+  currency: string,
+  fractionDigits = 2
+): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  }).format(amount)
+}
+
 export function formatDashboardCurrency(
   amount: number,
   tenantCode: string | null | undefined
@@ -10,10 +23,5 @@ export function formatDashboardCurrency(
 
   const currency = getTenantConfig(tenantCode).currency
 
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount)
+  return formatCurrencyForCode(amount, currency)
 }

--- a/apps/talos/src/lib/sku-constants.ts
+++ b/apps/talos/src/lib/sku-constants.ts
@@ -5,8 +5,8 @@
 export const SKU_FIELD_LIMITS = {
   /** SKU code max length - matches skuCode unique constraint */
   SKU_CODE_MAX: 50,
-  /** Description max length - matches @db.VarChar(42) */
-  DESCRIPTION_MAX: 42,
+  /** Description max length - matches @db.VarChar(255) */
+  DESCRIPTION_MAX: 255,
   /** ASIN max length */
   ASIN_MAX: 64,
   /** Category max length */

--- a/apps/talos/src/services/storageCost.service.ts
+++ b/apps/talos/src/services/storageCost.service.ts
@@ -1,53 +1,53 @@
 import { getTenantPrisma } from '@/lib/tenant/server'
 import {
- FinancialLedgerCategory,
- FinancialLedgerSourceType,
- Prisma,
- TransactionType,
+  FinancialLedgerCategory,
+  FinancialLedgerSourceType,
+  Prisma,
+  TransactionType,
 } from '@targon/prisma-talos'
 import { addMonths, addWeeks, eachDayOfInterval, endOfWeek, format, startOfWeek } from 'date-fns'
 import { randomUUID } from 'crypto'
 import {
- calculateStorageCost,
- getStorageRate,
- type StorageRateResult,
- type StorageTier,
+  calculateStorageCost,
+  getStorageRate,
+  type StorageRateResult,
+  type StorageTier,
 } from './storageRate.service'
 
 interface RecordStorageCostParams {
- warehouseCode: string
- warehouseName: string
- skuCode: string
- skuDescription: string
- lotRef: string
- transactionDate: Date
+  warehouseCode: string
+  warehouseName: string
+  skuCode: string
+  skuDescription: string
+  lotRef: string
+  transactionDate: Date
 }
 
 type WeeklyTransactionMovement = {
- transactionType: TransactionType
- cartonsIn: number
- cartonsOut: number
- transactionDate: Date
+  transactionType: TransactionType
+  cartonsIn: number
+  cartonsOut: number
+  transactionDate: Date
 }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
- typeof value === 'object' && value !== null && !Array.isArray(value)
+  typeof value === 'object' && value !== null && !Array.isArray(value)
 
 const asNumber = (value: unknown): number | null => {
- if (typeof value === 'number' && Number.isFinite(value)) return value
- if (typeof value === 'string' && value.trim() !== '') {
-  const parsed = Number(value)
-  return Number.isFinite(parsed) ? parsed : null
- }
- return null
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
 }
 
 const asIsoDateString = (value: unknown): string | null => {
- if (typeof value !== 'string') return null
- const trimmed = value.trim()
- if (!trimmed) return null
- const parsed = new Date(trimmed)
- return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+  if (typeof value !== 'string') return null
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  const parsed = new Date(trimmed)
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
 }
 
 /**
@@ -56,551 +56,590 @@ const asIsoDateString = (value: unknown): string | null => {
  * storage costs are captured when inventory first appears in a week
  */
 interface WarehouseBillingConfig {
- storageBillingModel?: 'DAILY' | 'WEEKLY_ARRIVAL_CUTOFF' | 'WEEKLY_PALLET'
- cutoffHour?: number
- halfWeekRate?: number
- fullWeekRate?: number
- weeklyPalletRate?: number
- graceDays?: number
+  storageBillingModel?: 'DAILY' | 'WEEKLY_ARRIVAL_CUTOFF' | 'WEEKLY_PALLET'
+  cutoffHour?: number
+  halfWeekRate?: number
+  fullWeekRate?: number
+  weeklyPalletRate?: number
+  graceDays?: number
 }
 
 function parseWarehouseBillingConfig(raw: unknown): WarehouseBillingConfig | null {
- if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
- const obj = raw as Record<string, unknown>
- if (obj.storageBillingModel === 'WEEKLY_PALLET') {
-  return {
-   storageBillingModel: 'WEEKLY_PALLET',
-   weeklyPalletRate: typeof obj.weeklyPalletRate === 'number' ? obj.weeklyPalletRate : undefined,
-   graceDays: typeof obj.graceDays === 'number' ? obj.graceDays : 2,
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
+  const obj = raw as Record<string, unknown>
+  if (obj.storageBillingModel === 'WEEKLY_PALLET') {
+    return {
+      storageBillingModel: 'WEEKLY_PALLET',
+      weeklyPalletRate: typeof obj.weeklyPalletRate === 'number' ? obj.weeklyPalletRate : undefined,
+      graceDays: typeof obj.graceDays === 'number' ? obj.graceDays : 2,
+    }
   }
- }
- if (obj.storageBillingModel !== 'WEEKLY_ARRIVAL_CUTOFF') return null
- return {
-  storageBillingModel: 'WEEKLY_ARRIVAL_CUTOFF',
-  cutoffHour: typeof obj.cutoffHour === 'number' ? obj.cutoffHour : 12,
-  halfWeekRate: typeof obj.halfWeekRate === 'number' ? obj.halfWeekRate : undefined,
-  fullWeekRate: typeof obj.fullWeekRate === 'number' ? obj.fullWeekRate : undefined,
- }
+  if (obj.storageBillingModel !== 'WEEKLY_ARRIVAL_CUTOFF') return null
+  return {
+    storageBillingModel: 'WEEKLY_ARRIVAL_CUTOFF',
+    cutoffHour: typeof obj.cutoffHour === 'number' ? obj.cutoffHour : 12,
+    halfWeekRate: typeof obj.halfWeekRate === 'number' ? obj.halfWeekRate : undefined,
+    fullWeekRate: typeof obj.fullWeekRate === 'number' ? obj.fullWeekRate : undefined,
+  }
 }
 
 export async function recordStorageCostEntry({
- warehouseCode,
- warehouseName,
- skuCode,
- skuDescription,
- lotRef,
- transactionDate,
+  warehouseCode,
+  warehouseName,
+  skuCode,
+  skuDescription,
+  lotRef,
+  transactionDate,
 }: RecordStorageCostParams) {
- const prisma = await getTenantPrisma()
- const weekEndingDate = endOfWeek(transactionDate, { weekStartsOn: 1 })
- const weekStartingDate = startOfWeek(transactionDate, { weekStartsOn: 1 })
+  const prisma = await getTenantPrisma()
+  const weekEndingDate = endOfWeek(transactionDate, { weekStartsOn: 1 })
+  const weekStartingDate = startOfWeek(transactionDate, { weekStartsOn: 1 })
 
- // Check for warehouse-specific billing model (e.g. FMC half-week/full-week cutoff)
- const warehouseRow = await prisma.warehouse.findFirst({
-  where: { code: warehouseCode },
-  select: { billingConfig: true },
- })
- const billingConfig = parseWarehouseBillingConfig(warehouseRow?.billingConfig)
+  // Check for warehouse-specific billing model (e.g. FMC half-week/full-week cutoff)
+  const warehouseRow = await prisma.warehouse.findFirst({
+    where: { code: warehouseCode },
+    select: { billingConfig: true },
+  })
+  const billingConfig = parseWarehouseBillingConfig(warehouseRow?.billingConfig)
 
- const firstReceive = await prisma.inventoryTransaction.findFirst({
- where: {
- warehouseCode,
- skuCode,
- lotRef,
- transactionType: TransactionType.RECEIVE,
- storageCartonsPerPallet: { not: null },
- },
- orderBy: { transactionDate: 'asc' },
- select: { transactionDate: true, storageCartonsPerPallet: true },
- })
+  const firstReceive = await prisma.inventoryTransaction.findFirst({
+    where: {
+      warehouseCode,
+      skuCode,
+      lotRef,
+      transactionType: TransactionType.RECEIVE,
+      storageCartonsPerPallet: { not: null },
+    },
+    orderBy: { transactionDate: 'asc' },
+    select: { transactionDate: true, storageCartonsPerPallet: true },
+  })
 
- const cartonsPerPallet =
- firstReceive?.storageCartonsPerPallet != null ? Number(firstReceive.storageCartonsPerPallet) : null
+  const cartonsPerPallet =
+    firstReceive?.storageCartonsPerPallet != null
+      ? Number(firstReceive.storageCartonsPerPallet)
+      : null
 
- const sixPlusStartDate = firstReceive?.transactionDate
- ? addMonths(firstReceive.transactionDate, 6)
- : null
- const sixPlusStartKey = sixPlusStartDate ? format(sixPlusStartDate, 'yyyy-MM-dd') : null
+  const sixPlusStartDate = firstReceive?.transactionDate
+    ? addMonths(firstReceive.transactionDate, 6)
+    : null
+  const sixPlusStartKey = sixPlusStartDate ? format(sixPlusStartDate, 'yyyy-MM-dd') : null
 
- // Compute storage week number from first receive
- const firstReceiveWeekEnd = firstReceive?.transactionDate
-  ? endOfWeek(firstReceive.transactionDate, { weekStartsOn: 1 })
-  : null
- const weekNumber = firstReceiveWeekEnd
-  ? Math.round((weekEndingDate.getTime() - firstReceiveWeekEnd.getTime()) / (7 * 24 * 60 * 60 * 1000)) + 1
-  : null
+  // Compute storage week number from first receive
+  const firstReceiveWeekEnd = firstReceive?.transactionDate
+    ? endOfWeek(firstReceive.transactionDate, { weekStartsOn: 1 })
+    : null
+  const weekNumber = firstReceiveWeekEnd
+    ? Math.round(
+        (weekEndingDate.getTime() - firstReceiveWeekEnd.getTime()) / (7 * 24 * 60 * 60 * 1000)
+      ) + 1
+    : null
 
- // Calculate opening carton balance (inventory prior to the start of the week)
- const openingAggregate = await prisma.inventoryTransaction.aggregate({
- _sum: {
- cartonsIn: true,
- cartonsOut: true,
- },
- where: {
- warehouseCode,
- skuCode,
- lotRef,
- transactionDate: { lt: weekStartingDate },
- },
- })
+  // Calculate opening carton balance (inventory prior to the start of the week)
+  const openingAggregate = await prisma.inventoryTransaction.aggregate({
+    _sum: {
+      cartonsIn: true,
+      cartonsOut: true,
+    },
+    where: {
+      warehouseCode,
+      skuCode,
+      lotRef,
+      transactionDate: { lt: weekStartingDate },
+    },
+  })
 
- const openingBalance =
- Number(openingAggregate._sum.cartonsIn || 0) - Number(openingAggregate._sum.cartonsOut || 0)
+  const openingBalance =
+    Number(openingAggregate._sum.cartonsIn || 0) - Number(openingAggregate._sum.cartonsOut || 0)
 
- // Gather all transactions for the week to understand weekly movement
- const weeklyTransactions: WeeklyTransactionMovement[] = await prisma.inventoryTransaction.findMany({
- where: {
- warehouseCode,
- skuCode,
- lotRef,
- transactionDate: {
- gte: weekStartingDate,
- lte: weekEndingDate,
- },
- },
- select: {
- transactionType: true,
- cartonsIn: true,
- cartonsOut: true,
- transactionDate: true,
- },
- orderBy: { transactionDate: 'asc' },
- })
+  // Gather all transactions for the week to understand weekly movement
+  const weeklyTransactions: WeeklyTransactionMovement[] =
+    await prisma.inventoryTransaction.findMany({
+      where: {
+        warehouseCode,
+        skuCode,
+        lotRef,
+        transactionDate: {
+          gte: weekStartingDate,
+          lte: weekEndingDate,
+        },
+      },
+      select: {
+        transactionType: true,
+        cartonsIn: true,
+        cartonsOut: true,
+        transactionDate: true,
+      },
+      orderBy: { transactionDate: 'asc' },
+    })
 
- let weeklyReceive = 0
- let weeklyShip = 0
- let weeklyAdjust = 0
+  let weeklyReceive = 0
+  let weeklyShip = 0
+  let weeklyAdjust = 0
 
- for (const movement of weeklyTransactions) {
- const inValue = Number(movement.cartonsIn || 0)
- const outValue = Number(movement.cartonsOut || 0)
+  for (const movement of weeklyTransactions) {
+    const inValue = Number(movement.cartonsIn || 0)
+    const outValue = Number(movement.cartonsOut || 0)
 
- switch (movement.transactionType) {
- case TransactionType.RECEIVE:
- weeklyReceive += inValue
- break
- case TransactionType.SHIP:
- weeklyShip += outValue
- break
- case TransactionType.ADJUST_IN:
- weeklyAdjust += inValue
- break
- case TransactionType.ADJUST_OUT:
- weeklyAdjust -= outValue
- break
- default:
- weeklyAdjust += inValue - outValue
- break
- }
- }
-
- const closingBalance = openingBalance + weeklyReceive - weeklyShip + weeklyAdjust
- const normalizedClosingBalance = Math.max(0, closingBalance)
-
- const dailyNetCartons = new Map<string, number>()
- for (const movement of weeklyTransactions) {
- const dayKey = format(new Date(movement.transactionDate), 'yyyy-MM-dd')
- const net = Number(movement.cartonsIn || 0) - Number(movement.cartonsOut || 0)
- dailyNetCartons.set(dayKey, (dailyNetCartons.get(dayKey) ?? 0) + net)
- }
-
- const daysInWeek = eachDayOfInterval({ start: weekStartingDate, end: weekEndingDate })
- const dailyRows: Array<{
- date: string
- tier: StorageTier
- netCartons: number
- closingCartons: number
- closingPallets: number | null
- }> = []
-
- let runningCartons = Math.max(0, openingBalance)
- let totalClosingCartons = 0
- let palletDays = 0
- let palletDaysStandard = 0
- let palletDaysSixPlus = 0
- let closingPallets = 0
-
- for (const day of daysInWeek) {
- const dayKey = format(day, 'yyyy-MM-dd')
- const dayTier: StorageTier =
- sixPlusStartKey && dayKey >= sixPlusStartKey ? 'SIX_PLUS' : 'STANDARD'
- const netCartons = dailyNetCartons.get(dayKey) ?? 0
-
- runningCartons = Math.max(0, runningCartons + netCartons)
- totalClosingCartons += runningCartons
-
- let dayClosingPallets: number | null = null
- if (cartonsPerPallet && cartonsPerPallet > 0) {
- dayClosingPallets = runningCartons === 0 ? 0 : Math.ceil(runningCartons / cartonsPerPallet)
- palletDays += dayClosingPallets
- if (dayTier === 'SIX_PLUS') {
- palletDaysSixPlus += dayClosingPallets
- } else {
- palletDaysStandard += dayClosingPallets
- }
- closingPallets = dayClosingPallets
- }
-
- dailyRows.push({
- date: dayKey,
- tier: dayTier,
- netCartons,
- closingCartons: runningCartons,
- closingPallets: dayClosingPallets,
- })
- }
-
- const averageBalance =
- daysInWeek.length > 0 ? Number((totalClosingCartons / daysInWeek.length).toFixed(2)) : 0
-
- const hasMovement =
- openingBalance !== 0 || weeklyReceive !== 0 || weeklyShip !== 0 || weeklyAdjust !== 0
-
- if (!hasMovement) {
- return null
- }
-
- const existing = await prisma.storageLedger.findUnique({
- where: {
- warehouseCode_skuCode_lotRef_weekEndingDate: {
- warehouseCode,
- skuCode,
- lotRef,
- weekEndingDate,
- },
- },
- })
-
- let storageRateStandard: StorageRateResult | null = null
- let storageRateSixPlus: StorageRateResult | null = null
- let ratePerPalletDay: number | null = null
- let rateEffectiveDate: Date | null = null
- let costRateId: string | null = null
- let isCostCalculated = false
- let totalCost: number | null = null
- let rateStandardPerPalletDay: number | null = null
- let rateSixPlusPerPalletDay: number | null = null
- let rateStandardEffectiveDate: string | null = null
- let rateSixPlusEffectiveDate: string | null = null
-
- if (cartonsPerPallet && cartonsPerPallet > 0) {
- if (billingConfig?.storageBillingModel === 'WEEKLY_PALLET' && billingConfig.weeklyPalletRate != null) {
-  // V Global-style weekly pallet billing: charge per pallet per week if stock present > graceDays
-  const daysWithStock = dailyRows.filter((d) => d.closingCartons > 0).length
-  const graceDays = billingConfig.graceDays ?? 2
-
-  if (daysWithStock > graceDays && closingPallets > 0) {
-   totalCost = Number((closingPallets * billingConfig.weeklyPalletRate).toFixed(2))
-  } else {
-   totalCost = 0
+    switch (movement.transactionType) {
+      case TransactionType.RECEIVE:
+        weeklyReceive += inValue
+        break
+      case TransactionType.SHIP:
+        weeklyShip += outValue
+        break
+      case TransactionType.ADJUST_IN:
+        weeklyAdjust += inValue
+        break
+      case TransactionType.ADJUST_OUT:
+        weeklyAdjust -= outValue
+        break
+      default:
+        weeklyAdjust += inValue - outValue
+        break
+    }
   }
-  ratePerPalletDay = billingConfig.weeklyPalletRate
-  isCostCalculated = true
- } else try {
-   if (existing?.isCostCalculated) {
-    const existingRate = existing.storageRatePerPalletDay != null ? Number(existing.storageRatePerPalletDay) : null
-    const existingTotal = existing.totalStorageCost != null ? Number(existing.totalStorageCost) : null
-    const snapshot = isRecord(existing.dailyBalanceData) ? existing.dailyBalanceData : null
-    const snapshotStandardRate = snapshot ? asNumber(snapshot['rateStandardPerPalletDay']) : null
-    const snapshotSixPlusRate = snapshot ? asNumber(snapshot['rateSixPlusPerPalletDay']) : null
-    const snapshotStandardEffective = snapshot ? asIsoDateString(snapshot['rateStandardEffectiveDate']) : null
-    const snapshotSixPlusEffective = snapshot ? asIsoDateString(snapshot['rateSixPlusEffectiveDate']) : null
 
-    rateStandardPerPalletDay = snapshotStandardRate ?? existingRate
-    rateSixPlusPerPalletDay = snapshotSixPlusRate ?? rateStandardPerPalletDay
-    rateStandardEffectiveDate =
-     snapshotStandardEffective ?? (existing.rateEffectiveDate ? existing.rateEffectiveDate.toISOString() : null)
-    rateSixPlusEffectiveDate = snapshotSixPlusEffective
+  const closingBalance = openingBalance + weeklyReceive - weeklyShip + weeklyAdjust
+  const normalizedClosingBalance = Math.max(0, closingBalance)
 
-    const canComputeStandard = palletDaysStandard === 0 || rateStandardPerPalletDay != null
-    const canComputeSixPlus = palletDaysSixPlus === 0 || rateSixPlusPerPalletDay != null
+  const dailyNetCartons = new Map<string, number>()
+  for (const movement of weeklyTransactions) {
+    const dayKey = format(new Date(movement.transactionDate), 'yyyy-MM-dd')
+    const net = Number(movement.cartonsIn || 0) - Number(movement.cartonsOut || 0)
+    dailyNetCartons.set(dayKey, (dailyNetCartons.get(dayKey) ?? 0) + net)
+  }
 
-    if (canComputeStandard && canComputeSixPlus && (palletDaysStandard + palletDaysSixPlus > 0)) {
-     const standardCost = await calculateStorageCost(palletDaysStandard, rateStandardPerPalletDay ?? 0)
-     const sixPlusCost = await calculateStorageCost(palletDaysSixPlus, rateSixPlusPerPalletDay ?? 0)
-     totalCost = Number((standardCost + sixPlusCost).toFixed(2))
-     isCostCalculated = true
+  const daysInWeek = eachDayOfInterval({ start: weekStartingDate, end: weekEndingDate })
+  const dailyRows: Array<{
+    date: string
+    tier: StorageTier
+    netCartons: number
+    closingCartons: number
+    closingPallets: number | null
+  }> = []
 
-     // FMC-style arrival-week override (cached-rate path)
-     if (
-      billingConfig?.storageBillingModel === 'WEEKLY_ARRIVAL_CUTOFF' &&
-      openingBalance === 0 &&
-      weeklyReceive > 0 &&
-      closingPallets > 0 &&
-      billingConfig.halfWeekRate != null &&
-      billingConfig.fullWeekRate != null
-     ) {
-      const earliestReceive = weeklyTransactions.find(
-       (t) => t.transactionType === TransactionType.RECEIVE && Number(t.cartonsIn || 0) > 0
-      )
-      if (earliestReceive) {
-       const deliveryHour = new Date(earliestReceive.transactionDate).getHours()
-       const weeklyRate =
-        deliveryHour < billingConfig.cutoffHour!
-         ? billingConfig.halfWeekRate
-         : billingConfig.fullWeekRate
-       totalCost = Number((closingPallets * weeklyRate).toFixed(2))
+  let runningCartons = Math.max(0, openingBalance)
+  let totalClosingCartons = 0
+  let palletDays = 0
+  let palletDaysStandard = 0
+  let palletDaysSixPlus = 0
+  let closingPallets = 0
+
+  for (const day of daysInWeek) {
+    const dayKey = format(day, 'yyyy-MM-dd')
+    const dayTier: StorageTier =
+      sixPlusStartKey && dayKey >= sixPlusStartKey ? 'SIX_PLUS' : 'STANDARD'
+    const netCartons = dailyNetCartons.get(dayKey) ?? 0
+
+    runningCartons = Math.max(0, runningCartons + netCartons)
+    totalClosingCartons += runningCartons
+
+    let dayClosingPallets: number | null = null
+    if (cartonsPerPallet && cartonsPerPallet > 0) {
+      dayClosingPallets = runningCartons === 0 ? 0 : Math.ceil(runningCartons / cartonsPerPallet)
+      palletDays += dayClosingPallets
+      if (dayTier === 'SIX_PLUS') {
+        palletDaysSixPlus += dayClosingPallets
+      } else {
+        palletDaysStandard += dayClosingPallets
       }
-     }
-    } else {
-     totalCost = existingTotal
-     isCostCalculated = true
+      closingPallets = dayClosingPallets
     }
 
-    costRateId = existing.costRateId ?? null
-    rateEffectiveDate = existing.rateEffectiveDate ?? null
+    dailyRows.push({
+      date: dayKey,
+      tier: dayTier,
+      netCartons,
+      closingCartons: runningCartons,
+      closingPallets: dayClosingPallets,
+    })
+  }
 
-    if (palletDays > 0 && totalCost != null) {
-     if (palletDaysSixPlus === 0 && rateStandardPerPalletDay != null) {
-      ratePerPalletDay = rateStandardPerPalletDay
-     } else if (palletDaysStandard === 0 && rateSixPlusPerPalletDay != null) {
-      ratePerPalletDay = rateSixPlusPerPalletDay
-     } else {
-      ratePerPalletDay = Number((totalCost / palletDays).toFixed(4))
-     }
-    } else {
-     ratePerPalletDay = existingRate
-    }
-   } else {
-    storageRateStandard = await getStorageRate(warehouseCode, weekEndingDate, 'STANDARD')
-    if (storageRateStandard) {
-     const standardCost = await calculateStorageCost(palletDaysStandard, storageRateStandard.ratePerPalletDay)
+  const averageBalance =
+    daysInWeek.length > 0 ? Number((totalClosingCartons / daysInWeek.length).toFixed(2)) : 0
 
-     let sixPlusCost = 0
-     if (palletDaysSixPlus > 0) {
-      storageRateSixPlus = await getStorageRate(warehouseCode, weekEndingDate, 'SIX_PLUS')
-      if (!storageRateSixPlus) {
-       throw new Error('Missing storage rate for 6+ month tier')
+  const hasMovement =
+    openingBalance !== 0 || weeklyReceive !== 0 || weeklyShip !== 0 || weeklyAdjust !== 0
+
+  if (!hasMovement) {
+    return null
+  }
+
+  const existing = await prisma.storageLedger.findUnique({
+    where: {
+      warehouseCode_skuCode_lotRef_weekEndingDate: {
+        warehouseCode,
+        skuCode,
+        lotRef,
+        weekEndingDate,
+      },
+    },
+  })
+
+  let storageRateStandard: StorageRateResult | null = null
+  let storageRateSixPlus: StorageRateResult | null = null
+  let ratePerPalletDay: number | null = null
+  let rateEffectiveDate: Date | null = null
+  let costRateId: string | null = null
+  let isCostCalculated = false
+  let totalCost: number | null = null
+  let rateStandardPerPalletDay: number | null = null
+  let rateSixPlusPerPalletDay: number | null = null
+  let rateStandardEffectiveDate: string | null = null
+  let rateSixPlusEffectiveDate: string | null = null
+
+  if (cartonsPerPallet && cartonsPerPallet > 0) {
+    if (
+      billingConfig?.storageBillingModel === 'WEEKLY_PALLET' &&
+      billingConfig.weeklyPalletRate != null
+    ) {
+      // V Global-style weekly pallet billing: charge per pallet per week if stock present > graceDays
+      const daysWithStock = dailyRows.filter(d => d.closingCartons > 0).length
+      const graceDays = billingConfig.graceDays ?? 2
+
+      if (daysWithStock > graceDays && closingPallets > 0) {
+        totalCost = Number((closingPallets * billingConfig.weeklyPalletRate).toFixed(2))
+      } else {
+        totalCost = 0
       }
-      sixPlusCost = await calculateStorageCost(palletDaysSixPlus, storageRateSixPlus.ratePerPalletDay)
-     }
+      ratePerPalletDay = billingConfig.weeklyPalletRate
+      isCostCalculated = true
+    } else
+      try {
+        if (existing?.isCostCalculated) {
+          const existingRate =
+            existing.storageRatePerPalletDay != null
+              ? Number(existing.storageRatePerPalletDay)
+              : null
+          const existingTotal =
+            existing.totalStorageCost != null ? Number(existing.totalStorageCost) : null
+          const snapshot = isRecord(existing.dailyBalanceData) ? existing.dailyBalanceData : null
+          const snapshotStandardRate = snapshot
+            ? asNumber(snapshot['rateStandardPerPalletDay'])
+            : null
+          const snapshotSixPlusRate = snapshot
+            ? asNumber(snapshot['rateSixPlusPerPalletDay'])
+            : null
+          const snapshotStandardEffective = snapshot
+            ? asIsoDateString(snapshot['rateStandardEffectiveDate'])
+            : null
+          const snapshotSixPlusEffective = snapshot
+            ? asIsoDateString(snapshot['rateSixPlusEffectiveDate'])
+            : null
 
-     totalCost = Number((standardCost + sixPlusCost).toFixed(2))
-     isCostCalculated = true
+          rateStandardPerPalletDay = snapshotStandardRate ?? existingRate
+          rateSixPlusPerPalletDay = snapshotSixPlusRate ?? rateStandardPerPalletDay
+          rateStandardEffectiveDate =
+            snapshotStandardEffective ??
+            (existing.rateEffectiveDate ? existing.rateEffectiveDate.toISOString() : null)
+          rateSixPlusEffectiveDate = snapshotSixPlusEffective
 
-     // FMC-style arrival-week override: half-week or full-week flat rate
-     if (
-      billingConfig?.storageBillingModel === 'WEEKLY_ARRIVAL_CUTOFF' &&
-      openingBalance === 0 &&
-      weeklyReceive > 0 &&
-      closingPallets > 0 &&
-      billingConfig.halfWeekRate != null &&
-      billingConfig.fullWeekRate != null
-     ) {
-      // Find earliest receive in this week to check delivery hour
-      const earliestReceive = weeklyTransactions.find(
-       (t) => t.transactionType === TransactionType.RECEIVE && Number(t.cartonsIn || 0) > 0
-      )
-      if (earliestReceive) {
-       const deliveryHour = new Date(earliestReceive.transactionDate).getHours()
-       const weeklyRate =
-        deliveryHour < billingConfig.cutoffHour!
-         ? billingConfig.halfWeekRate
-         : billingConfig.fullWeekRate
-       totalCost = Number((closingPallets * weeklyRate).toFixed(2))
+          const canComputeStandard = palletDaysStandard === 0 || rateStandardPerPalletDay != null
+          const canComputeSixPlus = palletDaysSixPlus === 0 || rateSixPlusPerPalletDay != null
+
+          if (
+            canComputeStandard &&
+            canComputeSixPlus &&
+            palletDaysStandard + palletDaysSixPlus > 0
+          ) {
+            const standardCost = await calculateStorageCost(
+              palletDaysStandard,
+              rateStandardPerPalletDay ?? 0
+            )
+            const sixPlusCost = await calculateStorageCost(
+              palletDaysSixPlus,
+              rateSixPlusPerPalletDay ?? 0
+            )
+            totalCost = Number((standardCost + sixPlusCost).toFixed(2))
+            isCostCalculated = true
+
+            // FMC-style arrival-week override (cached-rate path)
+            if (
+              billingConfig?.storageBillingModel === 'WEEKLY_ARRIVAL_CUTOFF' &&
+              openingBalance === 0 &&
+              weeklyReceive > 0 &&
+              closingPallets > 0 &&
+              billingConfig.halfWeekRate != null &&
+              billingConfig.fullWeekRate != null
+            ) {
+              const earliestReceive = weeklyTransactions.find(
+                t => t.transactionType === TransactionType.RECEIVE && Number(t.cartonsIn || 0) > 0
+              )
+              if (earliestReceive) {
+                const deliveryHour = new Date(earliestReceive.transactionDate).getHours()
+                const weeklyRate =
+                  deliveryHour < billingConfig.cutoffHour!
+                    ? billingConfig.halfWeekRate
+                    : billingConfig.fullWeekRate
+                totalCost = Number((closingPallets * weeklyRate).toFixed(2))
+              }
+            }
+          } else {
+            totalCost = existingTotal
+            isCostCalculated = true
+          }
+
+          costRateId = existing.costRateId ?? null
+          rateEffectiveDate = existing.rateEffectiveDate ?? null
+
+          if (palletDays > 0 && totalCost != null) {
+            if (palletDaysSixPlus === 0 && rateStandardPerPalletDay != null) {
+              ratePerPalletDay = rateStandardPerPalletDay
+            } else if (palletDaysStandard === 0 && rateSixPlusPerPalletDay != null) {
+              ratePerPalletDay = rateSixPlusPerPalletDay
+            } else {
+              ratePerPalletDay = Number((totalCost / palletDays).toFixed(4))
+            }
+          } else {
+            ratePerPalletDay = existingRate
+          }
+        } else {
+          storageRateStandard = await getStorageRate(warehouseCode, weekEndingDate, 'STANDARD')
+          if (storageRateStandard) {
+            const standardCost = await calculateStorageCost(
+              palletDaysStandard,
+              storageRateStandard.ratePerPalletDay
+            )
+
+            let sixPlusCost = 0
+            if (palletDaysSixPlus > 0) {
+              storageRateSixPlus = await getStorageRate(warehouseCode, weekEndingDate, 'SIX_PLUS')
+              if (!storageRateSixPlus) {
+                throw new Error('Missing storage rate for 6+ month tier')
+              }
+              sixPlusCost = await calculateStorageCost(
+                palletDaysSixPlus,
+                storageRateSixPlus.ratePerPalletDay
+              )
+            }
+
+            totalCost = Number((standardCost + sixPlusCost).toFixed(2))
+            isCostCalculated = true
+
+            // FMC-style arrival-week override: half-week or full-week flat rate
+            if (
+              billingConfig?.storageBillingModel === 'WEEKLY_ARRIVAL_CUTOFF' &&
+              openingBalance === 0 &&
+              weeklyReceive > 0 &&
+              closingPallets > 0 &&
+              billingConfig.halfWeekRate != null &&
+              billingConfig.fullWeekRate != null
+            ) {
+              // Find earliest receive in this week to check delivery hour
+              const earliestReceive = weeklyTransactions.find(
+                t => t.transactionType === TransactionType.RECEIVE && Number(t.cartonsIn || 0) > 0
+              )
+              if (earliestReceive) {
+                const deliveryHour = new Date(earliestReceive.transactionDate).getHours()
+                const weeklyRate =
+                  deliveryHour < billingConfig.cutoffHour!
+                    ? billingConfig.halfWeekRate
+                    : billingConfig.fullWeekRate
+                totalCost = Number((closingPallets * weeklyRate).toFixed(2))
+              }
+            }
+
+            rateStandardPerPalletDay = storageRateStandard.ratePerPalletDay
+            rateStandardEffectiveDate = storageRateStandard.effectiveDate.toISOString()
+
+            if (storageRateSixPlus) {
+              rateSixPlusPerPalletDay = storageRateSixPlus.ratePerPalletDay
+              rateSixPlusEffectiveDate = storageRateSixPlus.effectiveDate.toISOString()
+            }
+
+            if (palletDaysSixPlus === 0) {
+              ratePerPalletDay = storageRateStandard.ratePerPalletDay
+              rateEffectiveDate = storageRateStandard.effectiveDate
+              costRateId = storageRateStandard.costRateId ?? null
+            } else if (palletDaysStandard === 0 && storageRateSixPlus) {
+              ratePerPalletDay = storageRateSixPlus.ratePerPalletDay
+              rateEffectiveDate = storageRateSixPlus.effectiveDate
+              costRateId = storageRateSixPlus.costRateId ?? null
+            } else if (palletDays > 0) {
+              // Mixed-tier week: store a blended rate and keep the detailed split in dailyBalanceData.
+              ratePerPalletDay = Number((totalCost / palletDays).toFixed(4))
+              rateEffectiveDate = null
+              costRateId = null
+            } else {
+              ratePerPalletDay = storageRateStandard.ratePerPalletDay
+              rateEffectiveDate = storageRateStandard.effectiveDate
+              costRateId = storageRateStandard.costRateId ?? null
+            }
+          }
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error'
+        console.warn(`Storage rate lookup failed for ${warehouseCode}:`, message)
+        isCostCalculated = false
       }
-     }
+  }
 
-     rateStandardPerPalletDay = storageRateStandard.ratePerPalletDay
-     rateStandardEffectiveDate = storageRateStandard.effectiveDate.toISOString()
+  const daysWithStock = dailyRows.filter(d => d.closingCartons > 0).length
 
-     if (storageRateSixPlus) {
-      rateSixPlusPerPalletDay = storageRateSixPlus.ratePerPalletDay
-      rateSixPlusEffectiveDate = storageRateSixPlus.effectiveDate.toISOString()
-     }
+  const dailyBalanceData = {
+    methodology: 'tactical_storage_pallet_day_v2',
+    cartonsPerPallet,
+    billingModel: billingConfig?.storageBillingModel ?? 'DAILY',
+    weekNumber,
+    sixPlusStartDate: sixPlusStartDate ? sixPlusStartDate.toISOString() : null,
+    palletDaysStandard,
+    palletDaysSixPlus,
+    rateStandardPerPalletDay: rateStandardPerPalletDay ?? null,
+    rateSixPlusPerPalletDay: rateSixPlusPerPalletDay ?? null,
+    rateStandardEffectiveDate: rateStandardEffectiveDate ?? null,
+    rateSixPlusEffectiveDate: rateSixPlusEffectiveDate ?? null,
+    ...(billingConfig?.storageBillingModel === 'WEEKLY_PALLET' && {
+      weeklyPalletRate: billingConfig.weeklyPalletRate ?? null,
+      graceDays: billingConfig.graceDays ?? 2,
+      daysWithStock,
+    }),
+    days: dailyRows,
+  }
 
-     if (palletDaysSixPlus === 0) {
-      ratePerPalletDay = storageRateStandard.ratePerPalletDay
-      rateEffectiveDate = storageRateStandard.effectiveDate
-      costRateId = storageRateStandard.costRateId ?? null
-     } else if (palletDaysStandard === 0 && storageRateSixPlus) {
-      ratePerPalletDay = storageRateSixPlus.ratePerPalletDay
-      rateEffectiveDate = storageRateSixPlus.effectiveDate
-      costRateId = storageRateSixPlus.costRateId ?? null
-     } else if (palletDays > 0) {
-      // Mixed-tier week: store a blended rate and keep the detailed split in dailyBalanceData.
-      ratePerPalletDay = Number((totalCost / palletDays).toFixed(4))
-      rateEffectiveDate = null
-      costRateId = null
-     } else {
-      ratePerPalletDay = storageRateStandard.ratePerPalletDay
-      rateEffectiveDate = storageRateStandard.effectiveDate
-      costRateId = storageRateStandard.costRateId ?? null
-     }
-    }
-   }
- } catch (error) {
- const message = error instanceof Error ? error.message : 'Unknown error'
- console.warn(`Storage rate lookup failed for ${warehouseCode}:`, message)
- isCostCalculated = false
- }
- }
+  if (existing) {
+    const updated = await prisma.storageLedger.update({
+      where: { id: existing.id },
+      data: {
+        warehouseName,
+        skuDescription,
+        openingBalance,
+        weeklyReceive,
+        weeklyShip,
+        weeklyAdjust,
+        closingBalance: normalizedClosingBalance,
+        averageBalance,
+        dailyBalanceData,
+        closingPallets,
+        palletDays,
+        storageRatePerPalletDay: ratePerPalletDay,
+        totalStorageCost: totalCost,
+        rateEffectiveDate,
+        costRateId,
+        isCostCalculated,
+      },
+    })
 
- const daysWithStock = dailyRows.filter((d) => d.closingCartons > 0).length
+    await upsertFinancialLedgerEntryForStorage(prisma, updated)
+    return updated
+  }
 
- const dailyBalanceData = {
-  methodology: 'tactical_storage_pallet_day_v2',
-  cartonsPerPallet,
-  billingModel: billingConfig?.storageBillingModel ?? 'DAILY',
-  weekNumber,
-  sixPlusStartDate: sixPlusStartDate ? sixPlusStartDate.toISOString() : null,
-  palletDaysStandard,
-  palletDaysSixPlus,
-  rateStandardPerPalletDay: rateStandardPerPalletDay ?? null,
-  rateSixPlusPerPalletDay: rateSixPlusPerPalletDay ?? null,
-  rateStandardEffectiveDate: rateStandardEffectiveDate ?? null,
-  rateSixPlusEffectiveDate: rateSixPlusEffectiveDate ?? null,
-  ...(billingConfig?.storageBillingModel === 'WEEKLY_PALLET' && {
-   weeklyPalletRate: billingConfig.weeklyPalletRate ?? null,
-   graceDays: billingConfig.graceDays ?? 2,
-   daysWithStock,
-  }),
-  days: dailyRows,
- }
+  const created = await prisma.storageLedger.create({
+    data: {
+      storageLedgerId: randomUUID(),
+      warehouseCode,
+      warehouseName,
+      skuCode,
+      skuDescription,
+      lotRef,
+      weekEndingDate,
+      openingBalance,
+      weeklyReceive,
+      weeklyShip,
+      weeklyAdjust,
+      closingBalance: normalizedClosingBalance,
+      averageBalance,
+      dailyBalanceData,
+      closingPallets,
+      palletDays,
+      storageRatePerPalletDay: ratePerPalletDay,
+      totalStorageCost: totalCost,
+      rateEffectiveDate,
+      costRateId,
+      isCostCalculated,
+      createdByName: 'System',
+    },
+  })
 
- if (existing) {
- const updated = await prisma.storageLedger.update({
-  where: { id: existing.id },
-  data: {
-   warehouseName,
-   skuDescription,
-   openingBalance,
-   weeklyReceive,
-   weeklyShip,
-   weeklyAdjust,
-   closingBalance: normalizedClosingBalance,
-   averageBalance,
-   dailyBalanceData,
-   closingPallets,
-   palletDays,
-   storageRatePerPalletDay: ratePerPalletDay,
-   totalStorageCost: totalCost,
-   rateEffectiveDate,
-   costRateId,
-   isCostCalculated,
-  },
- })
-
- await upsertFinancialLedgerEntryForStorage(prisma, updated)
- return updated
- }
-
- const created = await prisma.storageLedger.create({
-  data: {
-   storageLedgerId: randomUUID(),
-   warehouseCode,
-   warehouseName,
-   skuCode,
-   skuDescription,
-   lotRef,
-   weekEndingDate,
-   openingBalance,
-   weeklyReceive,
-   weeklyShip,
-   weeklyAdjust,
-   closingBalance: normalizedClosingBalance,
-   averageBalance,
-   dailyBalanceData,
-   closingPallets,
-   palletDays,
-   storageRatePerPalletDay: ratePerPalletDay,
-   totalStorageCost: totalCost,
-   rateEffectiveDate,
-   costRateId,
-   isCostCalculated,
-   createdByName: 'System',
-  },
- })
-
- await upsertFinancialLedgerEntryForStorage(prisma, created)
- return created
+  await upsertFinancialLedgerEntryForStorage(prisma, created)
+  return created
 }
 
 async function upsertFinancialLedgerEntryForStorage(
- prisma: Prisma.TransactionClient,
- entry: {
-  id: string
-  storageLedgerId: string
-  warehouseCode: string
-  warehouseName: string
-  skuCode: string
-  skuDescription: string
-  lotRef: string
-  weekEndingDate: Date
-  palletDays: number
-  closingPallets: number
-  storageRatePerPalletDay: unknown
-  totalStorageCost: unknown
-  isCostCalculated: boolean
-  dailyBalanceData: unknown
-  createdAt: Date
-  createdByName: string
- }
+  prisma: Prisma.TransactionClient,
+  entry: {
+    id: string
+    storageLedgerId: string
+    warehouseCode: string
+    warehouseName: string
+    skuCode: string
+    skuDescription: string
+    lotRef: string
+    weekEndingDate: Date
+    palletDays: number
+    closingPallets: number
+    storageRatePerPalletDay: unknown
+    totalStorageCost: unknown
+    isCostCalculated: boolean
+    dailyBalanceData: unknown
+    createdAt: Date
+    createdByName: string
+  }
 ) {
- const total = entry.totalStorageCost != null ? Number(entry.totalStorageCost) : null
- if (!entry.isCostCalculated || total === null || !Number.isFinite(total)) {
-  await prisma.financialLedgerEntry.deleteMany({
-   where: {
-    sourceType: FinancialLedgerSourceType.STORAGE_LEDGER,
-    sourceId: entry.storageLedgerId,
-   },
+  const total = entry.totalStorageCost != null ? Number(entry.totalStorageCost) : null
+  if (!entry.isCostCalculated || total === null || !Number.isFinite(total)) {
+    await prisma.financialLedgerEntry.deleteMany({
+      where: {
+        sourceType: FinancialLedgerSourceType.STORAGE_LEDGER,
+        sourceId: entry.storageLedgerId,
+      },
+    })
+    return
+  }
+
+  const unitRateRaw =
+    entry.storageRatePerPalletDay != null ? Number(entry.storageRatePerPalletDay) : null
+  const unitRate = unitRateRaw !== null && Number.isFinite(unitRateRaw) ? unitRateRaw : null
+
+  // Derive week number from dailyBalanceData for the cost name label
+  const snapshot = isRecord(entry.dailyBalanceData) ? entry.dailyBalanceData : null
+  const wn = snapshot ? asNumber(snapshot['weekNumber']) : null
+  const isWeeklyPallet = snapshot?.['billingModel'] === 'WEEKLY_PALLET'
+  const costName = wn != null && wn > 0 ? `Storage (Week ${wn})` : 'Storage'
+  // For weekly pallet model, quantity = closing pallets; otherwise pallet-days
+  const quantity = isWeeklyPallet ? entry.closingPallets : entry.palletDays
+
+  await prisma.financialLedgerEntry.upsert({
+    where: {
+      sourceType_sourceId: {
+        sourceType: FinancialLedgerSourceType.STORAGE_LEDGER,
+        sourceId: entry.storageLedgerId,
+      },
+    },
+    create: {
+      id: entry.id,
+      sourceType: FinancialLedgerSourceType.STORAGE_LEDGER,
+      sourceId: entry.storageLedgerId,
+      category: FinancialLedgerCategory.Storage,
+      costName,
+      quantity: new Prisma.Decimal(quantity.toString()),
+      unitRate: unitRate !== null ? new Prisma.Decimal(unitRate.toFixed(4)) : null,
+      amount: new Prisma.Decimal(total.toFixed(2)),
+      warehouseCode: entry.warehouseCode,
+      warehouseName: entry.warehouseName,
+      skuCode: entry.skuCode,
+      skuDescription: entry.skuDescription,
+      lotRef: entry.lotRef,
+      storageLedgerId: entry.id,
+      effectiveAt: entry.weekEndingDate,
+      createdAt: entry.createdAt,
+      createdByName: entry.createdByName,
+    },
+    update: {
+      category: FinancialLedgerCategory.Storage,
+      costName,
+      quantity: new Prisma.Decimal(quantity.toString()),
+      unitRate: unitRate !== null ? new Prisma.Decimal(unitRate.toFixed(4)) : null,
+      amount: new Prisma.Decimal(total.toFixed(2)),
+      warehouseCode: entry.warehouseCode,
+      warehouseName: entry.warehouseName,
+      skuCode: entry.skuCode,
+      skuDescription: entry.skuDescription,
+      lotRef: entry.lotRef,
+      storageLedgerId: entry.id,
+      effectiveAt: entry.weekEndingDate,
+      createdByName: entry.createdByName,
+    },
   })
-  return
- }
-
- const unitRateRaw = entry.storageRatePerPalletDay != null ? Number(entry.storageRatePerPalletDay) : null
- const unitRate = unitRateRaw !== null && Number.isFinite(unitRateRaw) ? unitRateRaw : null
-
- // Derive week number from dailyBalanceData for the cost name label
- const snapshot = isRecord(entry.dailyBalanceData) ? entry.dailyBalanceData : null
- const wn = snapshot ? asNumber(snapshot['weekNumber']) : null
- const isWeeklyPallet = snapshot?.['billingModel'] === 'WEEKLY_PALLET'
- const costName = wn != null && wn > 0 ? `Storage (Week ${wn})` : 'Storage'
- // For weekly pallet model, quantity = closing pallets; otherwise pallet-days
- const quantity = isWeeklyPallet ? entry.closingPallets : entry.palletDays
-
- await prisma.financialLedgerEntry.upsert({
-  where: {
-   sourceType_sourceId: {
-    sourceType: FinancialLedgerSourceType.STORAGE_LEDGER,
-    sourceId: entry.storageLedgerId,
-   },
-  },
-  create: {
-   id: entry.id,
-   sourceType: FinancialLedgerSourceType.STORAGE_LEDGER,
-   sourceId: entry.storageLedgerId,
-   category: FinancialLedgerCategory.Storage,
-   costName,
-   quantity: new Prisma.Decimal(quantity.toString()),
-   unitRate: unitRate !== null ? new Prisma.Decimal(unitRate.toFixed(4)) : null,
-   amount: new Prisma.Decimal(total.toFixed(2)),
-   warehouseCode: entry.warehouseCode,
-   warehouseName: entry.warehouseName,
-   skuCode: entry.skuCode,
-   skuDescription: entry.skuDescription,
-   lotRef: entry.lotRef,
-   storageLedgerId: entry.id,
-   effectiveAt: entry.weekEndingDate,
-   createdAt: entry.createdAt,
-   createdByName: entry.createdByName,
-  },
-  update: {
-   category: FinancialLedgerCategory.Storage,
-   costName,
-   quantity: new Prisma.Decimal(quantity.toString()),
-   unitRate: unitRate !== null ? new Prisma.Decimal(unitRate.toFixed(4)) : null,
-   amount: new Prisma.Decimal(total.toFixed(2)),
-   warehouseCode: entry.warehouseCode,
-   warehouseName: entry.warehouseName,
-   skuCode: entry.skuCode,
-   skuDescription: entry.skuDescription,
-   lotRef: entry.lotRef,
-   storageLedgerId: entry.id,
-   effectiveAt: entry.weekEndingDate,
-   createdByName: entry.createdByName,
-  },
- })
 }
 
 /**
@@ -608,77 +647,77 @@ async function upsertFinancialLedgerEntryForStorage(
  * This is run as a weekly scheduled process to catch any missed entries
  */
 export async function ensureWeeklyStorageEntries(date: Date = new Date()) {
- const prisma = await getTenantPrisma()
- const weekEndingDate = endOfWeek(date, { weekStartsOn: 1 })
+  const prisma = await getTenantPrisma()
+  const weekEndingDate = endOfWeek(date, { weekStartsOn: 1 })
 
- // Get all lots with positive inventory balances
- const aggregates = await prisma.inventoryTransaction.groupBy({
-  by: ['warehouseCode', 'warehouseName', 'skuCode', 'skuDescription', 'lotRef'],
-  _sum: { cartonsIn: true, cartonsOut: true },
-  where: {
-  transactionDate: { lte: date },
-  },
+  // Get all lots with positive inventory balances
+  const aggregates = await prisma.inventoryTransaction.groupBy({
+    by: ['warehouseCode', 'warehouseName', 'skuCode', 'skuDescription', 'lotRef'],
+    _sum: { cartonsIn: true, cartonsOut: true },
+    where: {
+      transactionDate: { lte: date },
+    },
   })
 
- let processed = 0
- let costCalculated = 0
- let skipped = 0
- const errors: string[] = []
+  let processed = 0
+  let costCalculated = 0
+  let skipped = 0
+  const errors: string[] = []
 
- for (const agg of aggregates) {
- try {
- const netCartons = Number(agg._sum.cartonsIn ?? 0) - Number(agg._sum.cartonsOut ?? 0)
- if (netCartons <= 0) {
-  skipped++
-  continue
- }
+  for (const agg of aggregates) {
+    try {
+      const netCartons = Number(agg._sum.cartonsIn ?? 0) - Number(agg._sum.cartonsOut ?? 0)
+      if (netCartons <= 0) {
+        skipped++
+        continue
+      }
 
- // Check if entry already exists
- const exists = await prisma.storageLedger.findUnique({
- where: {
- warehouseCode_skuCode_lotRef_weekEndingDate: {
- warehouseCode: agg.warehouseCode,
- skuCode: agg.skuCode,
- lotRef: agg.lotRef,
- weekEndingDate
- }
- }
- })
+      // Check if entry already exists
+      const exists = await prisma.storageLedger.findUnique({
+        where: {
+          warehouseCode_skuCode_lotRef_weekEndingDate: {
+            warehouseCode: agg.warehouseCode,
+            skuCode: agg.skuCode,
+            lotRef: agg.lotRef,
+            weekEndingDate,
+          },
+        },
+      })
 
- if (!exists) {
- const result = await recordStorageCostEntry({
- warehouseCode: agg.warehouseCode,
- warehouseName: agg.warehouseName,
- skuCode: agg.skuCode,
- skuDescription: agg.skuDescription,
- lotRef: agg.lotRef,
- transactionDate: date,
- })
+      if (!exists) {
+        const result = await recordStorageCostEntry({
+          warehouseCode: agg.warehouseCode,
+          warehouseName: agg.warehouseName,
+          skuCode: agg.skuCode,
+          skuDescription: agg.skuDescription,
+          lotRef: agg.lotRef,
+          transactionDate: date,
+        })
 
- if (result) {
- processed++
- if (result.isCostCalculated) {
- costCalculated++
- }
- } else {
- skipped++
- }
- }
- } catch (error) {
- const message = error instanceof Error ? error.message : 'Unknown error'
- const errorMsg = `${agg.warehouseCode}/${agg.skuCode}/${agg.lotRef}: ${message}`
- errors.push(errorMsg)
- console.error('Storage entry creation failed:', errorMsg)
- }
- }
+        if (result) {
+          processed++
+          if (result.isCostCalculated) {
+            costCalculated++
+          }
+        } else {
+          skipped++
+        }
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      const errorMsg = `${agg.warehouseCode}/${agg.skuCode}/${agg.lotRef}: ${message}`
+      errors.push(errorMsg)
+      console.error('Storage entry creation failed:', errorMsg)
+    }
+  }
 
- return { 
- processed, 
- costCalculated, 
- skipped, 
- errors,
- weekEndingDate: weekEndingDate.toISOString()
- }
+  return {
+    processed,
+    costCalculated,
+    skipped,
+    errors,
+    weekEndingDate: weekEndingDate.toISOString(),
+  }
 }
 
 /**
@@ -686,63 +725,63 @@ export async function ensureWeeklyStorageEntries(date: Date = new Date()) {
  * This can be run after storage rates are updated
  */
 export async function recalculateStorageCosts(
- weekEndingDate?: Date,
- warehouseCode?: string
+  weekEndingDate?: Date,
+  warehouseCode?: string
 ): Promise<{
- recalculated: number
- errors: string[]
+  recalculated: number
+  errors: string[]
 }> {
- const prisma = await getTenantPrisma()
- const where: Prisma.StorageLedgerWhereInput = {
- isCostCalculated: false,
- }
- 
- if (weekEndingDate) {
- where.weekEndingDate = weekEndingDate
- }
- 
- if (warehouseCode) {
- where.warehouseCode = warehouseCode
- }
+  const prisma = await getTenantPrisma()
+  const where: Prisma.StorageLedgerWhereInput = {
+    isCostCalculated: false,
+  }
 
- // Get all entries without costs
- const entriesWithoutCosts = await prisma.storageLedger.findMany({
- where,
- select: {
- id: true,
- warehouseCode: true,
- warehouseName: true,
- skuCode: true,
- skuDescription: true,
- lotRef: true,
- weekEndingDate: true
- }
- })
+  if (weekEndingDate) {
+    where.weekEndingDate = weekEndingDate
+  }
 
- let recalculated = 0
- const errors: string[] = []
+  if (warehouseCode) {
+    where.warehouseCode = warehouseCode
+  }
 
- for (const entry of entriesWithoutCosts) {
- try {
- const result = await recordStorageCostEntry({
- warehouseCode: entry.warehouseCode,
- warehouseName: entry.warehouseName,
- skuCode: entry.skuCode,
- skuDescription: entry.skuDescription,
- lotRef: entry.lotRef,
- transactionDate: entry.weekEndingDate,
- })
+  // Get all entries without costs
+  const entriesWithoutCosts = await prisma.storageLedger.findMany({
+    where,
+    select: {
+      id: true,
+      warehouseCode: true,
+      warehouseName: true,
+      skuCode: true,
+      skuDescription: true,
+      lotRef: true,
+      weekEndingDate: true,
+    },
+  })
 
- if (result?.isCostCalculated) {
- recalculated++
- }
- } catch (error) {
- const message = error instanceof Error ? error.message : 'Unknown error'
- errors.push(`Entry ${entry.id}: ${message}`)
- }
- }
+  let recalculated = 0
+  const errors: string[] = []
 
- return { recalculated, errors }
+  for (const entry of entriesWithoutCosts) {
+    try {
+      const result = await recordStorageCostEntry({
+        warehouseCode: entry.warehouseCode,
+        warehouseName: entry.warehouseName,
+        skuCode: entry.skuCode,
+        skuDescription: entry.skuDescription,
+        lotRef: entry.lotRef,
+        transactionDate: entry.weekEndingDate,
+      })
+
+      if (result?.isCostCalculated) {
+        recalculated++
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      errors.push(`Entry ${entry.id}: ${message}`)
+    }
+  }
+
+  return { recalculated, errors }
 }
 
 /**
@@ -752,134 +791,243 @@ export async function recalculateStorageCosts(
  * weekly storage charges are recorded even when no inventory movement happens.
  */
 export async function backfillWeeklyStorageEntries(
- targetDate: Date = new Date(),
- warehouseCode?: string
+  targetDate: Date = new Date(),
+  warehouseCode?: string
 ): Promise<{
- created: number
- skipped: number
- errors: string[]
+  created: number
+  skipped: number
+  errors: string[]
 }> {
- const prisma = await getTenantPrisma()
- const targetWeekEnd = endOfWeek(targetDate, { weekStartsOn: 1 })
+  const prisma = await getTenantPrisma()
+  const targetWeekEnd = endOfWeek(targetDate, { weekStartsOn: 1 })
 
- // Find all distinct lot/warehouse combinations that have ever received inventory
- const lotsWithReceives = await prisma.inventoryTransaction.groupBy({
-  by: ['warehouseCode', 'warehouseName', 'skuCode', 'skuDescription', 'lotRef'],
-  _min: { transactionDate: true },
-  _sum: { cartonsIn: true, cartonsOut: true },
-  where: {
-   ...(warehouseCode ? { warehouseCode } : {}),
-  },
- })
+  // Find all distinct lot/warehouse combinations that have ever received inventory
+  const lotsWithReceives = await prisma.inventoryTransaction.groupBy({
+    by: ['warehouseCode', 'warehouseName', 'skuCode', 'skuDescription', 'lotRef'],
+    _min: { transactionDate: true },
+    _sum: { cartonsIn: true, cartonsOut: true },
+    where: {
+      ...(warehouseCode ? { warehouseCode } : {}),
+    },
+  })
 
- let created = 0
- let skipped = 0
- const errors: string[] = []
+  let created = 0
+  let skipped = 0
+  const errors: string[] = []
 
- for (const lot of lotsWithReceives) {
-  try {
-   const firstDate = lot._min.transactionDate
-   if (!firstDate) { skipped++; continue }
+  for (const lot of lotsWithReceives) {
+    try {
+      const firstDate = lot._min.transactionDate
+      if (!firstDate) {
+        skipped++
+        continue
+      }
 
-   const firstWeekEnd = endOfWeek(firstDate, { weekStartsOn: 1 })
+      const firstWeekEnd = endOfWeek(firstDate, { weekStartsOn: 1 })
 
-   // Walk through every week from first receive to target
-   let currentWeekEnd = firstWeekEnd
-   while (currentWeekEnd <= targetWeekEnd) {
-    // Check if entry already exists for this week
-    const exists = await prisma.storageLedger.findUnique({
-     where: {
-      warehouseCode_skuCode_lotRef_weekEndingDate: {
-       warehouseCode: lot.warehouseCode,
-       skuCode: lot.skuCode,
-       lotRef: lot.lotRef,
-       weekEndingDate: currentWeekEnd,
-      },
-     },
-     select: { id: true },
-    })
+      // Walk through every week from first receive to target
+      let currentWeekEnd = firstWeekEnd
+      while (currentWeekEnd <= targetWeekEnd) {
+        // Check if entry already exists for this week
+        const exists = await prisma.storageLedger.findUnique({
+          where: {
+            warehouseCode_skuCode_lotRef_weekEndingDate: {
+              warehouseCode: lot.warehouseCode,
+              skuCode: lot.skuCode,
+              lotRef: lot.lotRef,
+              weekEndingDate: currentWeekEnd,
+            },
+          },
+          select: { id: true },
+        })
 
-    if (!exists) {
-     // Check if lot had positive inventory at this point
-     const balanceAtWeek = await prisma.inventoryTransaction.aggregate({
-      _sum: { cartonsIn: true, cartonsOut: true },
-      where: {
-       warehouseCode: lot.warehouseCode,
-       skuCode: lot.skuCode,
-       lotRef: lot.lotRef,
-       transactionDate: { lte: currentWeekEnd },
-      },
-     })
-     const netCartons = Number(balanceAtWeek._sum.cartonsIn ?? 0) - Number(balanceAtWeek._sum.cartonsOut ?? 0)
+        if (!exists) {
+          // Check if lot had positive inventory at this point
+          const balanceAtWeek = await prisma.inventoryTransaction.aggregate({
+            _sum: { cartonsIn: true, cartonsOut: true },
+            where: {
+              warehouseCode: lot.warehouseCode,
+              skuCode: lot.skuCode,
+              lotRef: lot.lotRef,
+              transactionDate: { lte: currentWeekEnd },
+            },
+          })
+          const netCartons =
+            Number(balanceAtWeek._sum.cartonsIn ?? 0) - Number(balanceAtWeek._sum.cartonsOut ?? 0)
 
-     if (netCartons > 0) {
-      const result = await recordStorageCostEntry({
-       warehouseCode: lot.warehouseCode,
-       warehouseName: lot.warehouseName,
-       skuCode: lot.skuCode,
-       skuDescription: lot.skuDescription,
-       lotRef: lot.lotRef,
-       transactionDate: currentWeekEnd,
-      })
-      if (result) created++
-      else skipped++
-     } else {
-      skipped++
-     }
-    } else {
-     skipped++
+          if (netCartons > 0) {
+            const result = await recordStorageCostEntry({
+              warehouseCode: lot.warehouseCode,
+              warehouseName: lot.warehouseName,
+              skuCode: lot.skuCode,
+              skuDescription: lot.skuDescription,
+              lotRef: lot.lotRef,
+              transactionDate: currentWeekEnd,
+            })
+            if (result) created++
+            else skipped++
+          } else {
+            skipped++
+          }
+        } else {
+          skipped++
+        }
+
+        currentWeekEnd = addWeeks(currentWeekEnd, 1)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      errors.push(`${lot.warehouseCode}/${lot.skuCode}/${lot.lotRef}: ${message}`)
     }
-
-    currentWeekEnd = addWeeks(currentWeekEnd, 1)
-   }
-  } catch (error) {
-   const message = error instanceof Error ? error.message : 'Unknown error'
-   errors.push(`${lot.warehouseCode}/${lot.skuCode}/${lot.lotRef}: ${message}`)
   }
- }
 
- return { created, skipped, errors }
+  return { created, skipped, errors }
+}
+
+export async function materializeStorageLedgerEntriesForRange(
+  startDate: Date,
+  endDate: Date,
+  warehouseCode?: string
+): Promise<{
+  created: number
+  existing: number
+  skipped: number
+  errors: string[]
+}> {
+  const prisma = await getTenantPrisma()
+  const startWeekEnd = endOfWeek(startDate, { weekStartsOn: 1 })
+  const targetWeekEnd = endOfWeek(endDate, { weekStartsOn: 1 })
+
+  const transactionWhere: Prisma.InventoryTransactionWhereInput = {
+    transactionType: TransactionType.RECEIVE,
+    transactionDate: { lte: targetWeekEnd },
+  }
+  if (warehouseCode) {
+    transactionWhere.warehouseCode = warehouseCode
+  }
+
+  const lotsWithReceives = await prisma.inventoryTransaction.groupBy({
+    by: ['warehouseCode', 'warehouseName', 'skuCode', 'skuDescription', 'lotRef'],
+    _min: { transactionDate: true },
+    where: transactionWhere,
+  })
+
+  let created = 0
+  let existing = 0
+  let skipped = 0
+  const errors: string[] = []
+
+  for (const lot of lotsWithReceives) {
+    try {
+      const firstReceiveDate = lot._min.transactionDate
+      if (!firstReceiveDate) {
+        skipped++
+        continue
+      }
+
+      const firstReceiveWeekEnd = endOfWeek(firstReceiveDate, { weekStartsOn: 1 })
+      let currentWeekEnd = firstReceiveWeekEnd > startWeekEnd ? firstReceiveWeekEnd : startWeekEnd
+
+      while (currentWeekEnd <= targetWeekEnd) {
+        const existingEntry = await prisma.storageLedger.findUnique({
+          where: {
+            warehouseCode_skuCode_lotRef_weekEndingDate: {
+              warehouseCode: lot.warehouseCode,
+              skuCode: lot.skuCode,
+              lotRef: lot.lotRef,
+              weekEndingDate: currentWeekEnd,
+            },
+          },
+          select: { id: true },
+        })
+
+        if (existingEntry) {
+          existing++
+          currentWeekEnd = addWeeks(currentWeekEnd, 1)
+          continue
+        }
+
+        const balanceAtWeek = await prisma.inventoryTransaction.aggregate({
+          _sum: { cartonsIn: true, cartonsOut: true },
+          where: {
+            warehouseCode: lot.warehouseCode,
+            skuCode: lot.skuCode,
+            lotRef: lot.lotRef,
+            transactionDate: { lte: currentWeekEnd },
+          },
+        })
+        const netCartons =
+          Number(balanceAtWeek._sum.cartonsIn ?? 0) - Number(balanceAtWeek._sum.cartonsOut ?? 0)
+
+        if (netCartons > 0) {
+          const result = await recordStorageCostEntry({
+            warehouseCode: lot.warehouseCode,
+            warehouseName: lot.warehouseName,
+            skuCode: lot.skuCode,
+            skuDescription: lot.skuDescription,
+            lotRef: lot.lotRef,
+            transactionDate: currentWeekEnd,
+          })
+          if (result) {
+            created++
+          } else {
+            skipped++
+          }
+        } else {
+          skipped++
+        }
+
+        currentWeekEnd = addWeeks(currentWeekEnd, 1)
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown error'
+      errors.push(`${lot.warehouseCode}/${lot.skuCode}/${lot.lotRef}: ${message}`)
+    }
+  }
+
+  return { created, existing, skipped, errors }
 }
 
 /**
  * Get storage cost summary for a date range
  */
 export async function getStorageCostSummary(
- startDate: Date,
- endDate: Date,
- warehouseCode?: string
+  startDate: Date,
+  endDate: Date,
+  warehouseCode?: string
 ) {
- const prisma = await getTenantPrisma()
- const where: Prisma.StorageLedgerWhereInput = {
- weekEndingDate: {
- gte: startDate,
- lte: endDate
- }
- }
- 
- if (warehouseCode) {
- where.warehouseCode = warehouseCode
- }
+  const prisma = await getTenantPrisma()
+  const where: Prisma.StorageLedgerWhereInput = {
+    weekEndingDate: {
+      gte: startDate,
+      lte: endDate,
+    },
+  }
 
- const summary = await prisma.storageLedger.aggregate({
- _count: {
- id: true,
- totalStorageCost: true
- },
- _sum: {
- palletDays: true,
- totalStorageCost: true
- },
- where
- })
+  if (warehouseCode) {
+    where.warehouseCode = warehouseCode
+  }
 
- return {
- totalEntries: summary._count.id || 0,
- entriesWithCosts: summary._count.totalStorageCost || 0,
- totalPalletDays: Number(summary._sum.palletDays || 0),
- totalStorageCost: Number(summary._sum.totalStorageCost || 0),
- costCalculationRate: summary._count.id > 0 
- ? ((summary._count.totalStorageCost || 0) / summary._count.id * 100).toFixed(1)
- : '0'
- }
+  const summary = await prisma.storageLedger.aggregate({
+    _count: {
+      id: true,
+      totalStorageCost: true,
+    },
+    _sum: {
+      palletDays: true,
+      totalStorageCost: true,
+    },
+    where,
+  })
+
+  return {
+    totalEntries: summary._count.id || 0,
+    entriesWithCosts: summary._count.totalStorageCost || 0,
+    totalPalletDays: Number(summary._sum.palletDays || 0),
+    totalStorageCost: Number(summary._sum.totalStorageCost || 0),
+    costCalculationRate:
+      summary._count.id > 0
+        ? (((summary._count.totalStorageCost || 0) / summary._count.id) * 100).toFixed(1)
+        : '0',
+  }
 }


### PR DESCRIPTION
## Summary
- adds real transaction list/detail behavior and cargo-line visibility for Talos operations routes
- fixes storage-ledger materialization, tenant currency display, warehouse-rate currency labels, breadcrumb/action accessible names, outbound copy, and Amazon virtual warehouse pallet totals
- expands SKU descriptions to 255 chars with Prisma migration and repair script so truncated product names are not persisted or displayed

## Validation
- pnpm --filter @targon/talos test
- pnpm --filter @targon/talos type-check
- pnpm --filter @targon/talos lint (0 errors, 6 existing warnings)
- Chrome Codex extension verification on live /talos UI for US and UK routes, including dashboard, inventory, transactions, transaction detail, storage ledger, warehouse rates, outbound, and SKU Info

## Notes
- Unrelated local change left out of this PR: packages/auth/dist/index.js
