### PR TITLE
fix(argus): publish WPR output through Drive sync

### DIFF
--- a/apps/argus/scripts/lib/artifacts.mjs
+++ b/apps/argus/scripts/lib/artifacts.mjs
@@ -4,6 +4,7 @@ import path from 'node:path'
 export const DRIVE_SYNC_QUEUE_RELATIVE_PATH = '.drive-sync/queue.jsonl'
 export const WPR_DRIVE_SYNC_QUEUE_RELATIVE_PATH = '.drive-sync/wpr-queue.jsonl'
 export const WPR_CANONICAL_WEEK_FOLDER_RE = /^W\d{2}$/
+export const WPR_WORKSPACE_OUTPUT_PREFIX = 'wpr-workspace/output/'
 export const WPR_NONCANONICAL_NAME_RE = / \(\d+\)(?=\.|$)|__(?:backup|wpr_recovery|legacy|dup\d+)\b/i
 
 export function parseArgusMarket(raw) {
@@ -67,6 +68,18 @@ export function normalizeArtifactRelativePath(relativePath) {
   return normalized.split(path.sep).join('/')
 }
 
+export function isPublishableWprRelativePath(relativePath) {
+  const normalizedRelativePath = normalizeArtifactRelativePath(relativePath)
+  const [firstSegment] = normalizedRelativePath.split('/')
+  if (WPR_CANONICAL_WEEK_FOLDER_RE.test(firstSegment)) {
+    return true
+  }
+  if (normalizedRelativePath.startsWith(WPR_WORKSPACE_OUTPUT_PREFIX)) {
+    return true
+  }
+  return false
+}
+
 export function localPathForArtifact({ market, relativePath }) {
   return path.join(monitoringRootForMarket(market), normalizeArtifactRelativePath(relativePath))
 }
@@ -122,9 +135,8 @@ export function enqueueWprDriveSync({ market, localPath }) {
   if (relativePath === WPR_DRIVE_SYNC_QUEUE_RELATIVE_PATH) {
     return null
   }
-  const [weekFolder] = relativePath.split('/')
-  if (!WPR_CANONICAL_WEEK_FOLDER_RE.test(weekFolder)) {
-    throw new Error(`WPR Drive sync path must start with a canonical WNN week folder: ${relativePath}`)
+  if (!isPublishableWprRelativePath(relativePath)) {
+    throw new Error(`WPR Drive sync path must start with a canonical WNN week folder or ${WPR_WORKSPACE_OUTPUT_PREFIX}: ${relativePath}`)
   }
   const badSegment = relativePath.split('/').find((segment) => WPR_NONCANONICAL_NAME_RE.test(segment))
   if (badSegment !== undefined) {

--- a/apps/argus/scripts/lib/artifacts.test.mjs
+++ b/apps/argus/scripts/lib/artifacts.test.mjs
@@ -9,12 +9,10 @@ const moduleUrl = new URL(`./artifacts.mjs?test=${Date.now()}`, import.meta.url)
 test('Argus artifacts write to local monitoring roots and enqueue Drive sync', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-artifacts-'))
   const previousRoot = process.env.ARGUS_MONITORING_ROOT_US
-  const previousSalesRoot = process.env.ARGUS_SALES_ROOT_US
   const previousWprDataDir = process.env.WPR_DATA_DIR_US
 
   process.env.ARGUS_MONITORING_ROOT_US = path.join(tempRoot, 'monitoring-us')
   process.env.WPR_DATA_DIR_US = path.join(tempRoot, 'wpr-us', 'WPR', 'wpr-workspace', 'output')
-  delete process.env.ARGUS_SALES_ROOT_US
 
   try {
     const { appendRunLog, enqueueWprDriveSync, monitoringRootForMarket, wprRootForMarket, writeTextArtifact } = await import(moduleUrl.href)
@@ -66,9 +64,22 @@ test('Argus artifacts write to local monitoring roots and enqueue Drive sync', a
     const workspaceArtifactPath = path.join(wprRoot, 'wpr-workspace', 'output', 'wpr-data-latest.json')
     fs.mkdirSync(path.dirname(workspaceArtifactPath), { recursive: true })
     fs.writeFileSync(workspaceArtifactPath, '{}\n', 'utf8')
+    enqueueWprDriveSync({ market: 'us', localPath: workspaceArtifactPath })
+    const wprQueuedAfterWorkspace = fs.readFileSync(wprQueuePath, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
+    assert.deepEqual(
+      wprQueuedAfterWorkspace.map((entry) => entry.relativePath),
+      [
+        'W01/input/source.csv',
+        'wpr-workspace/output/wpr-data-latest.json',
+      ],
+    )
+
+    const workspaceInputArtifactPath = path.join(wprRoot, 'wpr-workspace', 'input', 'source.csv')
+    fs.mkdirSync(path.dirname(workspaceInputArtifactPath), { recursive: true })
+    fs.writeFileSync(workspaceInputArtifactPath, 'wpr\n', 'utf8')
     assert.throws(
-      () => enqueueWprDriveSync({ market: 'us', localPath: workspaceArtifactPath }),
-      /WPR Drive sync path must start with a canonical WNN week folder: wpr-workspace\/output\/wpr-data-latest\.json/,
+      () => enqueueWprDriveSync({ market: 'us', localPath: workspaceInputArtifactPath }),
+      /WPR Drive sync path must start with a canonical WNN week folder or wpr-workspace\/output\/: wpr-workspace\/input\/source\.csv/,
     )
 
     const duplicateNamedArtifactPath = path.join(wprRoot, 'W01', 'input', 'source (1).csv')
@@ -82,11 +93,6 @@ test('Argus artifacts write to local monitoring roots and enqueue Drive sync', a
       delete process.env.ARGUS_MONITORING_ROOT_US
     } else {
       process.env.ARGUS_MONITORING_ROOT_US = previousRoot
-    }
-    if (previousSalesRoot === undefined) {
-      delete process.env.ARGUS_SALES_ROOT_US
-    } else {
-      process.env.ARGUS_SALES_ROOT_US = previousSalesRoot
     }
     if (previousWprDataDir === undefined) {
       delete process.env.WPR_DATA_DIR_US

--- a/apps/argus/scripts/lib/drive-sync.mjs
+++ b/apps/argus/scripts/lib/drive-sync.mjs
@@ -2,15 +2,18 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { execFileSync } from 'node:child_process'
+import { execFileSync, spawnSync } from 'node:child_process'
 import {
+  WPR_NONCANONICAL_NAME_RE,
   driveSyncQueuePath,
+  isPublishableWprRelativePath,
   marketEnvSuffix,
   monitoringRootForMarket,
   normalizeArtifactRelativePath,
   parseArgusMarket,
   requireEnv,
   wprDriveSyncQueuePath,
+  wprRootForMarket,
 } from './artifacts.mjs'
 
 const DRIVE_SCOPE = 'https://www.googleapis.com/auth/drive'
@@ -18,7 +21,11 @@ const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
 const RESUMABLE_UPLOAD_THRESHOLD_BYTES = 1024 * 1024
 const DRIVE_SYNC_PUBLISHED_RELATIVE_PATH = '.drive-sync/published.json'
 const WPR_DRIVE_SYNC_PUBLISHED_RELATIVE_PATH = '.drive-sync/wpr-published.json'
+const DRIVE_SYNC_REJECTED_RELATIVE_PATH = '.drive-sync/rejected.jsonl'
+const WPR_DRIVE_SYNC_REJECTED_RELATIVE_PATH = '.drive-sync/wpr-rejected.jsonl'
 const DRIVE_SYNC_SCOPES = new Set(['monitoring', 'wpr'])
+const WPR_WORKSPACE_LOCK_FILE = '/tmp/argus-wpr-workspace.lock'
+const WPR_DRIVE_SYNC_LOCK_ENV = 'ARGUS_WPR_DRIVE_SYNC_LOCKED'
 
 function driveApiUrl(pathname, params = {}) {
   const url = new URL(pathname, 'https://www.googleapis.com')
@@ -166,6 +173,34 @@ async function createFolder({ token, parentId, name }) {
   })
 }
 
+async function listChildren({ token, parentId }) {
+  const files = []
+  let pageToken = null
+  do {
+    const params = {
+      q: [
+        `'${escapeDriveQueryValue(parentId)}' in parents`,
+        'trashed = false',
+      ].join(' and '),
+      fields: 'nextPageToken,files(id,name,mimeType,modifiedTime)',
+      supportsAllDrives: 'true',
+      includeItemsFromAllDrives: 'true',
+      pageSize: '1000',
+    }
+    if (pageToken !== null) {
+      params.pageToken = pageToken
+    }
+    const data = await driveJsonRequest({
+      method: 'GET',
+      url: driveApiUrl('/drive/v3/files', params),
+      token,
+    })
+    files.push(...(Array.isArray(data.files) ? data.files : []))
+    pageToken = typeof data.nextPageToken === 'string' ? data.nextPageToken : null
+  } while (pageToken !== null)
+  return files
+}
+
 async function ensureFolderPath({ token, rootFolderId, folderSegments }) {
   let parentId = rootFolderId
   for (const name of folderSegments) {
@@ -178,6 +213,67 @@ async function ensureFolderPath({ token, rootFolderId, folderSegments }) {
     parentId = created.id
   }
   return parentId
+}
+
+async function trashDriveFile({ token, fileId }) {
+  return driveJsonRequest({
+    method: 'PATCH',
+    url: driveApiUrl(`/drive/v3/files/${encodeURIComponent(fileId)}`, {
+      fields: 'id,name,trashed',
+      supportsAllDrives: 'true',
+    }),
+    token,
+    body: { trashed: true },
+  })
+}
+
+export async function pruneRemoteWprTree({ token, market }) {
+  const localRoot = wprRootForMarket(market)
+  const rootFolderId = driveRootFolderIdForMarket(market, 'wpr')
+
+  async function pruneFolder(parentId, relativeSegments) {
+    const children = [...await listChildren({ token, parentId })].sort((left, right) => {
+      const leftKey = `${left.name}\0${left.mimeType}`
+      const rightKey = `${right.name}\0${right.mimeType}`
+      if (leftKey !== rightKey) {
+        return leftKey.localeCompare(rightKey)
+      }
+      return String(right.modifiedTime ?? '').localeCompare(String(left.modifiedTime ?? ''))
+    })
+    const seenRemoteChildren = new Set()
+    for (const child of children) {
+      const remoteChildKey = `${child.name}\0${child.mimeType}`
+      if (seenRemoteChildren.has(remoteChildKey)) {
+        await trashDriveFile({ token, fileId: child.id })
+        continue
+      }
+      seenRemoteChildren.add(remoteChildKey)
+
+      const relativePath = path.join(...relativeSegments, child.name)
+      const localPath = path.join(localRoot, relativePath)
+      const isRemoteFolder = child.mimeType === FOLDER_MIME_TYPE
+      if (!fs.existsSync(localPath)) {
+        await trashDriveFile({ token, fileId: child.id })
+        continue
+      }
+
+      const localStat = fs.statSync(localPath)
+      if (isRemoteFolder) {
+        if (!localStat.isDirectory()) {
+          await trashDriveFile({ token, fileId: child.id })
+          continue
+        }
+        await pruneFolder(child.id, [...relativeSegments, child.name])
+        continue
+      }
+
+      if (!localStat.isFile()) {
+        await trashDriveFile({ token, fileId: child.id })
+      }
+    }
+  }
+
+  await pruneFolder(rootFolderId, [])
 }
 
 async function createEmptyFile({ token, parentId, fileName, contentType }) {
@@ -297,6 +393,14 @@ function queuePathForScope(market, scope) {
     return wprDriveSyncQueuePath(market)
   }
   return driveSyncQueuePath(market)
+}
+
+function rejectedQueuePathForScope(market, scope) {
+  const parsedScope = parseDriveSyncScope(scope)
+  const relativePath = parsedScope === 'wpr'
+    ? WPR_DRIVE_SYNC_REJECTED_RELATIVE_PATH
+    : DRIVE_SYNC_REJECTED_RELATIVE_PATH
+  return path.join(monitoringRootForMarket(market), relativePath)
 }
 
 function readQueueEntries(market, scope) {
@@ -448,6 +552,7 @@ function recordPublishedArtifact({ market, scope, entry, result }) {
 }
 
 function entryMatchesPublishedArtifact({ market, scope, entry }) {
+  if (parseDriveSyncScope(scope) === 'wpr') return false
   const state = readPublishedState(market, scope)
   const item = state.items?.[entry.relativePath]
   if (item === undefined) return false
@@ -465,6 +570,74 @@ function compactEntries(entries) {
     byRelativePath.set(entry.relativePath, entry)
   }
   return [...byRelativePath.values()]
+}
+
+function rejectReasonForQueueEntry(entry, scope) {
+  let normalizedRelativePath
+  try {
+    normalizedRelativePath = normalizeArtifactRelativePath(entry.relativePath)
+  } catch (error) {
+    if (error instanceof Error) {
+      return error.message
+    }
+    return String(error)
+  }
+
+  if (scope === 'wpr') {
+    if (!isPublishableWprRelativePath(normalizedRelativePath)) {
+      return `noncanonical WPR Drive sync path: ${normalizedRelativePath}`
+    }
+    const badSegment = normalizedRelativePath.split('/').find((segment) => WPR_NONCANONICAL_NAME_RE.test(segment))
+    if (badSegment !== undefined) {
+      return `noncanonical WPR Drive sync artifact name: ${badSegment}`
+    }
+  }
+
+  let stat
+  try {
+    stat = fs.statSync(entry.localPath)
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return `missing local file: ${entry.localPath}`
+    }
+    throw error
+  }
+
+  if (!stat.isFile()) {
+    return `local path is not a file: ${entry.localPath}`
+  }
+  return null
+}
+
+function partitionQueueEntries(entries, scope) {
+  const valid = []
+  const rejected = []
+  for (const entry of entries) {
+    const reason = rejectReasonForQueueEntry(entry, scope)
+    if (reason === null) {
+      valid.push(entry)
+      continue
+    }
+    rejected.push({ entry, reason })
+  }
+  return { valid, rejected }
+}
+
+function recordRejectedQueueEntries({ market, scope, rejected }) {
+  if (rejected.length === 0) {
+    return
+  }
+  const rejectedPath = rejectedQueuePathForScope(market, scope)
+  fs.mkdirSync(path.dirname(rejectedPath), { recursive: true })
+  const rejectedAt = new Date().toISOString()
+  const lines = rejected.map(({ entry, reason }) => JSON.stringify({
+    rejectedAt,
+    market,
+    scope,
+    reason,
+    entry,
+  }))
+  fs.appendFileSync(rejectedPath, `${lines.join('\n')}\n`, 'utf8')
 }
 
 function parseCliArgs(argv) {
@@ -499,6 +672,45 @@ function parseCliArgs(argv) {
   return args
 }
 
+function driveSyncScopeNeedsWprLock(scope) {
+  return scope === 'all' || parseDriveSyncScope(scope) === 'wpr'
+}
+
+function rerunCliUnderWprWorkspaceLock(args) {
+  if (!driveSyncScopeNeedsWprLock(args.scope)) {
+    return false
+  }
+  if (process.env[WPR_DRIVE_SYNC_LOCK_ENV] === '1') {
+    return false
+  }
+
+  const result = spawnSync(
+    '/usr/bin/lockf',
+    [
+      WPR_WORKSPACE_LOCK_FILE,
+      process.execPath,
+      process.argv[1],
+      ...process.argv.slice(2),
+    ],
+    {
+      env: { ...process.env, [WPR_DRIVE_SYNC_LOCK_ENV]: '1' },
+      stdio: 'inherit',
+    },
+  )
+
+  if (result.error !== undefined) {
+    throw result.error
+  }
+  if (result.signal !== null) {
+    throw new Error(`Drive sync lock wrapper terminated by signal: ${result.signal}`)
+  }
+  if (result.status === null) {
+    throw new Error('Drive sync lock wrapper exited without a status.')
+  }
+
+  process.exit(result.status)
+}
+
 export async function drainDriveSyncQueue({ market, dryRun }) {
   return drainScopedDriveSyncQueue({ market, dryRun, scope: 'monitoring' })
 }
@@ -508,15 +720,18 @@ export async function drainScopedDriveSyncQueue({ market, dryRun, scope }) {
   const queue = dryRun ? readQueueEntries(market, parsedScope) : claimQueueEntries(market, parsedScope)
   const { queuePath, processingPath, entries } = queue
   const compacted = compactEntries(entries)
+  const partitioned = partitionQueueEntries(compacted, parsedScope)
   if (dryRun) {
-    return compacted.map((entry) => {
+    return partitioned.valid.map((entry) => {
       const stat = fs.statSync(entry.localPath)
       return buildDriveSyncPlan({ market, relativePath: entry.relativePath, size: stat.size, scope: parsedScope })
     })
   }
+  recordRejectedQueueEntries({ market, scope: parsedScope, rejected: partitioned.rejected })
 
-  const pending = compacted.filter((entry) => !entryMatchesPublishedArtifact({ market, scope: parsedScope, entry }))
-  const token = pending.length === 0 ? null : accessToken()
+  const pending = partitioned.valid.filter((entry) => !entryMatchesPublishedArtifact({ market, scope: parsedScope, entry }))
+  const shouldPruneWpr = parsedScope === 'wpr' && compacted.length > 0
+  const token = pending.length === 0 && !shouldPruneWpr ? null : accessToken()
   const failed = []
   for (const entry of pending) {
     try {
@@ -537,7 +752,11 @@ export async function drainScopedDriveSyncQueue({ market, dryRun, scope }) {
   if (processingPath !== null) {
     fs.rmSync(processingPath, { force: true })
   }
+
   if (failed.length === 0) {
+    if (shouldPruneWpr) {
+      await pruneRemoteWprTree({ token, market })
+    }
     return []
   }
 
@@ -564,6 +783,7 @@ export async function drainAllDriveSyncQueues({ market, dryRun }) {
 
 async function main() {
   const args = parseCliArgs(process.argv.slice(2))
+  rerunCliUnderWprWorkspaceLock(args)
   monitoringRootForMarket(args.market)
   const result = args.scope === 'all'
     ? await drainAllDriveSyncQueues(args)

--- a/apps/argus/scripts/lib/drive-sync.test.mjs
+++ b/apps/argus/scripts/lib/drive-sync.test.mjs
@@ -358,3 +358,313 @@ test('Drive sync leaves active processing queues owned by a running process', as
     }
   }
 })
+
+test('WPR Drive sync does not touch Drive when the queue is empty', async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-drive-sync-wpr-empty-'))
+  const wprRoot = path.join(tempRoot, 'WPR')
+  const previousEnv = {
+    ARGUS_MONITORING_ROOT_US: process.env.ARGUS_MONITORING_ROOT_US,
+    ARGUS_DRIVE_WPR_FOLDER_ID_US: process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US,
+    WPR_DATA_DIR_US: process.env.WPR_DATA_DIR_US,
+    ARGUS_DRIVE_PROFILE: process.env.ARGUS_DRIVE_PROFILE,
+    GWORKSPACE_API_BIN: process.env.GWORKSPACE_API_BIN,
+    GWORKSPACE_API_PYTHON: process.env.GWORKSPACE_API_PYTHON,
+  }
+
+  process.env.ARGUS_MONITORING_ROOT_US = tempRoot
+  process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US = 'wpr-root-us'
+  process.env.WPR_DATA_DIR_US = path.join(wprRoot, 'wpr-workspace', 'output')
+  process.env.ARGUS_DRIVE_PROFILE = 'targon'
+  process.env.GWORKSPACE_API_BIN = 'gworkspace-api'
+  process.env.GWORKSPACE_API_PYTHON = '/usr/bin/false'
+
+  t.mock.method(globalThis, 'fetch', async () => {
+    assert.fail('Empty WPR queues must not call Drive API')
+  })
+
+  try {
+    const { drainScopedDriveSyncQueue } = await import(moduleUrl.href)
+    await drainScopedDriveSyncQueue({ market: 'us', dryRun: false, scope: 'wpr' })
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+})
+
+test('WPR Drive sync quarantines stale and noncanonical queue entries before publishing', async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-drive-sync-wpr-reject-'))
+  const wprRoot = path.join(tempRoot, 'WPR')
+  const previousEnv = {
+    ARGUS_MONITORING_ROOT_US: process.env.ARGUS_MONITORING_ROOT_US,
+    ARGUS_DRIVE_WPR_FOLDER_ID_US: process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US,
+    WPR_DATA_DIR_US: process.env.WPR_DATA_DIR_US,
+    ARGUS_DRIVE_PROFILE: process.env.ARGUS_DRIVE_PROFILE,
+    GWORKSPACE_API_BIN: process.env.GWORKSPACE_API_BIN,
+    GWORKSPACE_API_PYTHON: process.env.GWORKSPACE_API_PYTHON,
+  }
+
+  process.env.ARGUS_MONITORING_ROOT_US = tempRoot
+  process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US = 'wpr-root-us'
+  process.env.WPR_DATA_DIR_US = path.join(wprRoot, 'wpr-workspace', 'output')
+  process.env.ARGUS_DRIVE_PROFILE = 'targon'
+  process.env.GWORKSPACE_API_BIN = 'gworkspace-api'
+  process.env.GWORKSPACE_API_PYTHON = '/bin/echo'
+
+  const queuePath = path.join(tempRoot, '.drive-sync', 'wpr-queue.jsonl')
+  const staleLocalPath = path.join(tempRoot, 'missing.csv')
+  const invalidLocalPath = path.join(tempRoot, 'legacy.csv')
+  fs.mkdirSync(path.dirname(queuePath), { recursive: true })
+  fs.writeFileSync(invalidLocalPath, 'legacy\n', 'utf8')
+
+  const staleEntry = {
+    enqueuedAt: '2026-05-05T17:00:00.000Z',
+    market: 'us',
+    localPath: staleLocalPath,
+    relativePath: 'W16/input/source.csv',
+    size: 12,
+    mtimeMs: 1,
+  }
+  const invalidEntry = {
+    enqueuedAt: '2026-05-05T17:00:00.000Z',
+    market: 'us',
+    localPath: invalidLocalPath,
+    relativePath: 'Week 16 - 2026-04-12 (Sun)/input/source.csv',
+    size: fs.statSync(invalidLocalPath).size,
+    mtimeMs: fs.statSync(invalidLocalPath).mtimeMs,
+  }
+  fs.writeFileSync(queuePath, `${JSON.stringify(staleEntry)}\n${JSON.stringify(invalidEntry)}\n`, 'utf8')
+
+  t.mock.method(globalThis, 'fetch', async (url, options = {}) => {
+    const requestUrl = new URL(String(url))
+    assert.equal(options.method, 'GET')
+    assert.equal(requestUrl.pathname, '/drive/v3/files')
+    return new Response(JSON.stringify({ files: [] }), { status: 200 })
+  })
+
+  try {
+    const { drainScopedDriveSyncQueue } = await import(moduleUrl.href)
+    await drainScopedDriveSyncQueue({ market: 'us', dryRun: false, scope: 'wpr' })
+
+    assert.equal(fs.existsSync(queuePath), false)
+    const rejectedPath = path.join(tempRoot, '.drive-sync', 'wpr-rejected.jsonl')
+    const rejectedEntries = fs.readFileSync(rejectedPath, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
+    assert.equal(rejectedEntries.length, 2)
+    assert.match(rejectedEntries[0].reason, /missing local file/)
+    assert.match(rejectedEntries[1].reason, /noncanonical WPR Drive sync path/)
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+})
+
+test('WPR Drive sync prunes remote files missing from the local WPR tree', async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-drive-sync-wpr-prune-'))
+  const wprRoot = path.join(tempRoot, 'WPR')
+  const previousEnv = {
+    ARGUS_DRIVE_WPR_FOLDER_ID_US: process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US,
+    WPR_DATA_DIR_US: process.env.WPR_DATA_DIR_US,
+  }
+
+  process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US = 'wpr-root-us'
+  process.env.WPR_DATA_DIR_US = path.join(wprRoot, 'wpr-workspace', 'output')
+
+  const localFile = path.join(wprRoot, 'W01', 'input', 'source.csv')
+  fs.mkdirSync(path.dirname(localFile), { recursive: true })
+  fs.writeFileSync(localFile, 'source\n', 'utf8')
+  fs.mkdirSync(path.join(wprRoot, 'wpr-workspace', 'output'), { recursive: true })
+
+  const trashedIds = []
+  t.mock.method(globalThis, 'fetch', async (url, options = {}) => {
+    const requestUrl = new URL(String(url))
+    if (options.method === 'GET') {
+      const query = requestUrl.searchParams.get('q') ?? ''
+      if (query.includes("'wpr-root-us' in parents")) {
+        return new Response(JSON.stringify({
+          files: [
+            {
+              id: 'remote-w01-old',
+              name: 'W01',
+              mimeType: 'application/vnd.google-apps.folder',
+              modifiedTime: '2026-05-05T17:00:00.000Z',
+            },
+            {
+              id: 'remote-w01',
+              name: 'W01',
+              mimeType: 'application/vnd.google-apps.folder',
+              modifiedTime: '2026-05-05T18:00:00.000Z',
+            },
+            { id: 'remote-w41', name: 'W41', mimeType: 'application/vnd.google-apps.folder' },
+            { id: 'remote-snapshot', name: 'Listings-Snapshot-History.csv', mimeType: 'text/csv' },
+          ],
+        }), { status: 200 })
+      }
+      if (query.includes("'remote-w01' in parents")) {
+        return new Response(JSON.stringify({
+          files: [
+            { id: 'remote-input', name: 'input', mimeType: 'application/vnd.google-apps.folder' },
+            { id: 'remote-stale-folder', name: 'Sellerboard (API)', mimeType: 'application/vnd.google-apps.folder' },
+          ],
+        }), { status: 200 })
+      }
+      if (query.includes("'remote-input' in parents")) {
+        return new Response(JSON.stringify({
+          files: [
+            { id: 'remote-source', name: 'source.csv', mimeType: 'text/csv' },
+            { id: 'remote-stale-source', name: 'Listings-Snapshot-History.csv', mimeType: 'text/csv' },
+          ],
+        }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ files: [] }), { status: 200 })
+    }
+    if (options.method === 'PATCH' && requestUrl.pathname.startsWith('/drive/v3/files/')) {
+      const body = JSON.parse(options.body)
+      assert.equal(body.trashed, true)
+      trashedIds.push(decodeURIComponent(requestUrl.pathname.split('/').at(-1)))
+      return new Response(JSON.stringify({ id: trashedIds.at(-1), trashed: true }), { status: 200 })
+    }
+    assert.fail(`Unexpected Drive API request: ${options.method} ${requestUrl.pathname}`)
+  })
+
+  try {
+    const { pruneRemoteWprTree } = await import(moduleUrl.href)
+    await pruneRemoteWprTree({ token: 'token', market: 'us' })
+
+    assert.deepEqual(
+      trashedIds.sort(),
+      ['remote-snapshot', 'remote-stale-folder', 'remote-stale-source', 'remote-w01-old', 'remote-w41'].sort(),
+    )
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+})
+
+test('WPR Drive sync republishes queued entries even when the ledger says published', async (t) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-drive-sync-wpr-republish-'))
+  const wprRoot = path.join(tempRoot, 'WPR')
+  const previousEnv = {
+    ARGUS_MONITORING_ROOT_US: process.env.ARGUS_MONITORING_ROOT_US,
+    ARGUS_DRIVE_WPR_FOLDER_ID_US: process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US,
+    WPR_DATA_DIR_US: process.env.WPR_DATA_DIR_US,
+    ARGUS_DRIVE_PROFILE: process.env.ARGUS_DRIVE_PROFILE,
+    GWORKSPACE_API_BIN: process.env.GWORKSPACE_API_BIN,
+    GWORKSPACE_API_PYTHON: process.env.GWORKSPACE_API_PYTHON,
+  }
+
+  process.env.ARGUS_MONITORING_ROOT_US = tempRoot
+  process.env.ARGUS_DRIVE_WPR_FOLDER_ID_US = 'wpr-root-us'
+  process.env.WPR_DATA_DIR_US = path.join(wprRoot, 'wpr-workspace', 'output')
+  process.env.ARGUS_DRIVE_PROFILE = 'targon'
+  process.env.GWORKSPACE_API_BIN = 'gworkspace-api'
+  process.env.GWORKSPACE_API_PYTHON = '/bin/echo'
+
+  const relativePath = 'W01/input/source.csv'
+  const localPath = path.join(wprRoot, relativePath)
+  const queuePath = path.join(tempRoot, '.drive-sync', 'wpr-queue.jsonl')
+  const publishedPath = path.join(tempRoot, '.drive-sync', 'wpr-published.json')
+  fs.mkdirSync(path.dirname(localPath), { recursive: true })
+  fs.mkdirSync(path.dirname(queuePath), { recursive: true })
+  fs.mkdirSync(path.join(wprRoot, 'wpr-workspace', 'output'), { recursive: true })
+  fs.writeFileSync(localPath, 'source\n', 'utf8')
+
+  const stat = fs.statSync(localPath)
+  const entry = {
+    enqueuedAt: '2026-05-05T17:00:00.000Z',
+    market: 'us',
+    localPath,
+    relativePath,
+    size: stat.size,
+    mtimeMs: stat.mtimeMs,
+  }
+  fs.writeFileSync(queuePath, `${JSON.stringify(entry)}\n`, 'utf8')
+  fs.writeFileSync(publishedPath, `${JSON.stringify({
+    version: 1,
+    items: {
+      [relativePath]: {
+        ...entry,
+        fileId: 'remote-source',
+        driveModifiedTime: '2026-05-05T17:01:00.000Z',
+        publishedAt: '2026-05-05T17:01:01.000Z',
+      },
+    },
+  }, null, 2)}\n`, 'utf8')
+
+  let uploaded = false
+  t.mock.method(globalThis, 'fetch', async (url, options = {}) => {
+    const requestUrl = new URL(String(url))
+    if (options.method === 'GET') {
+      const query = requestUrl.searchParams.get('q') ?? ''
+      if (query.includes("'wpr-root-us' in parents") && query.includes("name = 'W01'")) {
+        return new Response(JSON.stringify({
+          files: [{ id: 'remote-w01', name: 'W01', mimeType: 'application/vnd.google-apps.folder' }],
+        }), { status: 200 })
+      }
+      if (query.includes("'remote-w01' in parents") && query.includes("name = 'input'")) {
+        return new Response(JSON.stringify({
+          files: [{ id: 'remote-input', name: 'input', mimeType: 'application/vnd.google-apps.folder' }],
+        }), { status: 200 })
+      }
+      if (query.includes("'remote-input' in parents") && query.includes("name = 'source.csv'")) {
+        return new Response(JSON.stringify({
+          files: [{ id: 'remote-source', name: 'source.csv', mimeType: 'text/csv' }],
+        }), { status: 200 })
+      }
+      if (query.includes("'wpr-root-us' in parents")) {
+        return new Response(JSON.stringify({
+          files: [{ id: 'remote-w01', name: 'W01', mimeType: 'application/vnd.google-apps.folder' }],
+        }), { status: 200 })
+      }
+      if (query.includes("'remote-w01' in parents")) {
+        return new Response(JSON.stringify({
+          files: [{ id: 'remote-input', name: 'input', mimeType: 'application/vnd.google-apps.folder' }],
+        }), { status: 200 })
+      }
+      if (query.includes("'remote-input' in parents")) {
+        return new Response(JSON.stringify({
+          files: [{ id: 'remote-source', name: 'source.csv', mimeType: 'text/csv' }],
+        }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ files: [] }), { status: 200 })
+    }
+    if (options.method === 'PATCH' && requestUrl.pathname.startsWith('/upload/drive/v3/files/')) {
+      uploaded = true
+      return new Response(JSON.stringify({
+        id: 'remote-source',
+        name: 'source.csv',
+        modifiedTime: '2026-05-05T17:02:00.000Z',
+      }), { status: 200 })
+    }
+    assert.fail(`Unexpected Drive API request: ${options.method} ${requestUrl.pathname}`)
+  })
+
+  try {
+    const { drainScopedDriveSyncQueue } = await import(moduleUrl.href)
+    await drainScopedDriveSyncQueue({ market: 'us', dryRun: false, scope: 'wpr' })
+
+    assert.equal(uploaded, true)
+    assert.equal(fs.existsSync(queuePath), false)
+  } finally {
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  }
+})

--- a/apps/argus/scripts/lib/enqueue-wpr-drive-sync.mjs
+++ b/apps/argus/scripts/lib/enqueue-wpr-drive-sync.mjs
@@ -2,7 +2,13 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
-import { WPR_CANONICAL_WEEK_FOLDER_RE, enqueueWprDriveSync, parseArgusMarket, wprRootForMarket } from './artifacts.mjs'
+import {
+  WPR_CANONICAL_WEEK_FOLDER_RE,
+  WPR_WORKSPACE_OUTPUT_PREFIX,
+  enqueueWprDriveSync,
+  parseArgusMarket,
+  wprRootForMarket,
+} from './artifacts.mjs'
 
 function parseCliArgs(argv) {
   const args = { market: null }
@@ -62,6 +68,10 @@ export function enqueueWprWeekTrees({ market, root }) {
       continue
     }
     count += enqueueTree({ market, root: path.join(root, entry.name) })
+  }
+  const outputRoot = path.join(root, WPR_WORKSPACE_OUTPUT_PREFIX)
+  if (fs.existsSync(outputRoot)) {
+    count += enqueueTree({ market, root: outputRoot })
   }
   return count
 }

--- a/apps/argus/scripts/lib/enqueue-wpr-drive-sync.test.mjs
+++ b/apps/argus/scripts/lib/enqueue-wpr-drive-sync.test.mjs
@@ -6,7 +6,7 @@ import test from 'node:test'
 
 const moduleUrl = new URL(`./enqueue-wpr-drive-sync.mjs?test=${Date.now()}`, import.meta.url)
 
-test('WPR Drive enqueue publishes canonical week folders only', async () => {
+test('WPR Drive enqueue publishes canonical week folders and workspace output', async () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'argus-wpr-enqueue-'))
   const monitoringRoot = path.join(tempRoot, 'monitoring-us')
   const wprRoot = path.join(tempRoot, 'wpr-us', 'WPR')
@@ -28,11 +28,14 @@ test('WPR Drive enqueue publishes canonical week folders only', async () => {
   try {
     const { enqueueWprWeekTrees } = await import(moduleUrl.href)
     const count = enqueueWprWeekTrees({ market: 'us', root: wprRoot })
-    assert.equal(count, 1)
+    assert.equal(count, 2)
 
     const queuePath = path.join(monitoringRoot, '.drive-sync', 'wpr-queue.jsonl')
     const queued = fs.readFileSync(queuePath, 'utf8').trim().split('\n').map((line) => JSON.parse(line))
-    assert.deepEqual(queued.map((entry) => entry.relativePath), ['W01/input/source.csv'])
+    assert.deepEqual(queued.map((entry) => entry.relativePath).sort(), [
+      'W01/input/source.csv',
+      'wpr-workspace/output/wpr-data-latest.json',
+    ])
   } finally {
     for (const [key, value] of Object.entries(previousEnv)) {
       if (value === undefined) {


### PR DESCRIPTION
## Summary
- Publishes WPR workspace output artifacts (`wpr-workspace/output/*`) through the WPR Drive sync queue.
- Keeps canonical WNN week folder publishing intact.
- Preserves rejection of stale missing files and noncanonical duplicate artifact names before Drive upload.

## Root Cause
The WPR workspace rebuild queued only canonical `WNN` week folders. The generated latest dashboard/output files under `wpr-workspace/output` were rebuilt locally but were not queued for Drive publishing, so remote Drive files could stay stale even with empty queues.

## Verification
- `pnpm --dir apps/argus exec node --test scripts/lib/enqueue-wpr-drive-sync.test.mjs scripts/lib/drive-sync.test.mjs scripts/lib/artifacts.test.mjs`
- Live Drive API verification after manual publish: US `wpr-data-latest.json` modified `2026-05-09T01:31:38Z`; UK `wpr-data-latest.json` modified `2026-05-09T01:36:14Z`.
- Launchd API-side logs verified fresh `ok` rows for weekly API sources and hourly listing attributes on `2026-05-09`.
