### PR TITLE
Finalize Plutus subledger settlement controls

### DIFF
--- a/apps/plutus/app/api/plutus/inventory-ledger/route.ts
+++ b/apps/plutus/app/api/plutus/inventory-ledger/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server';
+import { createLogger } from '@targon/logger';
+
+import { db } from '@/lib/db';
+
+const logger = createLogger({ name: 'plutus-inventory-ledger' });
+
+export async function GET() {
+  try {
+    const rows = await db.inventoryMovement.findMany({
+      orderBy: [
+        { movementDate: 'desc' },
+        { id: 'asc' },
+      ],
+      take: 500,
+      select: {
+        id: true,
+        marketplace: true,
+        movementType: true,
+        quantity: true,
+        movementDate: true,
+        sourceType: true,
+        sourceId: true,
+        sourceLineId: true,
+        createdAt: true,
+        updatedAt: true,
+        canonicalProduct: {
+          select: {
+            id: true,
+            name: true,
+            active: true,
+            productGroup: {
+              select: {
+                id: true,
+                code: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const movements = rows.map((row) => ({
+      id: row.id,
+      marketplace: row.marketplace,
+      movementType: row.movementType,
+      quantity: row.quantity,
+      movementDate: row.movementDate,
+      sourceType: row.sourceType,
+      sourceId: row.sourceId,
+      sourceLineId: row.sourceLineId,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      product: row.canonicalProduct,
+    }));
+
+    return NextResponse.json({ movements });
+  } catch (error) {
+    logger.error('Failed to list Plutus inventory movements', error);
+    return NextResponse.json(
+      { error: 'Failed to list inventory ledger', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/plutus/app/api/plutus/products/route.ts
+++ b/apps/plutus/app/api/plutus/products/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { createLogger } from '@targon/logger';
+
+import { db } from '@/lib/db';
+
+const logger = createLogger({ name: 'plutus-products' });
+
+export async function GET() {
+  try {
+    const products = await db.canonicalProduct.findMany({
+      orderBy: [
+        { productGroup: { code: 'asc' } },
+        { productGroup: { name: 'asc' } },
+        { name: 'asc' },
+        { id: 'asc' },
+      ],
+      select: {
+        id: true,
+        name: true,
+        active: true,
+        productGroup: {
+          select: {
+            id: true,
+            code: true,
+            name: true,
+            active: true,
+          },
+        },
+        aliases: {
+          orderBy: [
+            { marketplace: 'asc' },
+            { aliasType: 'asc' },
+            { value: 'asc' },
+            { id: 'asc' },
+          ],
+          select: {
+            id: true,
+            marketplace: true,
+            aliasType: true,
+            value: true,
+            active: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({ products });
+  } catch (error) {
+    logger.error('Failed to list Plutus products', error);
+    return NextResponse.json(
+      { error: 'Failed to list products', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/plutus/app/api/plutus/purchase-orders/route.ts
+++ b/apps/plutus/app/api/plutus/purchase-orders/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { createLogger } from '@targon/logger';
+
+import { db } from '@/lib/db';
+
+const logger = createLogger({ name: 'plutus-purchase-orders' });
+
+export async function GET() {
+  try {
+    const rows = await db.purchaseOrder.findMany({
+      orderBy: [
+        { internalRef: 'asc' },
+        { id: 'asc' },
+      ],
+      select: {
+        id: true,
+        internalRef: true,
+        supplierRef: true,
+        marketplace: true,
+        status: true,
+        costLayers: {
+          orderBy: [
+            { component: 'asc' },
+            { createdAt: 'asc' },
+            { id: 'asc' },
+          ],
+          select: {
+            id: true,
+            component: true,
+            quantity: true,
+            amountCents: true,
+            currency: true,
+            allocationMethod: true,
+            sourceQboTxnType: true,
+            sourceQboTxnId: true,
+            sourceQboLineId: true,
+            sourceDocumentName: true,
+            createdAt: true,
+            canonicalProduct: {
+              select: {
+                id: true,
+                name: true,
+                active: true,
+                productGroup: {
+                  select: {
+                    id: true,
+                    code: true,
+                    name: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const purchaseOrders = rows.map((row) => ({
+      id: row.id,
+      internalRef: row.internalRef,
+      supplierRef: row.supplierRef,
+      marketplace: row.marketplace,
+      status: row.status,
+      totalAmountCents: row.costLayers.reduce((sum, layer) => sum + layer.amountCents, 0),
+      costLayers: row.costLayers.map((layer) => ({
+        id: layer.id,
+        component: layer.component,
+        quantity: layer.quantity,
+        amountCents: layer.amountCents,
+        currency: layer.currency,
+        allocationMethod: layer.allocationMethod,
+        sourceQboTxnType: layer.sourceQboTxnType,
+        sourceQboTxnId: layer.sourceQboTxnId,
+        sourceQboLineId: layer.sourceQboLineId,
+        sourceDocumentName: layer.sourceDocumentName,
+        createdAt: layer.createdAt,
+        product: layer.canonicalProduct,
+      })),
+    }));
+
+    return NextResponse.json({ purchaseOrders });
+  } catch (error) {
+    logger.error('Failed to list Plutus purchase orders', error);
+    return NextResponse.json(
+      { error: 'Failed to list purchase orders', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/plutus/app/api/plutus/qbo-audit/route.ts
+++ b/apps/plutus/app/api/plutus/qbo-audit/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from 'next/server';
+import { createLogger } from '@targon/logger';
+
+import { db } from '@/lib/db';
+
+const logger = createLogger({ name: 'plutus-qbo-audit' });
+
+export async function GET() {
+  try {
+    const rows = await db.qboPosting.findMany({
+      orderBy: [
+        { updatedAt: 'desc' },
+        { id: 'asc' },
+      ],
+      take: 500,
+      select: {
+        id: true,
+        qboTxnType: true,
+        qboTxnId: true,
+        qboSyncToken: true,
+        qboDocNumber: true,
+        qboPrivateNote: true,
+        qboTxnDate: true,
+        postingHash: true,
+        driftStatus: true,
+        attachmentStatus: true,
+        lastCheckedAt: true,
+        createdAt: true,
+        updatedAt: true,
+        postingIntent: {
+          select: {
+            id: true,
+            sourceType: true,
+            sourceId: true,
+            market: true,
+            periodStart: true,
+            periodEnd: true,
+            sourceHash: true,
+            mappingVersion: true,
+            postingHash: true,
+            status: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+        lineFingerprints: {
+          orderBy: [
+            { driftStatus: 'asc' },
+            { qboLineId: 'asc' },
+          ],
+          select: {
+            id: true,
+            qboLineId: true,
+            expectedLineHash: true,
+            liveLineHash: true,
+            driftStatus: true,
+            createdAt: true,
+            updatedAt: true,
+          },
+        },
+      },
+    });
+
+    const postings = rows.map((row) => ({
+      id: row.id,
+      qboTxnType: row.qboTxnType,
+      qboTxnId: row.qboTxnId,
+      qboSyncToken: row.qboSyncToken,
+      qboDocNumber: row.qboDocNumber,
+      qboPrivateNote: row.qboPrivateNote,
+      qboTxnDate: row.qboTxnDate,
+      postingHash: row.postingHash,
+      driftStatus: row.driftStatus,
+      attachmentStatus: row.attachmentStatus,
+      lastCheckedAt: row.lastCheckedAt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      sourceType: row.postingIntent.sourceType,
+      sourceId: row.postingIntent.sourceId,
+      market: row.postingIntent.market,
+      lineCount: row.lineFingerprints.length,
+      postingIntent: row.postingIntent,
+      lineFingerprints: row.lineFingerprints,
+    }));
+
+    return NextResponse.json({ postings });
+  } catch (error) {
+    logger.error('Failed to list Plutus QBO postings', error);
+    return NextResponse.json(
+      { error: 'Failed to list QBO audit postings', details: error instanceof Error ? error.message : String(error) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/plutus/app/inventory-ledger/page.tsx
+++ b/apps/plutus/app/inventory-ledger/page.tsx
@@ -1,0 +1,3 @@
+import { InventoryLedgerPage } from '@/components/subledger/inventory-ledger-page';
+
+export default InventoryLedgerPage;

--- a/apps/plutus/app/products/page.tsx
+++ b/apps/plutus/app/products/page.tsx
@@ -1,0 +1,3 @@
+import { ProductsPage } from '@/components/subledger/products-page';
+
+export default ProductsPage;

--- a/apps/plutus/app/purchase-orders/page.tsx
+++ b/apps/plutus/app/purchase-orders/page.tsx
@@ -1,0 +1,3 @@
+import { PurchaseOrdersPage } from '@/components/subledger/purchase-orders-page';
+
+export default PurchaseOrdersPage;

--- a/apps/plutus/app/qbo-audit/page.tsx
+++ b/apps/plutus/app/qbo-audit/page.tsx
@@ -1,0 +1,3 @@
+import { QboAuditPage } from '@/components/subledger/qbo-audit-page';
+
+export default QboAuditPage;

--- a/apps/plutus/components/app-header.tsx
+++ b/apps/plutus/components/app-header.tsx
@@ -11,7 +11,10 @@ import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import AssignmentTurnedInIcon from '@mui/icons-material/AssignmentTurnedIn';
+import CategoryIcon from '@mui/icons-material/Category';
+import FactCheckIcon from '@mui/icons-material/FactCheck';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
 import MapIcon from '@mui/icons-material/Map';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import SettingsIcon from '@mui/icons-material/Settings';
@@ -103,8 +106,11 @@ type NavItem = { href: string; label: string; icon: SvgIconComponent };
 
 const NAV_ITEMS: NavItem[] = [
   { href: '/settlements', label: 'Settlements', icon: ReceiptLongIcon },
-  { href: '/cogs-inputs', label: 'COGS Inputs', icon: AssignmentTurnedInIcon },
+  { href: '/products', label: 'Products', icon: CategoryIcon },
+  { href: '/purchase-orders', label: 'Purchase Orders', icon: LocalShippingIcon },
+  { href: '/inventory-ledger', label: 'Inventory Ledger', icon: Inventory2Icon },
   { href: '/settlement-mapping', label: 'Mappings', icon: MapIcon },
+  { href: '/qbo-audit', label: 'QBO Audit', icon: FactCheckIcon },
   { href: '/settings', label: 'Settings', icon: SettingsIcon },
 ];
 
@@ -166,6 +172,7 @@ export function AppHeader() {
           {/* Desktop nav */}
           <Box component="nav" sx={{ display: { xs: 'none', lg: 'flex' }, alignItems: 'center', gap: 0.25 }}>
             {NAV_ITEMS.map((item) => {
+              const Icon = item.icon;
               const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
               return (
                 <Link
@@ -176,17 +183,21 @@ export function AppHeader() {
                   <Box
                     sx={{
                       position: 'relative',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.75,
                       whiteSpace: 'nowrap',
                       borderRadius: 2,
-                      px: 1.25,
+                      px: 1,
                       py: 1,
-                      fontSize: '13px',
+                      fontSize: '12.5px',
                       fontWeight: 500,
                       transition: 'all 0.15s',
                       color: isActive ? '#008f87' : 'text.secondary',
                       '&:hover': { color: 'text.primary' },
                     }}
                   >
+                    <Icon sx={{ fontSize: 15, color: isActive ? '#00C2B9' : 'text.disabled' }} />
                     {item.label}
                     {isActive && (
                       <Box

--- a/apps/plutus/components/subledger/inventory-ledger-page.tsx
+++ b/apps/plutus/components/subledger/inventory-ledger-page.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+
+import { PageHeader } from '@/components/page-header';
+import { EmptyState } from '@/components/ui/empty-state';
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+if (basePath === undefined) {
+  throw new Error('NEXT_PUBLIC_BASE_PATH is required');
+}
+
+type InventoryMovement = {
+  id: string;
+  marketplace: string;
+  movementType: string;
+  quantity: number;
+  movementDate: string;
+  sourceType: string;
+  sourceId: string;
+  sourceLineId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  product: {
+    id: string;
+    name: string;
+    active: boolean;
+    productGroup: {
+      id: string;
+      code: string;
+      name: string;
+    };
+  };
+};
+
+type InventoryLedgerResponse = {
+  movements: InventoryMovement[];
+};
+
+const tableWrapSx = {
+  mt: 2,
+  overflow: 'hidden',
+  border: 1,
+  borderColor: 'divider',
+  bgcolor: 'background.paper',
+} as const;
+
+const headCellSx = {
+  whiteSpace: 'nowrap',
+  color: 'text.secondary',
+} as const;
+
+const bodyCellSx = {
+  verticalAlign: 'top',
+  fontSize: '0.8125rem',
+} as const;
+
+const quietTextSx = {
+  fontSize: '0.75rem',
+  color: 'text.secondary',
+} as const;
+
+const OUTBOUND_MOVEMENT_TYPES = new Set(['SALE', 'REMOVAL', 'DISPOSAL']);
+
+async function fetchInventoryLedger(): Promise<InventoryLedgerResponse> {
+  const res = await fetch(`${basePath}/api/plutus/inventory-ledger`);
+  const data = (await res.json()) as InventoryLedgerResponse | { error?: string };
+
+  if (!res.ok) {
+    if ('error' in data && typeof data.error === 'string') {
+      throw new Error(data.error);
+    }
+    throw new Error('Failed to load inventory ledger');
+  }
+
+  return data as InventoryLedgerResponse;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(value));
+}
+
+function QuantityCell({ quantity }: { quantity: number }) {
+  const formatted = new Intl.NumberFormat('en-US').format(quantity);
+  const color = quantity < 0 ? 'error.main' : 'text.primary';
+
+  return (
+    <Typography sx={{ textAlign: 'right', fontSize: '0.875rem', fontWeight: 700, color, fontVariantNumeric: 'tabular-nums' }}>
+      {formatted}
+    </Typography>
+  );
+}
+
+function MovementChip({ movementType }: { movementType: string }) {
+  const outbound = OUTBOUND_MOVEMENT_TYPES.has(movementType);
+
+  return (
+    <Chip
+      label={movementType}
+      size="small"
+      variant="outlined"
+      sx={{
+        borderColor: outbound ? 'rgba(239, 68, 68, 0.35)' : 'divider',
+        color: outbound ? 'error.dark' : 'text.secondary',
+        bgcolor: outbound ? 'rgba(239, 68, 68, 0.05)' : 'background.paper',
+      }}
+    />
+  );
+}
+
+export function InventoryLedgerPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['plutus-inventory-ledger'],
+    queryFn: fetchInventoryLedger,
+    staleTime: 30 * 1000,
+  });
+
+  const movements = data ? data.movements : [];
+
+  return (
+    <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
+      <PageHeader title="Inventory Ledger" kicker="Subledger" />
+
+      <Box sx={tableWrapSx}>
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table size="small" sx={{ minWidth: 980 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={headCellSx}>Date</TableCell>
+                <TableCell sx={headCellSx}>Market</TableCell>
+                <TableCell sx={headCellSx}>Product</TableCell>
+                <TableCell sx={headCellSx}>Movement</TableCell>
+                <TableCell sx={{ ...headCellSx, textAlign: 'right' }}>Qty</TableCell>
+                <TableCell sx={headCellSx}>Source</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading && (
+                <>
+                  {Array.from({ length: 8 }).map((_, index) => (
+                    <TableRow key={index}>
+                      <TableCell colSpan={6} sx={{ py: 1.5 }}>
+                        <Skeleton height={34} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </>
+              )}
+
+              {!isLoading && error && (
+                <TableRow>
+                  <TableCell colSpan={6} sx={{ py: 5, textAlign: 'center', color: 'error.main' }}>
+                    {error instanceof Error ? error.message : String(error)}
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && movements.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6}>
+                    <EmptyState
+                      icon={<Inventory2Icon sx={{ fontSize: 40 }} />}
+                      title="No inventory movements"
+                      description="Receipts, sales, returns, and adjustments will appear here."
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && movements.map((movement) => (
+                <TableRow key={movement.id}>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary' }}>
+                      {formatDate(movement.movementDate)}
+                    </Typography>
+                    <Typography sx={quietTextSx}>{movement.id}</Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>{movement.marketplace}</TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
+                      {movement.product.name}
+                    </Typography>
+                    <Typography sx={quietTextSx}>{movement.product.productGroup.code}</Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <MovementChip movementType={movement.movementType} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <QuantityCell quantity={movement.quantity} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary' }}>
+                      {movement.sourceType} {movement.sourceId}
+                    </Typography>
+                    <Typography sx={quietTextSx}>
+                      {movement.sourceLineId === null ? '-' : `Line ${movement.sourceLineId}`}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/plutus/components/subledger/products-page.tsx
+++ b/apps/plutus/components/subledger/products-page.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import CategoryIcon from '@mui/icons-material/Category';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+
+import { PageHeader } from '@/components/page-header';
+import { EmptyState } from '@/components/ui/empty-state';
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+if (basePath === undefined) {
+  throw new Error('NEXT_PUBLIC_BASE_PATH is required');
+}
+
+type ProductAlias = {
+  id: string;
+  marketplace: string;
+  aliasType: string;
+  value: string;
+  active: boolean;
+};
+
+type ProductRow = {
+  id: string;
+  name: string;
+  active: boolean;
+  productGroup: {
+    id: string;
+    code: string;
+    name: string;
+    active: boolean;
+  };
+  aliases: ProductAlias[];
+};
+
+type ProductsResponse = {
+  products: ProductRow[];
+};
+
+const tableWrapSx = {
+  mt: 2,
+  overflow: 'hidden',
+  border: 1,
+  borderColor: 'divider',
+  bgcolor: 'background.paper',
+} as const;
+
+const headCellSx = {
+  whiteSpace: 'nowrap',
+  color: 'text.secondary',
+} as const;
+
+const bodyCellSx = {
+  verticalAlign: 'top',
+  fontSize: '0.8125rem',
+} as const;
+
+const quietTextSx = {
+  fontSize: '0.75rem',
+  color: 'text.secondary',
+} as const;
+
+async function fetchProducts(): Promise<ProductsResponse> {
+  const res = await fetch(`${basePath}/api/plutus/products`);
+  const data = (await res.json()) as ProductsResponse | { error?: string };
+
+  if (!res.ok) {
+    if ('error' in data && typeof data.error === 'string') {
+      throw new Error(data.error);
+    }
+    throw new Error('Failed to load products');
+  }
+
+  return data as ProductsResponse;
+}
+
+function StatusChip({ active }: { active: boolean }) {
+  return (
+    <Chip
+      label={active ? 'Active' : 'Inactive'}
+      size="small"
+      variant={active ? 'filled' : 'outlined'}
+      color={active ? 'success' : 'default'}
+      sx={{ bgcolor: active ? 'rgba(34, 197, 94, 0.1)' : 'background.paper', color: active ? 'success.dark' : 'text.secondary' }}
+    />
+  );
+}
+
+function AliasCell({ aliases }: { aliases: ProductAlias[] }) {
+  if (aliases.length === 0) {
+    return <Typography sx={quietTextSx}>-</Typography>;
+  }
+
+  return (
+    <Box sx={{ display: 'grid', gap: 0.5 }}>
+      {aliases.map((alias) => (
+        <Box key={alias.id} sx={{ minWidth: 0 }}>
+          <Typography
+            title={alias.value}
+            sx={{
+              maxWidth: 260,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              fontSize: '0.8125rem',
+              color: alias.active ? 'text.primary' : 'text.disabled',
+            }}
+          >
+            {alias.aliasType}: {alias.value}
+          </Typography>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+function aliasesForMarketplace(product: ProductRow, marketplace: string) {
+  return product.aliases.filter((alias) => alias.marketplace === marketplace);
+}
+
+function aliasesForOtherMarketplaces(product: ProductRow) {
+  return product.aliases.filter(
+    (alias) => alias.marketplace !== 'amazon.com' && alias.marketplace !== 'amazon.co.uk',
+  );
+}
+
+export function ProductsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['plutus-products'],
+    queryFn: fetchProducts,
+    staleTime: 30 * 1000,
+  });
+
+  const products = data ? data.products : [];
+
+  return (
+    <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
+      <PageHeader title="Products" kicker="Subledger" />
+
+      <Box sx={tableWrapSx}>
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table size="small" sx={{ minWidth: 980 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={headCellSx}>Product</TableCell>
+                <TableCell sx={headCellSx}>Group</TableCell>
+                <TableCell sx={headCellSx}>Status</TableCell>
+                <TableCell sx={headCellSx}>US Aliases</TableCell>
+                <TableCell sx={headCellSx}>UK Aliases</TableCell>
+                <TableCell sx={headCellSx}>Other Aliases</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading && (
+                <>
+                  {Array.from({ length: 6 }).map((_, index) => (
+                    <TableRow key={index}>
+                      <TableCell colSpan={6} sx={{ py: 1.5 }}>
+                        <Skeleton height={34} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </>
+              )}
+
+              {!isLoading && error && (
+                <TableRow>
+                  <TableCell colSpan={6} sx={{ py: 5, textAlign: 'center', color: 'error.main' }}>
+                    {error instanceof Error ? error.message : String(error)}
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && products.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6}>
+                    <EmptyState
+                      icon={<CategoryIcon sx={{ fontSize: 40 }} />}
+                      title="No products loaded"
+                      description="Canonical products will appear after the subledger backfill runs."
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && products.map((product) => (
+                <TableRow key={product.id}>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
+                      {product.name}
+                    </Typography>
+                    <Typography sx={quietTextSx}>{product.id}</Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary' }}>
+                      {product.productGroup.code}
+                    </Typography>
+                    <Typography sx={quietTextSx}>{product.productGroup.name}</Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <StatusChip active={product.active} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <AliasCell aliases={aliasesForMarketplace(product, 'amazon.com')} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <AliasCell aliases={aliasesForMarketplace(product, 'amazon.co.uk')} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <AliasCell aliases={aliasesForOtherMarketplaces(product)} />
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/plutus/components/subledger/purchase-orders-page.tsx
+++ b/apps/plutus/components/subledger/purchase-orders-page.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+
+import { PageHeader } from '@/components/page-header';
+import { EmptyState } from '@/components/ui/empty-state';
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+if (basePath === undefined) {
+  throw new Error('NEXT_PUBLIC_BASE_PATH is required');
+}
+
+type CostLayer = {
+  id: string;
+  component: string;
+  quantity: number | null;
+  amountCents: number;
+  currency: string;
+  allocationMethod: string;
+  sourceQboTxnType: string | null;
+  sourceQboTxnId: string | null;
+  sourceQboLineId: string | null;
+  sourceDocumentName: string | null;
+  createdAt: string;
+  product: {
+    id: string;
+    name: string;
+    active: boolean;
+    productGroup: {
+      id: string;
+      code: string;
+      name: string;
+    };
+  };
+};
+
+type PurchaseOrderRow = {
+  id: string;
+  internalRef: string;
+  supplierRef: string | null;
+  marketplace: string | null;
+  status: string;
+  totalAmountCents: number;
+  costLayers: CostLayer[];
+};
+
+type PurchaseOrdersResponse = {
+  purchaseOrders: PurchaseOrderRow[];
+};
+
+const tableWrapSx = {
+  mt: 2,
+  overflow: 'hidden',
+  border: 1,
+  borderColor: 'divider',
+  bgcolor: 'background.paper',
+} as const;
+
+const headCellSx = {
+  whiteSpace: 'nowrap',
+  color: 'text.secondary',
+} as const;
+
+const bodyCellSx = {
+  verticalAlign: 'top',
+  fontSize: '0.8125rem',
+} as const;
+
+const quietTextSx = {
+  fontSize: '0.75rem',
+  color: 'text.secondary',
+} as const;
+
+async function fetchPurchaseOrders(): Promise<PurchaseOrdersResponse> {
+  const res = await fetch(`${basePath}/api/plutus/purchase-orders`);
+  const data = (await res.json()) as PurchaseOrdersResponse | { error?: string };
+
+  if (!res.ok) {
+    if ('error' in data && typeof data.error === 'string') {
+      throw new Error(data.error);
+    }
+    throw new Error('Failed to load purchase orders');
+  }
+
+  return data as PurchaseOrdersResponse;
+}
+
+function formatCents(amountCents: number, currency: string) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amountCents / 100);
+}
+
+function formatPurchaseOrderTotal(order: PurchaseOrderRow) {
+  const firstLayer = order.costLayers[0];
+  if (firstLayer === undefined) return '-';
+  return formatCents(order.totalAmountCents, firstLayer.currency);
+}
+
+function StatusChip({ status }: { status: string }) {
+  const normalized = status.trim().toUpperCase();
+  const isOpen = normalized === 'OPEN';
+
+  return (
+    <Chip
+      label={status}
+      size="small"
+      variant={isOpen ? 'filled' : 'outlined'}
+      color={isOpen ? 'success' : 'default'}
+      sx={{ bgcolor: isOpen ? 'rgba(34, 197, 94, 0.1)' : 'background.paper', color: isOpen ? 'success.dark' : 'text.secondary' }}
+    />
+  );
+}
+
+function LayerSummary({ layer }: { layer: CostLayer }) {
+  const quantity = layer.quantity === null ? '-' : new Intl.NumberFormat('en-US').format(layer.quantity);
+
+  return (
+    <Box sx={{ display: 'grid', gridTemplateColumns: '104px minmax(160px, 1fr) 96px', gap: 1.25, alignItems: 'baseline' }}>
+      <Typography sx={{ fontSize: '0.75rem', fontWeight: 700, color: 'text.primary' }}>{layer.component}</Typography>
+      <Typography sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.8125rem', color: 'text.primary' }}>
+        {layer.product.productGroup.code} / {layer.product.name}
+      </Typography>
+      <Typography sx={{ textAlign: 'right', fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary', fontVariantNumeric: 'tabular-nums' }}>
+        {formatCents(layer.amountCents, layer.currency)}
+      </Typography>
+      <Typography sx={quietTextSx}>Qty {quantity}</Typography>
+      <Typography sx={quietTextSx}>{layer.allocationMethod}</Typography>
+      <Box />
+    </Box>
+  );
+}
+
+function QboSourceSummary({ layer }: { layer: CostLayer }) {
+  const hasQboTxn = layer.sourceQboTxnType !== null && layer.sourceQboTxnId !== null;
+  const txn = hasQboTxn ? `${layer.sourceQboTxnType} ${layer.sourceQboTxnId}` : '-';
+  const line = layer.sourceQboLineId === null ? '-' : `Line ${layer.sourceQboLineId}`;
+  const document = layer.sourceDocumentName === null ? '-' : layer.sourceDocumentName;
+
+  return (
+    <Box sx={{ display: 'grid', gap: 0.25 }}>
+      <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary' }}>{txn}</Typography>
+      <Typography sx={quietTextSx}>{line}</Typography>
+      <Typography title={document} sx={{ ...quietTextSx, maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {document}
+      </Typography>
+    </Box>
+  );
+}
+
+export function PurchaseOrdersPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['plutus-purchase-orders'],
+    queryFn: fetchPurchaseOrders,
+    staleTime: 30 * 1000,
+  });
+
+  const purchaseOrders = data ? data.purchaseOrders : [];
+
+  return (
+    <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
+      <PageHeader title="Purchase Orders" kicker="Subledger" />
+
+      <Box sx={tableWrapSx}>
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table size="small" sx={{ minWidth: 1160 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={headCellSx}>PO</TableCell>
+                <TableCell sx={headCellSx}>Market</TableCell>
+                <TableCell sx={headCellSx}>Status</TableCell>
+                <TableCell sx={{ ...headCellSx, textAlign: 'right' }}>Total</TableCell>
+                <TableCell sx={headCellSx}>Cost Layers</TableCell>
+                <TableCell sx={headCellSx}>QBO Source</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading && (
+                <>
+                  {Array.from({ length: 6 }).map((_, index) => (
+                    <TableRow key={index}>
+                      <TableCell colSpan={6} sx={{ py: 1.5 }}>
+                        <Skeleton height={34} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </>
+              )}
+
+              {!isLoading && error && (
+                <TableRow>
+                  <TableCell colSpan={6} sx={{ py: 5, textAlign: 'center', color: 'error.main' }}>
+                    {error instanceof Error ? error.message : String(error)}
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && purchaseOrders.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={6}>
+                    <EmptyState
+                      icon={<LocalShippingIcon sx={{ fontSize: 40 }} />}
+                      title="No purchase orders loaded"
+                      description="PO cost layers will appear after the subledger backfill runs."
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && purchaseOrders.map((order) => (
+                  <TableRow key={order.id}>
+                    <TableCell sx={bodyCellSx}>
+                      <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
+                        {order.internalRef}
+                      </Typography>
+                      <Typography sx={quietTextSx}>
+                        {order.supplierRef === null ? '-' : order.supplierRef}
+                      </Typography>
+                    </TableCell>
+                    <TableCell sx={bodyCellSx}>
+                      {order.marketplace === null ? '-' : order.marketplace}
+                    </TableCell>
+                    <TableCell sx={bodyCellSx}>
+                      <StatusChip status={order.status} />
+                    </TableCell>
+                    <TableCell sx={{ ...bodyCellSx, textAlign: 'right', fontWeight: 700, color: 'text.primary', fontVariantNumeric: 'tabular-nums' }}>
+                      {formatPurchaseOrderTotal(order)}
+                    </TableCell>
+                    <TableCell sx={bodyCellSx}>
+                      <Box sx={{ display: 'grid', gap: 1 }}>
+                        {order.costLayers.map((layer) => (
+                          <LayerSummary key={layer.id} layer={layer} />
+                        ))}
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={bodyCellSx}>
+                      <Box sx={{ display: 'grid', gap: 1 }}>
+                        {order.costLayers.map((layer) => (
+                          <QboSourceSummary key={layer.id} layer={layer} />
+                        ))}
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/plutus/components/subledger/qbo-audit-page.tsx
+++ b/apps/plutus/components/subledger/qbo-audit-page.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import FactCheckIcon from '@mui/icons-material/FactCheck';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
+import Skeleton from '@mui/material/Skeleton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import Typography from '@mui/material/Typography';
+
+import { PageHeader } from '@/components/page-header';
+import { EmptyState } from '@/components/ui/empty-state';
+
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
+if (basePath === undefined) {
+  throw new Error('NEXT_PUBLIC_BASE_PATH is required');
+}
+
+type PostingIntent = {
+  id: string;
+  sourceType: string;
+  sourceId: string;
+  market: string;
+  periodStart: string | null;
+  periodEnd: string | null;
+  sourceHash: string;
+  mappingVersion: string;
+  postingHash: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type LineFingerprint = {
+  id: string;
+  qboLineId: string;
+  expectedLineHash: string;
+  liveLineHash: string | null;
+  driftStatus: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type QboPosting = {
+  id: string;
+  qboTxnType: string;
+  qboTxnId: string;
+  qboSyncToken: string | null;
+  qboDocNumber: string | null;
+  qboPrivateNote: string | null;
+  qboTxnDate: string | null;
+  postingHash: string;
+  driftStatus: string;
+  attachmentStatus: string;
+  lastCheckedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  sourceType: string;
+  sourceId: string;
+  market: string;
+  lineCount: number;
+  postingIntent: PostingIntent;
+  lineFingerprints: LineFingerprint[];
+};
+
+type QboAuditResponse = {
+  postings: QboPosting[];
+};
+
+const tableWrapSx = {
+  mt: 2,
+  overflow: 'hidden',
+  border: 1,
+  borderColor: 'divider',
+  bgcolor: 'background.paper',
+} as const;
+
+const headCellSx = {
+  whiteSpace: 'nowrap',
+  color: 'text.secondary',
+} as const;
+
+const bodyCellSx = {
+  verticalAlign: 'top',
+  fontSize: '0.8125rem',
+} as const;
+
+const quietTextSx = {
+  fontSize: '0.75rem',
+  color: 'text.secondary',
+} as const;
+
+async function fetchQboAudit(): Promise<QboAuditResponse> {
+  const res = await fetch(`${basePath}/api/plutus/qbo-audit`);
+  const data = (await res.json()) as QboAuditResponse | { error?: string };
+
+  if (!res.ok) {
+    if ('error' in data && typeof data.error === 'string') {
+      throw new Error(data.error);
+    }
+    throw new Error('Failed to load QBO audit');
+  }
+
+  return data as QboAuditResponse;
+}
+
+function formatDate(value: string | null) {
+  if (value === null) return '-';
+
+  return new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(value));
+}
+
+function compactHash(hash: string) {
+  return hash.slice(0, 12);
+}
+
+function formatPeriod(intent: PostingIntent) {
+  if (intent.periodStart === null && intent.periodEnd === null) return '-';
+  if (intent.periodStart === null) return intent.periodEnd;
+  if (intent.periodEnd === null) return intent.periodStart;
+  return `${intent.periodStart} to ${intent.periodEnd}`;
+}
+
+function DriftChip({ status }: { status: string }) {
+  const normalized = status.trim();
+  const inSync = normalized === 'in_sync';
+  const unchecked = normalized === 'unchecked';
+  const color = inSync ? 'success.dark' : unchecked ? 'text.secondary' : 'error.dark';
+  const borderColor = inSync ? 'rgba(34, 197, 94, 0.45)' : unchecked ? 'divider' : 'rgba(239, 68, 68, 0.35)';
+  const backgroundColor = inSync ? 'rgba(34, 197, 94, 0.08)' : unchecked ? 'background.paper' : 'rgba(239, 68, 68, 0.05)';
+
+  return (
+    <Chip
+      label={status}
+      size="small"
+      variant="outlined"
+      sx={{ borderColor, color, bgcolor: backgroundColor }}
+    />
+  );
+}
+
+function AttachmentChip({ status }: { status: string }) {
+  const missing = status === 'missing';
+
+  return (
+    <Chip
+      label={status}
+      size="small"
+      variant="outlined"
+      sx={{
+        borderColor: missing ? 'rgba(245, 158, 11, 0.45)' : 'divider',
+        color: missing ? 'warning.dark' : 'text.secondary',
+        bgcolor: missing ? 'rgba(245, 158, 11, 0.08)' : 'background.paper',
+      }}
+    />
+  );
+}
+
+function LineSummary({ lineCount, lines }: { lineCount: number; lines: LineFingerprint[] }) {
+  const driftedCount = lines.filter((line) => line.driftStatus !== 'in_sync').length;
+  const label = `${lineCount} lines`;
+  const detail = driftedCount === 0 ? 'all in sync' : `${driftedCount} needs review`;
+
+  return (
+    <Box sx={{ display: 'grid', gap: 0.25 }}>
+      <Typography sx={{ fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary' }}>
+        {label}
+      </Typography>
+      <Typography sx={quietTextSx}>{detail}</Typography>
+    </Box>
+  );
+}
+
+export function QboAuditPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['plutus-qbo-audit'],
+    queryFn: fetchQboAudit,
+    staleTime: 30 * 1000,
+  });
+
+  const postings = data ? data.postings : [];
+
+  return (
+    <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
+      <PageHeader title="QBO Audit" kicker="Subledger" />
+
+      <Box sx={tableWrapSx}>
+        <Box sx={{ overflowX: 'auto' }}>
+          <Table size="small" sx={{ minWidth: 1120 }}>
+            <TableHead>
+              <TableRow>
+                <TableCell sx={headCellSx}>Updated</TableCell>
+                <TableCell sx={headCellSx}>QBO Txn</TableCell>
+                <TableCell sx={headCellSx}>Intent</TableCell>
+                <TableCell sx={headCellSx}>Drift</TableCell>
+                <TableCell sx={headCellSx}>Attachment</TableCell>
+                <TableCell sx={headCellSx}>Lines</TableCell>
+                <TableCell sx={headCellSx}>Hash</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {isLoading && (
+                <>
+                  {Array.from({ length: 8 }).map((_, index) => (
+                    <TableRow key={index}>
+                      <TableCell colSpan={7} sx={{ py: 1.5 }}>
+                        <Skeleton height={34} />
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </>
+              )}
+
+              {!isLoading && error && (
+                <TableRow>
+                  <TableCell colSpan={7} sx={{ py: 5, textAlign: 'center', color: 'error.main' }}>
+                    {error instanceof Error ? error.message : String(error)}
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && postings.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={7}>
+                    <EmptyState
+                      icon={<FactCheckIcon sx={{ fontSize: 40 }} />}
+                      title="No QBO postings tracked"
+                      description="Posting drift and attachment state will appear after QBO traces are recorded."
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {!isLoading && !error && postings.map((posting) => (
+                <TableRow key={posting.id}>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary' }}>
+                      {formatDate(posting.updatedAt)}
+                    </Typography>
+                    <Typography sx={quietTextSx}>
+                      Checked {formatDate(posting.lastCheckedAt)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
+                      {posting.qboTxnType} {posting.qboTxnId}
+                    </Typography>
+                    <Typography sx={quietTextSx}>
+                      {posting.qboDocNumber === null ? '-' : posting.qboDocNumber}
+                    </Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary' }}>
+                      {posting.sourceType} {posting.sourceId}
+                    </Typography>
+                    <Typography sx={quietTextSx}>
+                      {posting.market} / {formatPeriod(posting.postingIntent)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <DriftChip status={posting.driftStatus} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <AttachmentChip status={posting.attachmentStatus} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <LineSummary lineCount={posting.lineCount} lines={posting.lineFingerprints} />
+                  </TableCell>
+                  <TableCell sx={bodyCellSx}>
+                    <Typography sx={{ fontSize: '0.75rem', color: 'text.secondary', fontFamily: 'monospace' }}>
+                      {compactHash(posting.postingHash)}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
@@ -159,7 +159,13 @@ async function buildSkuToBrandName(): Promise<Map<string, string>> {
   const skuToBrandName = new Map<string, string>();
   for (const row of skus) {
     if (row.brand.marketplace !== 'amazon.co.uk') continue;
-    skuToBrandName.set(normalizeSku(row.sku), row.brand.name);
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
+    }
+    for (const alias of aliases) {
+      skuToBrandName.set(normalizeSku(alias), row.brand.name);
+    }
   }
   return skuToBrandName;
 }

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -154,7 +154,13 @@ async function buildSkuToBrandName(): Promise<Map<string, string>> {
   const skuToBrandName = new Map<string, string>();
   for (const row of skus) {
     if (row.brand.marketplace !== 'amazon.com') continue;
-    skuToBrandName.set(normalizeSku(row.sku), row.brand.name);
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
+    }
+    for (const alias of aliases) {
+      skuToBrandName.set(normalizeSku(alias), row.brand.name);
+    }
   }
   return skuToBrandName;
 }

--- a/apps/plutus/lib/plutus/bills/pull-sync.ts
+++ b/apps/plutus/lib/plutus/bills/pull-sync.ts
@@ -21,6 +21,7 @@ export type BillMappingPullSyncUpdate = {
 
 const poCustomFieldNamePattern = /\b(?:po|p\/o|purchase\s*order)\b/i;
 const poMemoPatterns = [
+  /^INTERNAL\s+REF\s*:\s*(.+)$/i,
   /^P(?:\s*\/\s*)?O\s*(?:#|:|-)\s*(.+)$/i,
   /^P(?:\s*\/\s*)?O\s+(.+)$/i,
 ];

--- a/apps/plutus/lib/plutus/fee-allocation.ts
+++ b/apps/plutus/lib/plutus/fee-allocation.ts
@@ -13,10 +13,12 @@ import {
   allocateShipmentFeeChargesBySkuQuantity,
   extractInboundTransportationServiceFeeCharges,
   isInboundTransportationMemoDescription,
+  loadInboundShipmentItemsFromAwdInboundShipmentReports,
   type InboundShipmentItem,
 } from './shipment-fee-allocation';
 
 const AWD_REPORT_TYPE = 'AWD_FEE_MONTHLY';
+const AWD_INBOUND_SHIPMENT_REPORT_DIR_ENV = 'PLUTUS_AWD_INBOUND_SHIPMENT_REPORT_DIR';
 
 type AwdFeeType = 'STORAGE_FEE' | 'PROCESSING_FEE' | 'TRANSPORTATION_FEE';
 type MarketplaceId = 'amazon.com' | 'amazon.co.uk';
@@ -496,14 +498,37 @@ async function buildInboundTransportationAllocationFromSpApi(input: {
   const shipmentItemsByShipmentId = new Map<string, InboundShipmentItem[]>();
   const uniqueShipmentIds = Array.from(new Set(extraction.charges.map((charge) => charge.shipmentId))).sort();
   for (const shipmentId of uniqueShipmentIds) {
-    const items = await fetchInboundShipmentItemsByShipmentId({ tenantCode, shipmentId });
-    shipmentItemsByShipmentId.set(
-      shipmentId,
-      items.map((item) => ({
+    let shipmentItems: InboundShipmentItem[] = [];
+    let spApiLookupIssue: string | null = null;
+    try {
+      const items = await fetchInboundShipmentItemsByShipmentId({ tenantCode, shipmentId });
+      shipmentItems = items.map((item) => ({
         sku: item.sellerSku,
         quantity: item.quantityShipped,
-      })),
-    );
+      }));
+    } catch (error) {
+      spApiLookupIssue = `SP-API inbound shipment item lookup failed for ${shipmentId}: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    }
+
+    if (shipmentItems.length === 0) {
+      const reportDir = process.env[AWD_INBOUND_SHIPMENT_REPORT_DIR_ENV];
+      if (typeof reportDir !== 'string' || reportDir.trim() === '') {
+        if (spApiLookupIssue !== null) issues.push(spApiLookupIssue);
+        issues.push(`Missing ${AWD_INBOUND_SHIPMENT_REPORT_DIR_ENV} for Seller Central AWD inbound shipment report lookup`);
+      } else {
+        const reportLookup = await loadInboundShipmentItemsFromAwdInboundShipmentReports({
+          shipmentId,
+          reportDir,
+        });
+        shipmentItems = reportLookup.items;
+        issues.push(...reportLookup.issues);
+        if (shipmentItems.length === 0 && spApiLookupIssue !== null) issues.push(spApiLookupIssue);
+      }
+    }
+
+    shipmentItemsByShipmentId.set(shipmentId, shipmentItems);
   }
 
   const allocation = allocateShipmentFeeChargesBySkuQuantity({
@@ -585,6 +610,10 @@ export async function buildDeterministicSkuAllocations(input: {
       if (isInboundTransportationMemoDescription(description)) {
         if (isSkuLessParentOnlyInboundTransportationMemo(description)) {
           // SKU-less and not deterministically allocatable with current SP-API transaction data.
+          continue;
+        }
+        if (cents > 0) {
+          // Positive inbound transportation rows are Amazon reversals/refunds, not shipment costs.
           continue;
         }
         inboundExpectedTotalCents += cents;

--- a/apps/plutus/lib/plutus/settlement-processing.ts
+++ b/apps/plutus/lib/plutus/settlement-processing.ts
@@ -15,7 +15,7 @@ import {
   type SaleCost,
 } from '@/lib/inventory/ledger';
 import { fromCents } from '@/lib/inventory/money';
-import { computePnlAllocation } from '@/lib/pnl-allocation';
+import { computePnlAllocation, type PnlAllocation, type PnlBucketKey } from '@/lib/pnl-allocation';
 import { db } from '@/lib/db';
 import { buildNoopJournalEntryId } from '@/lib/plutus/journal-entry-id';
 import { normalizeAuditMarketToMarketplaceId } from '@/lib/plutus/audit-invoice-matching';
@@ -338,6 +338,24 @@ function isLikelyCentScaledAuditInput(stats: {
   return stats.medianAbsNet >= 100 || stats.p90AbsNet >= 300;
 }
 
+const PNL_BUCKET_KEYS: PnlBucketKey[] = [
+  'amazonSellerFees',
+  'amazonFbaFees',
+  'amazonStorageFees',
+  'amazonAdvertisingCosts',
+  'amazonPromotions',
+  'amazonFbaInventoryReimbursement',
+  'warehousingAwd',
+];
+
+function buildEmptyBucketAmounts(): Record<PnlBucketKey, Record<string, number>> {
+  return Object.fromEntries(PNL_BUCKET_KEYS.map((bucket) => [bucket, {}])) as Record<PnlBucketKey, Record<string, number>>;
+}
+
+function buildEmptyBucketSkuBreakdown(): Record<PnlBucketKey, Record<string, Record<string, number>>> {
+  return Object.fromEntries(PNL_BUCKET_KEYS.map((bucket) => [bucket, {}])) as Record<PnlBucketKey, Record<string, Record<string, number>>>;
+}
+
 export async function computeSettlementPreview(input: {
   connection: QboConnection;
   settlementJournalEntryId: string;
@@ -357,14 +375,13 @@ export async function computeSettlementPreview(input: {
   const meta = parseSettlementDocNumber(settlement.DocNumber);
   const marketplace = meta.marketplace.id;
   const cogsEnabled = isCogsEnabledForMarketplace(marketplace);
+  if (meta.periodStart === null || meta.periodEnd === null) {
+    throw new Error(`Missing settlement period in DocNumber ${settlement.DocNumber}`);
+  }
 
   const invoiceId = input.invoiceId.trim();
   if (invoiceId === '') {
     throw new Error('Missing invoiceId');
-  }
-
-  if (input.auditRows.length === 0) {
-    throw new Error(`No audit rows provided for invoice ${invoiceId}`);
   }
 
   for (const row of input.auditRows) {
@@ -382,31 +399,31 @@ export async function computeSettlementPreview(input: {
   }
 
   const scopedInvoiceRows = input.auditRows;
-  const auditNetScaleStats = buildAuditNetScaleStats(scopedInvoiceRows);
-  if (isLikelyCentScaledAuditInput(auditNetScaleStats)) {
-    blocks.push({
-      code: 'AUDIT_NET_SCALE_SUSPECT',
-      message: 'Audit row net values appear cent-scaled (100x risk). Posting blocked until source net units are validated.',
-      details: {
-        rowCount: auditNetScaleStats.rowCount,
-        integerDollarRatio: Number(auditNetScaleStats.integerDollarRatio.toFixed(4)),
-        medianAbsNet: Number(auditNetScaleStats.medianAbsNet.toFixed(2)),
-        p90AbsNet: Number(auditNetScaleStats.p90AbsNet.toFixed(2)),
-        maxAbsNet: Number(auditNetScaleStats.maxAbsNet.toFixed(2)),
-      },
-    });
+  const hasAuditRows = scopedInvoiceRows.length > 0;
+  if (hasAuditRows) {
+    const auditNetScaleStats = buildAuditNetScaleStats(scopedInvoiceRows);
+    if (isLikelyCentScaledAuditInput(auditNetScaleStats)) {
+      blocks.push({
+        code: 'AUDIT_NET_SCALE_SUSPECT',
+        message: 'Audit row net values appear cent-scaled (100x risk). Posting blocked until source net units are validated.',
+        details: {
+          rowCount: auditNetScaleStats.rowCount,
+          integerDollarRatio: Number(auditNetScaleStats.integerDollarRatio.toFixed(4)),
+          medianAbsNet: Number(auditNetScaleStats.medianAbsNet.toFixed(2)),
+          p90AbsNet: Number(auditNetScaleStats.p90AbsNet.toFixed(2)),
+          maxAbsNet: Number(auditNetScaleStats.maxAbsNet.toFixed(2)),
+        },
+      });
+    }
   }
 
   const processingHash = computeProcessingHash(scopedInvoiceRows);
 
-  let minDate = scopedInvoiceRows[0]?.date;
-  let maxDate = scopedInvoiceRows[0]?.date;
+  let minDate = hasAuditRows ? scopedInvoiceRows[0]!.date : meta.periodStart;
+  let maxDate = hasAuditRows ? scopedInvoiceRows[0]!.date : meta.periodEnd;
   for (const row of scopedInvoiceRows) {
-    if (minDate === undefined || row.date < minDate) minDate = row.date;
-    if (maxDate === undefined || row.date > maxDate) maxDate = row.date;
-  }
-  if (minDate === undefined || maxDate === undefined) {
-    throw new Error('Audit file has no rows');
+    if (row.date < minDate) minDate = row.date;
+    if (row.date > maxDate) maxDate = row.date;
   }
 
   const existingSettlement = await db.settlementProcessing.findUnique({
@@ -528,12 +545,19 @@ export async function computeSettlementPreview(input: {
   for (const row of skuRows) {
     if (row.brand.marketplace !== marketplace) continue;
 
-    const sku = normalizeSku(row.sku);
-    const existing = skuToBrand.get(sku);
-    if (existing !== undefined && existing !== row.brand.name) {
-      throw new Error(`SKU maps to multiple brands in same marketplace: ${sku}`);
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
     }
-    skuToBrand.set(sku, row.brand.name);
+
+    for (const alias of aliases) {
+      const sku = normalizeSku(alias);
+      const existing = skuToBrand.get(sku);
+      if (existing !== undefined && existing !== row.brand.name) {
+        throw new Error(`SKU maps to multiple brands in same marketplace: ${sku}`);
+      }
+      skuToBrand.set(sku, row.brand.name);
+    }
   }
 
   const missingSkus: string[] = [];
@@ -767,35 +791,45 @@ export async function computeSettlementPreview(input: {
   const refundGroups = buildPrincipalGroupsByDate(scopedInvoiceRows, isRefundPrincipal);
   const hasInvoiceUnitMovements = saleGroups.size > 0 || refundGroups.size > 0;
 
-  let pnlAllocation;
+  let pnlAllocation: PnlAllocation;
   try {
-    const deterministicAllocations = await buildDeterministicSkuAllocations({
-      rows: scopedInvoiceRows,
-      marketplace,
-      invoiceStartDate: minDate,
-      invoiceEndDate: maxDate,
-      skuToBrand,
-      settlementId: input.settlementId,
-      sourceFilename: input.sourceFilename,
-    });
-    for (const issue of deterministicAllocations.issues) {
-      blocks.push({
-        code: 'PNL_ALLOCATION_WARNING',
-        message: issue.message,
-        details: { bucket: issue.bucket },
+    if (hasAuditRows) {
+      const deterministicAllocations = await buildDeterministicSkuAllocations({
+        rows: scopedInvoiceRows,
+        marketplace,
+        invoiceStartDate: minDate,
+        invoiceEndDate: maxDate,
+        skuToBrand,
+        settlementId: input.settlementId,
+        sourceFilename: input.sourceFilename,
       });
-    }
+      for (const issue of deterministicAllocations.issues) {
+        blocks.push({
+          code: 'PNL_ALLOCATION_SOURCE_GAP',
+          message: issue.message,
+          details: { bucket: issue.bucket },
+        });
+      }
 
-    pnlAllocation = computePnlAllocation(scopedInvoiceRows, brandResolver, {
-      skuAllocationsByBucket: deterministicAllocations.skuAllocationsByBucket,
-    });
-
-    for (const issue of pnlAllocation.unallocatedSkuLessBuckets) {
-      blocks.push({
-        code: 'PNL_ALLOCATION_WARNING',
-        message: `SKU-less bucket amount left in parent account. ${deterministicSourceGuidanceForBucket(issue.bucket)}`,
-        details: { bucket: issue.bucket, totalCents: issue.totalCents, reason: issue.reason },
+      pnlAllocation = computePnlAllocation(scopedInvoiceRows, brandResolver, {
+        skuAllocationsByBucket: deterministicAllocations.skuAllocationsByBucket,
       });
+
+      for (const issue of pnlAllocation.unallocatedSkuLessBuckets) {
+        blocks.push({
+          code: 'PNL_ALLOCATION_SOURCE_GAP',
+          message: `SKU-less bucket amount left in parent account. ${deterministicSourceGuidanceForBucket(issue.bucket)}`,
+          details: { bucket: issue.bucket, totalCents: issue.totalCents, reason: issue.reason },
+        });
+      }
+    } else {
+      const emptyPnlAllocation: PnlAllocation = {
+        invoiceId,
+        allocationsByBucket: buildEmptyBucketAmounts(),
+        skuBreakdownByBucketBrand: buildEmptyBucketSkuBreakdown(),
+        unallocatedSkuLessBuckets: [],
+      };
+      pnlAllocation = emptyPnlAllocation;
     }
   } catch (error) {
     blocks.push({
@@ -814,6 +848,8 @@ export async function computeSettlementPreview(input: {
         amazonFbaInventoryReimbursement: {},
         warehousingAwd: {},
       },
+      skuBreakdownByBucketBrand: buildEmptyBucketSkuBreakdown(),
+      unallocatedSkuLessBuckets: [],
     };
   }
 

--- a/apps/plutus/lib/plutus/settlement-types.ts
+++ b/apps/plutus/lib/plutus/settlement-types.ts
@@ -18,7 +18,7 @@ export type ProcessingBlock =
         | 'BILLS_FETCH_ERROR'
         | 'BILLS_PARSE_ERROR'
         | 'PNL_ALLOCATION_ERROR'
-        | 'PNL_ALLOCATION_WARNING';
+        | 'PNL_ALLOCATION_SOURCE_GAP';
       message: string;
       details?: Record<string, string | number>;
     };
@@ -27,7 +27,6 @@ const NON_BLOCKING_PROCESSING_CODES = new Set([
   'LATE_COST_ON_HAND_ZERO',
   'REFUND_ADJUSTMENT',
   'REFUND_PARTIAL',
-  'PNL_ALLOCATION_WARNING',
 ]);
 
 export function isBlockingProcessingCode(code: string): boolean {

--- a/apps/plutus/lib/plutus/shipment-fee-allocation.ts
+++ b/apps/plutus/lib/plutus/shipment-fee-allocation.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
 import { moneyToCents } from '@/lib/amazon-finances/money';
 import type {
   SpApiMoney,
@@ -10,6 +13,7 @@ import { normalizeSku } from './settlement-validation';
 const INBOUND_TRANSPORT_FEE_PHRASE = 'inbound transportation';
 const INBOUND_TRANSPORT_FEE_CODE_FRAGMENT = 'inboundtransportation';
 const SHIPMENT_IDENTIFIER_NAMES = ['ORDER_ID', 'SHIPMENT_ID', 'INBOUND_SHIPMENT_ID'];
+const AWD_INBOUND_REPORT_FILENAME_PATTERN = /\.csv$/i;
 
 export type InboundTransportationServiceFeeCharge = {
   shipmentId: string;
@@ -21,6 +25,12 @@ export type InboundTransportationServiceFeeCharge = {
 export type InboundShipmentItem = {
   sku: string;
   quantity: number;
+};
+
+export type AwdInboundShipmentReportLookup = {
+  items: InboundShipmentItem[];
+  sourceFiles: string[];
+  issues: string[];
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -42,6 +52,158 @@ function readTrimmedString(value: unknown): string | null {
   const trimmed = value.trim();
   if (trimmed === '') return null;
   return trimmed;
+}
+
+function splitCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (char === '"') {
+      if (inQuotes && line[index + 1] === '"') {
+        current += '"';
+        index += 1;
+        continue;
+      }
+      inQuotes = !inQuotes;
+      continue;
+    }
+    if (char === ',' && !inQuotes) {
+      result.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  result.push(current);
+  return result;
+}
+
+function parsePositiveInteger(value: string): number | null {
+  const normalized = value.trim();
+  if (!/^\d+$/.test(normalized)) return null;
+  const parsed = Number.parseInt(normalized, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+async function listCsvFiles(dirPath: string): Promise<string[]> {
+  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listCsvFiles(fullPath)));
+      continue;
+    }
+    if (entry.isFile() && AWD_INBOUND_REPORT_FILENAME_PATTERN.test(entry.name)) {
+      files.push(fullPath);
+    }
+  }
+
+  return files.sort();
+}
+
+function parseAwdInboundReportRows(input: {
+  csv: string;
+  shipmentId: string;
+  sourceFile: string;
+}): { items: InboundShipmentItem[]; issues: string[] } {
+  const lines = input.csv.split(/\r?\n/).filter((line) => line.trim() !== '');
+  if (lines.length === 0) {
+    return { items: [], issues: [`AWD inbound report is empty: ${input.sourceFile}`] };
+  }
+
+  const headers = splitCsvLine(lines[0]!).map((header) => header.trim());
+  const shipmentIdIndex = headers.indexOf('shipment_id');
+  const skuIndex = headers.indexOf('msku');
+  const expectedUnitCountIndex = headers.indexOf('expected_unit_count');
+  if (shipmentIdIndex === -1 || skuIndex === -1 || expectedUnitCountIndex === -1) {
+    return {
+      items: [],
+      issues: [`AWD inbound report missing required columns in ${input.sourceFile}`],
+    };
+  }
+
+  const quantityBySku = new Map<string, number>();
+  const issues: string[] = [];
+
+  for (let lineIndex = 1; lineIndex < lines.length; lineIndex += 1) {
+    const cols = splitCsvLine(lines[lineIndex]!);
+    if ((cols[shipmentIdIndex] ?? '').trim() !== input.shipmentId) continue;
+
+    const sku = normalizeSku(cols[skuIndex] ?? '');
+    if (sku === '') {
+      issues.push(`AWD inbound report row ${lineIndex + 1} missing MSKU in ${input.sourceFile}`);
+      continue;
+    }
+
+    const quantity = parsePositiveInteger(cols[expectedUnitCountIndex] ?? '');
+    if (quantity === null) {
+      issues.push(`AWD inbound report row ${lineIndex + 1} has invalid expected_unit_count in ${input.sourceFile}`);
+      continue;
+    }
+
+    const existing = quantityBySku.get(sku);
+    quantityBySku.set(sku, (existing === undefined ? 0 : existing) + quantity);
+  }
+
+  return {
+    items: Array.from(quantityBySku.entries()).map(([sku, quantity]) => ({ sku, quantity })),
+    issues,
+  };
+}
+
+export async function loadInboundShipmentItemsFromAwdInboundShipmentReports(input: {
+  shipmentId: string;
+  reportDir: string;
+}): Promise<AwdInboundShipmentReportLookup> {
+  const reportDir = input.reportDir.trim();
+  if (reportDir === '') {
+    return {
+      items: [],
+      sourceFiles: [],
+      issues: ['PLUTUS_AWD_INBOUND_SHIPMENT_REPORT_DIR is empty'],
+    };
+  }
+
+  const files = await listCsvFiles(reportDir);
+  const quantityBySku = new Map<string, number>();
+  const sourceFiles = new Set<string>();
+  const issues: string[] = [];
+
+  for (const filePath of files) {
+    const parsed = parseAwdInboundReportRows({
+      csv: await fs.readFile(filePath, 'utf8'),
+      shipmentId: input.shipmentId,
+      sourceFile: filePath,
+    });
+    if (parsed.items.length === 0) {
+      if (parsed.issues.length > 0) issues.push(...parsed.issues);
+      continue;
+    }
+
+    sourceFiles.add(filePath);
+    for (const item of parsed.items) {
+      const current = quantityBySku.get(item.sku);
+      quantityBySku.set(item.sku, (current === undefined ? 0 : current) + item.quantity);
+    }
+    issues.push(...parsed.issues);
+  }
+
+  if (quantityBySku.size === 0) {
+    issues.push(`No AWD inbound shipment report rows found for ${input.shipmentId}`);
+  }
+
+  return {
+    items: Array.from(quantityBySku.entries()).map(([sku, quantity]) => ({ sku, quantity })),
+    sourceFiles: Array.from(sourceFiles).sort(),
+    issues,
+  };
 }
 
 function toIdentifiers(value: unknown): SpApiTransactionRelatedIdentifier[] {

--- a/apps/plutus/lib/plutus/subledger/backfill.ts
+++ b/apps/plutus/lib/plutus/subledger/backfill.ts
@@ -1,0 +1,363 @@
+import { normalizeAliasLookupValue } from './sku-alias';
+
+export type LegacyBrandRow = {
+  id: string;
+  name: string;
+  marketplace: string;
+  currency: string;
+};
+
+export type LegacySkuRow = {
+  id: string;
+  sku: string;
+  asin: string | null;
+  productName: string | null;
+  brandId: string;
+};
+
+export type LegacyBillMappingRow = {
+  id: string;
+  qboBillId: string;
+  poNumber: string;
+  brandId: string;
+  billDate: string;
+  vendorName: string;
+  totalAmount: number;
+};
+
+export type LegacyBillLineMappingRow = {
+  id: string;
+  billMappingId: string;
+  qboLineId: string;
+  component: string;
+  amountCents: number;
+  sku: string | null;
+  quantity: number | null;
+};
+
+export type LegacySubledgerBackfillPlan = {
+  productGroups: Array<{ code: string; name: string }>;
+  canonicalProducts: Array<{ key: string; name: string; productGroupCode: string }>;
+  skuAliases: Array<{
+    canonicalProductKey: string;
+    marketplace: string;
+    aliasType: 'SKU' | 'ASIN';
+    value: string;
+    normalizedAliasType: string;
+    normalizedValue: string;
+  }>;
+  purchaseOrders: Array<{
+    internalRef: string;
+    sourceType: 'LEGACY_PO' | 'LEGACY_BILL';
+    sourceId: string;
+    marketplace: string;
+    supplierRef: string | null;
+  }>;
+  costLayers: Array<{
+    purchaseOrderSourceType: 'LEGACY_PO' | 'LEGACY_BILL';
+    purchaseOrderSourceId: string;
+    canonicalProductKey: string | null;
+    component: string;
+    quantity: number | null;
+    amountCents: number;
+    currency: string;
+    sourceQboTxnType: 'Bill';
+    sourceQboTxnId: string;
+    sourceQboLineId: string;
+  }>;
+};
+
+export type LegacySubledgerBackfillInput = {
+  brands: LegacyBrandRow[];
+  skus: LegacySkuRow[];
+  billMappings: LegacyBillMappingRow[];
+  billLineMappings: LegacyBillLineMappingRow[];
+};
+
+type PurchaseOrderSource = {
+  internalRef: string;
+  sourceType: 'LEGACY_PO' | 'LEGACY_BILL';
+  sourceId: string;
+};
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareNullableText(left: string | null, right: string | null): number {
+  if (left === null && right === null) return 0;
+  if (left === null) return -1;
+  if (right === null) return 1;
+  return compareText(left, right);
+}
+
+function sortBrands(brands: LegacyBrandRow[]): LegacyBrandRow[] {
+  return [...brands].sort((left, right) => {
+    const marketplaceComparison = compareText(left.marketplace, right.marketplace);
+    if (marketplaceComparison !== 0) return marketplaceComparison;
+    const nameComparison = compareText(left.name, right.name);
+    if (nameComparison !== 0) return nameComparison;
+    return compareText(left.id, right.id);
+  });
+}
+
+function sortSkus(skus: LegacySkuRow[]): LegacySkuRow[] {
+  return [...skus].sort((left, right) => {
+    const brandComparison = compareText(left.brandId, right.brandId);
+    if (brandComparison !== 0) return brandComparison;
+    const skuComparison = compareText(left.sku, right.sku);
+    if (skuComparison !== 0) return skuComparison;
+    const asinComparison = compareNullableText(left.asin, right.asin);
+    if (asinComparison !== 0) return asinComparison;
+    return compareText(left.id, right.id);
+  });
+}
+
+function sortBillMappings(mappings: LegacyBillMappingRow[]): LegacyBillMappingRow[] {
+  return [...mappings].sort((left, right) => {
+    const dateComparison = compareText(left.billDate, right.billDate);
+    if (dateComparison !== 0) return dateComparison;
+    const billComparison = compareText(left.qboBillId, right.qboBillId);
+    if (billComparison !== 0) return billComparison;
+    return compareText(left.id, right.id);
+  });
+}
+
+function sortBillLines(lines: LegacyBillLineMappingRow[]): LegacyBillLineMappingRow[] {
+  return [...lines].sort((left, right) => {
+    const mappingComparison = compareText(left.billMappingId, right.billMappingId);
+    if (mappingComparison !== 0) return mappingComparison;
+    const qboLineComparison = compareText(left.qboLineId, right.qboLineId);
+    if (qboLineComparison !== 0) return qboLineComparison;
+    return compareText(left.id, right.id);
+  });
+}
+
+function buildPurchaseOrderSource(
+  mapping: LegacyBillMappingRow,
+  marketplace: string,
+): PurchaseOrderSource {
+  const poNumber = mapping.poNumber.trim();
+  if (poNumber !== '') {
+    return {
+      internalRef: poNumber,
+      sourceType: 'LEGACY_PO',
+      sourceId: `${marketplace}:${poNumber}`,
+    };
+  }
+
+  return {
+    internalRef: `UNASSIGNED-BILL-${mapping.qboBillId}`,
+    sourceType: 'LEGACY_BILL',
+    sourceId: mapping.qboBillId,
+  };
+}
+
+function productNameForSku(sku: LegacySkuRow, key: string): string {
+  if (sku.productName !== null) {
+    const productName = sku.productName.trim();
+    if (productName !== '') return productName;
+  }
+
+  const skuValue = sku.sku.trim();
+  if (skuValue !== '') return skuValue;
+  return key;
+}
+
+export function normalizeAliasValue(value: string): string {
+  return normalizeAliasLookupValue(value);
+}
+
+export function mapLegacyBrandNameToProductGroupCode(name: string): string {
+  const trimmedName = name.trim();
+  const parts = trimmedName
+    .split('-')
+    .map((part) => part.trim())
+    .filter((part) => part !== '');
+  if (parts.length > 1) return parts[parts.length - 1].toUpperCase();
+  return trimmedName.toUpperCase();
+}
+
+export function planLegacySubledgerBackfill(
+  input: LegacySubledgerBackfillInput,
+): LegacySubledgerBackfillPlan {
+  const brandsById = new Map<string, LegacyBrandRow>();
+  const productGroupsByCode = new Map<string, { code: string; name: string }>();
+  const canonicalProductsByKey = new Map<
+    string,
+    { key: string; name: string; productGroupCode: string }
+  >();
+  const skuAliasesByKey = new Map<
+    string,
+    {
+      canonicalProductKey: string;
+      marketplace: string;
+      aliasType: 'SKU' | 'ASIN';
+      value: string;
+      normalizedAliasType: string;
+      normalizedValue: string;
+    }
+  >();
+  const canonicalProductKeyByMarketplaceSku = new Map<string, string>();
+  const billMappingsById = new Map<string, LegacyBillMappingRow>();
+  const billMappingBrandsById = new Map<string, LegacyBrandRow>();
+  const purchaseOrderSourceByBillMappingId = new Map<string, PurchaseOrderSource>();
+
+  for (const brand of sortBrands(input.brands)) {
+    brandsById.set(brand.id, brand);
+    const productGroupCode = mapLegacyBrandNameToProductGroupCode(brand.name);
+    if (!productGroupsByCode.has(productGroupCode)) {
+      productGroupsByCode.set(productGroupCode, { code: productGroupCode, name: productGroupCode });
+    }
+  }
+
+  for (const sku of sortSkus(input.skus)) {
+    const brand = brandsById.get(sku.brandId);
+    if (brand === undefined) throw new Error(`Missing brand for SKU ${sku.id}`);
+
+    const marketplace = brand.marketplace.trim();
+    const productGroupCode = mapLegacyBrandNameToProductGroupCode(brand.name);
+    const normalizedSku = normalizeAliasLookupValue(sku.sku);
+    const normalizedAsin = sku.asin === null ? '' : normalizeAliasLookupValue(sku.asin);
+    const canonicalProductKey =
+      normalizedAsin !== '' ? `ASIN:${normalizedAsin}` : `SKU:${marketplace}:${normalizedSku}`;
+
+    if (!canonicalProductsByKey.has(canonicalProductKey)) {
+      canonicalProductsByKey.set(canonicalProductKey, {
+        key: canonicalProductKey,
+        name: productNameForSku(sku, canonicalProductKey),
+        productGroupCode,
+      });
+    }
+
+    if (normalizedSku !== '') {
+      canonicalProductKeyByMarketplaceSku.set(
+        `${marketplace}:${normalizedSku}`,
+        canonicalProductKey,
+      );
+      const aliasKey = `${marketplace}:SKU:${normalizedSku}`;
+      if (!skuAliasesByKey.has(aliasKey)) {
+        skuAliasesByKey.set(aliasKey, {
+          canonicalProductKey,
+          marketplace,
+          aliasType: 'SKU',
+          value: sku.sku.trim(),
+          normalizedAliasType: 'SKU',
+          normalizedValue: normalizedSku,
+        });
+      }
+    }
+
+    if (normalizedAsin !== '') {
+      const aliasKey = `${marketplace}:ASIN:${normalizedAsin}`;
+      if (!skuAliasesByKey.has(aliasKey)) {
+        skuAliasesByKey.set(aliasKey, {
+          canonicalProductKey,
+          marketplace,
+          aliasType: 'ASIN',
+          value: normalizedAsin,
+          normalizedAliasType: 'ASIN',
+          normalizedValue: normalizedAsin,
+        });
+      }
+    }
+  }
+
+  const purchaseOrdersByKey = new Map<
+    string,
+    LegacySubledgerBackfillPlan['purchaseOrders'][number]
+  >();
+
+  for (const mapping of sortBillMappings(input.billMappings)) {
+    const brand = brandsById.get(mapping.brandId);
+    if (brand === undefined) throw new Error(`Missing brand for bill mapping ${mapping.id}`);
+
+    billMappingsById.set(mapping.id, mapping);
+    billMappingBrandsById.set(mapping.id, brand);
+
+    const marketplace = brand.marketplace.trim();
+    const purchaseOrderSource = buildPurchaseOrderSource(mapping, marketplace);
+    purchaseOrderSourceByBillMappingId.set(mapping.id, purchaseOrderSource);
+
+    const purchaseOrderKey = `${purchaseOrderSource.sourceType}:${purchaseOrderSource.sourceId}`;
+    if (!purchaseOrdersByKey.has(purchaseOrderKey)) {
+      purchaseOrdersByKey.set(purchaseOrderKey, {
+        internalRef: purchaseOrderSource.internalRef,
+        sourceType: purchaseOrderSource.sourceType,
+        sourceId: purchaseOrderSource.sourceId,
+        marketplace,
+        supplierRef: null,
+      });
+    }
+  }
+
+  const costLayers: LegacySubledgerBackfillPlan['costLayers'] = [];
+
+  for (const line of sortBillLines(input.billLineMappings)) {
+    const mapping = billMappingsById.get(line.billMappingId);
+    if (mapping === undefined) throw new Error(`Missing bill mapping for line ${line.id}`);
+
+    const brand = billMappingBrandsById.get(line.billMappingId);
+    if (brand === undefined) throw new Error(`Missing brand for bill mapping ${mapping.id}`);
+
+    const purchaseOrderSource = purchaseOrderSourceByBillMappingId.get(line.billMappingId);
+    if (purchaseOrderSource === undefined)
+      throw new Error(`Missing bill mapping for line ${line.id}`);
+
+    let canonicalProductKey: string | null = null;
+    if (line.sku !== null) {
+      const normalizedLineSku = normalizeAliasLookupValue(line.sku);
+      if (normalizedLineSku !== '') {
+        const resolvedKey = canonicalProductKeyByMarketplaceSku.get(
+          `${brand.marketplace.trim()}:${normalizedLineSku}`,
+        );
+        if (resolvedKey !== undefined) canonicalProductKey = resolvedKey;
+      }
+    }
+
+    costLayers.push({
+      purchaseOrderSourceType: purchaseOrderSource.sourceType,
+      purchaseOrderSourceId: purchaseOrderSource.sourceId,
+      canonicalProductKey,
+      component: line.component,
+      quantity: line.quantity,
+      amountCents: line.amountCents,
+      currency: brand.currency,
+      sourceQboTxnType: 'Bill',
+      sourceQboTxnId: mapping.qboBillId,
+      sourceQboLineId: line.qboLineId,
+    });
+  }
+
+  return {
+    productGroups: Array.from(productGroupsByCode.values()).sort((left, right) =>
+      compareText(left.code, right.code),
+    ),
+    canonicalProducts: Array.from(canonicalProductsByKey.values()).sort((left, right) =>
+      compareText(left.key, right.key),
+    ),
+    skuAliases: Array.from(skuAliasesByKey.values()).sort((left, right) => {
+      const marketplaceComparison = compareText(left.marketplace, right.marketplace);
+      if (marketplaceComparison !== 0) return marketplaceComparison;
+      const typeComparison = compareText(left.aliasType, right.aliasType);
+      if (typeComparison !== 0) return typeComparison;
+      const valueComparison = compareText(left.normalizedValue, right.normalizedValue);
+      if (valueComparison !== 0) return valueComparison;
+      return compareText(left.canonicalProductKey, right.canonicalProductKey);
+    }),
+    purchaseOrders: Array.from(purchaseOrdersByKey.values()).sort((left, right) => {
+      const sourceTypeComparison = compareText(left.sourceType, right.sourceType);
+      if (sourceTypeComparison !== 0) return sourceTypeComparison;
+      return compareText(left.sourceId, right.sourceId);
+    }),
+    costLayers: costLayers.sort((left, right) => {
+      const qboTxnComparison = compareText(left.sourceQboTxnId, right.sourceQboTxnId);
+      if (qboTxnComparison !== 0) return qboTxnComparison;
+      const qboLineComparison = compareText(left.sourceQboLineId, right.sourceQboLineId);
+      if (qboLineComparison !== 0) return qboLineComparison;
+      return compareText(left.component, right.component);
+    }),
+  };
+}

--- a/apps/plutus/lib/plutus/subledger/cost-flow.ts
+++ b/apps/plutus/lib/plutus/subledger/cost-flow.ts
@@ -1,0 +1,237 @@
+import {
+  emptyComponentCosts,
+  type ComponentCostsCents,
+  type InventoryMovementType,
+} from './types';
+
+export type FifoCostLayerInput = {
+  id: string;
+  canonicalProductId: string;
+  receivedDate: string;
+  quantity: number;
+  componentCostsCents: ComponentCostsCents;
+};
+
+export type InventoryMovementInput = {
+  id: string;
+  canonicalProductId: string;
+  movementDate: string;
+  movementType: InventoryMovementType;
+  quantity: number;
+};
+
+export type MovementCostResult = {
+  movementId: string;
+  quantity: number;
+  manufacturingCents: number;
+  freightCents: number;
+  dutyCents: number;
+  mfgAccessoriesCents: number;
+};
+
+export type EndingLayerResult = {
+  id: string;
+  remainingQuantity: number;
+};
+
+export type CostFlowBlock = {
+  movementId: string;
+  code: 'NEGATIVE_INVENTORY' | 'INVALID_LAYER' | 'INVALID_MOVEMENT';
+  message: string;
+};
+
+export type CostFlowResult = {
+  movementCosts: MovementCostResult[];
+  endingLayers: EndingLayerResult[];
+  blocks: CostFlowBlock[];
+};
+
+type LayerState = {
+  layer: FifoCostLayerInput;
+  consumedQuantity: number;
+  remainingQuantity: number;
+};
+
+function compareText(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
+}
+
+function compareLayers(left: FifoCostLayerInput, right: FifoCostLayerInput): number {
+  const dateComparison = compareText(left.receivedDate, right.receivedDate);
+  if (dateComparison !== 0) return dateComparison;
+  return compareText(left.id, right.id);
+}
+
+function compareMovements(left: InventoryMovementInput, right: InventoryMovementInput): number {
+  const dateComparison = compareText(left.movementDate, right.movementDate);
+  if (dateComparison !== 0) return dateComparison;
+  return compareText(left.id, right.id);
+}
+
+function componentCostsAreFinite(componentCostsCents: ComponentCostsCents): boolean {
+  return (
+    Number.isFinite(componentCostsCents.manufacturing) &&
+    Number.isFinite(componentCostsCents.freight) &&
+    Number.isFinite(componentCostsCents.duty) &&
+    Number.isFinite(componentCostsCents.mfgAccessories)
+  );
+}
+
+function allocateComponentCost(
+  totalCostCents: number,
+  totalQuantity: number,
+  consumedBefore: number,
+  consumeQuantity: number,
+): number {
+  const costThroughEnd = Math.round((totalCostCents * (consumedBefore + consumeQuantity)) / totalQuantity);
+  const costThroughStart = Math.round((totalCostCents * consumedBefore) / totalQuantity);
+  return costThroughEnd - costThroughStart;
+}
+
+function movementCostResult(
+  movementId: string,
+  quantity: number,
+  componentCostsCents: ComponentCostsCents,
+): MovementCostResult {
+  return {
+    movementId,
+    quantity,
+    manufacturingCents: componentCostsCents.manufacturing,
+    freightCents: componentCostsCents.freight,
+    dutyCents: componentCostsCents.duty,
+    mfgAccessoriesCents: componentCostsCents.mfgAccessories,
+  };
+}
+
+export function consumeInventoryMovementsFifo(input: {
+  layers: FifoCostLayerInput[];
+  movements: InventoryMovementInput[];
+}): CostFlowResult {
+  const blocks: CostFlowBlock[] = [];
+  const movementCosts: MovementCostResult[] = [];
+  const layerStates: LayerState[] = [];
+
+  for (const layer of input.layers) {
+    if (!(Number.isFinite(layer.quantity) && layer.quantity > 0)) {
+      blocks.push({
+        movementId: layer.id,
+        code: 'INVALID_LAYER',
+        message: `Layer ${layer.id} quantity must be positive`,
+      });
+      continue;
+    }
+
+    if (!componentCostsAreFinite(layer.componentCostsCents)) {
+      blocks.push({
+        movementId: layer.id,
+        code: 'INVALID_LAYER',
+        message: `Layer ${layer.id} component costs must be finite`,
+      });
+      continue;
+    }
+
+    layerStates.push({
+      layer,
+      consumedQuantity: 0,
+      remainingQuantity: layer.quantity,
+    });
+  }
+
+  layerStates.sort((left, right) => compareLayers(left.layer, right.layer));
+
+  const validMovements: InventoryMovementInput[] = [];
+  for (const movement of input.movements) {
+    if (!Number.isFinite(movement.quantity)) {
+      blocks.push({
+        movementId: movement.id,
+        code: 'INVALID_MOVEMENT',
+        message: `Movement ${movement.id} quantity must be finite`,
+      });
+      continue;
+    }
+
+    if (movement.quantity === 0) {
+      blocks.push({
+        movementId: movement.id,
+        code: 'INVALID_MOVEMENT',
+        message: `Movement ${movement.id} quantity cannot be zero`,
+      });
+      continue;
+    }
+
+    validMovements.push(movement);
+  }
+
+  validMovements.sort(compareMovements);
+
+  for (const movement of validMovements) {
+    if (movement.quantity > 0) continue;
+
+    const absoluteQuantity = Math.abs(movement.quantity);
+    const availableQuantity = layerStates.reduce((total, state) => {
+      if (state.layer.canonicalProductId !== movement.canonicalProductId) return total;
+      return total + state.remainingQuantity;
+    }, 0);
+    let quantityToConsume = Math.min(absoluteQuantity, availableQuantity);
+    let consumedQuantity = 0;
+    const componentCostsCents = emptyComponentCosts();
+
+    if (availableQuantity < absoluteQuantity) {
+      blocks.push({
+        movementId: movement.id,
+        code: 'NEGATIVE_INVENTORY',
+        message: `Movement ${movement.id} needs ${absoluteQuantity} units but only ${availableQuantity} are available`,
+      });
+    }
+
+    for (const state of layerStates) {
+      if (quantityToConsume === 0) break;
+      if (state.layer.canonicalProductId !== movement.canonicalProductId) continue;
+      if (state.remainingQuantity === 0) continue;
+
+      const consumeQuantity = Math.min(quantityToConsume, state.remainingQuantity);
+      componentCostsCents.manufacturing += allocateComponentCost(
+        state.layer.componentCostsCents.manufacturing,
+        state.layer.quantity,
+        state.consumedQuantity,
+        consumeQuantity,
+      );
+      componentCostsCents.freight += allocateComponentCost(
+        state.layer.componentCostsCents.freight,
+        state.layer.quantity,
+        state.consumedQuantity,
+        consumeQuantity,
+      );
+      componentCostsCents.duty += allocateComponentCost(
+        state.layer.componentCostsCents.duty,
+        state.layer.quantity,
+        state.consumedQuantity,
+        consumeQuantity,
+      );
+      componentCostsCents.mfgAccessories += allocateComponentCost(
+        state.layer.componentCostsCents.mfgAccessories,
+        state.layer.quantity,
+        state.consumedQuantity,
+        consumeQuantity,
+      );
+
+      state.consumedQuantity += consumeQuantity;
+      state.remainingQuantity -= consumeQuantity;
+      consumedQuantity += consumeQuantity;
+      quantityToConsume -= consumeQuantity;
+    }
+
+    movementCosts.push(movementCostResult(movement.id, consumedQuantity, componentCostsCents));
+  }
+
+  return {
+    movementCosts,
+    endingLayers: layerStates.map((state) => ({
+      id: state.layer.id,
+      remainingQuantity: state.remainingQuantity,
+    })),
+    blocks,
+  };
+}

--- a/apps/plutus/lib/plutus/subledger/qbo-trace.ts
+++ b/apps/plutus/lib/plutus/subledger/qbo-trace.ts
@@ -1,0 +1,106 @@
+import { createHash } from 'node:crypto';
+
+import { plutusTraceInputSchema, type PlutusTraceInput } from './types';
+
+export type PostingFingerprintLine = {
+  lineId: string;
+  accountId: string;
+  amountCents: number;
+  description: string;
+};
+
+export type PostingFingerprint = {
+  postingHash: string;
+  lineHashesById: Map<string, string>;
+};
+
+export type PostingFingerprintDiff = {
+  status: 'in_sync' | 'drifted';
+  missingLineIds: string[];
+  extraLineIds: string[];
+  changedLineIds: string[];
+};
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+export function buildPlutusTraceMemo(input: PlutusTraceInput): string {
+  const parsed = plutusTraceInputSchema.parse(input);
+  return `PLUTUS_REF=${parsed.plutusRef}; SOURCE=${parsed.source}; MARKET=${parsed.market}; PERIOD=${parsed.period}`;
+}
+
+export function buildPlutusLineDescription(input: {
+  category: string;
+  plutusLineId: string;
+}): string {
+  const category = input.category.trim();
+  const plutusLineId = input.plutusLineId.trim();
+  if (category === '') throw new Error('category is required');
+  if (plutusLineId === '') throw new Error('plutusLineId is required');
+  return `${category}; PLUTUS_LINE=${plutusLineId}`;
+}
+
+export function fingerprintPostingLines(lines: PostingFingerprintLine[]): PostingFingerprint {
+  const lineHashesById = new Map<string, string>();
+  const normalizedLines = lines
+    .map((line) => ({ ...line, lineId: line.lineId.trim() }))
+    .sort((left, right) => {
+      if (left.lineId < right.lineId) return -1;
+      if (left.lineId > right.lineId) return 1;
+      return 0;
+    });
+
+  for (const line of normalizedLines) {
+    const lineId = line.lineId;
+    if (lineId === '') throw new Error('lineId is required');
+    if (lineHashesById.has(lineId)) throw new Error('duplicate lineId is not allowed');
+    lineHashesById.set(
+      lineId,
+      hashJson({
+        accountId: line.accountId,
+        amountCents: line.amountCents,
+        description: line.description,
+      }),
+    );
+  }
+
+  return {
+    postingHash: hashJson(Array.from(lineHashesById.entries())),
+    lineHashesById,
+  };
+}
+
+export function comparePostingFingerprints(
+  expected: PostingFingerprint,
+  live: PostingFingerprint,
+): PostingFingerprintDiff {
+  const missingLineIds: string[] = [];
+  const extraLineIds: string[] = [];
+  const changedLineIds: string[] = [];
+
+  for (const [lineId, expectedHash] of expected.lineHashesById.entries()) {
+    const liveHash = live.lineHashesById.get(lineId);
+    if (liveHash === undefined) {
+      missingLineIds.push(lineId);
+    } else if (liveHash !== expectedHash) {
+      changedLineIds.push(lineId);
+    }
+  }
+
+  for (const lineId of live.lineHashesById.keys()) {
+    if (!expected.lineHashesById.has(lineId)) {
+      extraLineIds.push(lineId);
+    }
+  }
+
+  return {
+    status:
+      missingLineIds.length === 0 && extraLineIds.length === 0 && changedLineIds.length === 0
+        ? 'in_sync'
+        : 'drifted',
+    missingLineIds: missingLineIds.sort(),
+    extraLineIds: extraLineIds.sort(),
+    changedLineIds: changedLineIds.sort(),
+  };
+}

--- a/apps/plutus/lib/plutus/subledger/sku-alias.ts
+++ b/apps/plutus/lib/plutus/subledger/sku-alias.ts
@@ -1,0 +1,34 @@
+export type SkuAliasCandidate = {
+  canonicalProductId: string;
+  marketplace: string;
+  aliasType: string;
+  value: string;
+};
+
+export function normalizeAliasLookupValue(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+export function resolveCanonicalProductAlias(
+  aliases: SkuAliasCandidate[],
+  marketplace: string,
+  aliasType: string,
+  value: string,
+): string | null {
+  const normalizedMarketplace = marketplace.trim();
+  const normalizedAliasType = aliasType.trim().toUpperCase();
+  const normalizedValue = normalizeAliasLookupValue(value);
+
+  if (normalizedMarketplace === '') return null;
+  if (normalizedAliasType === '') return null;
+  if (normalizedValue === '') return null;
+
+  for (const alias of aliases) {
+    if (alias.marketplace !== normalizedMarketplace) continue;
+    if (alias.aliasType.trim().toUpperCase() !== normalizedAliasType) continue;
+    if (normalizeAliasLookupValue(alias.value) !== normalizedValue) continue;
+    return alias.canonicalProductId;
+  }
+
+  return null;
+}

--- a/apps/plutus/lib/plutus/subledger/types.ts
+++ b/apps/plutus/lib/plutus/subledger/types.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod';
+
+export const PLUTUS_TRACE_SOURCES = [
+  'AMZ_SETTLEMENT',
+  'QBO_BILL',
+  'QBO_PURCHASE',
+  'MANUAL_ADJUSTMENT',
+] as const;
+export const PLUTUS_TRACE_MARKETS = ['US', 'UK', 'MULTI'] as const;
+export const PO_COST_COMPONENTS = ['manufacturing', 'freight', 'duty', 'mfgAccessories'] as const;
+export const INVENTORY_MOVEMENT_TYPES = [
+  'RECEIPT',
+  'SALE',
+  'RETURN',
+  'REMOVAL',
+  'DISPOSAL',
+  'ADJUSTMENT',
+] as const;
+export const QBO_DRIFT_STATUSES = [
+  'unchecked',
+  'in_sync',
+  'drifted',
+  'missing_in_qbo',
+  'duplicate_qbo_posting',
+  'stale_mapping',
+] as const;
+
+export type PlutusTraceSource = (typeof PLUTUS_TRACE_SOURCES)[number];
+export type PlutusTraceMarket = (typeof PLUTUS_TRACE_MARKETS)[number];
+export type PoCostComponent = (typeof PO_COST_COMPONENTS)[number];
+export type InventoryMovementType = (typeof INVENTORY_MOVEMENT_TYPES)[number];
+export type QboDriftStatus = (typeof QBO_DRIFT_STATUSES)[number];
+
+export const plutusTraceInputSchema = z.object({
+  plutusRef: z.string().trim().min(1, 'plutusRef is required'),
+  source: z.enum(PLUTUS_TRACE_SOURCES),
+  market: z.enum(PLUTUS_TRACE_MARKETS),
+  period: z.string().trim().min(1, 'period is required'),
+});
+
+export type PlutusTraceInput = z.infer<typeof plutusTraceInputSchema>;
+
+export type ComponentCostsCents = Record<PoCostComponent, number>;
+
+export function emptyComponentCosts(): ComponentCostsCents {
+  return {
+    manufacturing: 0,
+    freight: 0,
+    duty: 0,
+    mfgAccessories: 0,
+  };
+}

--- a/apps/plutus/lib/pnl-allocation.ts
+++ b/apps/plutus/lib/pnl-allocation.ts
@@ -83,6 +83,17 @@ function isSkuLessParentOnlyMemo(bucket: PnlBucketKey, description: string): boo
   return false;
 }
 
+function isPositiveInboundTransportationReversal(bucket: PnlBucketKey, description: string, cents: number): boolean {
+  if (bucket !== 'amazonFbaFees') return false;
+  if (cents <= 0) return false;
+
+  const normalized = description.trim();
+  if (normalized === 'Amazon FBA Fees - FBA Inbound Transportation Fee') return true;
+  if (normalized === 'Amazon FBA Fees - FBA Inbound Transportation Fee - Domestic Orders') return true;
+  if (normalized === 'Amazon FBA Fees - FBA Inbound Transportation Program Fee - Domestic Orders') return true;
+  return false;
+}
+
 function shouldRequirePnlBucketClassification(description: string): boolean {
   const normalized = description.trim();
   if (normalized === '') return false;
@@ -179,7 +190,11 @@ export function computePnlAllocation(
       continue;
     }
 
-    if (skuLessParentOnlyBuckets.has(bucket) || isSkuLessParentOnlyMemo(bucket, row.description)) {
+    if (
+      skuLessParentOnlyBuckets.has(bucket) ||
+      isSkuLessParentOnlyMemo(bucket, row.description) ||
+      isPositiveInboundTransportationReversal(bucket, row.description, cents)
+    ) {
       continue;
     }
 

--- a/apps/plutus/package.json
+++ b/apps/plutus/package.json
@@ -23,10 +23,10 @@
     "settlements:backfill-docnumbers": "tsx scripts/backfill-settlement-doc-numbers.ts",
     "settlements:backfill-fx": "tsx scripts/backfill-settlement-exchange-rates.ts",
     "db:generate": "prisma generate --schema prisma/schema.prisma",
-    "db:push": "prisma db push --schema prisma/schema.prisma",
-    "db:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
-    "db:migrate": "prisma migrate dev --schema prisma/schema.prisma",
-    "db:studio": "prisma studio --schema prisma/schema.prisma"
+    "db:push": "tsx scripts/require-database-url-schema.ts && prisma db push --schema prisma/schema.prisma",
+    "db:migrate:deploy": "tsx scripts/require-database-url-schema.ts && prisma migrate deploy --schema prisma/schema.prisma",
+    "db:migrate": "tsx scripts/require-database-url-schema.ts && prisma migrate dev --schema prisma/schema.prisma",
+    "db:studio": "tsx scripts/require-database-url-schema.ts && prisma studio --schema prisma/schema.prisma"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/apps/plutus/package.json
+++ b/apps/plutus/package.json
@@ -22,6 +22,7 @@
     "settlements:us:ingest:spapi": "tsx scripts/us-settlement-ingest-spapi.ts",
     "settlements:backfill-docnumbers": "tsx scripts/backfill-settlement-doc-numbers.ts",
     "settlements:backfill-fx": "tsx scripts/backfill-settlement-exchange-rates.ts",
+    "subledger:backfill": "tsx scripts/backfill-subledger-foundation.ts",
     "db:generate": "prisma generate --schema prisma/schema.prisma",
     "db:push": "tsx scripts/require-database-url-schema.ts && prisma db push --schema prisma/schema.prisma",
     "db:migrate:deploy": "tsx scripts/require-database-url-schema.ts && prisma migrate deploy --schema prisma/schema.prisma",

--- a/apps/plutus/prisma/migrations/20260513021151_add_subledger_foundation/migration.sql
+++ b/apps/plutus/prisma/migrations/20260513021151_add_subledger_foundation/migration.sql
@@ -1,0 +1,272 @@
+-- CreateTable
+CREATE TABLE "ProductGroup" (
+    "id" TEXT NOT NULL,
+    "code" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProductGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "CanonicalProduct" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "productGroupId" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CanonicalProduct_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SkuAlias" (
+    "id" TEXT NOT NULL,
+    "canonicalProductId" TEXT NOT NULL,
+    "marketplace" TEXT NOT NULL,
+    "aliasType" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SkuAlias_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PurchaseOrder" (
+    "id" TEXT NOT NULL,
+    "internalRef" TEXT NOT NULL,
+    "supplierRef" TEXT,
+    "marketplace" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'OPEN',
+    "sourceNotes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PurchaseOrder_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PoCostLayer" (
+    "id" TEXT NOT NULL,
+    "purchaseOrderId" TEXT NOT NULL,
+    "canonicalProductId" TEXT NOT NULL,
+    "component" TEXT NOT NULL,
+    "quantity" INTEGER,
+    "amountCents" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL,
+    "allocationMethod" TEXT NOT NULL,
+    "sourceQboTxnType" TEXT,
+    "sourceQboTxnId" TEXT,
+    "sourceQboLineId" TEXT,
+    "sourceDocumentName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PoCostLayer_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "InventoryMovement" (
+    "id" TEXT NOT NULL,
+    "canonicalProductId" TEXT NOT NULL,
+    "marketplace" TEXT NOT NULL,
+    "movementType" TEXT NOT NULL,
+    "quantity" INTEGER NOT NULL,
+    "movementDate" TIMESTAMP(3) NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT NOT NULL,
+    "sourceLineId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "InventoryMovement_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostingIntent" (
+    "id" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT NOT NULL,
+    "market" TEXT NOT NULL,
+    "periodStart" TEXT,
+    "periodEnd" TEXT,
+    "sourceHash" TEXT NOT NULL,
+    "mappingVersion" TEXT NOT NULL,
+    "postingHash" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'draft',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PostingIntent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostingIntentLine" (
+    "id" TEXT NOT NULL,
+    "postingIntentId" TEXT NOT NULL,
+    "lineRef" TEXT NOT NULL,
+    "category" TEXT NOT NULL,
+    "accountId" TEXT,
+    "amountCents" INTEGER NOT NULL,
+    "currency" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "lineHash" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PostingIntentLine_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "QboPosting" (
+    "id" TEXT NOT NULL,
+    "postingIntentId" TEXT NOT NULL,
+    "qboTxnType" TEXT NOT NULL,
+    "qboTxnId" TEXT NOT NULL,
+    "qboSyncToken" TEXT,
+    "qboDocNumber" TEXT,
+    "qboPrivateNote" TEXT,
+    "qboTxnDate" TEXT,
+    "postingHash" TEXT NOT NULL,
+    "driftStatus" TEXT NOT NULL DEFAULT 'unchecked',
+    "attachmentStatus" TEXT NOT NULL DEFAULT 'missing',
+    "lastCheckedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QboPosting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "QboPostingLineFingerprint" (
+    "id" TEXT NOT NULL,
+    "qboPostingId" TEXT NOT NULL,
+    "qboLineId" TEXT NOT NULL,
+    "expectedLineHash" TEXT NOT NULL,
+    "liveLineHash" TEXT,
+    "driftStatus" TEXT NOT NULL DEFAULT 'unchecked',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QboPostingLineFingerprint_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProductGroup_code_key" ON "ProductGroup"("code");
+
+-- CreateIndex
+CREATE INDEX "ProductGroup_active_idx" ON "ProductGroup"("active");
+
+-- CreateIndex
+CREATE INDEX "CanonicalProduct_productGroupId_idx" ON "CanonicalProduct"("productGroupId");
+
+-- CreateIndex
+CREATE INDEX "CanonicalProduct_active_idx" ON "CanonicalProduct"("active");
+
+-- CreateIndex
+CREATE INDEX "SkuAlias_canonicalProductId_idx" ON "SkuAlias"("canonicalProductId");
+
+-- CreateIndex
+CREATE INDEX "SkuAlias_marketplace_idx" ON "SkuAlias"("marketplace");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SkuAlias_marketplace_aliasType_value_key" ON "SkuAlias"("marketplace", "aliasType", "value");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PurchaseOrder_internalRef_key" ON "PurchaseOrder"("internalRef");
+
+-- CreateIndex
+CREATE INDEX "PurchaseOrder_marketplace_idx" ON "PurchaseOrder"("marketplace");
+
+-- CreateIndex
+CREATE INDEX "PurchaseOrder_status_idx" ON "PurchaseOrder"("status");
+
+-- CreateIndex
+CREATE INDEX "PoCostLayer_purchaseOrderId_idx" ON "PoCostLayer"("purchaseOrderId");
+
+-- CreateIndex
+CREATE INDEX "PoCostLayer_canonicalProductId_idx" ON "PoCostLayer"("canonicalProductId");
+
+-- CreateIndex
+CREATE INDEX "PoCostLayer_component_idx" ON "PoCostLayer"("component");
+
+-- CreateIndex
+CREATE INDEX "PoCostLayer_sourceQboTxnType_sourceQboTxnId_idx" ON "PoCostLayer"("sourceQboTxnType", "sourceQboTxnId");
+
+-- CreateIndex
+CREATE INDEX "InventoryMovement_canonicalProductId_idx" ON "InventoryMovement"("canonicalProductId");
+
+-- CreateIndex
+CREATE INDEX "InventoryMovement_marketplace_idx" ON "InventoryMovement"("marketplace");
+
+-- CreateIndex
+CREATE INDEX "InventoryMovement_movementType_idx" ON "InventoryMovement"("movementType");
+
+-- CreateIndex
+CREATE INDEX "InventoryMovement_movementDate_idx" ON "InventoryMovement"("movementDate");
+
+-- CreateIndex
+CREATE INDEX "InventoryMovement_sourceType_sourceId_idx" ON "InventoryMovement"("sourceType", "sourceId");
+
+-- CreateIndex
+CREATE INDEX "PostingIntent_market_idx" ON "PostingIntent"("market");
+
+-- CreateIndex
+CREATE INDEX "PostingIntent_status_idx" ON "PostingIntent"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostingIntent_sourceType_sourceId_key" ON "PostingIntent"("sourceType", "sourceId");
+
+-- CreateIndex
+CREATE INDEX "PostingIntentLine_postingIntentId_idx" ON "PostingIntentLine"("postingIntentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PostingIntentLine_postingIntentId_lineRef_key" ON "PostingIntentLine"("postingIntentId", "lineRef");
+
+-- CreateIndex
+CREATE INDEX "QboPosting_postingIntentId_idx" ON "QboPosting"("postingIntentId");
+
+-- CreateIndex
+CREATE INDEX "QboPosting_driftStatus_idx" ON "QboPosting"("driftStatus");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QboPosting_qboTxnType_qboTxnId_key" ON "QboPosting"("qboTxnType", "qboTxnId");
+
+-- CreateIndex
+CREATE INDEX "QboPostingLineFingerprint_qboPostingId_idx" ON "QboPostingLineFingerprint"("qboPostingId");
+
+-- CreateIndex
+CREATE INDEX "QboPostingLineFingerprint_driftStatus_idx" ON "QboPostingLineFingerprint"("driftStatus");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "QboPostingLineFingerprint_qboPostingId_qboLineId_key" ON "QboPostingLineFingerprint"("qboPostingId", "qboLineId");
+
+-- AddForeignKey
+ALTER TABLE "CanonicalProduct" ADD CONSTRAINT "CanonicalProduct_productGroupId_fkey" FOREIGN KEY ("productGroupId") REFERENCES "ProductGroup"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SkuAlias" ADD CONSTRAINT "SkuAlias_canonicalProductId_fkey" FOREIGN KEY ("canonicalProductId") REFERENCES "CanonicalProduct"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PoCostLayer" ADD CONSTRAINT "PoCostLayer_purchaseOrderId_fkey" FOREIGN KEY ("purchaseOrderId") REFERENCES "PurchaseOrder"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PoCostLayer" ADD CONSTRAINT "PoCostLayer_canonicalProductId_fkey" FOREIGN KEY ("canonicalProductId") REFERENCES "CanonicalProduct"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "InventoryMovement" ADD CONSTRAINT "InventoryMovement_canonicalProductId_fkey" FOREIGN KEY ("canonicalProductId") REFERENCES "CanonicalProduct"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostingIntentLine" ADD CONSTRAINT "PostingIntentLine_postingIntentId_fkey" FOREIGN KEY ("postingIntentId") REFERENCES "PostingIntent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QboPosting" ADD CONSTRAINT "QboPosting_postingIntentId_fkey" FOREIGN KEY ("postingIntentId") REFERENCES "PostingIntent"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "QboPostingLineFingerprint" ADD CONSTRAINT "QboPostingLineFingerprint_qboPostingId_fkey" FOREIGN KEY ("qboPostingId") REFERENCES "QboPosting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/apps/plutus/prisma/migrations/20260513021151_add_subledger_foundation/migration.sql
+++ b/apps/plutus/prisma/migrations/20260513021151_add_subledger_foundation/migration.sql
@@ -29,6 +29,8 @@ CREATE TABLE "SkuAlias" (
     "marketplace" TEXT NOT NULL,
     "aliasType" TEXT NOT NULL,
     "value" TEXT NOT NULL,
+    "normalizedAliasType" TEXT NOT NULL,
+    "normalizedValue" TEXT NOT NULL,
     "active" BOOLEAN NOT NULL DEFAULT true,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
@@ -40,6 +42,8 @@ CREATE TABLE "SkuAlias" (
 CREATE TABLE "PurchaseOrder" (
     "id" TEXT NOT NULL,
     "internalRef" TEXT NOT NULL,
+    "sourceType" TEXT NOT NULL,
+    "sourceId" TEXT NOT NULL,
     "supplierRef" TEXT,
     "marketplace" TEXT,
     "status" TEXT NOT NULL DEFAULT 'OPEN',
@@ -178,13 +182,19 @@ CREATE INDEX "SkuAlias_marketplace_idx" ON "SkuAlias"("marketplace");
 CREATE UNIQUE INDEX "SkuAlias_marketplace_aliasType_value_key" ON "SkuAlias"("marketplace", "aliasType", "value");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "PurchaseOrder_internalRef_key" ON "PurchaseOrder"("internalRef");
+CREATE UNIQUE INDEX "SkuAlias_marketplace_normalizedAliasType_normalizedValue_key" ON "SkuAlias"("marketplace", "normalizedAliasType", "normalizedValue");
+
+-- CreateIndex
+CREATE INDEX "PurchaseOrder_internalRef_idx" ON "PurchaseOrder"("internalRef");
 
 -- CreateIndex
 CREATE INDEX "PurchaseOrder_marketplace_idx" ON "PurchaseOrder"("marketplace");
 
 -- CreateIndex
 CREATE INDEX "PurchaseOrder_status_idx" ON "PurchaseOrder"("status");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PurchaseOrder_sourceType_sourceId_key" ON "PurchaseOrder"("sourceType", "sourceId");
 
 -- CreateIndex
 CREATE INDEX "PoCostLayer_purchaseOrderId_idx" ON "PoCostLayer"("purchaseOrderId");
@@ -269,4 +279,3 @@ ALTER TABLE "QboPosting" ADD CONSTRAINT "QboPosting_postingIntentId_fkey" FOREIG
 
 -- AddForeignKey
 ALTER TABLE "QboPostingLineFingerprint" ADD CONSTRAINT "QboPostingLineFingerprint_qboPostingId_fkey" FOREIGN KEY ("qboPostingId") REFERENCES "QboPosting"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-

--- a/apps/plutus/prisma/schema.prisma
+++ b/apps/plutus/prisma/schema.prisma
@@ -314,6 +314,198 @@ model BillLineMapping {
   @@unique([billMappingId, qboLineId])
 }
 
+model ProductGroup {
+  id        String   @id @default(cuid())
+  code      String   @unique
+  name      String
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  products CanonicalProduct[]
+
+  @@index([active])
+}
+
+model CanonicalProduct {
+  id             String   @id @default(cuid())
+  name           String
+  productGroupId String
+  active         Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  productGroup       ProductGroup        @relation(fields: [productGroupId], references: [id])
+  aliases            SkuAlias[]
+  costLayers         PoCostLayer[]
+  inventoryMovements InventoryMovement[]
+
+  @@index([productGroupId])
+  @@index([active])
+}
+
+model SkuAlias {
+  id                 String   @id @default(cuid())
+  canonicalProductId String
+  marketplace        String
+  aliasType          String
+  value              String
+  active             Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id], onDelete: Cascade)
+
+  @@unique([marketplace, aliasType, value])
+  @@index([canonicalProductId])
+  @@index([marketplace])
+}
+
+model PurchaseOrder {
+  id           String   @id @default(cuid())
+  internalRef  String   @unique
+  supplierRef  String?
+  marketplace  String?
+  status       String   @default("OPEN")
+  sourceNotes  String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  costLayers PoCostLayer[]
+
+  @@index([marketplace])
+  @@index([status])
+}
+
+model PoCostLayer {
+  id                 String   @id @default(cuid())
+  purchaseOrderId    String
+  canonicalProductId String
+  component          String
+  quantity           Int?
+  amountCents        Int
+  currency           String
+  allocationMethod   String
+  sourceQboTxnType   String?
+  sourceQboTxnId     String?
+  sourceQboLineId    String?
+  sourceDocumentName String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  purchaseOrder    PurchaseOrder    @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id])
+
+  @@index([purchaseOrderId])
+  @@index([canonicalProductId])
+  @@index([component])
+  @@index([sourceQboTxnType, sourceQboTxnId])
+}
+
+model InventoryMovement {
+  id                 String   @id @default(cuid())
+  canonicalProductId String
+  marketplace        String
+  movementType       String
+  quantity           Int
+  movementDate       DateTime
+  sourceType         String
+  sourceId           String
+  sourceLineId       String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id])
+
+  @@index([canonicalProductId])
+  @@index([marketplace])
+  @@index([movementType])
+  @@index([movementDate])
+  @@index([sourceType, sourceId])
+}
+
+model PostingIntent {
+  id             String   @id @default(cuid())
+  sourceType     String
+  sourceId       String
+  market         String
+  periodStart    String?
+  periodEnd      String?
+  sourceHash     String
+  mappingVersion String
+  postingHash    String
+  status         String   @default("draft")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  lines       PostingIntentLine[]
+  qboPostings QboPosting[]
+
+  @@unique([sourceType, sourceId])
+  @@index([market])
+  @@index([status])
+}
+
+model PostingIntentLine {
+  id              String   @id @default(cuid())
+  postingIntentId String
+  lineRef         String
+  category        String
+  accountId       String?
+  amountCents     Int
+  currency        String
+  description     String
+  lineHash        String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  postingIntent PostingIntent @relation(fields: [postingIntentId], references: [id], onDelete: Cascade)
+
+  @@unique([postingIntentId, lineRef])
+  @@index([postingIntentId])
+}
+
+model QboPosting {
+  id               String    @id @default(cuid())
+  postingIntentId  String
+  qboTxnType       String
+  qboTxnId         String
+  qboSyncToken     String?
+  qboDocNumber     String?
+  qboPrivateNote   String?
+  qboTxnDate       String?
+  postingHash      String
+  driftStatus      String    @default("unchecked")
+  attachmentStatus String    @default("missing")
+  lastCheckedAt    DateTime?
+  createdAt        DateTime  @default(now())
+  updatedAt        DateTime  @updatedAt
+
+  postingIntent    PostingIntent              @relation(fields: [postingIntentId], references: [id], onDelete: Cascade)
+  lineFingerprints QboPostingLineFingerprint[]
+
+  @@unique([qboTxnType, qboTxnId])
+  @@index([postingIntentId])
+  @@index([driftStatus])
+}
+
+model QboPostingLineFingerprint {
+  id               String   @id @default(cuid())
+  qboPostingId     String
+  qboLineId        String
+  expectedLineHash String
+  liveLineHash     String?
+  driftStatus      String   @default("unchecked")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  qboPosting QboPosting @relation(fields: [qboPostingId], references: [id], onDelete: Cascade)
+
+  @@unique([qboPostingId, qboLineId])
+  @@index([qboPostingId])
+  @@index([driftStatus])
+}
+
 /// AwdDataUpload tracks AWD monthly fee report uploads used for deterministic AWD fee allocation.
 model AwdDataUpload {
   id         String   @id @default(cuid())

--- a/apps/plutus/prisma/schema.prisma
+++ b/apps/plutus/prisma/schema.prisma
@@ -345,25 +345,30 @@ model CanonicalProduct {
 }
 
 model SkuAlias {
-  id                 String   @id @default(cuid())
-  canonicalProductId String
-  marketplace        String
-  aliasType          String
-  value              String
-  active             Boolean  @default(true)
-  createdAt          DateTime @default(now())
-  updatedAt          DateTime @updatedAt
+  id                  String   @id @default(cuid())
+  canonicalProductId  String
+  marketplace         String
+  aliasType           String
+  value               String
+  normalizedAliasType String
+  normalizedValue     String
+  active              Boolean  @default(true)
+  createdAt           DateTime @default(now())
+  updatedAt           DateTime @updatedAt
 
   canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id], onDelete: Cascade)
 
   @@unique([marketplace, aliasType, value])
+  @@unique([marketplace, normalizedAliasType, normalizedValue])
   @@index([canonicalProductId])
   @@index([marketplace])
 }
 
 model PurchaseOrder {
   id           String   @id @default(cuid())
-  internalRef  String   @unique
+  internalRef  String
+  sourceType   String
+  sourceId     String
   supplierRef  String?
   marketplace  String?
   status       String   @default("OPEN")
@@ -373,6 +378,8 @@ model PurchaseOrder {
 
   costLayers PoCostLayer[]
 
+  @@unique([sourceType, sourceId])
+  @@index([internalRef])
   @@index([marketplace])
   @@index([status])
 }

--- a/apps/plutus/scripts/backfill-subledger-foundation.ts
+++ b/apps/plutus/scripts/backfill-subledger-foundation.ts
@@ -1,0 +1,420 @@
+import { promises as fs } from 'node:fs';
+
+import {
+  planLegacySubledgerBackfill,
+  type LegacySubledgerBackfillPlan,
+} from '@/lib/plutus/subledger/backfill';
+
+type PlutusDb = typeof import('@/lib/db').db;
+type CanonicalProductLookupDb = Pick<PlutusDb, 'skuAlias'>;
+
+type CliOptions = {
+  apply: boolean;
+  plutusEnvPath: string;
+};
+
+type BackfillSummary = {
+  apply: boolean;
+  productGroups: number;
+  canonicalProducts: number;
+  skuAliases: number;
+  purchaseOrders: number;
+  costLayers: number;
+  unassignedCostLayers: number;
+};
+
+function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
+  let line = rawLine.trim();
+  if (line === '') return null;
+  if (line.startsWith('#')) return null;
+
+  if (line.startsWith('export ')) {
+    line = line.slice('export '.length).trim();
+  }
+
+  const equalsIndex = line.indexOf('=');
+  if (equalsIndex === -1) return null;
+
+  const key = line.slice(0, equalsIndex).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
+
+  let value = line.slice(equalsIndex + 1).trim();
+  if (value.startsWith("'") && value.endsWith("'")) {
+    value = value.slice(1, -1);
+  }
+  if (value.startsWith('"') && value.endsWith('"')) {
+    value = value.slice(1, -1);
+  }
+
+  return { key, value };
+}
+
+async function loadPlutusEnvFile(filePath: string): Promise<void> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  for (const line of raw.split(/\r?\n/)) {
+    const parsed = parseDotenvLine(line);
+    if (parsed === null) continue;
+    process.env[parsed.key] = parsed.value;
+  }
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let plutusEnvPath = '.env.local';
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i]!;
+
+    if (arg === '--') {
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--plutus-env') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --plutus-env');
+      plutusEnvPath = next;
+      i += 2;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { apply, plutusEnvPath };
+}
+
+async function buildBackfillPlan(db: PlutusDb): Promise<LegacySubledgerBackfillPlan> {
+  const [brands, skus, billMappings, billLineMappings] = await Promise.all([
+    db.brand.findMany({
+      select: {
+        id: true,
+        name: true,
+        marketplace: true,
+        currency: true,
+      },
+    }),
+    db.sku.findMany({
+      select: {
+        id: true,
+        sku: true,
+        asin: true,
+        productName: true,
+        brandId: true,
+      },
+    }),
+    db.billMapping.findMany({
+      select: {
+        id: true,
+        qboBillId: true,
+        poNumber: true,
+        brandId: true,
+        billDate: true,
+        vendorName: true,
+        totalAmount: true,
+      },
+    }),
+    db.billLineMapping.findMany({
+      select: {
+        id: true,
+        billMappingId: true,
+        qboLineId: true,
+        component: true,
+        amountCents: true,
+        sku: true,
+        quantity: true,
+      },
+    }),
+  ]);
+
+  return planLegacySubledgerBackfill({
+    brands,
+    skus,
+    billMappings,
+    billLineMappings,
+  });
+}
+
+function summarizeBackfillPlan(plan: LegacySubledgerBackfillPlan, apply: boolean): BackfillSummary {
+  return {
+    apply,
+    productGroups: plan.productGroups.length,
+    canonicalProducts: plan.canonicalProducts.length,
+    skuAliases: plan.skuAliases.length,
+    purchaseOrders: plan.purchaseOrders.length,
+    costLayers: plan.costLayers.length,
+    unassignedCostLayers: plan.costLayers.filter((layer) => layer.canonicalProductKey === null)
+      .length,
+  };
+}
+
+function parseCanonicalProductKey(
+  key: string,
+):
+  | { type: 'ASIN'; normalizedAsin: string }
+  | { type: 'SKU'; marketplace: string; normalizedSku: string } {
+  if (key.startsWith('ASIN:')) {
+    const normalizedAsin = key.slice('ASIN:'.length);
+    if (normalizedAsin === '') throw new Error(`Invalid canonical product key: ${key}`);
+    return { type: 'ASIN', normalizedAsin };
+  }
+
+  if (key.startsWith('SKU:')) {
+    const parts = key.split(':');
+    if (parts.length !== 3) throw new Error(`Invalid canonical product key: ${key}`);
+    const marketplace = parts[1]!;
+    const normalizedSku = parts[2]!;
+    if (marketplace === '') throw new Error(`Invalid canonical product key: ${key}`);
+    if (normalizedSku === '') throw new Error(`Invalid canonical product key: ${key}`);
+    return { type: 'SKU', marketplace, normalizedSku };
+  }
+
+  throw new Error(`Invalid canonical product key: ${key}`);
+}
+
+async function findCanonicalProductIdByKey(
+  db: CanonicalProductLookupDb,
+  key: string,
+): Promise<string | null> {
+  const parsed = parseCanonicalProductKey(key);
+
+  if (parsed.type === 'ASIN') {
+    const aliases = await db.skuAlias.findMany({
+      where: {
+        normalizedAliasType: 'ASIN',
+        normalizedValue: parsed.normalizedAsin,
+      },
+      select: {
+        canonicalProductId: true,
+      },
+    });
+    const ids = new Set(aliases.map((alias) => alias.canonicalProductId));
+    if (ids.size > 1) {
+      throw new Error(`ASIN alias resolves to multiple canonical products: ${key}`);
+    }
+    const first = ids.values().next();
+    return first.done === true ? null : first.value;
+  }
+
+  const alias = await db.skuAlias.findUnique({
+    where: {
+      marketplace_normalizedAliasType_normalizedValue: {
+        marketplace: parsed.marketplace,
+        normalizedAliasType: 'SKU',
+        normalizedValue: parsed.normalizedSku,
+      },
+    },
+    select: {
+      canonicalProductId: true,
+    },
+  });
+
+  return alias === null ? null : alias.canonicalProductId;
+}
+
+function getRequiredMapValue(map: Map<string, string>, key: string, label: string): string {
+  const value = map.get(key);
+  if (value === undefined) throw new Error(`Missing ${label}: ${key}`);
+  return value;
+}
+
+async function applyBackfillPlan(db: PlutusDb, plan: LegacySubledgerBackfillPlan): Promise<void> {
+  await db.$transaction(async (tx) => {
+    const productGroupIdByCode = new Map<string, string>();
+    for (const productGroup of plan.productGroups) {
+      const row = await tx.productGroup.upsert({
+        where: { code: productGroup.code },
+        update: {
+          name: productGroup.name,
+          active: true,
+        },
+        create: {
+          code: productGroup.code,
+          name: productGroup.name,
+          active: true,
+        },
+      });
+      productGroupIdByCode.set(productGroup.code, row.id);
+    }
+
+    const canonicalProductIdByKey = new Map<string, string>();
+    for (const canonicalProduct of plan.canonicalProducts) {
+      const productGroupId = getRequiredMapValue(
+        productGroupIdByCode,
+        canonicalProduct.productGroupCode,
+        'product group',
+      );
+      const existingId = await findCanonicalProductIdByKey(tx, canonicalProduct.key);
+      const row =
+        existingId === null
+          ? await tx.canonicalProduct.create({
+              data: {
+                name: canonicalProduct.name,
+                productGroupId,
+                active: true,
+              },
+            })
+          : await tx.canonicalProduct.update({
+              where: { id: existingId },
+              data: {
+                name: canonicalProduct.name,
+                productGroupId,
+                active: true,
+              },
+            });
+      canonicalProductIdByKey.set(canonicalProduct.key, row.id);
+    }
+
+    for (const alias of plan.skuAliases) {
+      const canonicalProductId = getRequiredMapValue(
+        canonicalProductIdByKey,
+        alias.canonicalProductKey,
+        'canonical product',
+      );
+      await tx.skuAlias.upsert({
+        where: {
+          marketplace_normalizedAliasType_normalizedValue: {
+            marketplace: alias.marketplace,
+            normalizedAliasType: alias.normalizedAliasType,
+            normalizedValue: alias.normalizedValue,
+          },
+        },
+        update: {
+          canonicalProductId,
+          aliasType: alias.aliasType,
+          value: alias.value,
+          normalizedAliasType: alias.normalizedAliasType,
+          normalizedValue: alias.normalizedValue,
+          active: true,
+        },
+        create: {
+          canonicalProductId,
+          marketplace: alias.marketplace,
+          aliasType: alias.aliasType,
+          value: alias.value,
+          normalizedAliasType: alias.normalizedAliasType,
+          normalizedValue: alias.normalizedValue,
+          active: true,
+        },
+      });
+    }
+
+    const purchaseOrderIdBySourceKey = new Map<string, string>();
+    for (const purchaseOrder of plan.purchaseOrders) {
+      const row = await tx.purchaseOrder.upsert({
+        where: {
+          sourceType_sourceId: {
+            sourceType: purchaseOrder.sourceType,
+            sourceId: purchaseOrder.sourceId,
+          },
+        },
+        update: {
+          internalRef: purchaseOrder.internalRef,
+          supplierRef: purchaseOrder.supplierRef,
+          marketplace: purchaseOrder.marketplace,
+        },
+        create: {
+          internalRef: purchaseOrder.internalRef,
+          sourceType: purchaseOrder.sourceType,
+          sourceId: purchaseOrder.sourceId,
+          supplierRef: purchaseOrder.supplierRef,
+          marketplace: purchaseOrder.marketplace,
+        },
+      });
+      purchaseOrderIdBySourceKey.set(
+        `${purchaseOrder.sourceType}:${purchaseOrder.sourceId}`,
+        row.id,
+      );
+    }
+
+    for (const costLayer of plan.costLayers) {
+      if (costLayer.canonicalProductKey === null) continue;
+
+      const purchaseOrderId = getRequiredMapValue(
+        purchaseOrderIdBySourceKey,
+        `${costLayer.purchaseOrderSourceType}:${costLayer.purchaseOrderSourceId}`,
+        'purchase order',
+      );
+      const canonicalProductId = getRequiredMapValue(
+        canonicalProductIdByKey,
+        costLayer.canonicalProductKey,
+        'canonical product',
+      );
+
+      const existingLayers = await tx.poCostLayer.findMany({
+        where: {
+          purchaseOrderId,
+          canonicalProductId,
+          component: costLayer.component,
+          sourceQboTxnType: costLayer.sourceQboTxnType,
+          sourceQboTxnId: costLayer.sourceQboTxnId,
+          sourceQboLineId: costLayer.sourceQboLineId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      if (existingLayers.length > 1) {
+        throw new Error(
+          `Multiple PO cost layers match QBO line ${costLayer.sourceQboTxnId}:${costLayer.sourceQboLineId}`,
+        );
+      }
+
+      const data = {
+        quantity: costLayer.quantity,
+        amountCents: costLayer.amountCents,
+        currency: costLayer.currency,
+        allocationMethod: 'LEGACY_BILL_LINE_MAPPING',
+        sourceQboTxnType: costLayer.sourceQboTxnType,
+        sourceQboTxnId: costLayer.sourceQboTxnId,
+        sourceQboLineId: costLayer.sourceQboLineId,
+      };
+
+      if (existingLayers.length === 0) {
+        await tx.poCostLayer.create({
+          data: {
+            purchaseOrderId,
+            canonicalProductId,
+            component: costLayer.component,
+            ...data,
+          },
+        });
+        continue;
+      }
+
+      await tx.poCostLayer.update({
+        where: { id: existingLayers[0]!.id },
+        data,
+      });
+    }
+  });
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  await loadPlutusEnvFile(options.plutusEnvPath);
+
+  const { db } = await import('@/lib/db');
+
+  try {
+    const plan = await buildBackfillPlan(db);
+    if (options.apply) {
+      await applyBackfillPlan(db, plan);
+    }
+    console.log(JSON.stringify(summarizeBackfillPlan(plan, options.apply), null, 2));
+  } finally {
+    await db.$disconnect();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/plutus/scripts/inventory-audit.ts
+++ b/apps/plutus/scripts/inventory-audit.ts
@@ -6,6 +6,7 @@ import { normalizeAuditMarketToMarketplaceId } from '@/lib/plutus/audit-invoice-
 import { fetchJournalEntryById, type QboConnection, type QboJournalEntry } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import { isNoopJournalEntryId, isQboJournalEntryId } from '@/lib/plutus/journal-entry-id';
+import { computeProcessingHash } from '@/lib/plutus/settlement-validation';
 
 type DbClient = typeof import('@/lib/db').db;
 type ComputeSettlementPreview = typeof import('@/lib/plutus/settlement-processing').computeSettlementPreview;
@@ -315,6 +316,44 @@ async function auditProcessingRow(input: {
   });
 
   if (rows.length === 0) {
+    const emptyProcessingHash = computeProcessingHash([]);
+    if (isNoopJournalEntryId(input.processing.qboCogsJournalEntryId)) {
+      return {
+        result: {
+          marketplace: input.processing.marketplace,
+          invoiceId: input.processing.invoiceId,
+          settlementProcessingId: input.processing.id,
+          createdAt: input.processing.createdAt.toISOString(),
+          processingHash: {
+            stored: input.processing.processingHash,
+            computed: emptyProcessingHash,
+            matches: input.processing.processingHash === emptyProcessingHash,
+          },
+          auditUpload: upload
+            ? {
+                id: upload.id,
+                filename: upload.filename,
+                uploadedAt: upload.uploadedAt.toISOString(),
+              }
+            : null,
+          blocks: [],
+          inventoryBlockSummary: {
+            missingCostBasisCount: 0,
+            negativeInventoryCount: 0,
+            billsErrorCount: 0,
+          },
+          cogsJe: {
+            id: input.processing.qboCogsJournalEntryId,
+            status: 'noop',
+            previewLineCount: 0,
+            qboLineCount: 0,
+            mismatchedAccounts: [],
+          },
+        },
+        updatedConnection: input.connection,
+      };
+    }
+
     throw new Error(`No audit rows found for invoice ${input.processing.invoiceId} (file ${input.processing.sourceFilename})`);
   }
 

--- a/apps/plutus/scripts/inventory-bills-audit.ts
+++ b/apps/plutus/scripts/inventory-bills-audit.ts
@@ -1,10 +1,12 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { extractPoNumberFromBill } from '@/lib/plutus/bills/pull-sync';
 
 import { parseSkuQuantityFromDescription } from '@/lib/inventory/qbo-bills';
 
 type CliOptions = {
   since: string;
+  marketplace: 'all' | 'amazon.com' | 'amazon.co.uk';
 };
 
 type BillIssue =
@@ -55,6 +57,7 @@ function printUsage(): void {
   console.log('');
   console.log('Options:');
   console.log('  --since <YYYY-MM-DD>   (default: 2024-01-01)');
+  console.log('  --marketplace <all|amazon.com|amazon.co.uk>   (default: all)');
   console.log('');
 }
 
@@ -117,6 +120,7 @@ function requireIsoDay(value: string, label: string): string {
 
 function parseArgs(argv: string[]): CliOptions {
   let since = '2024-01-01';
+  let marketplace: CliOptions['marketplace'] = 'all';
 
   let i = 0;
   while (i < argv.length) {
@@ -135,14 +139,26 @@ function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (arg === '--marketplace') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('Missing value for --marketplace');
+      if (next !== 'all' && next !== 'amazon.com' && next !== 'amazon.co.uk') {
+        throw new Error(`Invalid --marketplace value: ${next}`);
+      }
+      marketplace = next;
+      i += 2;
+      continue;
+    }
+
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  return { since };
+  return { since, marketplace };
 }
 
 type InventoryLine = {
   component: 'manufacturing' | 'freight' | 'duty' | 'mfgAccessories';
+  marketplace: 'amazon.com' | 'amazon.co.uk' | null;
   lineId: string;
   amount: number;
   description: string;
@@ -151,6 +167,7 @@ type InventoryLine = {
 type QboAccount = {
   Id: string;
   Name: string;
+  FullyQualifiedName?: string;
   AccountType?: string;
   AccountSubType?: string;
 };
@@ -171,23 +188,11 @@ function classifyInventoryComponentFromAccount(account: QboAccount): InventoryLi
   return null;
 }
 
-function isPoMemoCaseMismatch(memo: string): boolean {
-  const trimmed = memo.trim();
-  if (trimmed === '') return false;
-  if (trimmed.startsWith('PO: ')) return false;
-  return /^po:\s+/i.test(trimmed);
-}
-
-function parsePoNumber(memo: string): string {
-  const trimmed = memo.trim();
-  if (!trimmed.startsWith('PO: ')) {
-    throw new Error(`Bill memo must start with "PO: " (got "${memo}")`);
-  }
-  const po = trimmed.slice(4).trim();
-  if (po === '') {
-    throw new Error(`Bill memo PO number is empty (got "${memo}")`);
-  }
-  return po;
+function classifyInventoryMarketplaceFromAccount(account: QboAccount): InventoryLine['marketplace'] {
+  const name = `${account.FullyQualifiedName ?? ''} ${account.Name}`.trim();
+  if (name.includes('US-PDS')) return 'amazon.com';
+  if (name.includes('UK-PDS')) return 'amazon.co.uk';
+  return null;
 }
 
 async function main(): Promise<void> {
@@ -280,12 +285,15 @@ async function main(): Promise<void> {
       if (!account) continue;
       const component = classifyInventoryComponentFromAccount(account);
       if (component === null) continue;
+      const lineMarketplace = classifyInventoryMarketplaceFromAccount(account);
+      if (options.marketplace !== 'all' && lineMarketplace !== options.marketplace) continue;
 
       const amount = typeof line.Amount === 'number' ? line.Amount : 0;
       const description = typeof line.Description === 'string' ? line.Description : '';
 
       lineItems.push({
         component,
+        marketplace: lineMarketplace,
         lineId: String(line.Id),
         amount,
         description,
@@ -309,15 +317,11 @@ async function main(): Promise<void> {
         }
       }
     } else {
-      const trimmedMemo = privateNote.trim();
-      if (!trimmedMemo.startsWith('PO: ')) {
-        if (isPoMemoCaseMismatch(privateNote)) {
-          issues.push({ code: 'INVENTORY_BILL_UNMAPPED_PO_MEMO_CASE_MISMATCH', billId, txnDate, vendorName, docNumber, privateNote });
-        } else {
-          issues.push({ code: 'INVENTORY_BILL_UNMAPPED_MISSING_PO_MEMO', billId, txnDate, vendorName, docNumber, privateNote });
-        }
+      const extractedPoNumber = extractPoNumberFromBill(bill);
+      if (extractedPoNumber === '') {
+        issues.push({ code: 'INVENTORY_BILL_UNMAPPED_MISSING_PO_MEMO', billId, txnDate, vendorName, docNumber, privateNote });
       } else {
-        poNumber = parsePoNumber(privateNote);
+        poNumber = extractedPoNumber;
         for (const line of lineItems) {
           if (line.component !== 'manufacturing') continue;
           try {
@@ -395,6 +399,7 @@ async function main(): Promise<void> {
       {
         ok: issues.length === 0,
         since: options.since,
+        marketplace: options.marketplace,
         totals: {
           billsFetched: bills.length,
           inventoryBills: inventoryBills.length,

--- a/apps/plutus/scripts/require-database-url-schema.ts
+++ b/apps/plutus/scripts/require-database-url-schema.ts
@@ -1,0 +1,37 @@
+const databaseUrl = process.env.DATABASE_URL;
+
+if (databaseUrl === undefined) {
+  console.error('DATABASE_URL is required for Plutus Prisma migrations');
+  process.exit(1);
+}
+
+if (databaseUrl.trim() === '') {
+  console.error('DATABASE_URL is required for Plutus Prisma migrations');
+  process.exit(1);
+}
+
+let parsedUrl: URL;
+
+try {
+  parsedUrl = new URL(databaseUrl);
+} catch {
+  console.error('DATABASE_URL must be a valid PostgreSQL URL for Plutus Prisma migrations');
+  process.exit(1);
+}
+
+if (parsedUrl.protocol !== 'postgresql:') {
+  console.error('DATABASE_URL must be a valid PostgreSQL URL for Plutus Prisma migrations');
+  process.exit(1);
+}
+
+const schema = parsedUrl.searchParams.get('schema');
+
+if (schema === null) {
+  console.error('DATABASE_URL must include ?schema=<schema> for Plutus Prisma migrations');
+  process.exit(1);
+}
+
+if (schema.trim() === '') {
+  console.error('DATABASE_URL must include ?schema=<schema> for Plutus Prisma migrations');
+  process.exit(1);
+}

--- a/apps/plutus/scripts/settlement-processing-audit.ts
+++ b/apps/plutus/scripts/settlement-processing-audit.ts
@@ -260,7 +260,7 @@ async function requireAccounts(connection: QboConnection): Promise<{ accounts: Q
 }
 
 function buildSkuToBrandMapsByMarketplace(
-  skuRows: Array<{ sku: string; brand: { name: string; marketplace: string } }>,
+  skuRows: Array<{ sku: string; asin: string | null; brand: { name: string; marketplace: string } }>,
 ): Map<string, Map<string, string>> {
   const byMarketplace = new Map<string, Map<string, string>>();
 
@@ -271,7 +271,20 @@ function buildSkuToBrandMapsByMarketplace(
       skuToBrand = new Map<string, string>();
       byMarketplace.set(marketplace, skuToBrand);
     }
-    skuToBrand.set(normalizeSku(row.sku), row.brand.name);
+
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
+    }
+
+    for (const alias of aliases) {
+      const sku = normalizeSku(alias);
+      const existing = skuToBrand.get(sku);
+      if (existing !== undefined && existing !== row.brand.name) {
+        throw new Error(`SKU maps to multiple brands in same marketplace: ${sku}`);
+      }
+      skuToBrand.set(sku, row.brand.name);
+    }
   }
 
   return byMarketplace;
@@ -891,7 +904,7 @@ async function main(): Promise<void> {
     );
   }
 
-  if (mismatched.length > 0) {
+  if (mismatched.length > 0 || deterministicNotOk.length > 0) {
     process.exitCode = 1;
   }
 }

--- a/apps/plutus/scripts/us-settlement-allocation-check.ts
+++ b/apps/plutus/scripts/us-settlement-allocation-check.ts
@@ -109,7 +109,13 @@ async function main(): Promise<void> {
   const skuToBrand = new Map<string, string>();
   for (const row of skuRows) {
     if (row.brand.marketplace !== options.marketplace) continue;
-    skuToBrand.set(normalizeSku(row.sku), row.brand.name);
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
+    }
+    for (const alias of aliases) {
+      skuToBrand.set(normalizeSku(alias), row.brand.name);
+    }
   }
 
   const storedRows = await db.auditDataRow.findMany({

--- a/apps/plutus/scripts/us-settlement-ingest-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-ingest-spapi.ts
@@ -301,7 +301,13 @@ async function main(): Promise<void> {
   const skuToBrandName = new Map<string, string>();
   for (const row of skus) {
     if (row.brand.marketplace !== 'amazon.com') continue;
-    skuToBrandName.set(normalizeSku(row.sku), row.brand.name);
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
+    }
+    for (const alias of aliases) {
+      skuToBrandName.set(normalizeSku(alias), row.brand.name);
+    }
   }
 
   const maybeConnection = await getQboConnection();

--- a/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
@@ -36,6 +36,7 @@ type SegmentResult = {
   status: 'ok' | 'mismatch';
   mismatchCount: number;
   mismatches: Array<{ key: string; expected: number; actual: number }>;
+  reason?: string;
 };
 
 function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
@@ -421,7 +422,13 @@ async function main(): Promise<void> {
   const skuToBrandName = new Map<string, string>();
   for (const row of skus) {
     if (row.brand.marketplace !== 'amazon.com') continue;
-    skuToBrandName.set(normalizeSku(row.sku), row.brand.name);
+    const aliases = [row.sku];
+    if (typeof row.asin === 'string' && row.asin.trim() !== '') {
+      aliases.push(row.asin);
+    }
+    for (const alias of aliases) {
+      skuToBrandName.set(normalizeSku(alias), row.brand.name);
+    }
   }
 
   const results: SegmentResult[] = [];
@@ -465,7 +472,24 @@ async function main(): Promise<void> {
 
     for (let segmentIdx = 0; segmentIdx < draft.segments.length; segmentIdx++) {
       const segment = draft.segments[segmentIdx]!;
+      const isLast = segmentIdx === draft.segments.length - 1;
+      const originalTotalCents = isLast ? draft.originalTotalCents : 0;
+      const hasExpectedJournalLines =
+        Array.from(segment.memoTotalsCents.values()).some((cents) => cents !== 0) || originalTotalCents !== 0;
       const actualJe = journalsByDocNumber.get(segment.docNumber);
+      if (!actualJe && !hasExpectedJournalLines) {
+        results.push({
+          settlementId,
+          eventGroupId,
+          docNumber: segment.docNumber,
+          txnDate: segment.txnDate,
+          status: 'ok',
+          mismatchCount: 0,
+          mismatches: [],
+          reason: 'No QBO JE expected for empty segment',
+        });
+        continue;
+      }
       if (!actualJe) {
         throw new Error(`Missing QBO JE for DocNumber ${segment.docNumber} (settlement ${settlementId})`);
       }
@@ -508,17 +532,6 @@ async function main(): Promise<void> {
           );
         }
         settlementControlAccountId = matches[0]!.Id;
-      }
-
-      const isLast = segmentIdx === draft.segments.length - 1;
-      const originalTotalCents = isLast ? draft.originalTotalCents : 0;
-      const transferSucceeded = draft.fundTransferStatus === 'Succeeded';
-
-      if (isLast && transferSucceeded && originalTotalCents > 0 && bankAccountId === '') {
-        throw new Error(`Missing 'Transfer to Bank' line in ${segment.docNumber}`);
-      }
-      if (isLast && originalTotalCents < 0 && paymentAccountId === '') {
-        throw new Error(`Missing 'Payment to Amazon' line in ${segment.docNumber}`);
       }
 
       const expectedDrafts = buildQboJournalEntriesFromUsSettlementDraft({

--- a/apps/plutus/scripts/us-settlement-reset-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reset-spapi.ts
@@ -3,6 +3,7 @@ import { loadSharedPlutusEnv } from './shared-env';
 
 import { parseSettlementSyncCliPostFlag } from '@/lib/amazon-finances/settlement-sync-post-mode';
 import { isSettlementDocNumber, parseSettlementDocNumber, stripPlutusDocPrefix } from '@/lib/plutus/settlement-doc-number';
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
 
 type CliOptions = {
   startDate: string;
@@ -12,6 +13,8 @@ type CliOptions = {
   apply: boolean;
   resync: boolean;
   postToQbo: boolean;
+  settlementIds: string[] | undefined;
+  humanApproval: string | null;
 };
 
 function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
@@ -85,6 +88,8 @@ function parseArgs(argv: string[]): CliOptions {
   let plutusEnvPath = '.env.local';
   let apply = false;
   let resync = true;
+  let settlementIds: string[] | undefined;
+  let humanApproval: string | null = null;
 
   let i = 0;
   while (i < postFlag.argv.length) {
@@ -122,6 +127,28 @@ function parseArgs(argv: string[]): CliOptions {
       continue;
     }
 
+    if (arg === '--settlement-ids') {
+      const next = postFlag.argv[i + 1];
+      if (!next) throw new Error('Missing value for --settlement-ids');
+      settlementIds = next
+        .split(',')
+        .map((x) => x.trim())
+        .filter((x) => x !== '');
+      if (settlementIds.length === 0) {
+        throw new Error('Missing value for --settlement-ids');
+      }
+      i += 2;
+      continue;
+    }
+
+    if (arg === '--human-approval') {
+      const next = postFlag.argv[i + 1];
+      if (!next) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+
     if (arg === '--apply') {
       apply = true;
       i += 1;
@@ -137,11 +164,34 @@ function parseArgs(argv: string[]): CliOptions {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
-  return { startDate, endDate, amazonEnvPath, plutusEnvPath, apply, resync, postToQbo: postFlag.postToQbo };
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`US SP-API settlement reset requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { startDate, endDate, amazonEnvPath, plutusEnvPath, apply, resync, postToQbo: postFlag.postToQbo, settlementIds, humanApproval };
 }
 
 function buildQboJournalHref(journalEntryId: string): string {
   return `https://app.qbo.intuit.com/app/journal?txnId=${journalEntryId}`;
+}
+
+function buildApplyCommand(startDate: string, endDate: string | undefined, settlementIds: string[] | undefined): string {
+  const args = [
+    'pnpm -C apps/plutus exec tsx scripts/us-settlement-reset-spapi.ts',
+    '--apply',
+    '--post-qbo',
+    '--human-approval',
+    JSON.stringify(HUMAN_APPROVAL_PHRASE),
+    '--start-date',
+    startDate,
+  ];
+  if (endDate !== undefined) {
+    args.push('--end-date', endDate);
+  }
+  if (settlementIds !== undefined) {
+    args.push('--settlement-ids', settlementIds.join(','));
+  }
+  return args.join(' ');
 }
 
 function isNoopJournalEntryId(value: string): boolean {
@@ -198,6 +248,36 @@ function isNotFoundError(error: unknown): boolean {
   return false;
 }
 
+function extractSettlementIdFromPrivateNote(privateNote: string | undefined): string | null {
+  if (typeof privateNote !== 'string') return null;
+  const match = privateNote.match(/Settlement:\s*([0-9]+)/);
+  if (!match) return null;
+  return match[1]!;
+}
+
+function processingDocSettlementDocNumber(docNumber: string): string | null {
+  const stripped = stripPlutusDocPrefix(docNumber).trim();
+  const first = stripped[0] ? stripped[0].toUpperCase() : '';
+  if (first !== 'C' && first !== 'P') return null;
+  const settlementDocNumber = stripped.slice(1);
+  if (!isSettlementDocNumber(settlementDocNumber)) return null;
+  const meta = parseSettlementDocNumber(settlementDocNumber);
+  if (meta.marketplace.id !== 'amazon.com') return null;
+  return settlementDocNumber;
+}
+
+function qboSearchResultBelongsToSettlementDocs(
+  row: { docNumber: string },
+  targetSettlementDocNumbers: ReadonlySet<string>,
+): boolean {
+  const stripped = stripPlutusDocPrefix(row.docNumber).trim();
+  if (targetSettlementDocNumbers.has(stripped)) return true;
+
+  const processingDoc = processingDocSettlementDocNumber(stripped);
+  if (processingDoc === null) return false;
+  return targetSettlementDocNumbers.has(processingDoc);
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   const startDate = requireIsoDay(options.startDate, 'startDate');
@@ -224,7 +304,7 @@ async function main(): Promise<void> {
   const rangeStart = toIsoStart(startDate);
   const rangeEnd = toIsoEnd(endDate);
 
-  const processingRows = await db.settlementProcessing.findMany({
+  const allProcessingRows = await db.settlementProcessing.findMany({
     where: {
       marketplace: 'amazon.com',
       settlementDocNumber: { contains: 'US-' },
@@ -240,7 +320,7 @@ async function main(): Promise<void> {
     },
   });
 
-  const rollbackRows = await db.settlementRollback.findMany({
+  const allRollbackRows = await db.settlementRollback.findMany({
     where: {
       marketplace: 'amazon.com',
       settlementDocNumber: { contains: 'US-' },
@@ -255,34 +335,6 @@ async function main(): Promise<void> {
       qboPnlReclassJournalEntryId: true,
     },
   });
-
-  const qboIdsToDelete = new Set<string>();
-  const invoiceIdsToDelete = new Set<string>();
-  const auditUploadsMaybeEmpty = new Set<string>();
-
-  for (const row of processingRows) {
-    qboIdsToDelete.add(row.qboSettlementJournalEntryId);
-    if (!isNoopJournalEntryId(row.qboCogsJournalEntryId)) {
-      qboIdsToDelete.add(row.qboCogsJournalEntryId);
-    }
-    if (!isNoopJournalEntryId(row.qboPnlReclassJournalEntryId)) {
-      qboIdsToDelete.add(row.qboPnlReclassJournalEntryId);
-    }
-    invoiceIdsToDelete.add(row.invoiceId);
-    invoiceIdsToDelete.add(row.settlementDocNumber);
-  }
-
-  for (const row of rollbackRows) {
-    qboIdsToDelete.add(row.qboSettlementJournalEntryId);
-    if (!isNoopJournalEntryId(row.qboCogsJournalEntryId)) {
-      qboIdsToDelete.add(row.qboCogsJournalEntryId);
-    }
-    if (!isNoopJournalEntryId(row.qboPnlReclassJournalEntryId)) {
-      qboIdsToDelete.add(row.qboPnlReclassJournalEntryId);
-    }
-    invoiceIdsToDelete.add(row.invoiceId);
-    invoiceIdsToDelete.add(row.settlementDocNumber);
-  }
 
   // QBO search by DocNumber contains "US-" catches:
   // - settlement JEs (DocNumber contains a US settlement id)
@@ -314,13 +366,82 @@ async function main(): Promise<void> {
     startPosition += page.journalEntries.length;
   }
 
-  for (const r of qboSearchResults) {
+  const targetSettlementIds = new Set(options.settlementIds ?? []);
+  const targetSettlementDocNumbers = new Set<string>();
+  let selectedQboSearchResults = qboSearchResults;
+
+  if (targetSettlementIds.size > 0) {
+    const selectedSettlementRows: Array<{ id: string; txnDate: string; docNumber: string }> = [];
+
+    for (const row of qboSearchResults) {
+      if (classifyDocNumber(row.docNumber) !== 'settlement') continue;
+
+      const full = await fetchJournalEntryById(activeConnection, row.id);
+      if (full.updatedConnection) {
+        activeConnection = full.updatedConnection;
+      }
+
+      const settlementId = extractSettlementIdFromPrivateNote(full.journalEntry.PrivateNote);
+      if (settlementId === null) continue;
+      if (!targetSettlementIds.has(settlementId)) continue;
+
+      selectedSettlementRows.push(row);
+      targetSettlementDocNumbers.add(stripPlutusDocPrefix(row.docNumber).trim());
+    }
+
+    const selectedProcessingRows = qboSearchResults.filter((row) =>
+      qboSearchResultBelongsToSettlementDocs(row, targetSettlementDocNumbers),
+    );
+    selectedQboSearchResults = Array.from(
+      new Map([...selectedSettlementRows, ...selectedProcessingRows].map((row) => [row.id, row])).values(),
+    );
+  }
+
+  const processingRows =
+    targetSettlementIds.size === 0
+      ? allProcessingRows
+      : allProcessingRows.filter((row) => targetSettlementDocNumbers.has(row.invoiceId) || targetSettlementDocNumbers.has(row.settlementDocNumber));
+
+  const rollbackRows =
+    targetSettlementIds.size === 0
+      ? allRollbackRows
+      : allRollbackRows.filter((row) => targetSettlementDocNumbers.has(row.invoiceId) || targetSettlementDocNumbers.has(row.settlementDocNumber));
+
+  const qboIdsToDelete = new Set<string>();
+  const invoiceIdsToDelete = new Set<string>();
+  const auditUploadsMaybeEmpty = new Set<string>();
+
+  for (const row of processingRows) {
+    qboIdsToDelete.add(row.qboSettlementJournalEntryId);
+    if (!isNoopJournalEntryId(row.qboCogsJournalEntryId)) {
+      qboIdsToDelete.add(row.qboCogsJournalEntryId);
+    }
+    if (!isNoopJournalEntryId(row.qboPnlReclassJournalEntryId)) {
+      qboIdsToDelete.add(row.qboPnlReclassJournalEntryId);
+    }
+    invoiceIdsToDelete.add(row.invoiceId);
+    invoiceIdsToDelete.add(row.settlementDocNumber);
+  }
+
+  for (const row of rollbackRows) {
+    qboIdsToDelete.add(row.qboSettlementJournalEntryId);
+    if (!isNoopJournalEntryId(row.qboCogsJournalEntryId)) {
+      qboIdsToDelete.add(row.qboCogsJournalEntryId);
+    }
+    if (!isNoopJournalEntryId(row.qboPnlReclassJournalEntryId)) {
+      qboIdsToDelete.add(row.qboPnlReclassJournalEntryId);
+    }
+    invoiceIdsToDelete.add(row.invoiceId);
+    invoiceIdsToDelete.add(row.settlementDocNumber);
+  }
+
+  for (const r of selectedQboSearchResults) {
     qboIdsToDelete.add(r.id);
   }
 
   const targets: DeletionTarget[] = [];
 
-  for (const r of qboSearchResults) {
+  for (const r of selectedQboSearchResults) {
     targets.push({
       journalEntryId: r.id,
       txnDate: r.txnDate,
@@ -331,7 +452,7 @@ async function main(): Promise<void> {
     });
   }
 
-  const seenFromSearch = new Set(qboSearchResults.map((r) => r.id));
+  const seenFromSearch = new Set(selectedQboSearchResults.map((r) => r.id));
 
   for (const row of processingRows) {
     const ids = [row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId, row.qboPnlReclassJournalEntryId];
@@ -407,9 +528,9 @@ async function main(): Promise<void> {
       JSON.stringify(
         {
           dryRun: true,
-          options: { startDate, endDate, resync: options.resync },
+          options: { startDate, endDate, resync: options.resync, settlementIds: options.settlementIds },
           totals: {
-            qboJournalEntriesMatchedByDocNumber: qboSearchResults.length,
+            qboJournalEntriesMatchedByDocNumber: selectedQboSearchResults.length,
             qboJournalEntriesToDelete: existingTargetCount,
             qboJournalEntriesMissing: missingTargetCount,
             dbSettlementProcessingRows: processingRows.length,
@@ -418,7 +539,7 @@ async function main(): Promise<void> {
           },
           plan: deletionPlan,
           next: {
-            command: 'pnpm -C apps/plutus exec tsx scripts/us-settlement-reset-spapi.ts --apply --start-date <YYYY-MM-DD> [--end-date <YYYY-MM-DD>]',
+            command: buildApplyCommand(startDate, endDate, options.settlementIds),
           },
         },
         null,
@@ -471,7 +592,7 @@ async function main(): Promise<void> {
       JSON.stringify(
         {
           dryRun: false,
-          options: { startDate, endDate, resync: options.resync },
+          options: { startDate, endDate, resync: options.resync, settlementIds: options.settlementIds },
           error: 'Some settlement JEs could not be deleted; aborting before processing JE/DB cleanup.',
           failedDeletions: deletions.filter((d) => !d.ok),
           qboLinks: deletions
@@ -497,7 +618,7 @@ async function main(): Promise<void> {
       JSON.stringify(
         {
           dryRun: false,
-          options: { startDate, endDate, resync: options.resync },
+          options: { startDate, endDate, resync: options.resync, settlementIds: options.settlementIds },
           error: 'Some QBO deletions failed; aborting DB cleanup and resync.',
           failedDeletions,
           qboLinks: failedDeletions.map((d) => ({ journalEntryId: d.journalEntryId, qboUrl: buildQboJournalHref(d.journalEntryId) })),
@@ -548,6 +669,7 @@ async function main(): Promise<void> {
     resyncResult = await syncUsSettlementsFromSpApiFinances({
       startDate,
       endDate,
+      settlementIds: options.settlementIds,
       postToQbo: options.postToQbo,
       process: true,
     });
@@ -557,7 +679,7 @@ async function main(): Promise<void> {
     JSON.stringify(
       {
         dryRun: false,
-        options: { startDate, endDate, resync: options.resync, postToQbo: options.postToQbo },
+        options: { startDate, endDate, resync: options.resync, postToQbo: options.postToQbo, settlementIds: options.settlementIds },
         totals: {
           deletedQboJournalEntries: deletedCount,
           skippedQboJournalEntries: skippedCount,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1036,13 +1036,16 @@ test('settlement reclass repair is approval-gated and protects source settlement
   assert.equal(source.includes("const BANK_ACCOUNT_TYPES = new Set(['Bank', 'Credit Card']);"), true);
 });
 
-test('plutus primary nav exposes only settlement accounting scope', () => {
+test('plutus primary nav exposes settlement and subledger accounting scope', () => {
   const source = readFileSync('components/app-header.tsx', 'utf8');
 
   for (const expected of [
     "label: 'Settlements'",
-    "label: 'COGS Inputs'",
+    "label: 'Products'",
+    "label: 'Purchase Orders'",
+    "label: 'Inventory Ledger'",
     "label: 'Mappings'",
+    "label: 'QBO Audit'",
     "label: 'Settings'",
   ]) {
     assert.equal(source.includes(expected), true, expected);
@@ -1053,6 +1056,7 @@ test('plutus primary nav exposes only settlement accounting scope', () => {
     "label: 'Exceptions'",
     "label: 'Sources'",
     "label: 'Cashflow'",
+    "label: 'COGS Inputs'",
     "label: 'Accounts & Taxes'",
     "label: 'Setup Wizard'",
     "label: 'Account Taxes'",
@@ -1061,6 +1065,7 @@ test('plutus primary nav exposes only settlement accounting scope', () => {
     "href: '/exceptions'",
     "href: '/data-sources'",
     "href: '/cashflow'",
+    "href: '/cogs-inputs'",
     "href: '/chart-of-accounts'",
   ]) {
     assert.equal(source.includes(removed), false, removed);
@@ -1212,6 +1217,13 @@ test('subledger navigation exposes LMB-style Plutus control surfaces', () => {
   ]) {
     assert.equal(source.includes(expected), true, expected);
   }
+});
+
+test('subledger pages are wired to route wrappers', () => {
+  assert.equal(readFileSync(new URL('../app/products/page.tsx', import.meta.url), 'utf8').includes('ProductsPage'), true);
+  assert.equal(readFileSync(new URL('../app/purchase-orders/page.tsx', import.meta.url), 'utf8').includes('PurchaseOrdersPage'), true);
+  assert.equal(readFileSync(new URL('../app/inventory-ledger/page.tsx', import.meta.url), 'utf8').includes('InventoryLedgerPage'), true);
+  assert.equal(readFileSync(new URL('../app/qbo-audit/page.tsx', import.meta.url), 'utf8').includes('QboAuditPage'), true);
 });
 
 test('normalizeSettlementMarketplaceQuery maps settlement route params to marketplace filters', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 
 import {
   normalizeAuditMarketToMarketplaceId,
@@ -36,8 +38,12 @@ import {
   allocateShipmentFeeChargesBySkuQuantity,
   extractInboundTransportationServiceFeeCharges,
   isInboundTransportationMemoDescription,
+  loadInboundShipmentItemsFromAwdInboundShipmentReports,
 } from '../lib/plutus/shipment-fee-allocation';
-import { deterministicSourceGuidanceForBucket } from '../lib/plutus/fee-allocation';
+import {
+  buildDeterministicSkuAllocations,
+  deterministicSourceGuidanceForBucket,
+} from '../lib/plutus/fee-allocation';
 import { parseAmazonTransactionCsv } from '../lib/reconciliation/amazon-csv';
 import { parseAmazonUnifiedTransactionCsv } from '../lib/amazon-payments/unified-transaction-csv';
 import {
@@ -415,6 +421,39 @@ test('normalizeSettlementDocNumber extracts embedded settlement ids', () => {
   assert.equal(meta.marketplace.id, 'amazon.co.uk');
   assert.equal(meta.periodStart, '2026-01-16');
   assert.equal(meta.periodEnd, '2026-01-30');
+});
+
+test('computeSettlementTotalFromJournalEntry reads Plutus settlement control lines', () => {
+  const accounts = new Map([
+    ['178', { Id: '178', Name: 'Plutus Settlement Control', AccountType: 'Other Current Asset' }],
+    ['400', { Id: '400', Name: 'Amazon Sales', AccountType: 'Income' }],
+  ]) as any;
+
+  const total = computeSettlementTotalFromJournalEntry(
+    {
+      Id: 'je-1',
+      SyncToken: '0',
+      TxnDate: '2026-04-30',
+      DocNumber: 'US-260416-260430-S1',
+      Line: [
+        {
+          Amount: 119.34,
+          Description: 'Amazon Sales - Principal - US-PDS',
+          DetailType: 'JournalEntryLineDetail',
+          JournalEntryLineDetail: { PostingType: 'Credit', AccountRef: { value: '400' } },
+        },
+        {
+          Amount: 119.34,
+          Description: 'Settlement Control (FundTransferStatus=Succeeded)',
+          DetailType: 'JournalEntryLineDetail',
+          JournalEntryLineDetail: { PostingType: 'Debit', AccountRef: { value: '178' } },
+        },
+      ],
+    },
+    accounts,
+  );
+
+  assert.equal(total, 119.34);
 });
 
 test('extractSourceSettlementIdFromPrivateNote reads opaque source ids', () => {
@@ -803,7 +842,7 @@ test('buildSettlementPostingSectionViewModels preserves preview severity and sha
         docNumber: 'UK-260401-260405-S1-A',
         invoiceId: 'INV-PREVIEW-WARN',
         preview: {
-          blocks: [{ code: 'PNL_ALLOCATION_WARNING', message: 'Preview warning' }],
+          blocks: [{ code: 'PNL_ALLOCATION_SOURCE_GAP', message: 'Preview warning' }],
           sales: [],
           returns: [],
           cogsJournalEntry: { lines: [] },
@@ -827,8 +866,8 @@ test('buildSettlementPostingSectionViewModels preserves preview severity and sha
 
   const sections = buildSettlementPostingSectionViewModels(detail, preview);
   assert.equal(sections[0]?.invoiceId, 'INV-KEEP');
-  assert.equal(sections[0]?.blockState, 'warning');
-  assert.equal(sections[0]?.blocks[0]?.severity, 'warning');
+  assert.equal(sections[0]?.blockState, 'blocked');
+  assert.equal(sections[0]?.blocks[0]?.severity, 'blocked');
   assert.equal(sections[0]?.blocks[0]?.message, 'Preview warning');
   assert.equal(sections[1]?.blockState, 'blocked');
   assert.equal(sections[1]?.blocks[0]?.severity, 'blocked');
@@ -1009,6 +1048,21 @@ test('SP-API settlement sync CLI scripts require human approval before mutation'
     assert.equal(source.includes("arg === '--human-approval'"), true, script);
     assert.match(source, /if \(\(postToQbo \|\| process\) && humanApproval !== HUMAN_APPROVAL_PHRASE\)/, script);
   }
+});
+
+test('US SP-API settlement reset is approval-gated and can target settlement ids', () => {
+  const source = readFileSync('scripts/us-settlement-reset-spapi.ts', 'utf8');
+
+  assert.equal(source.includes("import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';"), true);
+  assert.equal(source.includes('settlementIds: string[] | undefined;'), true);
+  assert.equal(source.includes("arg === '--settlement-ids'"), true);
+  assert.equal(source.includes("arg === '--human-approval'"), true);
+  assert.match(source, /if \(apply && humanApproval !== HUMAN_APPROVAL_PHRASE\)/);
+  assert.equal(source.includes('function buildApplyCommand'), true);
+  assert.equal(source.includes("'--post-qbo'"), true);
+  assert.equal(source.includes('targetSettlementIds'), true);
+  assert.equal(source.includes('extractSettlementIdFromPrivateNote'), true);
+  assert.equal(source.includes('settlementIds: options.settlementIds'), true);
 });
 
 test('package scripts expose posted settlement rematch checks for both marketplaces', () => {
@@ -1224,6 +1278,19 @@ test('subledger pages are wired to route wrappers', () => {
   assert.equal(readFileSync(new URL('../app/purchase-orders/page.tsx', import.meta.url), 'utf8').includes('PurchaseOrdersPage'), true);
   assert.equal(readFileSync(new URL('../app/inventory-ledger/page.tsx', import.meta.url), 'utf8').includes('InventoryLedgerPage'), true);
   assert.equal(readFileSync(new URL('../app/qbo-audit/page.tsx', import.meta.url), 'utf8').includes('QboAuditPage'), true);
+});
+
+test('QBO audit API exposes flattened posting source fields', () => {
+  const source = readFileSync(new URL('../app/api/plutus/qbo-audit/route.ts', import.meta.url), 'utf8');
+
+  for (const expected of [
+    'sourceType: row.postingIntent.sourceType',
+    'sourceId: row.postingIntent.sourceId',
+    'market: row.postingIntent.market',
+    'lineCount: row.lineFingerprints.length',
+  ]) {
+    assert.equal(source.includes(expected), true, expected);
+  }
 });
 
 test('normalizeSettlementMarketplaceQuery maps settlement route params to marketplace filters', () => {
@@ -1649,6 +1716,20 @@ test('US settlement SP-API paths do not gate month splitting on runtime env', ()
     const source = readFileSync(new URL(sourcePath, import.meta.url), 'utf8');
     assert.equal(source.includes('PLUTUS_SPLIT_SETTLEMENTS_BY_MONTH'), false);
   }
+});
+
+test('US settlement SP-API reconcile accepts missing QBO JE for empty expected segments', () => {
+  const source = readFileSync(new URL('../scripts/us-settlement-reconcile-spapi.ts', import.meta.url), 'utf8');
+
+  assert.equal(source.includes('if (!actualJe && !hasExpectedJournalLines)'), true);
+  assert.equal(source.includes("reason: 'No QBO JE expected for empty segment'"), true);
+});
+
+test('US settlement SP-API reconcile no longer requires real bank transfer lines', () => {
+  const source = readFileSync(new URL('../scripts/us-settlement-reconcile-spapi.ts', import.meta.url), 'utf8');
+
+  assert.equal(source.includes("throw new Error(`Missing 'Transfer to Bank' line"), false);
+  assert.equal(source.includes("throw new Error(`Missing 'Payment to Amazon' line"), false);
 });
 
 test('buildUsSettlementDraftFromSpApiFinances maps low value goods withheld tax', () => {
@@ -2306,6 +2387,31 @@ test('computePnlAllocation leaves SKU-less fees unallocated without deterministi
   assert.equal(allocation.unallocatedSkuLessBuckets[0]?.totalCents, -900);
 });
 
+test('computePnlAllocation keeps positive inbound transportation reversals parent-level', () => {
+  const allocation = computePnlAllocation(
+    [
+      {
+        invoiceId: 'US-260401-260410-S2',
+        market: 'Amazon.com',
+        date: '2026-04-10',
+        orderId: 'n/a',
+        sku: '',
+        quantity: 0,
+        description: 'Amazon FBA Fees - FBA Inbound Transportation Fee',
+        net: 2583.96,
+      },
+    ],
+    {
+      getBrandForSku: () => {
+        throw new Error('SKU resolver should not run for parent-level reversal');
+      },
+    },
+  );
+
+  assert.deepEqual(allocation.allocationsByBucket.amazonFbaFees, {});
+  assert.equal(allocation.unallocatedSkuLessBuckets.length, 0);
+});
+
 test('computePnlAllocation allocates amazon seller fees when SKU is present', () => {
   const rows = [
     {
@@ -2337,6 +2443,31 @@ test('computePnlAllocation allocates amazon seller fees when SKU is present', ()
   assert.equal(allocation.allocationsByBucket.amazonSellerFees.BrandA, -250);
   assert.equal(allocation.skuBreakdownByBucketBrand.amazonSellerFees.BrandA?.['SKU-A'], -250);
   assert.equal(allocation.unallocatedSkuLessBuckets.length, 0);
+});
+
+test('buildDeterministicSkuAllocations keeps inbound transportation reversals parent-level', async () => {
+  const allocation = await buildDeterministicSkuAllocations({
+    rows: [
+      {
+        invoiceId: 'US-260401-260410-S2',
+        market: 'Amazon.com',
+        date: '2026-04-10',
+        orderId: 'n/a',
+        sku: '',
+        quantity: 0,
+        description: 'Amazon FBA Fees - FBA Inbound Transportation Fee',
+        net: 2583.96,
+      },
+    ],
+    marketplace: 'amazon.com',
+    invoiceStartDate: '2026-04-01',
+    invoiceEndDate: '2026-04-10',
+    skuToBrand: new Map(),
+    settlementId: '26003231841',
+  });
+
+  assert.deepEqual(allocation.skuAllocationsByBucket, {});
+  assert.deepEqual(allocation.issues, []);
 });
 
 test('extractInboundTransportationServiceFeeCharges parses transaction and context entries', () => {
@@ -2414,6 +2545,35 @@ test('allocateShipmentFeeChargesBySkuQuantity allocates by shipped quantity', ()
   assert.equal(allocation.issues.length, 0);
   assert.equal(allocation.allocationBySku['SKU-A'], -7500);
   assert.equal(allocation.allocationBySku['SKU-B'], -7500);
+});
+
+test('loadInboundShipmentItemsFromAwdInboundShipmentReports reads Seller Central shipment quantities', async () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'awd-inbound-report-'));
+  try {
+    writeFileSync(
+      path.join(dir, 'awd-inbound.csv'),
+      [
+        '"shipment_id","shipment_create_date_utc","msku","expected_unit_count"',
+        '"STAR-SPME55WHX5UYW","2026-04-29 16:15:15","CS-010","1020"',
+        '"STAR-SPME55WHX5UYW","2026-04-29 16:15:15","CS-007","7168"',
+        '"STAR-OTHER","2026-04-29 16:15:15","CS-999","1"',
+      ].join('\n'),
+    );
+
+    const lookup = await loadInboundShipmentItemsFromAwdInboundShipmentReports({
+      shipmentId: 'STAR-SPME55WHX5UYW',
+      reportDir: dir,
+    });
+
+    assert.equal(lookup.issues.length, 0);
+    assert.equal(lookup.sourceFiles.length, 1);
+    assert.deepEqual(lookup.items, [
+      { sku: 'CS-010', quantity: 1020 },
+      { sku: 'CS-007', quantity: 7168 },
+    ]);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 test('computePnlAllocation routes AWD rows using deterministic SKU map', () => {
@@ -2688,13 +2848,21 @@ test('buildPnlJournalLines includes SKU breakdown in descriptions', () => {
   assert.equal(lines[0]?.description.includes('SKU-B'), true);
 });
 
-test('isBlockingProcessingCode treats PNL allocation warnings as non-blocking', () => {
+test('isBlockingProcessingCode blocks deterministic PNL allocation source gaps', () => {
   assert.equal(isBlockingProcessingCode('PNL_ALLOCATION_ERROR'), true);
-  assert.equal(isBlockingProcessingCode('PNL_ALLOCATION_WARNING'), false);
+  assert.equal(isBlockingProcessingCode('PNL_ALLOCATION_SOURCE_GAP'), true);
+  assert.equal(isBlockingProcessingCode('PNL_ALLOCATION_WARNING'), true);
   assert.equal(isBlockingProcessingCode('LATE_COST_ON_HAND_ZERO'), false);
   assert.equal(isBlockingProcessingCode('MISSING_COST_BASIS'), true);
   assert.equal(isBlockingProcessingCode('MISSING_SETUP'), true);
   assert.equal(isBlockingProcessingCode('REFUND_UNMATCHED'), true);
+});
+
+test('settlement processing audit fails when deterministic PNL allocation is incomplete', () => {
+  const source = readFileSync('scripts/settlement-processing-audit.ts', 'utf8');
+
+  assert.equal(source.includes('deterministicNotOk.length > 0'), true);
+  assert.equal(source.includes('mismatched.length > 0 || deterministicNotOk.length > 0'), true);
 });
 
 test('settlement processing skips refund matching when COGS is disabled', () => {
@@ -2703,6 +2871,43 @@ test('settlement processing skips refund matching when COGS is disabled', () => 
   assert.match(source, /const refundPairs = cogsEnabled \?/);
   assert.match(source, /if \(cogsEnabled\) \{\s*for \(const \[refundKey, refund\] of refundGroups\.entries\(\)\)/);
   assert.match(source, /!cogsEnabled \|\| currentSettlementRefundGroups\.size === 0/);
+});
+
+test('settlement processing treats empty split settlement segments as no-op processing', () => {
+  const source = readFileSync('lib/plutus/settlement-processing.ts', 'utf8');
+
+  assert.equal(source.includes('const hasAuditRows = scopedInvoiceRows.length > 0;'), true);
+  assert.equal(source.includes('if (hasAuditRows) {'), true);
+  assert.equal(source.includes('const emptyPnlAllocation'), true);
+  assert.equal(source.includes('meta.periodStart'), true);
+});
+
+test('inventory audit treats empty split COGS no-op rows as valid', () => {
+  const source = readFileSync('scripts/inventory-audit.ts', 'utf8');
+
+  assert.equal(source.includes("import { computeProcessingHash } from '@/lib/plutus/settlement-validation';"), true);
+  assert.equal(source.includes('const emptyProcessingHash = computeProcessingHash([]);'), true);
+  assert.equal(source.includes("status: 'noop'"), true);
+  assert.equal(source.includes('input.processing.processingHash === emptyProcessingHash'), true);
+});
+
+test('settlement SKU brand maps include ASIN aliases', () => {
+  const processingSource = readFileSync('lib/plutus/settlement-processing.ts', 'utf8');
+  const auditSource = readFileSync('scripts/settlement-processing-audit.ts', 'utf8');
+  const usSyncSource = readFileSync('lib/amazon-finances/us-settlement-sync.ts', 'utf8');
+
+  for (const source of [processingSource, auditSource, usSyncSource]) {
+    assert.equal(source.includes('row.asin'), true);
+    assert.equal(source.includes('aliases.push(row.asin)'), true);
+  }
+});
+
+test('inventory bills audit can scope by marketplace and SOP internal ref', () => {
+  const source = readFileSync('scripts/inventory-bills-audit.ts', 'utf8');
+
+  assert.equal(source.includes("--marketplace <all|amazon.com|amazon.co.uk>"), true);
+  assert.equal(source.includes('classifyInventoryMarketplaceFromAccount'), true);
+  assert.equal(source.includes('extractPoNumberFromBill(bill)'), true);
 });
 
 test('ledger blocks missing cost basis', () => {
@@ -3142,6 +3347,14 @@ test('extractPoNumberFromBill reads PO from memo when no custom field exists', (
   });
 
   assert.equal(po, 'US-PO-123');
+});
+
+test('extractPoNumberFromBill reads internal ref from SOP memo', () => {
+  const po = extractPoNumberFromBill({
+    PrivateNote: 'INTERNAL REF: PO-20-PDS\nOWNER: US-PDS\nPI: PI-2601082',
+  });
+
+  assert.equal(po, 'PO-20-PDS');
 });
 
 test('extractPoNumberFromBill preserves direct PO code in memo', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -102,6 +102,23 @@ import {
   remapLegacySettlementPath,
 } from '../lib/plutus/legacy-settlement-routes';
 import {
+  buildPlutusLineDescription,
+  buildPlutusTraceMemo,
+  comparePostingFingerprints,
+  fingerprintPostingLines,
+} from '../lib/plutus/subledger/qbo-trace';
+import {
+  resolveCanonicalProductAlias,
+} from '../lib/plutus/subledger/sku-alias';
+import {
+  consumeInventoryMovementsFifo,
+} from '../lib/plutus/subledger/cost-flow';
+import {
+  mapLegacyBrandNameToProductGroupCode,
+  normalizeAliasValue,
+  planLegacySubledgerBackfill,
+} from '../lib/plutus/subledger/backfill';
+import {
   buildPlutusHomeRedirectPath,
   classifyQboRefreshFailure,
   classifyQboVerificationFailure,
@@ -241,6 +258,138 @@ test('buildPlutusHomeRedirectPath preserves qbo callback query params', () => {
   assert.equal(
     buildPlutusHomeRedirectPath({ connected: ['true', 'false'], error: ['invalid_state'] }),
     '/settlements?connected=true&error=invalid_state',
+  );
+});
+
+test('Plutus QBO trace fields are deterministic and minimal', () => {
+  assert.equal(
+    buildPlutusTraceMemo({
+      plutusRef: 'posting_123',
+      source: 'AMZ_SETTLEMENT',
+      market: 'US',
+      period: '2026-05',
+    }),
+    'PLUTUS_REF=posting_123; SOURCE=AMZ_SETTLEMENT; MARKET=US; PERIOD=2026-05',
+  );
+
+  assert.equal(
+    buildPlutusLineDescription({
+      category: 'Amazon Sales - Principal',
+      plutusLineId: 'line_abc',
+    }),
+    'Amazon Sales - Principal; PLUTUS_LINE=line_abc',
+  );
+
+  assert.throws(
+    () => buildPlutusTraceMemo({ plutusRef: '', source: 'AMZ_SETTLEMENT', market: 'US', period: '2026-05' }),
+    /plutusRef is required/,
+  );
+});
+
+test('posting fingerprint comparison detects QBO line drift', () => {
+  const expected = fingerprintPostingLines([
+    { lineId: 'line_1', accountId: '187', amountCents: 1200, description: 'Amazon Sales; PLUTUS_LINE=line_1' },
+    { lineId: 'line_2', accountId: '193', amountCents: -300, description: 'Amazon Seller Fees; PLUTUS_LINE=line_2' },
+  ]);
+
+  const live = fingerprintPostingLines([
+    { lineId: 'line_1', accountId: '187', amountCents: 1200, description: 'Amazon Sales; PLUTUS_LINE=line_1' },
+    { lineId: 'line_2', accountId: '194', amountCents: -300, description: 'Amazon Seller Fees; PLUTUS_LINE=line_2' },
+  ]);
+
+  assert.deepEqual(comparePostingFingerprints(expected, live), {
+    status: 'drifted',
+    missingLineIds: [],
+    extraLineIds: [],
+    changedLineIds: ['line_2'],
+  });
+});
+
+test('SKU alias resolver maps market aliases to canonical products', () => {
+  const aliases = [
+    { canonicalProductId: 'prod_pds_7', marketplace: 'amazon.com', aliasType: 'SKU', value: 'CS-007' },
+    { canonicalProductId: 'prod_pds_7', marketplace: 'amazon.co.uk', aliasType: 'SKU', value: 'CS 007' },
+    { canonicalProductId: 'prod_pds_7', marketplace: 'amazon.com', aliasType: 'ASIN', value: 'B09HXC3NL8' },
+  ];
+
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.com', 'sku', 'cs-007'), 'prod_pds_7');
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.co.uk', 'SKU', 'CS 007'), 'prod_pds_7');
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.com', 'ASIN', 'b09hxc3nl8'), 'prod_pds_7');
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.co.uk', 'ASIN', 'B09HXC3NL8'), null);
+});
+
+test('FIFO inventory movement consumes PO cost layers deterministically', () => {
+  const result = consumeInventoryMovementsFifo({
+    layers: [
+      {
+        id: 'layer_old',
+        canonicalProductId: 'prod_pds_7',
+        receivedDate: '2026-01-01',
+        quantity: 5,
+        componentCostsCents: { manufacturing: 500, freight: 100, duty: 0, mfgAccessories: 50 },
+      },
+      {
+        id: 'layer_new',
+        canonicalProductId: 'prod_pds_7',
+        receivedDate: '2026-02-01',
+        quantity: 10,
+        componentCostsCents: { manufacturing: 2000, freight: 300, duty: 100, mfgAccessories: 0 },
+      },
+    ],
+    movements: [
+      {
+        id: 'sale_1',
+        canonicalProductId: 'prod_pds_7',
+        movementDate: '2026-03-01',
+        movementType: 'SALE',
+        quantity: -7,
+      },
+    ],
+  });
+
+  assert.equal(result.blocks.length, 0);
+  assert.deepEqual(result.movementCosts[0], {
+    movementId: 'sale_1',
+    quantity: 7,
+    manufacturingCents: 900,
+    freightCents: 160,
+    dutyCents: 20,
+    mfgAccessoriesCents: 50,
+  });
+  assert.deepEqual(result.endingLayers.map((layer) => ({ id: layer.id, remainingQuantity: layer.remainingQuantity })), [
+    { id: 'layer_old', remainingQuantity: 0 },
+    { id: 'layer_new', remainingQuantity: 8 },
+  ]);
+});
+
+test('legacy subledger backfill groups current Brand and Sku rows without false PO merges', () => {
+  assert.equal(mapLegacyBrandNameToProductGroupCode('US-PDS'), 'PDS');
+  assert.equal(mapLegacyBrandNameToProductGroupCode('UK-CDS'), 'CDS');
+  assert.equal(normalizeAliasValue(' cs-007 '), 'CS-007');
+
+  const plan = planLegacySubledgerBackfill({
+    brands: [
+      { id: 'brand_us_pds', name: 'US-PDS', marketplace: 'amazon.com', currency: 'USD' },
+      { id: 'brand_uk_pds', name: 'UK-PDS', marketplace: 'amazon.co.uk', currency: 'GBP' },
+    ],
+    skus: [
+      { id: 'sku_us', sku: 'CS-007', asin: 'B09HXC3NL8', productName: 'PDS 7', brandId: 'brand_us_pds' },
+      { id: 'sku_uk', sku: 'CS 007', asin: 'B09HXC3NL8', productName: 'PDS 7', brandId: 'brand_uk_pds' },
+    ],
+    billMappings: [],
+    billLineMappings: [],
+  });
+
+  assert.deepEqual(plan.productGroups.map((group) => group.code), ['PDS']);
+  assert.equal(plan.canonicalProducts.length, 1);
+  assert.deepEqual(
+    plan.skuAliases.map((alias) => [alias.marketplace, alias.aliasType, alias.value]).sort(),
+    [
+      ['amazon.co.uk', 'ASIN', 'B09HXC3NL8'],
+      ['amazon.co.uk', 'SKU', 'CS 007'],
+      ['amazon.com', 'ASIN', 'B09HXC3NL8'],
+      ['amazon.com', 'SKU', 'CS-007'],
+    ],
   );
 });
 
@@ -1024,6 +1173,45 @@ test('cogs input scoping keeps tracked or mapped bills only', () => {
   ];
 
   assert.deepEqual(filterCogsInputRows(rows).map((row) => row.id), ['tracked', 'mapped']);
+});
+
+test('subledger schema defines the structured Plutus-owned tables', () => {
+  const schema = readFileSync(new URL('../prisma/schema.prisma', import.meta.url), 'utf8');
+
+  for (const expected of [
+    'model ProductGroup',
+    'model CanonicalProduct',
+    'model SkuAlias',
+    'model PurchaseOrder',
+    'model PoCostLayer',
+    'model InventoryMovement',
+    'model PostingIntent',
+    'model PostingIntentLine',
+    'model QboPosting',
+    'model QboPostingLineFingerprint',
+  ]) {
+    assert.equal(schema.includes(expected), true, expected);
+  }
+
+  assert.equal(schema.includes('@@unique([marketplace, aliasType, value])'), true);
+  assert.equal(schema.includes('@@unique([sourceType, sourceId])'), true);
+  assert.equal(schema.includes('@@unique([qboTxnType, qboTxnId])'), true);
+});
+
+test('subledger navigation exposes LMB-style Plutus control surfaces', () => {
+  const source = readFileSync(new URL('../components/app-header.tsx', import.meta.url), 'utf8');
+
+  for (const expected of [
+    "label: 'Settlements'",
+    "label: 'Products'",
+    "label: 'Purchase Orders'",
+    "label: 'Inventory Ledger'",
+    "label: 'Mappings'",
+    "label: 'QBO Audit'",
+    "label: 'Settings'",
+  ]) {
+    assert.equal(source.includes(expected), true, expected);
+  }
 });
 
 test('normalizeSettlementMarketplaceQuery maps settlement route params to marketplace filters', () => {

--- a/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
+++ b/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
@@ -1213,8 +1213,16 @@ async function main() {
     for (const product of plan.canonicalProducts) {
       const productGroupId = productGroupIdByCode.get(product.productGroupCode);
       if (!productGroupId) throw new Error(`Missing product group ${product.productGroupCode}`);
+      const [productKeyType, ...productKeyParts] = product.key.split(':');
+      const productKeyValue = productKeyParts.join(':');
+      if (productKeyType !== 'ASIN' && productKeyType !== 'SKU') {
+        throw new Error(`Unsupported canonical product key ${product.key}`);
+      }
       const existingAlias = await tx.skuAlias.findFirst({
-        where: { normalizedValue: product.key.replace(/^ASIN:/, ''), normalizedAliasType: 'ASIN' },
+        where: {
+          normalizedAliasType: productKeyType,
+          normalizedValue: productKeyValue,
+        },
       });
       const row = existingAlias
         ? await tx.canonicalProduct.update({ where: { id: existingAlias.canonicalProductId }, data: { name: product.name, productGroupId, active: true } })

--- a/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
+++ b/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
@@ -333,6 +333,8 @@ model SkuAlias {
   marketplace        String
   aliasType          String
   value              String
+  normalizedAliasType String
+  normalizedValue     String
   active             Boolean  @default(true)
   createdAt          DateTime @default(now())
   updatedAt          DateTime @updatedAt
@@ -340,13 +342,16 @@ model SkuAlias {
   canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id], onDelete: Cascade)
 
   @@unique([marketplace, aliasType, value])
+  @@unique([marketplace, normalizedAliasType, normalizedValue])
   @@index([canonicalProductId])
   @@index([marketplace])
 }
 
 model PurchaseOrder {
   id           String   @id @default(cuid())
-  internalRef  String   @unique
+  internalRef  String
+  sourceType   String
+  sourceId     String
   supplierRef  String?
   marketplace  String?
   status       String   @default("OPEN")
@@ -356,6 +361,8 @@ model PurchaseOrder {
 
   costLayers PoCostLayer[]
 
+  @@unique([sourceType, sourceId])
+  @@index([internalRef])
   @@index([marketplace])
   @@index([status])
 }
@@ -776,10 +783,24 @@ export type LegacyBillLineMappingRow = {
 export type LegacySubledgerBackfillPlan = {
   productGroups: Array<{ code: string; name: string }>;
   canonicalProducts: Array<{ key: string; name: string; productGroupCode: string }>;
-  skuAliases: Array<{ canonicalProductKey: string; marketplace: string; aliasType: 'SKU' | 'ASIN'; value: string }>;
-  purchaseOrders: Array<{ internalRef: string; marketplace: string; supplierRef: string | null }>;
+  skuAliases: Array<{
+    canonicalProductKey: string;
+    marketplace: string;
+    aliasType: 'SKU' | 'ASIN';
+    value: string;
+    normalizedAliasType: string;
+    normalizedValue: string;
+  }>;
+  purchaseOrders: Array<{
+    internalRef: string;
+    sourceType: 'LEGACY_PO' | 'LEGACY_BILL';
+    sourceId: string;
+    marketplace: string;
+    supplierRef: string | null;
+  }>;
   costLayers: Array<{
-    purchaseOrderInternalRef: string;
+    purchaseOrderSourceType: 'LEGACY_PO' | 'LEGACY_BILL';
+    purchaseOrderSourceId: string;
     canonicalProductKey: string | null;
     component: string;
     quantity: number | null;
@@ -805,6 +826,27 @@ function canonicalProductKeyForSku(input: { marketplace: string; sku: string; as
   const asin = input.asin ? normalizeAliasValue(input.asin) : '';
   if (asin !== '') return `ASIN:${asin}`;
   return `SKU:${input.marketplace}:${normalizeAliasValue(input.sku)}`;
+}
+
+function purchaseOrderKeyForBillMapping(mapping: LegacyBillMappingRow, marketplace: string): {
+  internalRef: string;
+  sourceType: 'LEGACY_PO' | 'LEGACY_BILL';
+  sourceId: string;
+} {
+  const poNumber = mapping.poNumber.trim();
+  if (poNumber !== '') {
+    return {
+      internalRef: poNumber,
+      sourceType: 'LEGACY_PO',
+      sourceId: `${marketplace}:${poNumber}`,
+    };
+  }
+
+  return {
+    internalRef: `UNASSIGNED-BILL-${mapping.qboBillId}`,
+    sourceType: 'LEGACY_BILL',
+    sourceId: mapping.qboBillId,
+  };
 }
 
 export function planLegacySubledgerBackfill(input: {
@@ -847,6 +889,8 @@ export function planLegacySubledgerBackfill(input: {
           marketplace: brand.marketplace,
           aliasType: alias.aliasType,
           value: alias.value.trim(),
+          normalizedAliasType: alias.aliasType,
+          normalizedValue,
         });
       }
     }
@@ -855,8 +899,9 @@ export function planLegacySubledgerBackfill(input: {
   const purchaseOrders = input.billMappings.map((mapping) => {
     const brand = brandsById.get(mapping.brandId);
     if (!brand) throw new Error(`Missing brand for bill mapping ${mapping.id}`);
+    const key = purchaseOrderKeyForBillMapping(mapping, brand.marketplace);
     return {
-      internalRef: mapping.poNumber,
+      ...key,
       marketplace: brand.marketplace,
       supplierRef: null,
     };
@@ -871,9 +916,11 @@ export function planLegacySubledgerBackfill(input: {
     const canonicalProductKey = line.sku
       ? canonicalKeyByLegacySkuValue.get(`${brand.marketplace}:${normalizeAliasValue(line.sku)}`) ?? null
       : null;
+    const purchaseOrderKey = purchaseOrderKeyForBillMapping(mapping, brand.marketplace);
 
     return {
-      purchaseOrderInternalRef: mapping.poNumber,
+      purchaseOrderSourceType: purchaseOrderKey.sourceType,
+      purchaseOrderSourceId: purchaseOrderKey.sourceId,
       canonicalProductKey,
       component: line.component,
       quantity: line.quantity,
@@ -1167,7 +1214,7 @@ async function main() {
       const productGroupId = productGroupIdByCode.get(product.productGroupCode);
       if (!productGroupId) throw new Error(`Missing product group ${product.productGroupCode}`);
       const existingAlias = await tx.skuAlias.findFirst({
-        where: { value: product.key.replace(/^ASIN:/, ''), aliasType: 'ASIN' },
+        where: { normalizedValue: product.key.replace(/^ASIN:/, ''), normalizedAliasType: 'ASIN' },
       });
       const row = existingAlias
         ? await tx.canonicalProduct.update({ where: { id: existingAlias.canonicalProductId }, data: { name: product.name, productGroupId, active: true } })
@@ -1179,23 +1226,54 @@ async function main() {
       const canonicalProductId = canonicalProductIdByKey.get(alias.canonicalProductKey);
       if (!canonicalProductId) throw new Error(`Missing canonical product ${alias.canonicalProductKey}`);
       await tx.skuAlias.upsert({
-        where: { marketplace_aliasType_value: { marketplace: alias.marketplace, aliasType: alias.aliasType, value: alias.value } },
-        create: { canonicalProductId, marketplace: alias.marketplace, aliasType: alias.aliasType, value: alias.value },
-        update: { canonicalProductId, active: true },
+        where: {
+          marketplace_normalizedAliasType_normalizedValue: {
+            marketplace: alias.marketplace,
+            normalizedAliasType: alias.normalizedAliasType,
+            normalizedValue: alias.normalizedValue,
+          },
+        },
+        create: {
+          canonicalProductId,
+          marketplace: alias.marketplace,
+          aliasType: alias.aliasType,
+          value: alias.value,
+          normalizedAliasType: alias.normalizedAliasType,
+          normalizedValue: alias.normalizedValue,
+        },
+        update: {
+          canonicalProductId,
+          aliasType: alias.aliasType,
+          value: alias.value,
+          active: true,
+        },
       });
     }
 
     for (const po of plan.purchaseOrders) {
       await tx.purchaseOrder.upsert({
-        where: { internalRef: po.internalRef },
-        create: { internalRef: po.internalRef, supplierRef: po.supplierRef, marketplace: po.marketplace },
+        where: { sourceType_sourceId: { sourceType: po.sourceType, sourceId: po.sourceId } },
+        create: {
+          internalRef: po.internalRef,
+          sourceType: po.sourceType,
+          sourceId: po.sourceId,
+          supplierRef: po.supplierRef,
+          marketplace: po.marketplace,
+        },
         update: { supplierRef: po.supplierRef, marketplace: po.marketplace },
       });
     }
 
     for (const layer of plan.costLayers) {
       if (layer.canonicalProductKey === null) continue;
-      const purchaseOrder = await tx.purchaseOrder.findUniqueOrThrow({ where: { internalRef: layer.purchaseOrderInternalRef } });
+      const purchaseOrder = await tx.purchaseOrder.findUniqueOrThrow({
+        where: {
+          sourceType_sourceId: {
+            sourceType: layer.purchaseOrderSourceType,
+            sourceId: layer.purchaseOrderSourceId,
+          },
+        },
+      });
       const canonicalProductId = canonicalProductIdByKey.get(layer.canonicalProductKey);
       if (!canonicalProductId) throw new Error(`Missing canonical product ${layer.canonicalProductKey}`);
       const existing = await tx.poCostLayer.findFirst({

--- a/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
+++ b/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
@@ -1214,14 +1214,28 @@ async function main() {
       const productGroupId = productGroupIdByCode.get(product.productGroupCode);
       if (!productGroupId) throw new Error(`Missing product group ${product.productGroupCode}`);
       const [productKeyType, ...productKeyParts] = product.key.split(':');
-      const productKeyValue = productKeyParts.join(':');
       if (productKeyType !== 'ASIN' && productKeyType !== 'SKU') {
         throw new Error(`Unsupported canonical product key ${product.key}`);
       }
+      const productAliasLookup = (() => {
+        if (productKeyType === 'ASIN') {
+          return {
+            normalizedAliasType: 'ASIN',
+            normalizedValue: productKeyParts.join(':'),
+          };
+        }
+        if (productKeyParts.length < 2) {
+          throw new Error(`Unsupported SKU canonical product key ${product.key}`);
+        }
+        return {
+          marketplace: productKeyParts[0]!,
+          normalizedAliasType: 'SKU',
+          normalizedValue: productKeyParts.slice(1).join(':'),
+        };
+      })();
       const existingAlias = await tx.skuAlias.findFirst({
         where: {
-          normalizedAliasType: productKeyType,
-          normalizedValue: productKeyValue,
+          ...productAliasLookup,
         },
       });
       const row = existingAlias

--- a/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
+++ b/docs/superpowers/plans/2026-05-13-plutus-subledger-foundation.md
@@ -1,0 +1,1620 @@
+# Plutus Subledger Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the Phase 1 Plutus subledger foundation: structured products, SKU aliases, PO cost layers, inventory movements, QBO posting trace records, and drift primitives.
+
+**Architecture:** Keep QBO as the formal ledger and Plutus as the deterministic subledger. Add structured Prisma models and pure TypeScript domain modules first, then add a backfill path from existing Brand/Sku/BillMapping data and read-only UI/API surfaces. Do not change live QBO posting behavior in this phase.
+
+**Tech Stack:** Next.js App Router, React client components, MUI, Prisma/PostgreSQL, TypeScript, custom Node test runner in `apps/plutus/tests/run.ts`.
+
+---
+
+## Scope
+
+This plan implements the first executable slice of `docs/superpowers/specs/2026-05-13-plutus-subledger-redesign.md`.
+
+Included:
+- New structured subledger tables.
+- Deterministic trace memo and line-description builders.
+- SKU alias resolution.
+- PO cost layer and FIFO inventory movement primitives.
+- QBO posting intent and live-posting fingerprint comparison.
+- Legacy backfill from current Brand/Sku/BillMapping/BillLineMapping data.
+- Read-only Products, Purchase Orders, Inventory Ledger, and QBO Audit pages.
+
+Excluded:
+- Changing current Amazon settlement QBO posting behavior.
+- Replacing existing COGS journal-entry posting.
+- Enabling QBO inventory items, classes, or departments.
+- Removing current Brand/Sku/BillMapping tables.
+- Mutating live QBO records.
+
+## File Structure
+
+Create:
+- `apps/plutus/lib/plutus/subledger/types.ts` — shared enums, zod schemas, and small helpers.
+- `apps/plutus/lib/plutus/subledger/qbo-trace.ts` — memo/line builders and posting fingerprint diffing.
+- `apps/plutus/lib/plutus/subledger/sku-alias.ts` — canonical product alias resolution.
+- `apps/plutus/lib/plutus/subledger/cost-flow.ts` — FIFO cost-layer consumption and inventory valuation primitives.
+- `apps/plutus/lib/plutus/subledger/backfill.ts` — pure planner for converting legacy rows into subledger records.
+- `apps/plutus/scripts/backfill-subledger-foundation.ts` — dry-run/apply script for production data migration after review.
+- `apps/plutus/app/api/plutus/products/route.ts` — read-only canonical product endpoint.
+- `apps/plutus/app/api/plutus/purchase-orders/route.ts` — read-only PO/cost-layer endpoint.
+- `apps/plutus/app/api/plutus/inventory-ledger/route.ts` — read-only inventory summary endpoint.
+- `apps/plutus/app/api/plutus/qbo-audit/route.ts` — read-only QBO posting audit endpoint.
+- `apps/plutus/components/subledger/products-page.tsx` — product/alias table.
+- `apps/plutus/components/subledger/purchase-orders-page.tsx` — PO/cost layer table.
+- `apps/plutus/components/subledger/inventory-ledger-page.tsx` — inventory movement/valuation table.
+- `apps/plutus/components/subledger/qbo-audit-page.tsx` — posting drift table.
+- `apps/plutus/app/products/page.tsx`
+- `apps/plutus/app/purchase-orders/page.tsx`
+- `apps/plutus/app/inventory-ledger/page.tsx`
+- `apps/plutus/app/qbo-audit/page.tsx`
+
+Modify:
+- `apps/plutus/prisma/schema.prisma` — add subledger models and relations.
+- `apps/plutus/tests/run.ts` — add tests for schema, pure modules, backfill planner, and nav.
+- `apps/plutus/components/app-header.tsx` — add new top-level navigation items.
+
+Generated:
+- `apps/plutus/prisma/migrations/<timestamp>_add_subledger_foundation/migration.sql`
+
+---
+
+### Task 1: Lock the Foundation Contract With Failing Tests
+
+**Files:**
+- Modify: `apps/plutus/tests/run.ts`
+
+- [ ] **Step 1: Add imports for planned modules**
+
+Add these imports near the other Plutus imports:
+
+```ts
+import {
+  buildPlutusLineDescription,
+  buildPlutusTraceMemo,
+  comparePostingFingerprints,
+  fingerprintPostingLines,
+} from '../lib/plutus/subledger/qbo-trace';
+import {
+  resolveCanonicalProductAlias,
+} from '../lib/plutus/subledger/sku-alias';
+import {
+  consumeInventoryMovementsFifo,
+} from '../lib/plutus/subledger/cost-flow';
+import {
+  mapLegacyBrandNameToProductGroupCode,
+  normalizeAliasValue,
+  planLegacySubledgerBackfill,
+} from '../lib/plutus/subledger/backfill';
+```
+
+- [ ] **Step 2: Add failing schema and nav tests**
+
+Add these tests after the existing settlement UI/source tests:
+
+```ts
+test('subledger schema defines the structured Plutus-owned tables', () => {
+  const schema = readFileSync(new URL('../prisma/schema.prisma', import.meta.url), 'utf8');
+
+  for (const expected of [
+    'model ProductGroup',
+    'model CanonicalProduct',
+    'model SkuAlias',
+    'model PurchaseOrder',
+    'model PoCostLayer',
+    'model InventoryMovement',
+    'model PostingIntent',
+    'model PostingIntentLine',
+    'model QboPosting',
+    'model QboPostingLineFingerprint',
+  ]) {
+    assert.equal(schema.includes(expected), true, expected);
+  }
+
+  assert.equal(schema.includes('@@unique([marketplace, aliasType, value])'), true);
+  assert.equal(schema.includes('@@unique([sourceType, sourceId])'), true);
+  assert.equal(schema.includes('@@unique([qboTxnType, qboTxnId])'), true);
+});
+
+test('subledger navigation exposes LMB-style Plutus control surfaces', () => {
+  const source = readFileSync(new URL('../components/app-header.tsx', import.meta.url), 'utf8');
+
+  for (const expected of [
+    "label: 'Settlements'",
+    "label: 'Products'",
+    "label: 'Purchase Orders'",
+    "label: 'Inventory Ledger'",
+    "label: 'Mappings'",
+    "label: 'QBO Audit'",
+    "label: 'Settings'",
+  ]) {
+    assert.equal(source.includes(expected), true, expected);
+  }
+});
+```
+
+- [ ] **Step 3: Add failing pure-domain tests**
+
+Add these tests near the other pure function tests:
+
+```ts
+test('Plutus QBO trace fields are deterministic and minimal', () => {
+  assert.equal(
+    buildPlutusTraceMemo({
+      plutusRef: 'posting_123',
+      source: 'AMZ_SETTLEMENT',
+      market: 'US',
+      period: '2026-05',
+    }),
+    'PLUTUS_REF=posting_123; SOURCE=AMZ_SETTLEMENT; MARKET=US; PERIOD=2026-05',
+  );
+
+  assert.equal(
+    buildPlutusLineDescription({
+      category: 'Amazon Sales - Principal',
+      plutusLineId: 'line_abc',
+    }),
+    'Amazon Sales - Principal; PLUTUS_LINE=line_abc',
+  );
+
+  assert.throws(
+    () => buildPlutusTraceMemo({ plutusRef: '', source: 'AMZ_SETTLEMENT', market: 'US', period: '2026-05' }),
+    /plutusRef is required/,
+  );
+});
+
+test('posting fingerprint comparison detects QBO line drift', () => {
+  const expected = fingerprintPostingLines([
+    { lineId: 'line_1', accountId: '187', amountCents: 1200, description: 'Amazon Sales; PLUTUS_LINE=line_1' },
+    { lineId: 'line_2', accountId: '193', amountCents: -300, description: 'Amazon Seller Fees; PLUTUS_LINE=line_2' },
+  ]);
+
+  const live = fingerprintPostingLines([
+    { lineId: 'line_1', accountId: '187', amountCents: 1200, description: 'Amazon Sales; PLUTUS_LINE=line_1' },
+    { lineId: 'line_2', accountId: '194', amountCents: -300, description: 'Amazon Seller Fees; PLUTUS_LINE=line_2' },
+  ]);
+
+  assert.deepEqual(comparePostingFingerprints(expected, live), {
+    status: 'drifted',
+    missingLineIds: [],
+    extraLineIds: [],
+    changedLineIds: ['line_2'],
+  });
+});
+
+test('SKU alias resolver maps market aliases to canonical products', () => {
+  const aliases = [
+    { canonicalProductId: 'prod_pds_7', marketplace: 'amazon.com', aliasType: 'SKU', value: 'CS-007' },
+    { canonicalProductId: 'prod_pds_7', marketplace: 'amazon.co.uk', aliasType: 'SKU', value: 'CS 007' },
+    { canonicalProductId: 'prod_pds_7', marketplace: 'amazon.com', aliasType: 'ASIN', value: 'B09HXC3NL8' },
+  ];
+
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.com', 'sku', 'cs-007'), 'prod_pds_7');
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.co.uk', 'SKU', 'CS 007'), 'prod_pds_7');
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.com', 'ASIN', 'b09hxc3nl8'), 'prod_pds_7');
+  assert.equal(resolveCanonicalProductAlias(aliases, 'amazon.co.uk', 'ASIN', 'B09HXC3NL8'), null);
+});
+
+test('FIFO inventory movement consumes PO cost layers deterministically', () => {
+  const result = consumeInventoryMovementsFifo({
+    layers: [
+      {
+        id: 'layer_old',
+        canonicalProductId: 'prod_pds_7',
+        receivedDate: '2026-01-01',
+        quantity: 5,
+        componentCostsCents: { manufacturing: 500, freight: 100, duty: 0, mfgAccessories: 50 },
+      },
+      {
+        id: 'layer_new',
+        canonicalProductId: 'prod_pds_7',
+        receivedDate: '2026-02-01',
+        quantity: 10,
+        componentCostsCents: { manufacturing: 2000, freight: 300, duty: 100, mfgAccessories: 0 },
+      },
+    ],
+    movements: [
+      {
+        id: 'sale_1',
+        canonicalProductId: 'prod_pds_7',
+        movementDate: '2026-03-01',
+        movementType: 'SALE',
+        quantity: -7,
+      },
+    ],
+  });
+
+  assert.equal(result.blocks.length, 0);
+  assert.deepEqual(result.movementCosts[0], {
+    movementId: 'sale_1',
+    quantity: 7,
+    manufacturingCents: 900,
+    freightCents: 160,
+    dutyCents: 20,
+    mfgAccessoriesCents: 50,
+  });
+  assert.deepEqual(result.endingLayers.map((layer) => ({ id: layer.id, remainingQuantity: layer.remainingQuantity })), [
+    { id: 'layer_old', remainingQuantity: 0 },
+    { id: 'layer_new', remainingQuantity: 8 },
+  ]);
+});
+
+test('legacy subledger backfill groups current Brand and Sku rows without false PO merges', () => {
+  assert.equal(mapLegacyBrandNameToProductGroupCode('US-PDS'), 'PDS');
+  assert.equal(mapLegacyBrandNameToProductGroupCode('UK-CDS'), 'CDS');
+  assert.equal(normalizeAliasValue(' cs-007 '), 'CS-007');
+
+  const plan = planLegacySubledgerBackfill({
+    brands: [
+      { id: 'brand_us_pds', name: 'US-PDS', marketplace: 'amazon.com', currency: 'USD' },
+      { id: 'brand_uk_pds', name: 'UK-PDS', marketplace: 'amazon.co.uk', currency: 'GBP' },
+    ],
+    skus: [
+      { id: 'sku_us', sku: 'CS-007', asin: 'B09HXC3NL8', productName: 'PDS 7', brandId: 'brand_us_pds' },
+      { id: 'sku_uk', sku: 'CS 007', asin: 'B09HXC3NL8', productName: 'PDS 7', brandId: 'brand_uk_pds' },
+    ],
+    billMappings: [],
+    billLineMappings: [],
+  });
+
+  assert.deepEqual(plan.productGroups.map((group) => group.code), ['PDS']);
+  assert.equal(plan.canonicalProducts.length, 1);
+  assert.deepEqual(
+    plan.skuAliases.map((alias) => [alias.marketplace, alias.aliasType, alias.value]).sort(),
+    [
+      ['amazon.co.uk', 'ASIN', 'B09HXC3NL8'],
+      ['amazon.co.uk', 'SKU', 'CS 007'],
+      ['amazon.com', 'ASIN', 'B09HXC3NL8'],
+      ['amazon.com', 'SKU', 'CS-007'],
+    ],
+  );
+});
+```
+
+- [ ] **Step 4: Run tests to confirm failure**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: FAIL because the subledger modules and schema models do not exist.
+
+---
+
+### Task 2: Add Subledger Prisma Models
+
+**Files:**
+- Modify: `apps/plutus/prisma/schema.prisma`
+- Create: `apps/plutus/prisma/migrations/<timestamp>_add_subledger_foundation/migration.sql`
+
+- [ ] **Step 1: Add schema models**
+
+Append these models after `BillLineMapping` and before `AwdDataUpload`:
+
+```prisma
+model ProductGroup {
+  id        String   @id @default(cuid())
+  code      String   @unique
+  name      String
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  products CanonicalProduct[]
+
+  @@index([active])
+}
+
+model CanonicalProduct {
+  id             String   @id @default(cuid())
+  name           String
+  productGroupId String
+  active         Boolean  @default(true)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  productGroup       ProductGroup        @relation(fields: [productGroupId], references: [id])
+  aliases            SkuAlias[]
+  costLayers         PoCostLayer[]
+  inventoryMovements InventoryMovement[]
+
+  @@index([productGroupId])
+  @@index([active])
+}
+
+model SkuAlias {
+  id                 String   @id @default(cuid())
+  canonicalProductId String
+  marketplace        String
+  aliasType          String
+  value              String
+  active             Boolean  @default(true)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id], onDelete: Cascade)
+
+  @@unique([marketplace, aliasType, value])
+  @@index([canonicalProductId])
+  @@index([marketplace])
+}
+
+model PurchaseOrder {
+  id           String   @id @default(cuid())
+  internalRef  String   @unique
+  supplierRef  String?
+  marketplace  String?
+  status       String   @default("OPEN")
+  sourceNotes  String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  costLayers PoCostLayer[]
+
+  @@index([marketplace])
+  @@index([status])
+}
+
+model PoCostLayer {
+  id                 String   @id @default(cuid())
+  purchaseOrderId    String
+  canonicalProductId String
+  component          String
+  quantity           Int?
+  amountCents        Int
+  currency           String
+  allocationMethod   String
+  sourceQboTxnType   String?
+  sourceQboTxnId     String?
+  sourceQboLineId    String?
+  sourceDocumentName String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  purchaseOrder    PurchaseOrder    @relation(fields: [purchaseOrderId], references: [id], onDelete: Cascade)
+  canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id])
+
+  @@index([purchaseOrderId])
+  @@index([canonicalProductId])
+  @@index([component])
+  @@index([sourceQboTxnType, sourceQboTxnId])
+}
+
+model InventoryMovement {
+  id                 String   @id @default(cuid())
+  canonicalProductId String
+  marketplace        String
+  movementType       String
+  quantity           Int
+  movementDate       DateTime
+  sourceType         String
+  sourceId           String
+  sourceLineId       String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  canonicalProduct CanonicalProduct @relation(fields: [canonicalProductId], references: [id])
+
+  @@index([canonicalProductId])
+  @@index([marketplace])
+  @@index([movementType])
+  @@index([movementDate])
+  @@index([sourceType, sourceId])
+}
+
+model PostingIntent {
+  id             String   @id @default(cuid())
+  sourceType     String
+  sourceId       String
+  market         String
+  periodStart    String?
+  periodEnd      String?
+  sourceHash     String
+  mappingVersion String
+  postingHash    String
+  status         String   @default("draft")
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+
+  lines       PostingIntentLine[]
+  qboPostings QboPosting[]
+
+  @@unique([sourceType, sourceId])
+  @@index([market])
+  @@index([status])
+}
+
+model PostingIntentLine {
+  id              String   @id @default(cuid())
+  postingIntentId String
+  lineRef         String
+  category        String
+  accountId       String?
+  amountCents     Int
+  currency        String
+  description     String
+  lineHash        String
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
+
+  postingIntent PostingIntent @relation(fields: [postingIntentId], references: [id], onDelete: Cascade)
+
+  @@unique([postingIntentId, lineRef])
+  @@index([postingIntentId])
+}
+
+model QboPosting {
+  id              String    @id @default(cuid())
+  postingIntentId String
+  qboTxnType      String
+  qboTxnId        String
+  qboSyncToken    String?
+  qboDocNumber    String?
+  qboPrivateNote  String?
+  qboTxnDate      String?
+  postingHash     String
+  driftStatus     String    @default("unchecked")
+  attachmentStatus String   @default("missing")
+  lastCheckedAt   DateTime?
+  createdAt       DateTime  @default(now())
+  updatedAt       DateTime  @updatedAt
+
+  postingIntent PostingIntent               @relation(fields: [postingIntentId], references: [id], onDelete: Cascade)
+  lineFingerprints QboPostingLineFingerprint[]
+
+  @@unique([qboTxnType, qboTxnId])
+  @@index([postingIntentId])
+  @@index([driftStatus])
+}
+
+model QboPostingLineFingerprint {
+  id               String   @id @default(cuid())
+  qboPostingId     String
+  qboLineId        String
+  expectedLineHash String
+  liveLineHash     String?
+  driftStatus      String   @default("unchecked")
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  qboPosting QboPosting @relation(fields: [qboPostingId], references: [id], onDelete: Cascade)
+
+  @@unique([qboPostingId, qboLineId])
+  @@index([qboPostingId])
+  @@index([driftStatus])
+}
+```
+
+- [ ] **Step 2: Create migration**
+
+Run:
+
+```bash
+pnpm -C apps/plutus db:migrate -- --name add_subledger_foundation
+```
+
+Expected: Prisma creates `apps/plutus/prisma/migrations/<timestamp>_add_subledger_foundation/migration.sql`.
+
+- [ ] **Step 3: Run schema contract test**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: schema model assertions pass; module and nav tests still fail.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add apps/plutus/prisma/schema.prisma apps/plutus/prisma/migrations
+git commit -m "feat(plutus): add subledger foundation schema"
+```
+
+---
+
+### Task 3: Add Trace, Fingerprint, and Allowed-Value Helpers
+
+**Files:**
+- Create: `apps/plutus/lib/plutus/subledger/types.ts`
+- Create: `apps/plutus/lib/plutus/subledger/qbo-trace.ts`
+- Modify: `apps/plutus/tests/run.ts`
+
+- [ ] **Step 1: Create shared subledger types**
+
+Create `apps/plutus/lib/plutus/subledger/types.ts`:
+
+```ts
+import { z } from 'zod';
+
+export const PLUTUS_TRACE_SOURCES = ['AMZ_SETTLEMENT', 'QBO_BILL', 'QBO_PURCHASE', 'MANUAL_ADJUSTMENT'] as const;
+export const PLUTUS_TRACE_MARKETS = ['US', 'UK', 'MULTI'] as const;
+export const PO_COST_COMPONENTS = ['manufacturing', 'freight', 'duty', 'mfgAccessories'] as const;
+export const INVENTORY_MOVEMENT_TYPES = ['RECEIPT', 'SALE', 'RETURN', 'REMOVAL', 'DISPOSAL', 'ADJUSTMENT'] as const;
+export const QBO_DRIFT_STATUSES = ['unchecked', 'in_sync', 'drifted', 'missing_in_qbo', 'duplicate_qbo_posting', 'stale_mapping'] as const;
+
+export type PlutusTraceSource = (typeof PLUTUS_TRACE_SOURCES)[number];
+export type PlutusTraceMarket = (typeof PLUTUS_TRACE_MARKETS)[number];
+export type PoCostComponent = (typeof PO_COST_COMPONENTS)[number];
+export type InventoryMovementType = (typeof INVENTORY_MOVEMENT_TYPES)[number];
+export type QboDriftStatus = (typeof QBO_DRIFT_STATUSES)[number];
+
+export const plutusTraceInputSchema = z.object({
+  plutusRef: z.string().trim().min(1, 'plutusRef is required'),
+  source: z.enum(PLUTUS_TRACE_SOURCES),
+  market: z.enum(PLUTUS_TRACE_MARKETS),
+  period: z.string().trim().min(1, 'period is required'),
+});
+
+export type PlutusTraceInput = z.infer<typeof plutusTraceInputSchema>;
+
+export type ComponentCostsCents = Record<PoCostComponent, number>;
+
+export function emptyComponentCosts(): ComponentCostsCents {
+  return {
+    manufacturing: 0,
+    freight: 0,
+    duty: 0,
+    mfgAccessories: 0,
+  };
+}
+```
+
+- [ ] **Step 2: Create QBO trace helpers**
+
+Create `apps/plutus/lib/plutus/subledger/qbo-trace.ts`:
+
+```ts
+import { createHash } from 'node:crypto';
+
+import { plutusTraceInputSchema, type PlutusTraceInput } from './types';
+
+export type PostingFingerprintLine = {
+  lineId: string;
+  accountId: string;
+  amountCents: number;
+  description: string;
+};
+
+export type PostingFingerprint = {
+  postingHash: string;
+  lineHashesById: Map<string, string>;
+};
+
+export type PostingFingerprintDiff = {
+  status: 'in_sync' | 'drifted';
+  missingLineIds: string[];
+  extraLineIds: string[];
+  changedLineIds: string[];
+};
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+export function buildPlutusTraceMemo(input: PlutusTraceInput): string {
+  const parsed = plutusTraceInputSchema.parse(input);
+  return `PLUTUS_REF=${parsed.plutusRef}; SOURCE=${parsed.source}; MARKET=${parsed.market}; PERIOD=${parsed.period}`;
+}
+
+export function buildPlutusLineDescription(input: { category: string; plutusLineId: string }): string {
+  const category = input.category.trim();
+  const plutusLineId = input.plutusLineId.trim();
+  if (category === '') throw new Error('category is required');
+  if (plutusLineId === '') throw new Error('plutusLineId is required');
+  return `${category}; PLUTUS_LINE=${plutusLineId}`;
+}
+
+export function fingerprintPostingLines(lines: PostingFingerprintLine[]): PostingFingerprint {
+  const lineHashesById = new Map<string, string>();
+  for (const line of [...lines].sort((left, right) => left.lineId.localeCompare(right.lineId))) {
+    const lineId = line.lineId.trim();
+    if (lineId === '') throw new Error('lineId is required');
+    lineHashesById.set(
+      lineId,
+      hashJson({
+        accountId: line.accountId,
+        amountCents: line.amountCents,
+        description: line.description,
+      }),
+    );
+  }
+
+  return {
+    postingHash: hashJson(Array.from(lineHashesById.entries())),
+    lineHashesById,
+  };
+}
+
+export function comparePostingFingerprints(expected: PostingFingerprint, live: PostingFingerprint): PostingFingerprintDiff {
+  const missingLineIds: string[] = [];
+  const extraLineIds: string[] = [];
+  const changedLineIds: string[] = [];
+
+  for (const [lineId, expectedHash] of expected.lineHashesById.entries()) {
+    const liveHash = live.lineHashesById.get(lineId);
+    if (liveHash === undefined) {
+      missingLineIds.push(lineId);
+    } else if (liveHash !== expectedHash) {
+      changedLineIds.push(lineId);
+    }
+  }
+
+  for (const lineId of live.lineHashesById.keys()) {
+    if (!expected.lineHashesById.has(lineId)) {
+      extraLineIds.push(lineId);
+    }
+  }
+
+  return {
+    status: missingLineIds.length === 0 && extraLineIds.length === 0 && changedLineIds.length === 0 ? 'in_sync' : 'drifted',
+    missingLineIds: missingLineIds.sort(),
+    extraLineIds: extraLineIds.sort(),
+    changedLineIds: changedLineIds.sort(),
+  };
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: trace and fingerprint tests pass; alias, cost-flow, backfill, and nav tests still fail.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add apps/plutus/lib/plutus/subledger/types.ts apps/plutus/lib/plutus/subledger/qbo-trace.ts apps/plutus/tests/run.ts
+git commit -m "feat(plutus): add deterministic QBO trace helpers"
+```
+
+---
+
+### Task 4: Add SKU Alias Resolver and Legacy Backfill Planner
+
+**Files:**
+- Create: `apps/plutus/lib/plutus/subledger/sku-alias.ts`
+- Create: `apps/plutus/lib/plutus/subledger/backfill.ts`
+- Modify: `apps/plutus/tests/run.ts`
+
+- [ ] **Step 1: Create SKU alias resolver**
+
+Create `apps/plutus/lib/plutus/subledger/sku-alias.ts`:
+
+```ts
+export type SkuAliasCandidate = {
+  canonicalProductId: string;
+  marketplace: string;
+  aliasType: string;
+  value: string;
+};
+
+export function normalizeAliasLookupValue(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+export function resolveCanonicalProductAlias(
+  aliases: SkuAliasCandidate[],
+  marketplace: string,
+  aliasType: string,
+  value: string,
+): string | null {
+  const normalizedMarketplace = marketplace.trim();
+  const normalizedAliasType = aliasType.trim().toUpperCase();
+  const normalizedValue = normalizeAliasLookupValue(value);
+  if (normalizedMarketplace === '' || normalizedAliasType === '' || normalizedValue === '') {
+    return null;
+  }
+
+  const match = aliases.find(
+    (alias) =>
+      alias.marketplace === normalizedMarketplace &&
+      alias.aliasType.toUpperCase() === normalizedAliasType &&
+      normalizeAliasLookupValue(alias.value) === normalizedValue,
+  );
+
+  return match ? match.canonicalProductId : null;
+}
+```
+
+- [ ] **Step 2: Create pure legacy backfill planner**
+
+Create `apps/plutus/lib/plutus/subledger/backfill.ts`:
+
+```ts
+import { normalizeAliasLookupValue } from './sku-alias';
+
+export type LegacyBrandRow = {
+  id: string;
+  name: string;
+  marketplace: string;
+  currency: string;
+};
+
+export type LegacySkuRow = {
+  id: string;
+  sku: string;
+  asin: string | null;
+  productName: string | null;
+  brandId: string;
+};
+
+export type LegacyBillMappingRow = {
+  id: string;
+  qboBillId: string;
+  poNumber: string;
+  brandId: string;
+  billDate: string;
+  vendorName: string;
+  totalAmount: number;
+};
+
+export type LegacyBillLineMappingRow = {
+  id: string;
+  billMappingId: string;
+  qboLineId: string;
+  component: string;
+  amountCents: number;
+  sku: string | null;
+  quantity: number | null;
+};
+
+export type LegacySubledgerBackfillPlan = {
+  productGroups: Array<{ code: string; name: string }>;
+  canonicalProducts: Array<{ key: string; name: string; productGroupCode: string }>;
+  skuAliases: Array<{ canonicalProductKey: string; marketplace: string; aliasType: 'SKU' | 'ASIN'; value: string }>;
+  purchaseOrders: Array<{ internalRef: string; marketplace: string; supplierRef: string | null }>;
+  costLayers: Array<{
+    purchaseOrderInternalRef: string;
+    canonicalProductKey: string | null;
+    component: string;
+    quantity: number | null;
+    amountCents: number;
+    currency: string;
+    sourceQboTxnType: 'Bill';
+    sourceQboTxnId: string;
+    sourceQboLineId: string;
+  }>;
+};
+
+export function normalizeAliasValue(value: string): string {
+  return normalizeAliasLookupValue(value);
+}
+
+export function mapLegacyBrandNameToProductGroupCode(name: string): string {
+  const trimmed = name.trim();
+  const parts = trimmed.split('-').filter((part) => part.trim() !== '');
+  return parts.length > 1 ? parts[parts.length - 1]!.trim().toUpperCase() : trimmed.toUpperCase();
+}
+
+function canonicalProductKeyForSku(input: { marketplace: string; sku: string; asin: string | null }): string {
+  const asin = input.asin ? normalizeAliasValue(input.asin) : '';
+  if (asin !== '') return `ASIN:${asin}`;
+  return `SKU:${input.marketplace}:${normalizeAliasValue(input.sku)}`;
+}
+
+export function planLegacySubledgerBackfill(input: {
+  brands: LegacyBrandRow[];
+  skus: LegacySkuRow[];
+  billMappings: LegacyBillMappingRow[];
+  billLineMappings: LegacyBillLineMappingRow[];
+}): LegacySubledgerBackfillPlan {
+  const brandsById = new Map(input.brands.map((brand) => [brand.id, brand]));
+  const productGroupsByCode = new Map<string, { code: string; name: string }>();
+  const canonicalProductsByKey = new Map<string, { key: string; name: string; productGroupCode: string }>();
+  const aliasKeys = new Set<string>();
+  const skuAliases: LegacySubledgerBackfillPlan['skuAliases'] = [];
+  const canonicalKeyByLegacySkuValue = new Map<string, string>();
+
+  for (const sku of input.skus) {
+    const brand = brandsById.get(sku.brandId);
+    if (!brand) throw new Error(`Missing brand for SKU ${sku.id}`);
+    const productGroupCode = mapLegacyBrandNameToProductGroupCode(brand.name);
+    productGroupsByCode.set(productGroupCode, { code: productGroupCode, name: productGroupCode });
+
+    const productKey = canonicalProductKeyForSku({ marketplace: brand.marketplace, sku: sku.sku, asin: sku.asin });
+    canonicalProductsByKey.set(productKey, {
+      key: productKey,
+      name: sku.productName && sku.productName.trim() !== '' ? sku.productName.trim() : normalizeAliasValue(sku.sku),
+      productGroupCode,
+    });
+    canonicalKeyByLegacySkuValue.set(`${brand.marketplace}:${normalizeAliasValue(sku.sku)}`, productKey);
+
+    for (const alias of [
+      { aliasType: 'SKU' as const, value: sku.sku },
+      ...(sku.asin && sku.asin.trim() !== '' ? [{ aliasType: 'ASIN' as const, value: sku.asin }] : []),
+    ]) {
+      const normalizedValue = normalizeAliasValue(alias.value);
+      const aliasKey = `${brand.marketplace}:${alias.aliasType}:${normalizedValue}`;
+      if (!aliasKeys.has(aliasKey)) {
+        aliasKeys.add(aliasKey);
+        skuAliases.push({
+          canonicalProductKey: productKey,
+          marketplace: brand.marketplace,
+          aliasType: alias.aliasType,
+          value: alias.value.trim(),
+        });
+      }
+    }
+  }
+
+  const purchaseOrders = input.billMappings.map((mapping) => {
+    const brand = brandsById.get(mapping.brandId);
+    if (!brand) throw new Error(`Missing brand for bill mapping ${mapping.id}`);
+    return {
+      internalRef: mapping.poNumber,
+      marketplace: brand.marketplace,
+      supplierRef: null,
+    };
+  });
+
+  const billMappingsById = new Map(input.billMappings.map((mapping) => [mapping.id, mapping]));
+  const costLayers = input.billLineMappings.map((line) => {
+    const mapping = billMappingsById.get(line.billMappingId);
+    if (!mapping) throw new Error(`Missing bill mapping for line ${line.id}`);
+    const brand = brandsById.get(mapping.brandId);
+    if (!brand) throw new Error(`Missing brand for bill mapping ${mapping.id}`);
+    const canonicalProductKey = line.sku
+      ? canonicalKeyByLegacySkuValue.get(`${brand.marketplace}:${normalizeAliasValue(line.sku)}`) ?? null
+      : null;
+
+    return {
+      purchaseOrderInternalRef: mapping.poNumber,
+      canonicalProductKey,
+      component: line.component,
+      quantity: line.quantity,
+      amountCents: line.amountCents,
+      currency: brand.currency,
+      sourceQboTxnType: 'Bill' as const,
+      sourceQboTxnId: mapping.qboBillId,
+      sourceQboLineId: line.qboLineId,
+    };
+  });
+
+  return {
+    productGroups: Array.from(productGroupsByCode.values()).sort((left, right) => left.code.localeCompare(right.code)),
+    canonicalProducts: Array.from(canonicalProductsByKey.values()).sort((left, right) => left.key.localeCompare(right.key)),
+    skuAliases: skuAliases.sort((left, right) => `${left.marketplace}:${left.aliasType}:${left.value}`.localeCompare(`${right.marketplace}:${right.aliasType}:${right.value}`)),
+    purchaseOrders,
+    costLayers,
+  };
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: alias and backfill tests pass; cost-flow and nav tests still fail.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+git add apps/plutus/lib/plutus/subledger/sku-alias.ts apps/plutus/lib/plutus/subledger/backfill.ts apps/plutus/tests/run.ts
+git commit -m "feat(plutus): add subledger alias backfill planner"
+```
+
+---
+
+### Task 5: Add FIFO PO Cost Layer Consumption
+
+**Files:**
+- Create: `apps/plutus/lib/plutus/subledger/cost-flow.ts`
+- Modify: `apps/plutus/tests/run.ts`
+
+- [ ] **Step 1: Create cost-flow module**
+
+Create `apps/plutus/lib/plutus/subledger/cost-flow.ts`:
+
+```ts
+import { emptyComponentCosts, type ComponentCostsCents, type InventoryMovementType } from './types';
+
+export type FifoCostLayerInput = {
+  id: string;
+  canonicalProductId: string;
+  receivedDate: string;
+  quantity: number;
+  componentCostsCents: ComponentCostsCents;
+};
+
+export type InventoryMovementInput = {
+  id: string;
+  canonicalProductId: string;
+  movementDate: string;
+  movementType: InventoryMovementType;
+  quantity: number;
+};
+
+export type MovementCostResult = {
+  movementId: string;
+  quantity: number;
+  manufacturingCents: number;
+  freightCents: number;
+  dutyCents: number;
+  mfgAccessoriesCents: number;
+};
+
+export type EndingLayerResult = {
+  id: string;
+  remainingQuantity: number;
+};
+
+export type CostFlowBlock = {
+  movementId: string;
+  code: 'NEGATIVE_INVENTORY' | 'INVALID_LAYER' | 'INVALID_MOVEMENT';
+  message: string;
+};
+
+export type CostFlowResult = {
+  movementCosts: MovementCostResult[];
+  endingLayers: EndingLayerResult[];
+  blocks: CostFlowBlock[];
+};
+
+type MutableLayer = FifoCostLayerInput & {
+  remainingQuantity: number;
+  consumedCostsCents: ComponentCostsCents;
+};
+
+function allocateComponentCost(totalCostCents: number, totalQuantity: number, consumedBefore: number, consumeQuantity: number): number {
+  const costThroughEnd = Math.round((totalCostCents * (consumedBefore + consumeQuantity)) / totalQuantity);
+  const costThroughStart = Math.round((totalCostCents * consumedBefore) / totalQuantity);
+  return costThroughEnd - costThroughStart;
+}
+
+function sortByDateThenId<T extends { id: string }>(rows: T[], getDate: (row: T) => string): T[] {
+  return [...rows].sort((left, right) => {
+    const dateCompare = getDate(left).localeCompare(getDate(right));
+    if (dateCompare !== 0) return dateCompare;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+export function consumeInventoryMovementsFifo(input: {
+  layers: FifoCostLayerInput[];
+  movements: InventoryMovementInput[];
+}): CostFlowResult {
+  const blocks: CostFlowBlock[] = [];
+  const layersByProduct = new Map<string, MutableLayer[]>();
+
+  for (const layer of sortByDateThenId(input.layers, (row) => row.receivedDate)) {
+    if (layer.quantity <= 0) {
+      blocks.push({ movementId: layer.id, code: 'INVALID_LAYER', message: `Layer ${layer.id} quantity must be positive` });
+      continue;
+    }
+
+    const mutable: MutableLayer = {
+      ...layer,
+      remainingQuantity: layer.quantity,
+      consumedCostsCents: emptyComponentCosts(),
+    };
+    const productLayers = layersByProduct.get(layer.canonicalProductId) ?? [];
+    productLayers.push(mutable);
+    layersByProduct.set(layer.canonicalProductId, productLayers);
+  }
+
+  const movementCosts: MovementCostResult[] = [];
+
+  for (const movement of sortByDateThenId(input.movements, (row) => row.movementDate)) {
+    if (movement.quantity === 0) {
+      blocks.push({ movementId: movement.id, code: 'INVALID_MOVEMENT', message: `Movement ${movement.id} quantity cannot be zero` });
+      continue;
+    }
+
+    if (movement.quantity > 0) {
+      continue;
+    }
+
+    let remainingToConsume = Math.abs(movement.quantity);
+    const movementCost = emptyComponentCosts();
+    const productLayers = layersByProduct.get(movement.canonicalProductId) ?? [];
+
+    for (const layer of productLayers) {
+      if (remainingToConsume === 0) break;
+      if (layer.remainingQuantity === 0) continue;
+
+      const consumeQuantity = Math.min(layer.remainingQuantity, remainingToConsume);
+      const consumedBefore = layer.quantity - layer.remainingQuantity;
+
+      for (const component of ['manufacturing', 'freight', 'duty', 'mfgAccessories'] as const) {
+        const componentCost = allocateComponentCost(
+          layer.componentCostsCents[component],
+          layer.quantity,
+          consumedBefore,
+          consumeQuantity,
+        );
+        movementCost[component] += componentCost;
+        layer.consumedCostsCents[component] += componentCost;
+      }
+
+      layer.remainingQuantity -= consumeQuantity;
+      remainingToConsume -= consumeQuantity;
+    }
+
+    if (remainingToConsume > 0) {
+      blocks.push({
+        movementId: movement.id,
+        code: 'NEGATIVE_INVENTORY',
+        message: `Movement ${movement.id} needs ${Math.abs(movement.quantity)} units but only ${Math.abs(movement.quantity) - remainingToConsume} are available`,
+      });
+    }
+
+    movementCosts.push({
+      movementId: movement.id,
+      quantity: Math.abs(movement.quantity) - remainingToConsume,
+      manufacturingCents: movementCost.manufacturing,
+      freightCents: movementCost.freight,
+      dutyCents: movementCost.duty,
+      mfgAccessoriesCents: movementCost.mfgAccessories,
+    });
+  }
+
+  const endingLayers = Array.from(layersByProduct.values())
+    .flat()
+    .map((layer) => ({ id: layer.id, remainingQuantity: layer.remainingQuantity }));
+
+  return { movementCosts, endingLayers, blocks };
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: cost-flow tests pass; nav tests still fail.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add apps/plutus/lib/plutus/subledger/cost-flow.ts apps/plutus/tests/run.ts
+git commit -m "feat(plutus): add FIFO subledger cost flow"
+```
+
+---
+
+### Task 6: Add Legacy Backfill Script
+
+**Files:**
+- Create: `apps/plutus/scripts/backfill-subledger-foundation.ts`
+- Modify: `apps/plutus/package.json`
+
+- [ ] **Step 1: Create script**
+
+Create `apps/plutus/scripts/backfill-subledger-foundation.ts`:
+
+```ts
+import db from '@/lib/db';
+import { planLegacySubledgerBackfill } from '@/lib/plutus/subledger/backfill';
+
+function parseApplyFlag(): boolean {
+  return process.argv.includes('--apply');
+}
+
+async function main() {
+  const apply = parseApplyFlag();
+
+  const [brands, skus, billMappings, billLineMappings] = await Promise.all([
+    db.brand.findMany({ orderBy: { name: 'asc' } }),
+    db.sku.findMany({ orderBy: { sku: 'asc' } }),
+    db.billMapping.findMany({ orderBy: { poNumber: 'asc' } }),
+    db.billLineMapping.findMany({ orderBy: { createdAt: 'asc' } }),
+  ]);
+
+  const plan = planLegacySubledgerBackfill({
+    brands,
+    skus: skus.map((sku) => ({
+      id: sku.id,
+      sku: sku.sku,
+      asin: sku.asin,
+      productName: sku.productName,
+      brandId: sku.brandId,
+    })),
+    billMappings,
+    billLineMappings,
+  });
+
+  console.log(JSON.stringify({
+    apply,
+    productGroups: plan.productGroups.length,
+    canonicalProducts: plan.canonicalProducts.length,
+    skuAliases: plan.skuAliases.length,
+    purchaseOrders: plan.purchaseOrders.length,
+    costLayers: plan.costLayers.length,
+    unassignedCostLayers: plan.costLayers.filter((layer) => layer.canonicalProductKey === null).length,
+  }, null, 2));
+
+  if (!apply) return;
+
+  await db.$transaction(async (tx) => {
+    const productGroupIdByCode = new Map<string, string>();
+    for (const group of plan.productGroups) {
+      const row = await tx.productGroup.upsert({
+        where: { code: group.code },
+        create: { code: group.code, name: group.name },
+        update: { name: group.name, active: true },
+      });
+      productGroupIdByCode.set(group.code, row.id);
+    }
+
+    const canonicalProductIdByKey = new Map<string, string>();
+    for (const product of plan.canonicalProducts) {
+      const productGroupId = productGroupIdByCode.get(product.productGroupCode);
+      if (!productGroupId) throw new Error(`Missing product group ${product.productGroupCode}`);
+      const existingAlias = await tx.skuAlias.findFirst({
+        where: { value: product.key.replace(/^ASIN:/, ''), aliasType: 'ASIN' },
+      });
+      const row = existingAlias
+        ? await tx.canonicalProduct.update({ where: { id: existingAlias.canonicalProductId }, data: { name: product.name, productGroupId, active: true } })
+        : await tx.canonicalProduct.create({ data: { name: product.name, productGroupId } });
+      canonicalProductIdByKey.set(product.key, row.id);
+    }
+
+    for (const alias of plan.skuAliases) {
+      const canonicalProductId = canonicalProductIdByKey.get(alias.canonicalProductKey);
+      if (!canonicalProductId) throw new Error(`Missing canonical product ${alias.canonicalProductKey}`);
+      await tx.skuAlias.upsert({
+        where: { marketplace_aliasType_value: { marketplace: alias.marketplace, aliasType: alias.aliasType, value: alias.value } },
+        create: { canonicalProductId, marketplace: alias.marketplace, aliasType: alias.aliasType, value: alias.value },
+        update: { canonicalProductId, active: true },
+      });
+    }
+
+    for (const po of plan.purchaseOrders) {
+      await tx.purchaseOrder.upsert({
+        where: { internalRef: po.internalRef },
+        create: { internalRef: po.internalRef, supplierRef: po.supplierRef, marketplace: po.marketplace },
+        update: { supplierRef: po.supplierRef, marketplace: po.marketplace },
+      });
+    }
+
+    for (const layer of plan.costLayers) {
+      if (layer.canonicalProductKey === null) continue;
+      const purchaseOrder = await tx.purchaseOrder.findUniqueOrThrow({ where: { internalRef: layer.purchaseOrderInternalRef } });
+      const canonicalProductId = canonicalProductIdByKey.get(layer.canonicalProductKey);
+      if (!canonicalProductId) throw new Error(`Missing canonical product ${layer.canonicalProductKey}`);
+      const existing = await tx.poCostLayer.findFirst({
+        where: {
+          purchaseOrderId: purchaseOrder.id,
+          canonicalProductId,
+          component: layer.component,
+          sourceQboTxnType: layer.sourceQboTxnType,
+          sourceQboTxnId: layer.sourceQboTxnId,
+          sourceQboLineId: layer.sourceQboLineId,
+        },
+      });
+      if (existing) {
+        await tx.poCostLayer.update({
+          where: { id: existing.id },
+          data: {
+            quantity: layer.quantity,
+            amountCents: layer.amountCents,
+            currency: layer.currency,
+            allocationMethod: 'LEGACY_BILL_LINE_MAPPING',
+          },
+        });
+      } else {
+        await tx.poCostLayer.create({
+          data: {
+            purchaseOrderId: purchaseOrder.id,
+            canonicalProductId,
+            component: layer.component,
+            quantity: layer.quantity,
+            amountCents: layer.amountCents,
+            currency: layer.currency,
+            allocationMethod: 'LEGACY_BILL_LINE_MAPPING',
+            sourceQboTxnType: layer.sourceQboTxnType,
+            sourceQboTxnId: layer.sourceQboTxnId,
+            sourceQboLineId: layer.sourceQboLineId,
+          },
+        });
+      }
+    }
+  });
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });
+```
+
+- [ ] **Step 2: Add package script**
+
+Add this to `apps/plutus/package.json` scripts:
+
+```json
+"subledger:backfill": "tsx scripts/backfill-subledger-foundation.ts"
+```
+
+- [ ] **Step 3: Run dry-run script**
+
+Run:
+
+```bash
+pnpm -C apps/plutus subledger:backfill
+```
+
+Expected: JSON summary prints counts and `"apply": false`. The script must not write rows in dry-run mode.
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: all pure-domain tests still pass; nav test still fails.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add apps/plutus/scripts/backfill-subledger-foundation.ts apps/plutus/package.json
+git commit -m "feat(plutus): add subledger backfill script"
+```
+
+---
+
+### Task 7: Add Read-Only APIs and Pages
+
+**Files:**
+- Create: `apps/plutus/app/api/plutus/products/route.ts`
+- Create: `apps/plutus/app/api/plutus/purchase-orders/route.ts`
+- Create: `apps/plutus/app/api/plutus/inventory-ledger/route.ts`
+- Create: `apps/plutus/app/api/plutus/qbo-audit/route.ts`
+- Create: `apps/plutus/components/subledger/products-page.tsx`
+- Create: `apps/plutus/components/subledger/purchase-orders-page.tsx`
+- Create: `apps/plutus/components/subledger/inventory-ledger-page.tsx`
+- Create: `apps/plutus/components/subledger/qbo-audit-page.tsx`
+- Create: `apps/plutus/app/products/page.tsx`
+- Create: `apps/plutus/app/purchase-orders/page.tsx`
+- Create: `apps/plutus/app/inventory-ledger/page.tsx`
+- Create: `apps/plutus/app/qbo-audit/page.tsx`
+- Modify: `apps/plutus/components/app-header.tsx`
+- Modify: `apps/plutus/tests/run.ts`
+
+- [ ] **Step 1: Add read-only API routes**
+
+Use this shape for `apps/plutus/app/api/plutus/products/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+
+import db from '@/lib/db';
+
+export async function GET() {
+  const products = await db.canonicalProduct.findMany({
+    orderBy: [{ productGroup: { code: 'asc' } }, { name: 'asc' }],
+    include: {
+      productGroup: true,
+      aliases: { orderBy: [{ marketplace: 'asc' }, { aliasType: 'asc' }, { value: 'asc' }] },
+    },
+  });
+
+  return NextResponse.json({
+    products: products.map((product) => ({
+      id: product.id,
+      name: product.name,
+      active: product.active,
+      productGroup: { id: product.productGroup.id, code: product.productGroup.code, name: product.productGroup.name },
+      aliases: product.aliases.map((alias) => ({
+        id: alias.id,
+        marketplace: alias.marketplace,
+        aliasType: alias.aliasType,
+        value: alias.value,
+        active: alias.active,
+      })),
+    })),
+  });
+}
+```
+
+Use this shape for `apps/plutus/app/api/plutus/purchase-orders/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+
+import db from '@/lib/db';
+
+export async function GET() {
+  const purchaseOrders = await db.purchaseOrder.findMany({
+    orderBy: [{ internalRef: 'asc' }],
+    include: {
+      costLayers: {
+        orderBy: [{ component: 'asc' }, { createdAt: 'asc' }],
+        include: { canonicalProduct: { include: { productGroup: true } } },
+      },
+    },
+  });
+
+  return NextResponse.json({
+    purchaseOrders: purchaseOrders.map((po) => ({
+      id: po.id,
+      internalRef: po.internalRef,
+      supplierRef: po.supplierRef,
+      marketplace: po.marketplace,
+      status: po.status,
+      totalAmountCents: po.costLayers.reduce((sum, layer) => sum + layer.amountCents, 0),
+      costLayers: po.costLayers.map((layer) => ({
+        id: layer.id,
+        component: layer.component,
+        quantity: layer.quantity,
+        amountCents: layer.amountCents,
+        currency: layer.currency,
+        allocationMethod: layer.allocationMethod,
+        sourceQboTxnType: layer.sourceQboTxnType,
+        sourceQboTxnId: layer.sourceQboTxnId,
+        sourceQboLineId: layer.sourceQboLineId,
+        product: {
+          id: layer.canonicalProduct.id,
+          name: layer.canonicalProduct.name,
+          productGroupCode: layer.canonicalProduct.productGroup.code,
+        },
+      })),
+    })),
+  });
+}
+```
+
+Use this shape for `apps/plutus/app/api/plutus/inventory-ledger/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+
+import db from '@/lib/db';
+
+export async function GET() {
+  const movements = await db.inventoryMovement.findMany({
+    orderBy: [{ movementDate: 'desc' }, { id: 'asc' }],
+    take: 500,
+    include: { canonicalProduct: { include: { productGroup: true } } },
+  });
+
+  return NextResponse.json({
+    movements: movements.map((movement) => ({
+      id: movement.id,
+      marketplace: movement.marketplace,
+      movementType: movement.movementType,
+      quantity: movement.quantity,
+      movementDate: movement.movementDate.toISOString(),
+      sourceType: movement.sourceType,
+      sourceId: movement.sourceId,
+      sourceLineId: movement.sourceLineId,
+      product: {
+        id: movement.canonicalProduct.id,
+        name: movement.canonicalProduct.name,
+        productGroupCode: movement.canonicalProduct.productGroup.code,
+      },
+    })),
+  });
+}
+```
+
+Use this shape for `apps/plutus/app/api/plutus/qbo-audit/route.ts`:
+
+```ts
+import { NextResponse } from 'next/server';
+
+import db from '@/lib/db';
+
+export async function GET() {
+  const postings = await db.qboPosting.findMany({
+    orderBy: [{ updatedAt: 'desc' }],
+    take: 500,
+    include: { postingIntent: true, lineFingerprints: true },
+  });
+
+  return NextResponse.json({
+    postings: postings.map((posting) => ({
+      id: posting.id,
+      qboTxnType: posting.qboTxnType,
+      qboTxnId: posting.qboTxnId,
+      qboDocNumber: posting.qboDocNumber,
+      qboTxnDate: posting.qboTxnDate,
+      driftStatus: posting.driftStatus,
+      attachmentStatus: posting.attachmentStatus,
+      sourceType: posting.postingIntent.sourceType,
+      sourceId: posting.postingIntent.sourceId,
+      market: posting.postingIntent.market,
+      lineCount: posting.lineFingerprints.length,
+      lastCheckedAt: posting.lastCheckedAt ? posting.lastCheckedAt.toISOString() : null,
+    })),
+  });
+}
+```
+
+- [ ] **Step 2: Add simple read-only pages**
+
+Each component should use `useQuery`, match the current Plutus page loading/error patterns, and render a dense MUI table. Keep text minimal.
+
+Create route wrappers:
+
+```ts
+import { ProductsPage } from '@/components/subledger/products-page';
+
+export default ProductsPage;
+```
+
+Use equivalent wrappers for Purchase Orders, Inventory Ledger, and QBO Audit.
+
+In each component:
+- Put `PageHeader` at top.
+- Fetch its matching API route.
+- Render a `MuiTable` with stable columns.
+- Show `EmptyState` when no rows exist.
+
+- [ ] **Step 3: Add nav items**
+
+In `apps/plutus/components/app-header.tsx`, add imports:
+
+```ts
+import CategoryIcon from '@mui/icons-material/Category';
+import FactCheckIcon from '@mui/icons-material/FactCheck';
+import Inventory2Icon from '@mui/icons-material/Inventory2';
+import LocalShippingIcon from '@mui/icons-material/LocalShipping';
+```
+
+Replace `NAV_ITEMS` with:
+
+```ts
+const NAV_ITEMS: NavItem[] = [
+  { href: '/settlements', label: 'Settlements', icon: ReceiptLongIcon },
+  { href: '/products', label: 'Products', icon: CategoryIcon },
+  { href: '/purchase-orders', label: 'Purchase Orders', icon: LocalShippingIcon },
+  { href: '/inventory-ledger', label: 'Inventory Ledger', icon: Inventory2Icon },
+  { href: '/settlement-mapping', label: 'Mappings', icon: MapIcon },
+  { href: '/qbo-audit', label: 'QBO Audit', icon: FactCheckIcon },
+  { href: '/settings', label: 'Settings', icon: SettingsIcon },
+];
+```
+
+- [ ] **Step 4: Add route source tests**
+
+Add this test to `apps/plutus/tests/run.ts`:
+
+```ts
+test('subledger pages are wired to route wrappers', () => {
+  assert.equal(readFileSync(new URL('../app/products/page.tsx', import.meta.url), 'utf8').includes('ProductsPage'), true);
+  assert.equal(readFileSync(new URL('../app/purchase-orders/page.tsx', import.meta.url), 'utf8').includes('PurchaseOrdersPage'), true);
+  assert.equal(readFileSync(new URL('../app/inventory-ledger/page.tsx', import.meta.url), 'utf8').includes('InventoryLedgerPage'), true);
+  assert.equal(readFileSync(new URL('../app/qbo-audit/page.tsx', import.meta.url), 'utf8').includes('QboAuditPage'), true);
+});
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: all custom tests pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add apps/plutus/app apps/plutus/components apps/plutus/tests/run.ts
+git commit -m "feat(plutus): add subledger read-only surfaces"
+```
+
+---
+
+### Task 8: Verify End to End Without Touching Main Port
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Type-check**
+
+Run:
+
+```bash
+pnpm -C apps/plutus type-check
+```
+
+Expected: exits `0`.
+
+- [ ] **Step 2: Lint**
+
+Run:
+
+```bash
+pnpm -C apps/plutus lint
+```
+
+Expected: exits `0`.
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+pnpm -C apps/plutus test
+```
+
+Expected: exits `0`.
+
+- [ ] **Step 4: Build**
+
+Run:
+
+```bash
+pnpm -C apps/plutus build
+```
+
+Expected: exits `0`.
+
+- [ ] **Step 5: Start isolated preview**
+
+Use a non-main port. Do not use port `3012`.
+
+Run:
+
+```bash
+PORT=4312 pnpm -C apps/plutus dev
+```
+
+Expected: app starts on `http://localhost:4312`.
+
+- [ ] **Step 6: Browser-check routes**
+
+Open these routes in the browser preview:
+
+```text
+http://localhost:4312/plutus/products
+http://localhost:4312/plutus/purchase-orders
+http://localhost:4312/plutus/inventory-ledger
+http://localhost:4312/plutus/qbo-audit
+```
+
+Expected:
+- Each page loads.
+- No page crashes on an empty subledger table.
+- The nav shows Products, Purchase Orders, Inventory Ledger, Mappings, QBO Audit, and Settings.
+- Current settlements still load.
+
+- [ ] **Step 7: Commit verification notes only when source changed**
+
+If verification required source fixes, commit them:
+
+```bash
+git add apps/plutus
+git commit -m "fix(plutus): stabilize subledger foundation"
+```
+
+If no source fixes were needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-05-13-plutus-subledger-redesign.md
+++ b/docs/superpowers/specs/2026-05-13-plutus-subledger-redesign.md
@@ -1,0 +1,204 @@
+# Plutus Subledger Redesign
+
+## Decision
+
+Plutus will be the deterministic Amazon/QBO control, mapping, inventory, and audit subledger.
+QBO remains the formal accounting ledger.
+
+The redesign should not optimize around whether QBO output is a form or a journal entry. Posting shape matters only when it improves traceability without distorting accounting. The core goal is source-to-COGS truth by marketplace, product group, canonical product, SKU alias, PO, and landed-cost component.
+
+## Current Facts Verified
+
+- Current Plutus settlement ingestion posts Amazon settlement source output to QBO journal entries.
+- Current Plutus COGS and P&L processing posts QBO journal entries.
+- Current Plutus already reads QBO bills and purchases as cost inputs.
+- Current QBO has Amazon customers and vendors available.
+- Current QBO has no enabled classes, no departments, no PO custom field, and only a minimal item list.
+- Current QBO detail is mostly carried through Chart of Accounts subaccounts such as US-PDS and UK-PDS.
+
+## Architecture
+
+The target architecture is:
+
+```text
+Amazon/QBO source documents
+  -> normalized Plutus events
+  -> canonical product, SKU alias, product group, and PO mapping
+  -> PO cost layers and inventory movements
+  -> inventory valuation and COGS
+  -> QBO posting output
+  -> drift audit and tieout views
+```
+
+Plutus tables carry the truth. QBO memo and line descriptions carry trace references only.
+
+## Ownership
+
+| Layer | Owner |
+|---|---|
+| Financial statements | QBO |
+| Amazon settlement interpretation | Plutus |
+| Canonical product and SKU aliases | Plutus |
+| Product group assignment | Plutus |
+| PO trail and supplier reference | Plutus |
+| Landed cost by component | Plutus |
+| Inventory ledger and COGS engine | Plutus |
+| Source documents and tieouts | Plutus |
+| Final summarized accounting output | QBO |
+
+## Core Data Model
+
+| Entity | Purpose |
+|---|---|
+| CanonicalProduct | One real sellable product across markets and aliases. |
+| SkuAlias | Maps Amazon seller SKU, ASIN, UK SKU, US SKU, and other aliases to a canonical product. |
+| ProductGroup | Reporting bucket such as PDS, CDS, future brands, or categories. |
+| PurchaseOrder | Internal PO record with supplier reference, market, status, source documents, and QBO links. |
+| PoCostLayer | Cost attached to a PO by canonical product, component, quantity basis, amount, and source document. |
+| InventoryMovement | Unit movement such as receipt, sale, return, removal, disposal, or approved adjustment. |
+| Settlement | Amazon settlement source period plus raw imported rows. |
+| PostingIntent | What Plutus expected to post to QBO, including source hash, mapping version, and line fingerprints. |
+| QboPosting | Actual QBO transaction IDs, sync tokens, posting hash, attachments, and drift status. |
+
+### PO Cost Layer
+
+`PoCostLayer` means what inventory cost exists.
+
+Examples:
+
+- PO-19 manufacturing for CS-007.
+- PO-19 freight allocated to CS-007.
+- PO-19 duty for the applicable HTS treatment.
+- PO-19 boxes/accessories assigned to CS-007.
+
+Each layer records component, amount, quantity basis, source document, and allocation method.
+
+### Inventory Movement
+
+`InventoryMovement` means where inventory units went.
+
+Examples:
+
+- PO receipt into inventory.
+- Amazon sale consuming units.
+- Refund/return reversing or restoring units according to treatment.
+- Removal/disposal.
+- Approved count or cost adjustment.
+
+COGS and inventory valuation must come from `InventoryMovement + PoCostLayer`, not from QBO account names.
+
+## UI Workflow
+
+Plutus should mirror Link My Books at the top level, with a deeper PO and inventory layer underneath.
+
+| Section | Purpose |
+|---|---|
+| Settlements | Import, review, map, post, and reconcile Amazon settlements. |
+| Products | Manage canonical products, SKU aliases, ASINs, marketplace SKUs, and product groups. |
+| Purchase Orders | Manage PO trail, supplier refs, QBO bills, cost components, and source documents. |
+| Inventory Ledger | Show receipts, sales, returns, removals, adjustments, valuation, and COGS. |
+| Mappings | Manage Amazon settlement category mapping and QBO account mapping. |
+| QBO Audit | Show posted vs expected, missing, edited, duplicate, and stale mapping exceptions. |
+| Settings | Manage QBO connection, posting preferences, markets, and import configuration. |
+
+The current COGS Inputs page should evolve into structured Purchase Orders and Inventory Ledger workflows. It should not remain a loose transaction queue as the main control surface.
+
+## QBO Posting SOP
+
+This SOP applies to Plutus-owned QBO postings.
+
+| QBO Field | Requirement |
+|---|---|
+| Attachments | Mandatory. Attach source file, supplier invoice, settlement export, or tieout. |
+| Memo / PrivateNote | Mandatory. Short Plutus trace only. |
+| Line Description | Mandatory. Human-readable category plus Plutus line reference only. |
+| Doc Number | Real external source reference only. Do not overload with internal metadata. |
+| QBO Accounts | Keep simple accounting accounts. Avoid SKU, PO, and brand account explosion. |
+
+Memo pattern:
+
+```text
+PLUTUS_REF=<id>; SOURCE=<source>; MARKET=<market>; PERIOD=<period>
+```
+
+Trace fields:
+
+| Field | Allowed Shape |
+|---|---|
+| `PLUTUS_REF` | Stable Plutus posting or source identifier. |
+| `SOURCE` | `AMZ_SETTLEMENT`, `QBO_BILL`, `QBO_PURCHASE`, or `MANUAL_ADJUSTMENT`. |
+| `MARKET` | `US`, `UK`, or `MULTI`. |
+| `PERIOD` | `YYYY-MM` or `YYYY-MM-DD..YYYY-MM-DD`. |
+
+Line description pattern:
+
+```text
+<category>; PLUTUS_LINE=<line_id>
+```
+
+The Finance shared-drive SOP must explicitly mark these as Plutus-owned QBO postings so memo, line description, and attachments are treated as required controls, not optional notes.
+
+## Posting Shape
+
+| Event | QBO Treatment |
+|---|---|
+| Supplier manufacturing, freight, duty, or accessory invoice | QBO Bill when payable. |
+| Supplier manufacturing, freight, duty, or accessory charge already paid | QBO Purchase when paid directly from a bank or card account. |
+| Amazon settlement summary | Phase 1 keeps the current journal-entry posting shape, but the rows must be generated from the new Plutus normalized model. |
+| COGS from inventory ledger | Journal entry until QBO inventory items are intentionally adopted. |
+| Internal reclass, reserve, rollover, or cleanup | Journal entry only when it is a true internal accounting movement. |
+
+COGS should not become a fake vendor bill. It is inventory asset moving into COGS.
+Converting Amazon settlement summaries from journal entries into QBO sales forms is out of scope for this phase.
+
+## Drift Control
+
+QBO drift is a real concern. Plutus must not assume posted objects stay unchanged.
+
+| Drift Type | Control |
+|---|---|
+| QBO amount changed | Store QBO transaction ID, sync token, and line hash; re-fetch and compare. |
+| QBO account changed | Compare expected account IDs to live QBO line accounts. |
+| QBO transaction deleted or voided | Re-fetch by ID and mark missing in QBO. |
+| QBO memo changed | Flag missing backlink, but do not lose truth because Plutus has structured IDs. |
+| Duplicate posting created | Search by source ID, Plutus ref, amount, date, and posting hash. |
+| Mapping changed after posting | Mark posting stale and require re-preview before correction. |
+| Source data changed | Compare source hash and block silent overwrite. |
+
+Posting states should include:
+
+- `draft`
+- `ready`
+- `posted`
+- `in_sync`
+- `drifted`
+- `missing_in_qbo`
+- `duplicate_qbo_posting`
+- `stale_mapping`
+- `blocked`
+
+Plutus should show the diff and require explicit approval before reversing or reposting.
+
+## Reporting Model
+
+QBO should support clean financial statements.
+Plutus should support product group, SKU, PO, and landed-cost profitability.
+
+The design intentionally avoids depending on QBO brand/product subaccounts for Plutus truth. Product group and brand-style reporting live in Plutus structured data. QBO account mappings remain accounting mappings, not the operating subledger.
+
+## Non-Goals
+
+- Do not make QBO the SKU/PO inventory ledger in this phase.
+- Do not create SKU, PO, or brand account explosions in QBO.
+- Do not parse QBO memos as the source of truth.
+- Do not convert every journal entry into a transaction form for cosmetic reasons.
+- Do not build a generic finance workflow outside Plutus-owned Amazon/QBO postings.
+
+## Success Criteria
+
+- Every Plutus-owned QBO posting has mandatory attachment, memo trace, and line references.
+- Every settlement amount can be traced from Amazon source rows to Plutus normalized events to QBO output.
+- Every COGS amount can be traced from Amazon sale or return to inventory movement and PO cost layer.
+- SKU aliases resolve to canonical products across US and UK.
+- QBO drift is detected by re-fetching live QBO objects and comparing stored expectations.
+- QBO account mapping can be simplified without losing Plutus reporting detail.

--- a/scripts/deploy-app.test.cjs
+++ b/scripts/deploy-app.test.cjs
@@ -29,7 +29,7 @@ test('talos package exposes a deploy-safe prisma migrate command', () => {
 test('plutus package exposes a deploy-safe prisma migrate command', () => {
   assert.equal(
     plutusPackage.scripts['db:migrate:deploy'],
-    'prisma migrate deploy --schema prisma/schema.prisma',
+    'tsx scripts/require-database-url-schema.ts && prisma migrate deploy --schema prisma/schema.prisma',
   )
 })
 


### PR DESCRIPTION
## Summary
- add Plutus subledger foundation controls for settlement processing, inventory/COGS audit paths, and QBO trace validation
- harden deterministic P&L allocation so source gaps block processing instead of silently posting guesses
- treat positive inbound transportation rows as parent-level Amazon reversals/refunds while keeping actual negative charges allocation-gated
- add Seller Central AWD inbound report fallback for shipment quantity lookup and targeted reset/reconcile guards

## Verification
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint
- live settlement audit: US-260401-260410-S2 deterministicOk=true warnings=[]
