### PR TITLE
fix(argus): harden runner failure states

### DIFF
--- a/apps/argus/lib/monitoring/reader.test.ts
+++ b/apps/argus/lib/monitoring/reader.test.ts
@@ -9,5 +9,6 @@ test('monitoring reader reports Argus runner tasks instead of legacy per-source 
   assert.match(source, /taskId: schedulerTaskId\(market, 'tracking-fetch'\)/)
   assert.match(source, /launchdLabel: ARGUS_RUNNER_LAUNCHD_LABEL/)
   assert.match(source, /readRunnerLedgerTask\(spec\.taskId\)/)
+  assert.match(source, /const HEALTHY_RUNNER_TASK_STATUSES = new Set<MonitoringSchedulerJob\['taskStatus'\]>\(\['succeeded'\]\)/)
   assert.doesNotMatch(source, /schedulerLaunchdLabel\(market, 'com\.targon\.weekly-api-sources'\)/)
 })

--- a/apps/argus/lib/monitoring/reader.ts
+++ b/apps/argus/lib/monitoring/reader.ts
@@ -92,7 +92,7 @@ const DAY_IN_MINUTES = 24 * HOUR_IN_MINUTES
 const ARGUS_RUNNER_LAUNCHD_LABEL = 'com.targon.argus.runner'
 const ARGUS_RUNNER_PLIST_PATH = path.join(HOME_DIR, `Library/LaunchAgents/${ARGUS_RUNNER_LAUNCHD_LABEL}.plist`)
 const FAILED_RUNNER_TASK_STATUSES = new Set<MonitoringSchedulerJob['taskStatus']>(['failed', 'blocked', 'stale'])
-const HEALTHY_RUNNER_TASK_STATUSES = new Set<MonitoringSchedulerJob['taskStatus']>(['succeeded', 'queued', 'waiting'])
+const HEALTHY_RUNNER_TASK_STATUSES = new Set<MonitoringSchedulerJob['taskStatus']>(['succeeded'])
 
 interface SchedulerSpec {
   id: string

--- a/apps/argus/scripts/runner/cli.mjs
+++ b/apps/argus/scripts/runner/cli.mjs
@@ -134,7 +134,16 @@ async function executeTask({ task, owner, ledgerPath }) {
   const startedAt = new Date()
   ledger = markTaskRunning(ledger, task.task_id, owner, startedAt)
   saveLedger(ledgerPath, ledger)
-  const result = await runTask(task, ARGUS_DIR, process.env)
+  let result
+  try {
+    result = await runTask(task, ARGUS_DIR, process.env)
+  } catch (error) {
+    result = {
+      status: 'failed',
+      lastError: error instanceof Error ? error.message : String(error),
+      metadata: { outcome: 'process-error' },
+    }
+  }
   ledger = loadLedger(ledgerPath)
   ledger = markTaskFinished(ledger, task.task_id, {
     ...result,

--- a/apps/argus/scripts/runner/cli.test.mjs
+++ b/apps/argus/scripts/runner/cli.test.mjs
@@ -36,3 +36,10 @@ test('runner tick persists the global lock before doing scheduled work', () => {
     /if \(!lock\.acquired\) \{[\s\S]*return\n  \}\n  saveLedger\(ledgerPath, ledger\)\n\n  try \{/,
   )
 })
+
+test('runner tick records a terminal task state when execution throws', () => {
+  assert.match(
+    cliSource,
+    /try \{\n    result = await runTask\(task, ARGUS_DIR, process\.env\)\n  \} catch \(error\) \{[\s\S]*status: 'failed'[\s\S]*outcome: 'process-error'/,
+  )
+})


### PR DESCRIPTION
## Summary
- records failed terminal state if runner task execution throws before normalization
- stops reporting queued/waiting tasks as healthy when launchd itself is failing

## Verification
- node --test apps/argus/scripts/runner/*.test.mjs apps/argus/scripts/api/install.test.mjs apps/argus/scripts/api/daily-account-health/collect.test.mjs apps/argus/scripts/api/weekly-sources/collect-spapi.test.mjs apps/argus/scripts/api/weekly-sources/run.test.mjs apps/argus/scripts/browser/weekly-market-config.test.mjs apps/argus/scripts/lib/drive-sync.test.mjs
- pnpm exec tsx --test apps/argus/lib/monitoring/reader.test.ts
- pnpm --filter argus type-check
- pnpm --filter argus lint
- pnpm --filter argus build
- git diff --check -- apps/argus