### PR TITLE
fix(plutus): gate inventory bills for COGS

### DIFF
--- a/apps/plutus/lib/inventory/qbo-bills.ts
+++ b/apps/plutus/lib/inventory/qbo-bills.ts
@@ -43,10 +43,72 @@ export type ParsedBills = {
 
 const poCustomFieldNamePattern = /\b(?:po|p\/o|purchase\s*order)\b/i;
 const poMemoPatterns = [
+  /^INTERNAL\s+REF\s*:\s*(.+)$/i,
   /^P(?:\s*\/\s*)?O\s*(?:#|:|-)\s*(.+)$/i,
   /^P(?:\s*\/\s*)?O\s+(.+)$/i,
 ];
 const directPoCodePattern = /^P(?:\s*\/\s*)?O-[A-Za-z0-9].*$/i;
+
+function parseStructuredFieldEntries(value: string): Array<{ key: string; value: string }> {
+  const fields: Array<{ key: string; value: string }> = [];
+
+  for (const part of value.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed === '') continue;
+
+    const equalsIndex = trimmed.indexOf('=');
+    const colonIndex = trimmed.indexOf(':');
+    const separatorIndex =
+      equalsIndex === -1
+        ? colonIndex
+        : colonIndex === -1
+          ? equalsIndex
+          : Math.min(equalsIndex, colonIndex);
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+    const fieldValue = trimmed.slice(separatorIndex + 1).trim();
+    if (key === '' || fieldValue === '') continue;
+    fields.push({ key, value: fieldValue });
+  }
+
+  return fields;
+}
+
+function parseStructuredFields(value: string): Map<string, string> {
+  const fields = new Map<string, string>();
+
+  for (const field of parseStructuredFieldEntries(value)) {
+    fields.set(field.key, field.value);
+  }
+
+  return fields;
+}
+
+function parseInternalRefPo(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '') return '';
+
+  const poValues = parseStructuredFieldEntries(trimmed)
+    .filter((field) => field.key === 'PO')
+    .map((field) => field.value.trim())
+    .filter((fieldValue) => fieldValue !== '');
+  const uniquePoValues = Array.from(new Set(poValues));
+  if (uniquePoValues.length === 1) return uniquePoValues[0]!;
+  if (uniquePoValues.length > 1) return '';
+
+  const firstSegment = trimmed.split(';')[0]!.trim();
+  if (directPoCodePattern.test(firstSegment)) return firstSegment;
+
+  return '';
+}
+
+function parsePoFromDescription(description: string): string {
+  const fields = parseStructuredFields(description.trim().replace(/×/g, 'x').replace(/\s+/g, ' '));
+  const structuredPo = fields.get('PO');
+  if (structuredPo && structuredPo.trim() !== '') return structuredPo.trim();
+  return '';
+}
 
 function extractPoNumberFromCustomFields(customFields: QboBill['CustomField']): string {
   if (!customFields || customFields.length === 0) return '';
@@ -91,7 +153,9 @@ function extractPoNumberFromPrivateNote(privateNote: string | undefined): string
       if (!match) continue;
       const po = match[1];
       if (!po) continue;
-      const trimmed = po.trim();
+      const trimmed = pattern.source.includes('INTERNAL')
+        ? parseInternalRefPo(po)
+        : po.trim();
       if (trimmed === '') continue;
       return trimmed;
     }
@@ -106,10 +170,51 @@ function extractPoNumberFromBill(bill: Pick<QboBill, 'PrivateNote' | 'CustomFiel
   return extractPoNumberFromPrivateNote(bill.PrivateNote);
 }
 
