### PR TITLE
fix(argus): keep WPR payload weeks in API summary

### DIFF
--- a/apps/argus/lib/wpr/reader-market.test.ts
+++ b/apps/argus/lib/wpr/reader-market.test.ts
@@ -121,9 +121,8 @@ const weekStartDateByLabel: Record<string, string> = {
   W18: '2026-05-03',
 }
 
-function writePayload(dataDir: string, stableWeek: string, latestCompletedWeek: string) {
-  const currentWeek = 'W18'
-  const weeks = [stableWeek, latestCompletedWeek, currentWeek]
+function writePayload(dataDir: string, defaultWeek: string, comparisonWeek: string) {
+  const weeks = [defaultWeek, comparisonWeek]
   const windowsByWeek: Record<string, ReturnType<typeof buildWeekBundle>> = {}
   const weekStartDates: Record<string, string> = {}
   const changeLogByWeek: Record<string, unknown[]> = {}
@@ -132,17 +131,17 @@ function writePayload(dataDir: string, stableWeek: string, latestCompletedWeek: 
     weekStartDates[week] = weekStartDateByLabel[week]
     changeLogByWeek[week] = []
   }
-  const bundle = windowsByWeek[currentWeek]
+  const bundle = windowsByWeek[defaultWeek]
   writeFileSync(
     path.join(dataDir, 'wpr-data-latest.json'),
     JSON.stringify({
       ...bundle,
-      defaultWeek: currentWeek,
+      defaultWeek,
       weeks,
       weekStartDates,
       sourceOverview: {
         week_labels: weeks,
-        latest_week: currentWeek,
+        latest_week: defaultWeek,
         weeks_with_data: weeks.length,
         source_completeness: 'ok',
         critical_gaps: [],
@@ -173,20 +172,20 @@ test('getWprWeekSummary caches payloads by market and path', async () => {
   assert.equal(ukSummary.defaultWeek, 'W07')
 })
 
-test('createWprWeekSummary excludes current and newest completed weeks by default', () => {
+test('createWprWeekSummary returns the chart-ready weeks already selected by the payload builder', () => {
   const summary = createWprWeekSummary({
-    defaultWeek: 'W18',
-    weeks: ['W16', 'W17', 'W18'],
+    defaultWeek: 'W17',
+    weeks: ['W16', 'W17'],
     weekStartDates: {
       W16: '2026-04-12',
       W17: '2026-04-19',
-      W18: '2026-04-26',
     },
   }, new Date('2026-04-28T16:00:00.000Z'))
 
-  assert.equal(summary.defaultWeek, 'W16')
-  assert.deepEqual(summary.weeks, ['W16'])
+  assert.equal(summary.defaultWeek, 'W17')
+  assert.deepEqual(summary.weeks, ['W16', 'W17'])
   assert.deepEqual(summary.weekStartDates, {
     W16: '2026-04-12',
+    W17: '2026-04-19',
   })
 })

--- a/apps/argus/lib/wpr/reader.ts
+++ b/apps/argus/lib/wpr/reader.ts
@@ -21,9 +21,6 @@ type CacheState = {
 };
 
 const cacheByMarket = new Map<ArgusMarket, CacheState>();
-const DAY_MS = 24 * 60 * 60 * 1000;
-const WEEK_MS = 7 * DAY_MS;
-
 function resolveLatestJsonPath(market: ArgusMarket): string {
   return join(getArgusMarketConfig(market).wprDataDir, 'wpr-data-latest.json');
 }
@@ -62,19 +59,6 @@ export async function getWprWeekSummary(market: ArgusMarket = DEFAULT_ARGUS_MARK
   return createWprWeekSummary(payload);
 }
 
-function dateOnlyTime(date: Date): number {
-  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
-}
-
-function parseWeekStartDate(value: string, week: WeekLabel): number {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-  if (match === null) {
-    throw new Error(`Invalid WPR week start date for ${week}: ${value}`);
-  }
-
-  return Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3]));
-}
-
 function requireWeekStartDate(
   weekStartDates: Record<WeekLabel, string>,
   week: WeekLabel,
@@ -86,55 +70,22 @@ function requireWeekStartDate(
   return value;
 }
 
-function resolveCompletedWeeks(
-  weeks: WeekLabel[],
-  weekStartDates: Record<WeekLabel, string>,
-  today: Date,
-): WeekLabel[] {
-  const todayTime = dateOnlyTime(today);
-  const completedWeeks: WeekLabel[] = [];
-  for (const week of weeks) {
-    const startTime = parseWeekStartDate(requireWeekStartDate(weekStartDates, week), week);
-    const endTime = startTime + WEEK_MS;
-    if (endTime <= todayTime) {
-      completedWeeks.push(week);
-    }
-  }
-
-  return completedWeeks;
-}
-
-function resolveStableWeeks(
-  weeks: WeekLabel[],
-  weekStartDates: Record<WeekLabel, string>,
-  today: Date,
-): WeekLabel[] {
-  const completedWeeks = resolveCompletedWeeks(weeks, weekStartDates, today);
-  if (completedWeeks.length <= 1) {
-    throw new Error('No stable WPR chart weeks are available.');
-  }
-
-  return completedWeeks.slice(0, completedWeeks.length - 1);
-}
-
 export function createWprWeekSummary(
   payload: Pick<WprPayload, 'defaultWeek' | 'weeks' | 'weekStartDates'>,
-  today = new Date(),
+  _today = new Date(),
 ): WprWeekSummaryResponse {
-  const weeks = resolveStableWeeks(payload.weeks, payload.weekStartDates, today);
-  let defaultWeek = payload.defaultWeek;
-  if (!weeks.includes(defaultWeek)) {
-    defaultWeek = weeks[weeks.length - 1];
+  if (!payload.weeks.includes(payload.defaultWeek)) {
+    throw new Error(`WPR default week is not in the payload week list: ${payload.defaultWeek}`);
   }
 
   const weekStartDates: Record<WeekLabel, string> = {};
-  for (const week of weeks) {
+  for (const week of payload.weeks) {
     weekStartDates[week] = requireWeekStartDate(payload.weekStartDates, week);
   }
 
   return {
-    defaultWeek,
-    weeks,
+    defaultWeek: payload.defaultWeek,
+    weeks: payload.weeks,
     weekStartDates,
   };
 }


### PR DESCRIPTION
## Summary
- Remove duplicate week freshness trimming from the Argus WPR API summary reader.
- Treat the generated payload as the source of chart-ready weeks and default week.
- Add regression coverage so a payload default of W17 stays W17 instead of being downgraded to W16.

## Root cause
The WPR dashboard builder already removes the newest raw completed week before writing `wpr-data-latest.json`. The API reader applied the same trim again, so the UK payload defaulted to W17 but `/api/wpr/weeks?market=uk` returned W16.

## Verification
- `pnpm --dir apps/argus exec tsx lib/wpr/reader-market.test.ts`
- `pnpm --dir apps/argus exec tsx app/api/wpr/payload/route.test.ts app/api/wpr/changelog-week-route.test.ts`
- `pnpm --dir apps/argus run type-check`
- `pnpm --dir apps/argus run lint`
- `git diff --check -- apps/argus/lib/wpr/reader.ts apps/argus/lib/wpr/reader-market.test.ts`
- Direct route-handler proof for the local UK WPR payload returns `defaultWeek: W17`.
