### PR TITLE
[codex] promote dev to main for Plutus settlement totals

### DIFF
--- a/apps/plutus/lib/plutus/settlement-doc-number.ts
+++ b/apps/plutus/lib/plutus/settlement-doc-number.ts
@@ -295,7 +295,9 @@ export function computeSettlementTotalFromJournalEntry(
 
     hasAnyLine = true;
 
-    if (account.AccountType !== 'Bank' && account.AccountType !== 'Credit Card') continue;
+    const isCashLine = account.AccountType === 'Bank' || account.AccountType === 'Credit Card';
+    const isSettlementControlLine = account.Name.trim().toLowerCase() === 'plutus settlement control';
+    if (!isCashLine && !isSettlementControlLine) continue;
 
     found = true;
     const signed = line.JournalEntryLineDetail.PostingType === 'Debit' ? amount : -amount;

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -72,6 +72,7 @@ import { isBlockingProcessingCode } from '../lib/plutus/settlement-types';
 import { buildPrincipalGroupsByDate, matchRefundsToSales } from '../lib/plutus/settlement-validation';
 import {
   buildPlutusSettlementDocNumber,
+  computeSettlementTotalFromJournalEntry,
   isSettlementDocNumber,
   normalizeSettlementDocNumber,
   parseSettlementDocNumber,
@@ -281,6 +282,41 @@ test('extractSourceSettlementIdFromPrivateNote falls back to audit rebuild sourc
     ),
     'UK-251205-260102-S1',
   );
+});
+
+test('computeSettlementTotalFromJournalEntry reads Plutus settlement control lines', () => {
+  const total = computeSettlementTotalFromJournalEntry(
+    {
+      Id: '1375',
+      SyncToken: '0',
+      TxnDate: '2026-04-30',
+      DocNumber: 'US-260416-260430-S1',
+      Line: [
+        {
+          Id: '1',
+          Amount: 119.34,
+          DetailType: 'JournalEntryLineDetail',
+          JournalEntryLineDetail: {
+            PostingType: 'Debit',
+            AccountRef: { value: '178', name: 'Plutus Settlement Control' },
+          },
+        },
+      ],
+    },
+    new Map([
+      [
+        '178',
+        {
+          Id: '178',
+          Name: 'Plutus Settlement Control',
+          AccountType: 'Other Current Asset',
+          Active: true,
+        },
+      ],
+    ]),
+  );
+
+  assert.equal(total, 119.34);
 });
 
 test('settlementJournalEntryMatchesSource recognizes legacy combined settlement postings', () => {


### PR DESCRIPTION
## Summary
- Promote dev to main, including the Plutus settlement-total hotfix.
- Plutus now displays settlement totals from Plutus Settlement Control journal lines instead of falsely showing $0.00.

## Validation
- PR #5428 CI passed on dev.
- Local Plutus checks passed: test, type-check, lint, diff check.
- Live QBO parser verification returned non-zero totals for affected settlement JEs.
