### PR TITLE
fix(plutus): ignore placeholder structured skus

### DIFF
--- a/apps/plutus/lib/inventory/qbo-bills.ts
+++ b/apps/plutus/lib/inventory/qbo-bills.ts
@@ -85,6 +85,14 @@ function parseStructuredFields(value: string): Map<string, string> {
   return fields;
 }
 
+function normalizeStructuredSkuValue(value: string | undefined): string | null {
+  if (value === undefined) return null;
+
+  const sku = value.trim().replace(/\s+/g, '-').toUpperCase();
+  if (sku === '' || sku === 'N/A') return null;
+  return sku;
+}
+
 function parseInternalRefPo(value: string): string {
   const trimmed = value.trim();
   if (trimmed === '') return '';
@@ -191,11 +199,8 @@ export function parseSkuFromDescription(description: string): string {
   }
 
   const fields = parseStructuredFields(normalized);
-  const structuredSku = fields.get('SKU') ?? fields.get('FORSKU');
-  if (structuredSku && structuredSku.trim() !== '') {
-    const sku = structuredSku.trim().replace(/\s+/g, '-').toUpperCase();
-    if (sku !== 'N/A') return sku;
-  }
+  const structuredSku = normalizeStructuredSkuValue(fields.get('SKU')) ?? normalizeStructuredSkuValue(fields.get('FORSKU'));
+  if (structuredSku) return structuredSku;
 
   const parsed = parseSkuQuantityFromDescription(description);
   return parsed.sku;
@@ -208,11 +213,16 @@ export function parseSkuQuantityFromDescription(description: string): { sku: str
   }
 
   const fields = parseStructuredFields(normalized);
-  const structuredSku = fields.get('SKU');
   const structuredQty = fields.get('QTY') ?? fields.get('QUANTITY');
-  if (structuredSku && structuredQty) {
+  if (structuredQty) {
+    const structuredSku =
+      normalizeStructuredSkuValue(fields.get('SKU')) ?? normalizeStructuredSkuValue(fields.get('FORSKU'));
+    if (!structuredSku) {
+      throw new Error(`Missing SKU in description: "${description}"`);
+    }
+
     return {
-      sku: structuredSku.trim().replace(/\s+/g, '-').toUpperCase(),
+      sku: structuredSku,
       quantity: parsePositiveIntegerField(structuredQty, 'quantity', description),
     };
   }

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -3198,6 +3198,27 @@ test('parseSkuFromDescription reads package cost FOR_SKU fields', () => {
   assert.equal(parsedSku, 'CS-007');
 });
 
+test('structured SKU parsers ignore placeholder SKU values', () => {
+  assert.equal(
+    parseSkuFromDescription(
+      'PKG; OWNER=PO-19-PDS; SKU=N/A; FOR_SKU=CS-007; QTY=29440; PO=PO-19-PDS; SOURCE=PI-250804BOXB',
+    ),
+    'CS-007',
+  );
+
+  assert.deepEqual(
+    parseSkuQuantityFromDescription(
+      'MFG; OWNER=US-PDS; PO=PO-19-PDS; SKU=N/A; FOR_SKU=CS-007; QTY=29440; SOURCE=PI-250804BOXB',
+    ),
+    { sku: 'CS-007', quantity: 29440 },
+  );
+
+  assert.throws(
+    () => parseSkuQuantityFromDescription('MFG; OWNER=US-PDS; SKU=N/A; QTY=29440; SOURCE=PI-250804BOXB'),
+    /Missing SKU/,
+  );
+});
+
 test('parseQboBillsToInventoryEvents reads SOP internal ref and deterministic line fields', () => {
   const bill: QboBill = {
     Id: 'B-PO20',


### PR DESCRIPTION
## Summary
- ignore structured SKU=N/A placeholders when parsing QBO bill lines
- prefer FOR_SKU when it carries the actual SKU
- fail closed for quantity-bearing structured lines without a real SKU

## Verification
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint
- git diff --check