### PR TITLE
fix(plutus): keep non-po mapped costs brand-level

### DIFF
--- a/apps/plutus/lib/inventory/qbo-bills.ts
+++ b/apps/plutus/lib/inventory/qbo-bills.ts
@@ -521,7 +521,14 @@ export function buildInventoryEventsFromMappings(
 
       const component = line.component as InventoryComponent;
 
+      const poNumber = mapping.poNumber.trim();
+
       if (component === 'manufacturing') {
+        if (poNumber === '') {
+          throw new Error(
+            `Manufacturing bill mapping line requires poNumber: billId=${mapping.qboBillId} lineId=${line.qboLineId}`,
+          );
+        }
         if (!line.sku || !line.quantity || line.quantity <= 0) {
           throw new Error(
             `Manufacturing bill mapping line requires sku+quantity: billId=${mapping.qboBillId} lineId=${line.qboLineId}`,
@@ -529,13 +536,25 @@ export function buildInventoryEventsFromMappings(
         }
 
         // Per-SKU manufacturing event
-        addPoUnits(poUnitsBySku, mapping.poNumber, line.sku, line.quantity);
+        addPoUnits(poUnitsBySku, poNumber, line.sku, line.quantity);
         events.push({
           kind: 'manufacturing',
           date: mapping.billDate,
-          poNumber: mapping.poNumber,
+          poNumber,
           sku: line.sku,
           units: line.quantity,
+          costCents: line.amountCents,
+        });
+        continue;
+      }
+
+      if (poNumber === '' && !line.sku) {
+        events.push({
+          kind: 'brand_cost',
+          date: mapping.billDate,
+          poNumber,
+          brandId: mapping.brandId,
+          component,
           costCents: line.amountCents,
         });
         continue;
@@ -545,7 +564,7 @@ export function buildInventoryEventsFromMappings(
       events.push({
         kind: 'cost',
         date: mapping.billDate,
-        poNumber: mapping.poNumber,
+        poNumber,
         component,
         costCents: line.amountCents,
         ...(line.sku ? { sku: line.sku } : {}),

--- a/apps/plutus/scripts/inventory-bills-audit.ts
+++ b/apps/plutus/scripts/inventory-bills-audit.ts
@@ -50,6 +50,18 @@ type BillIssue =
       lineId: string;
       amount: number;
       description: string;
+    }
+  | {
+      code: 'INVENTORY_BILL_MAPPING_SKU_WITHOUT_SOURCE';
+      billId: string;
+      txnDate: string;
+      vendorName: string;
+      docNumber: string;
+      privateNote: string;
+      lineId: string;
+      amount: number;
+      mappedSku: string;
+      description: string;
     };
 
 function printUsage(): void {
@@ -195,6 +207,16 @@ function classifyInventoryMarketplaceFromAccount(account: QboAccount): Inventory
   return null;
 }
 
+function hasStructuredPlaceholderSku(description: string): boolean {
+  return description
+    .replace(/×/g, 'x')
+    .split(';')
+    .some((part) => {
+      const trimmed = part.trim();
+      return /^(?:SKU|FOR_SKU|FORSKU)\s*[:=]\s*N\/A$/i.test(trimmed);
+    });
+}
+
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2));
   await loadPlutusEnv();
@@ -304,11 +326,37 @@ async function main(): Promise<void> {
 
     const mapping = mappingByBillId.get(billId);
     const mapped = mapping !== undefined;
+    const lineItemById = new Map(lineItems.map((line) => [line.lineId, line]));
 
     let poNumber: string | null = null;
     if (mapped) {
       poNumber = mapping.poNumber;
       for (const mLine of mapping.lines) {
+        const sourceLine = lineItemById.get(mLine.qboLineId);
+        if (mLine.sku && sourceLine && hasStructuredPlaceholderSku(sourceLine.description)) {
+          let parsedSku: string | null = null;
+          try {
+            parsedSku = parseSkuFromDescription(sourceLine.description);
+          } catch {
+            parsedSku = null;
+          }
+
+          if (parsedSku === null) {
+            issues.push({
+              code: 'INVENTORY_BILL_MAPPING_SKU_WITHOUT_SOURCE',
+              billId,
+              txnDate,
+              vendorName,
+              docNumber,
+              privateNote,
+              lineId: sourceLine.lineId,
+              amount: sourceLine.amount,
+              mappedSku: mLine.sku,
+              description: sourceLine.description,
+            });
+          }
+        }
+
         if (mLine.component === 'manufacturing') {
           if (!mLine.sku || !mLine.quantity || mLine.quantity <= 0) {
             continue;

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -3048,6 +3048,56 @@ test('bill mappings allocate non-sku costs by PO units', () => {
   assert.equal(stateB?.valueByComponentCents.freight, 200);
 });
 
+test('bill mappings keep blank-PO sku-less costs at brand level', () => {
+  const parsed = buildInventoryEventsFromMappings([
+    {
+      qboBillId: 'B-BRAND',
+      poNumber: '',
+      brandId: 'brand-us-pds',
+      billDate: '2026-02-01',
+      lines: [
+        { qboLineId: '1', component: 'mfgAccessories', amountCents: 56000, sku: null, quantity: null },
+      ],
+    },
+  ]);
+
+  assert.equal(parsed.events.length, 1);
+  const event = parsed.events[0];
+  assert.equal(event?.kind, 'brand_cost');
+  if (event?.kind !== 'brand_cost') throw new Error('expected brand-level cost event');
+  assert.equal(event.brandId, 'brand-us-pds');
+  assert.equal(event.component, 'mfgAccessories');
+  assert.equal(event.costCents, 56000);
+
+  const replay = replayInventoryLedger({
+    parsedBills: parsed,
+    knownSales: [],
+    knownReturns: [],
+    computeSales: [],
+  });
+
+  assert.equal(replay.blocks.length, 0);
+  assert.equal(replay.snapshot.bySku.size, 0);
+});
+
+test('bill mappings require PO on manufacturing lines', () => {
+  assert.throws(
+    () =>
+      buildInventoryEventsFromMappings([
+        {
+          qboBillId: 'B-MFG',
+          poNumber: '',
+          brandId: 'brand-us-pds',
+          billDate: '2026-02-01',
+          lines: [
+            { qboLineId: '1', component: 'manufacturing', amountCents: 56000, sku: 'SKU-A', quantity: 10 },
+          ],
+        },
+      ]),
+    /Manufacturing bill mapping line requires poNumber/,
+  );
+});
+
 test('parseQboBillsToInventoryEvents scopes explicit inventory accounts by marketplace', () => {
   const bill: QboBill = {
     Id: 'B-1',


### PR DESCRIPTION
## Summary
- keep blank-PO, SKU-less mapped inventory costs as brand-level events instead of forcing PO/SKU allocation
- require PO numbers on mapped manufacturing bill lines
- add inventory bill audit coverage for mapped SKUs that are not supported by structured QBO line descriptions

## Verification
- pnpm --filter @targon/plutus test
- pnpm --filter @targon/plutus type-check
- pnpm --filter @targon/plutus lint
- git diff --check
- live QBO audit with patched code identifies Bill 48 stale SKU mapping