### PR TITLE
fix(argus): recover stale runner tasks

### DIFF
--- a/apps/argus/scripts/browser/run-weekly.sh
+++ b/apps/argus/scripts/browser/run-weekly.sh
@@ -136,6 +136,8 @@ if [ "$FAILED" -gt 0 ]; then
   RUN_SUMMARY="$FAILED of 4 weekly browser collectors failed: $FAILED_STEPS_CSV"
   RUN_ERROR_MESSAGE="Failed steps: $FAILED_STEPS_CSV"
   log "$RUN_ERROR_MESSAGE"
+  printf '%s\n' "$RUN_ERROR_MESSAGE" >&2
+  tail -120 "$LOG" >&2
 fi
 
 RUN_LOG_ARGS=(

--- a/apps/argus/scripts/browser/weekly-market-config.test.mjs
+++ b/apps/argus/scripts/browser/weekly-market-config.test.mjs
@@ -36,6 +36,11 @@ test('weekly browser runner passes market-specific detail logs into child collec
   assert.match(runWeekly, /ARGUS_BRAND_METRICS_LOG/)
 })
 
+test('weekly browser runner emits failure details for runner outcome classification', () => {
+  assert.match(runWeekly, /printf '%s\\n' "\$RUN_ERROR_MESSAGE" >&2/)
+  assert.match(runWeekly, /tail -120 "\$LOG" >&2/)
+})
+
 test('ScaleInsights reruns reuse an existing same-week XLSX', () => {
   assert.match(scaleInsights, /target_file="\$DEST\/\$\{PREFIX\}_SI-KeywordRanking\.xlsx"/)
   assert.match(scaleInsights, /target_meta_file="\$target_file\.meta\.json"/)

--- a/apps/argus/scripts/runner/task-store.mjs
+++ b/apps/argus/scripts/runner/task-store.mjs
@@ -7,6 +7,11 @@ const LEDGER_VERSION = 1
 const MARKETS = ['us', 'uk']
 const RUNNER_LOCK_TTL_MS = 20 * 60 * 1000
 const BROWSER_LANE_LOCK_TTL_MS = 4 * 60 * 60 * 1000
+const RUNNING_TASK_STALE_AFTER_MS = {
+  api: 2 * 60 * 60 * 1000,
+  browser: 4 * 60 * 60 * 1000,
+  publisher: 30 * 60 * 1000,
+}
 const REQUEUEABLE_STATUSES = new Set(['succeeded', 'failed', 'waiting', 'stale'])
 
 const SOURCE_DEFINITIONS = [
@@ -142,6 +147,10 @@ export function scheduleDueTasks(ledger, definitions, now) {
     task.cadence = definition.cadence
     task.freshness_window = `${definition.freshnessWindowMinutes}m`
     task.outputs = [...definition.outputs]
+    if (isRunningTaskStale(task, now)) {
+      markTaskStale(task, nowIso)
+      continue
+    }
     if (REQUEUEABLE_STATUSES.has(task.status) && task.due_at <= nowIso) {
       task.status = 'queued'
       task.lock_owner = null
@@ -329,6 +338,46 @@ function retryMinutesForTask(task) {
     return task.retry_minutes
   }
   return 30
+}
+
+function isRunningTaskStale(task, now) {
+  if (task.status !== 'running') {
+    return false
+  }
+  if (task.started_at === null) {
+    return true
+  }
+
+  const startedAtMs = Date.parse(task.started_at)
+  if (Number.isNaN(startedAtMs)) {
+    return true
+  }
+
+  const ageMs = now.getTime() - startedAtMs
+  return ageMs > staleAfterMsForTaskKind(task.kind)
+}
+
+function staleAfterMsForTaskKind(kind) {
+  const staleAfterMs = RUNNING_TASK_STALE_AFTER_MS[kind]
+  if (staleAfterMs === undefined) {
+    throw new Error(`Unsupported Argus runner task kind: ${kind}`)
+  }
+  return staleAfterMs
+}
+
+function markTaskStale(task, finishedAt) {
+  const staleStartedAt = task.started_at
+  const staleLockOwner = task.lock_owner
+  task.status = 'stale'
+  task.finished_at = finishedAt
+  task.lock_owner = null
+  task.last_error = 'stale-running-task'
+  task.due_at = finishedAt
+  task.metadata = mergeMetadata(task.metadata, {
+    outcome: 'stale-running-task',
+    staleStartedAt,
+    staleLockOwner,
+  })
 }
 
 function mergeMetadata(existing, updates) {

--- a/apps/argus/scripts/runner/task-store.test.mjs
+++ b/apps/argus/scripts/runner/task-store.test.mjs
@@ -117,6 +117,36 @@ test('blocked browser auth tasks stay blocked for operator recovery', () => {
   assert.equal(task.last_error, 'browser-auth')
 })
 
+test('stale running publisher tasks clear their lock and preserve stale evidence', () => {
+  const now = new Date('2026-05-11T08:00:00.000Z')
+  const ledger = scheduleDueTasks(createEmptyLedger(), buildDefaultTasks(), now)
+  const running = markTaskRunning(ledger, 'us:drive-sync', 'runner-1', now)
+  const staled = scheduleDueTasks(running, buildDefaultTasks(), new Date('2026-05-11T08:31:00.000Z'))
+  const task = staled.tasks.find((entry) => entry.task_id === 'us:drive-sync')
+
+  assert.equal(task.status, 'stale')
+  assert.equal(task.due_at, '2026-05-11T08:31:00.000Z')
+  assert.equal(task.finished_at, '2026-05-11T08:31:00.000Z')
+  assert.equal(task.lock_owner, null)
+  assert.equal(task.last_error, 'stale-running-task')
+  assert.equal(task.metadata.outcome, 'stale-running-task')
+  assert.equal(task.metadata.staleStartedAt, '2026-05-11T08:00:00.000Z')
+  assert.equal(task.metadata.staleLockOwner, 'runner-1')
+})
+
+test('stale tasks requeue on a later scheduler pass', () => {
+  const now = new Date('2026-05-11T08:00:00.000Z')
+  const ledger = scheduleDueTasks(createEmptyLedger(), buildDefaultTasks(), now)
+  const running = markTaskRunning(ledger, 'us:drive-sync', 'runner-1', now)
+  const staled = scheduleDueTasks(running, buildDefaultTasks(), new Date('2026-05-11T08:31:00.000Z'))
+  const requeued = scheduleDueTasks(staled, buildDefaultTasks(), new Date('2026-05-11T08:32:00.000Z'))
+  const task = requeued.tasks.find((entry) => entry.task_id === 'us:drive-sync')
+
+  assert.equal(task.status, 'queued')
+  assert.equal(task.lock_owner, null)
+  assert.equal(task.last_error, 'stale-running-task')
+})
+
 test('global runner lock prevents overlapping ticks', () => {
   const now = new Date('2026-05-11T08:00:00.000Z')
   const first = tryAcquireLock(createEmptyLedger(), 'runner-1', now)


### PR DESCRIPTION
## Summary
- mark orphaned running Argus tasks stale from the scheduler using kind-specific ceilings
- preserve stale task evidence and clear stale lock owners before a later tick requeues them
- emit weekly browser failure log details to stderr so the runner can classify blocked auth and download failures structurally
- add scheduler and browser adapter regression tests

## Verification
- node --test apps/argus/scripts/runner/task-store.test.mjs
- node --test apps/argus/scripts/runner/*.test.mjs apps/argus/scripts/api/install.test.mjs apps/argus/scripts/api/daily-account-health/collect.test.mjs apps/argus/scripts/api/weekly-sources/collect-spapi.test.mjs apps/argus/scripts/api/weekly-sources/run.test.mjs apps/argus/scripts/browser/weekly-market-config.test.mjs apps/argus/scripts/lib/drive-sync.test.mjs
- pnpm --filter argus type-check
- pnpm --filter argus lint
- pnpm --filter argus build
- git diff --check -- apps/argus