+function parsePositiveIntegerField(value: string, label: string, description: string): number {
+  const normalized = value.replace(/,/g, '').trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid ${label} in description: "${description}"`);
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`Invalid ${label} in description: "${description}"`);
+  }
+
+  return parsed;
+}
+
+export function parseSkuFromDescription(description: string): string {
+  const normalized = description.trim().replace(/×/g, 'x').replace(/\s+/g, ' ');
+  if (normalized === '') {
+    throw new Error('Line description is empty');
+  }
+
+  const fields = parseStructuredFields(normalized);
+  const structuredSku = fields.get('SKU') ?? fields.get('FORSKU');
+  if (structuredSku && structuredSku.trim() !== '') {
+    const sku = structuredSku.trim().replace(/\s+/g, '-').toUpperCase();
+    if (sku !== 'N/A') return sku;
+  }
+
+  const parsed = parseSkuQuantityFromDescription(description);
+  return parsed.sku;
+}
+
 export function parseSkuQuantityFromDescription(description: string): { sku: string; quantity: number } {
   const normalized = description.trim().replace(/×/g, 'x').replace(/\s+/g, ' ');
   if (normalized === '') {
     throw new Error('Line description is empty');
+  }
+
+  const fields = parseStructuredFields(normalized);
+  const structuredSku = fields.get('SKU');
+  const structuredQty = fields.get('QTY') ?? fields.get('QUANTITY');
+  if (structuredSku && structuredQty) {
+    return {
+      sku: structuredSku.trim().replace(/\s+/g, '-').toUpperCase(),
+      quantity: parsePositiveIntegerField(structuredQty, 'quantity', description),
+    };
   }
 
   const qtyMatch = normalized.match(/(\d+)\s*(units?)?$/i);
@@ -286,8 +391,7 @@ export function parseQboBillsToInventoryEvents(
 
     if (candidateLines.length === 0) continue;
 
-    const poNumber = extractPoNumberFromBill(bill);
-    if (poNumber === '') continue;
+    const billPoNumber = extractPoNumberFromBill(bill);
 
     candidateLines.sort((a, b) => {
       const aLineId = a.line.Id ? a.line.Id : '';
@@ -307,6 +411,9 @@ export function parseQboBillsToInventoryEvents(
       const costCents = toCents(rawAmount);
 
       const description = line.Description ? line.Description : '';
+      const linePoNumber = parsePoFromDescription(description);
+      const poNumber = linePoNumber !== '' ? linePoNumber : billPoNumber;
+      if (poNumber === '') continue;
 
       if (component === 'manufacturing') {
         const parsed = parseSkuQuantityFromDescription(description);
@@ -325,8 +432,7 @@ export function parseQboBillsToInventoryEvents(
       // Cost-only components (freight/duty/accessories)
       let sku: string | undefined = undefined;
       try {
-        const parsed = parseSkuQuantityFromDescription(description);
-        sku = parsed.sku;
+        sku = parseSkuFromDescription(description);
       } catch {
         sku = undefined;
       }

--- a/apps/plutus/lib/plutus/bills/pull-sync.ts
+++ b/apps/plutus/lib/plutus/bills/pull-sync.ts
@@ -27,6 +27,50 @@ const poMemoPatterns = [
 ];
 const directPoCodePattern = /^P(?:\s*\/\s*)?O-[A-Za-z0-9].*$/i;
 
+function parseStructuredFieldEntries(value: string): Array<{ key: string; value: string }> {
+  const fields: Array<{ key: string; value: string }> = [];
+
+  for (const part of value.split(';')) {
+    const trimmed = part.trim();
+    if (trimmed === '') continue;
+
+    const equalsIndex = trimmed.indexOf('=');
+    const colonIndex = trimmed.indexOf(':');
+    const separatorIndex =
+      equalsIndex === -1
+        ? colonIndex
+        : colonIndex === -1
+          ? equalsIndex
+          : Math.min(equalsIndex, colonIndex);
+    if (separatorIndex === -1) continue;
+
+    const key = trimmed.slice(0, separatorIndex).trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
+    const fieldValue = trimmed.slice(separatorIndex + 1).trim();
+    if (key === '' || fieldValue === '') continue;
+    fields.push({ key, value: fieldValue });
+  }
+
+  return fields;
+}
+
+function parseInternalRefPo(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '') return '';
+
+  const poValues = parseStructuredFieldEntries(trimmed)
+    .filter((field) => field.key === 'PO')
+    .map((field) => field.value.trim())
+    .filter((fieldValue) => fieldValue !== '');
+  const uniquePoValues = Array.from(new Set(poValues));
+  if (uniquePoValues.length === 1) return uniquePoValues[0]!;
+  if (uniquePoValues.length > 1) return '';
+
+  const firstSegment = trimmed.split(';')[0]!.trim();
+  if (directPoCodePattern.test(firstSegment)) return firstSegment;
+
+  return '';
+}
+
 export function extractPoNumberFromBill(bill: Pick<QboBill, 'PrivateNote' | 'CustomField'>): string {
   const customFieldPo = extractPoNumberFromCustomFields(bill.CustomField);
   if (customFieldPo !== '') return customFieldPo;
@@ -76,7 +120,9 @@ function extractPoNumberFromPrivateNote(privateNote: string | undefined): string
       if (!match) continue;
       const po = match[1];
       if (!po) continue;
-      const trimmed = po.trim();
+      const trimmed = pattern.source.includes('INTERNAL')
+        ? parseInternalRefPo(po)
+        : po.trim();
       if (trimmed === '') continue;
       return trimmed;
     }

--- a/apps/plutus/lib/plutus/settlement-processing.ts
+++ b/apps/plutus/lib/plutus/settlement-processing.ts
@@ -1,4 +1,4 @@
-import type { QboAccount, QboBill, QboConnection } from '@/lib/qbo/api';
+import type { QboBill, QboConnection } from '@/lib/qbo/api';
 import {
   createJournalEntry,
   deleteJournalEntry,
@@ -8,7 +8,7 @@ import {
   fetchPreferences,
 } from '@/lib/qbo/api';
 import { parseSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
-import { parseQboBillsToInventoryEvents, buildInventoryEventsFromMappings, type InventoryAccountMappings, type ParsedBills } from '@/lib/inventory/qbo-bills';
+import { buildInventoryEventsFromMappings, type ParsedBills } from '@/lib/inventory/qbo-bills';
 import {
   replayInventoryLedger,
   type LedgerBlock,
@@ -599,9 +599,6 @@ export async function computeSettlementPreview(input: {
     includeInactive: true,
   });
 
-  const accountsById = new Map<string, QboAccount>();
-  for (const account of accountsResult.accounts) accountsById.set(account.Id, account);
-
   let billsConnection =
     accountsResult.updatedConnection
       ? accountsResult.updatedConnection
@@ -609,62 +606,15 @@ export async function computeSettlementPreview(input: {
         ? settlementResult.updatedConnection
         : input.connection;
 
-  let inventoryMappings: InventoryAccountMappings | null = null;
   if (cogsEnabled) {
-    const invManufacturing = mapping.invManufacturing;
-    if (!invManufacturing) throw new Error('Missing invManufacturing mapping');
-    const invFreight = mapping.invFreight;
-    if (!invFreight) throw new Error('Missing invFreight mapping');
-    const invDuty = mapping.invDuty;
-    if (!invDuty) throw new Error('Missing invDuty mapping');
-    const invMfgAccessories = mapping.invMfgAccessories;
-    if (!invMfgAccessories) throw new Error('Missing invMfgAccessories mapping');
-
-    inventoryMappings = {
-      invManufacturing,
-      invFreight,
-      invDuty,
-      invMfgAccessories,
-    };
+    if (!mapping.invManufacturing) throw new Error('Missing invManufacturing mapping');
+    if (!mapping.invFreight) throw new Error('Missing invFreight mapping');
+    if (!mapping.invDuty) throw new Error('Missing invDuty mapping');
+    if (!mapping.invMfgAccessories) throw new Error('Missing invMfgAccessories mapping');
   }
 
-  // Bill sources:
-  // - QBO bills parsing (best-effort, relies on memo/description conventions)
-  // - Plutus bill mappings (authoritative for mapped bills)
-  //
-  // Important: we must NOT ignore QBO bills just because *some* mappings exist, otherwise a single mapped
-  // warehousing/expense bill can accidentally wipe out inventory cost basis from all other QBO bills.
-  function mergeParsedBills(a: ParsedBills, b: ParsedBills): ParsedBills {
-    const poUnitsBySku = new Map<string, Map<string, number>>();
-
-    function mergePoUnits(source: Map<string, Map<string, number>>) {
-      for (const [poNumber, skuUnits] of source.entries()) {
-        const existing = poUnitsBySku.get(poNumber);
-        if (!existing) {
-          poUnitsBySku.set(poNumber, new Map(skuUnits));
-          continue;
-        }
-
-        for (const [sku, units] of skuUnits.entries()) {
-          const current = existing.get(sku);
-          existing.set(sku, (current === undefined ? 0 : current) + units);
-        }
-      }
-    }
-
-    mergePoUnits(a.poUnitsBySku);
-    mergePoUnits(b.poUnitsBySku);
-
-    const events = [...a.events, ...b.events];
-    events.sort((x, y) => {
-      if (x.date !== y.date) return x.date.localeCompare(y.date);
-      if (x.kind !== y.kind) return x.kind === 'manufacturing' ? -1 : 1;
-      return 0;
-    });
-
-    return { events, poUnitsBySku };
-  }
-
+  // Plutus bill mappings are the COGS-approved bill source. Raw QBO inventory
+  // bills can be audited separately, but they must not enter COGS until mapped.
   const plutusMappings = cogsEnabled
     ? await db.billMapping.findMany({
         where: {
@@ -676,11 +626,7 @@ export async function computeSettlementPreview(input: {
       })
     : [];
 
-  const mappedBillIds = new Set(plutusMappings.map((m) => m.qboBillId));
-
-  // QBO Bills -> Inventory events (only inventory-account lines are used)
   let parsedBillsFromMappings: ParsedBills = { events: [], poUnitsBySku: new Map() };
-  let parsedBillsFromQbo: ParsedBills = { events: [], poUnitsBySku: new Map() };
   let allBills: QboBill[] = [];
 
   if (cogsEnabled) {
@@ -760,21 +706,9 @@ export async function computeSettlementPreview(input: {
       }
     }
 
-    try {
-      if (inventoryMappings === null) throw new Error('Missing inventory mappings');
-      const unmappedBills = allBills.filter((b) => !mappedBillIds.has(b.Id));
-      parsedBillsFromQbo = parseQboBillsToInventoryEvents(unmappedBills, accountsById, inventoryMappings, marketplace);
-    } catch (error) {
-      blocks.push({
-        code: 'BILLS_PARSE_ERROR',
-        message: 'Failed to parse bills into inventory events',
-        details: { error: error instanceof Error ? error.message : String(error) },
-      });
-      parsedBillsFromQbo = { events: [], poUnitsBySku: new Map() };
-    }
   }
 
-  const parsedBills = mergeParsedBills(parsedBillsFromQbo, parsedBillsFromMappings);
+  const parsedBills = parsedBillsFromMappings;
 
   // Build brand resolver for P&L allocation
   const brandResolver = {

--- a/apps/plutus/scripts/inventory-bills-audit.ts
+++ b/apps/plutus/scripts/inventory-bills-audit.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { extractPoNumberFromBill } from '@/lib/plutus/bills/pull-sync';
 
-import { parseSkuQuantityFromDescription } from '@/lib/inventory/qbo-bills';
+import { parseSkuFromDescription, parseSkuQuantityFromDescription } from '@/lib/inventory/qbo-bills';
 
 type CliOptions = {
   since: string;
@@ -367,7 +367,7 @@ async function main(): Promise<void> {
 
       let parsedSku: string | null = null;
       try {
-        parsedSku = parseSkuQuantityFromDescription(line.description).sku;
+        parsedSku = parseSkuFromDescription(line.description);
       } catch {
         parsedSku = null;
       }

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -18,7 +18,12 @@ import {
   createEmptyLedgerSnapshot,
   replayInventoryLedger,
 } from '../lib/inventory/ledger';
-import { buildInventoryEventsFromMappings, parseQboBillsToInventoryEvents } from '../lib/inventory/qbo-bills';
+import {
+  buildInventoryEventsFromMappings,
+  parseQboBillsToInventoryEvents,
+  parseSkuFromDescription,
+  parseSkuQuantityFromDescription,
+} from '../lib/inventory/qbo-bills';
 import {
   buildAccountComponentMap,
   extractTrackedLinesFromBill,
@@ -3168,6 +3173,195 @@ test('parseQboBillsToInventoryEvents reads PO number from bill custom fields', (
   assert.equal(parsed.events[0].poNumber, 'PO-CF-1');
 });
 
+test('parseSkuQuantityFromDescription reads deterministic manufacturing line fields', () => {
+  const parsed = parseSkuQuantityFromDescription(
+    'MFG; OWNER=US-PDS; PO=PO-20-PDS; SKU=CS-12LD-7M; QTY=6720; UNIT_COST=1.250; SOURCE=PI-2601082',
+  );
+
+  assert.equal(parsed.sku, 'CS-12LD-7M');
+  assert.equal(parsed.quantity, 6720);
+});
+
+test('parseSkuFromDescription reads deterministic cost line fields without quantity', () => {
+  const parsedSku = parseSkuFromDescription(
+    'FREIGHT; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; SERVICE=FOREST SHIPPING; SOURCE=FSHY2509087198',
+  );
+
+  assert.equal(parsedSku, 'CS-007');
+});
+
+test('parseSkuFromDescription reads package cost FOR_SKU fields', () => {
+  const parsedSku = parseSkuFromDescription(
+    'PKG; OWNER=PO-19-PDS; ITEM=CS-007-BOX; QTY=29440; FOR_SKU=CS-007; PO=PO-19-PDS; SOURCE=PI-250804BOXB',
+  );
+
+  assert.equal(parsedSku, 'CS-007');
+});
+
+test('parseQboBillsToInventoryEvents reads SOP internal ref and deterministic line fields', () => {
+  const bill: QboBill = {
+    Id: 'B-PO20',
+    SyncToken: '0',
+    TxnDate: '2026-02-07',
+    TotalAmt: 9559.54,
+    PrivateNote: 'INTERNAL REF: PO=PO-20-PDS; OWNER=US-PDS\nPI: PI-2601082',
+    Line: [
+      {
+        Id: '1',
+        Amount: 8400,
+        Description: 'MFG; OWNER=US-PDS; PO=PO-20-PDS; SKU=CS-12LD-7M; QTY=6720; UNIT_COST=1.250; SOURCE=PI-2601082',
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: 'us-mfg', name: 'Manufacturing - US-PDS' },
+        },
+      },
+      {
+        Id: '2',
+        Amount: 1159.54,
+        Description: 'MFG; OWNER=US-PDS; PO=PO-20-PDS; SKU=CS-1SD-32M; QTY=2856; UNIT_COST=0.406; SOURCE=PI-2601082',
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: 'us-mfg', name: 'Manufacturing - US-PDS' },
+        },
+      },
+      {
+        Id: '3',
+        Amount: 100,
+        Description: 'FREIGHT; OWNER=US-PDS; PO=PO-20-PDS; SKU=CS-12LD-7M; SERVICE=FOREST SHIPPING; SOURCE=FSHY-1',
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: 'us-freight', name: 'Freight - US-PDS' },
+        },
+      },
+    ],
+  };
+
+  const accountsById = new Map<string, QboAccount>([
+    [
+      'us-mfg',
+      {
+        Id: 'us-mfg',
+        SyncToken: '0',
+        Name: 'Manufacturing - US-PDS',
+        AccountType: 'Other Current Asset',
+        AccountSubType: 'Inventory',
+        FullyQualifiedName: 'Inventory Asset:Manufacturing - US-PDS',
+      },
+    ],
+    [
+      'us-freight',
+      {
+        Id: 'us-freight',
+        SyncToken: '0',
+        Name: 'Freight - US-PDS',
+        AccountType: 'Other Current Asset',
+        AccountSubType: 'Inventory',
+        FullyQualifiedName: 'Inventory Asset:Freight - US-PDS',
+      },
+    ],
+  ]);
+
+  const mappings = {
+    invManufacturing: 'inventory-root',
+    invFreight: 'inventory-root',
+    invDuty: 'inventory-root',
+    invMfgAccessories: 'inventory-root',
+  };
+
+  const parsed = parseQboBillsToInventoryEvents([bill], accountsById, mappings, 'amazon.com');
+  assert.equal(parsed.events.length, 3);
+  const mfgEvents = parsed.events.filter((event) => event.kind === 'manufacturing');
+  assert.equal(mfgEvents.length, 2);
+  assert.equal(mfgEvents[0]?.poNumber, 'PO-20-PDS');
+  assert.equal(mfgEvents[0]?.sku, 'CS-12LD-7M');
+  assert.equal(mfgEvents[0]?.units, 6720);
+  assert.equal(mfgEvents[1]?.sku, 'CS-1SD-32M');
+  assert.equal(mfgEvents[1]?.units, 2856);
+
+  const freightEvent = parsed.events.find((event) => event.kind === 'cost' && event.component === 'freight');
+  assert.equal(freightEvent?.kind, 'cost');
+  if (freightEvent?.kind !== 'cost') throw new Error('expected freight cost event');
+  assert.equal(freightEvent.poNumber, 'PO-20-PDS');
+  assert.equal(freightEvent.sku, 'CS-12LD-7M');
+});
+
+test('parseQboBillsToInventoryEvents uses line PO for multi-PO package bills', () => {
+  const bill: QboBill = {
+    Id: 'B-MULTI-PO',
+    SyncToken: '0',
+    TxnDate: '2025-08-04',
+    TotalAmt: 1484.85,
+    PrivateNote: 'INTERNAL REF: PO=PO-18-PDS; PO=PO-19-PDS; OWNER=RESIDUAL\nSUPPLIER REF: PI=PI-250804BOXB',
+    Line: [
+      {
+        Id: '19',
+        Amount: 409.6,
+        Description: 'PKG; OWNER=PO-18-PDS; ITEM=CS-12LD-7M-BOX; QTY=4096; FOR_SKU=CS-12LD-7M; PO=PO-18-PDS; SOURCE=PI-250804BOXB',
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: 'us-accessories', name: 'Mfg Accessories - US-PDS' },
+        },
+      },
+      {
+        Id: '20',
+        Amount: 969.6,
+        Description: 'PKG; OWNER=PO-19-PDS; ITEM=CS-12LD-7M-BOX; QTY=9696; FOR_SKU=CS-12LD-7M; PO=PO-19-PDS; SOURCE=PI-250804BOXB',
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: 'us-accessories', name: 'Mfg Accessories - US-PDS' },
+        },
+      },
+      {
+        Id: '21',
+        Amount: 2,
+        Description: 'PKG; OWNER=RESIDUAL; ITEM=CS-12LD-7M-BOX; QTY=20; FOR_SKU=CS-12LD-7M; SOURCE=PI-250804BOXB',
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: 'us-accessories', name: 'Mfg Accessories - US-PDS' },
+        },
+      },
+    ],
+  };
+
+  const accountsById = new Map<string, QboAccount>([
+    [
+      'us-accessories',
+      {
+        Id: 'us-accessories',
+        SyncToken: '0',
+        Name: 'Mfg Accessories - US-PDS',
+        AccountType: 'Other Current Asset',
+        AccountSubType: 'Inventory',
+        FullyQualifiedName: 'Inventory Asset:Mfg Accessories - US-PDS',
+      },
+    ],
+  ]);
+
+  const mappings = {
+    invManufacturing: 'inventory-root',
+    invFreight: 'inventory-root',
+    invDuty: 'inventory-root',
+    invMfgAccessories: 'inventory-root',
+  };
+
+  const parsed = parseQboBillsToInventoryEvents([bill], accountsById, mappings, 'amazon.com');
+  const costEvents = parsed.events.filter((event) => event.kind === 'cost');
+  assert.equal(costEvents.length, 2);
+  assert.equal(costEvents[0]?.poNumber, 'PO-18-PDS');
+  assert.equal(costEvents[0]?.sku, 'CS-12LD-7M');
+  assert.equal(costEvents[1]?.poNumber, 'PO-19-PDS');
+  assert.equal(costEvents[1]?.sku, 'CS-12LD-7M');
+});
+
+test('pull-sync does not collapse non-PO or multi-PO internal refs into one PO', () => {
+  assert.equal(
+    extractPoNumberFromBill({
+      PrivateNote: 'INTERNAL REF: OWNER=US-PDS; PRODUCT=NITRILE_GLOVES',
+    }),
+    '',
+  );
+  assert.equal(
+    extractPoNumberFromBill({
+      PrivateNote: 'INTERNAL REF: PO=PO-18-PDS; PO=PO-19-PDS; OWNER=RESIDUAL',
+    }),
+    '',
+  );
+});
+
 test('parseQboBillsToInventoryEvents rejects inventory accounts without marketplace markers', () => {
   const bill: QboBill = {
     Id: 'B-NO-MARKET',
@@ -3355,6 +3549,14 @@ test('extractPoNumberFromBill reads internal ref from SOP memo', () => {
   });
 
   assert.equal(po, 'PO-20-PDS');
+});
+
+test('extractPoNumberFromBill reads structured PO from SOP memo', () => {
+  const po = extractPoNumberFromBill({
+    PrivateNote: 'INTERNAL REF: PO=PO-19-PDS; SHIPMENT=FBA19523CMQ9; OWNER=US-PDS\nNOTES: Actuals',
+  });
+
+  assert.equal(po, 'PO-19-PDS');
 });
 
 test('extractPoNumberFromBill preserves direct PO code in memo', () => {


### PR DESCRIPTION
## Summary
- parse QBO SOP bill fields for structured PO, SKU, FOR_SKU, and qty formats
- keep raw QBO inventory bills out of COGS until they are approved Plutus bill mappings
- update inventory bill audit coverage for package cost rows and multi-PO bills

## Verification
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint
- live QBO US inventory audit: 24 processed, withIssues=0
- live QBO US inventory bills audit: issues=0
