### PR TITLE
test(sso): remove retired Argus hosted smoke

### DIFF
--- a/apps/sso/tests/fixtures/hosted-smoke-config.test.ts
+++ b/apps/sso/tests/fixtures/hosted-smoke-config.test.ts
@@ -11,7 +11,7 @@ import {
 test('hosted smoke grants cover every hosted app route under test', () => {
   assert.deepEqual(
     hostedSmokeAppGrants.map((grant) => grant.appSlug),
-    ['talos', 'atlas', 'kairos', 'xplan', 'plutus', 'hermes', 'argus'],
+    ['talos', 'atlas', 'kairos', 'xplan', 'plutus', 'hermes'],
   )
 })
 

--- a/apps/sso/tests/fixtures/hosted-smoke-config.ts
+++ b/apps/sso/tests/fixtures/hosted-smoke-config.ts
@@ -51,13 +51,6 @@ export const hostedSmokeAppGrants: HostedSmokeGrant[] = [
     tenantMemberships: [],
     locked: false,
   },
-  {
-    appSlug: 'argus',
-    appName: 'Argus',
-    departments: ['Account / Listing'],
-    tenantMemberships: [],
-    locked: false,
-  },
 ]
 
 function requireHostedSmokeEnv(name: string, env: HostedSmokeEnv): string {

--- a/apps/sso/tests/hosted-deep-links.spec.ts
+++ b/apps/sso/tests/hosted-deep-links.spec.ts
@@ -24,7 +24,6 @@ const hostedRouteChecks: HostedRouteCheck[] = [
   { name: 'xplan', path: '/xplan/1-setup', visibleText: 'Setup' },
   { name: 'plutus', path: '/plutus/settlements', visibleText: 'Settlements' },
   { name: 'hermes', path: '/hermes/insights', visibleText: 'Insights' },
-  { name: 'argus', path: '/argus/wpr', visibleText: 'Weekly performance reporting' },
   { name: 'talos-dashboard', path: '/talos/dashboard', visibleText: 'Dashboard' },
   { name: 'talos-inventory', path: '/talos/operations/inventory', visibleText: 'Inventory' },
   { name: 'talos-inbound', path: '/talos/operations/inbound', visibleText: 'Inbound' },


### PR DESCRIPTION
## Summary
- Remove Argus from hosted auth smoke route checks because the hosted Argus route now returns 410.
- Remove the matching smoke grant fixture entry.

## Verification
- pnpm --filter @targon/sso test:auth-contracts
