### PR TITLE
Fix Plutus bill mapping PO sync state

### DIFF
--- a/apps/plutus/app/api/plutus/bills/route.ts
+++ b/apps/plutus/app/api/plutus/bills/route.ts
@@ -31,6 +31,42 @@ import { parsePoFromDescription } from '@/lib/inventory/qbo-bills';
 
 const logger = createLogger({ name: 'plutus-bills' });
 
+function buildPrivateNoteWithPo(privateNote: string | undefined, poNumber: string): string {
+  const normalizedPoNumber = poNumber.trim();
+  const existingNote = privateNote ? privateNote : '';
+  if (normalizedPoNumber === '') return existingNote;
+
+  const rawLines = existingNote.split(/\r?\n/);
+  const outputLines: string[] = [];
+  let replacedInternalRef = false;
+
+  for (const rawLine of rawLines) {
+    const line = rawLine.trim();
+    if (line === '') continue;
+
+    if (/^INTERNAL\s+REF\s*:/i.test(line)) {
+      const [, rest = ''] = line.split(/:(.*)/s);
+      const remainingFields = rest
+        .split(';')
+        .map((part) => part.trim())
+        .filter((part) => part !== '' && !/^PO\s*[:=]/i.test(part));
+      outputLines.push(
+        `INTERNAL REF: PO=${normalizedPoNumber}${remainingFields.length > 0 ? `; ${remainingFields.join('; ')}` : ''}`,
+      );
+      replacedInternalRef = true;
+      continue;
+    }
+
+    outputLines.push(line);
+  }
+
+  if (!replacedInternalRef) {
+    outputLines.unshift(`INTERNAL REF: PO=${normalizedPoNumber}`);
+  }
+
+  return outputLines.join('\n');
+}
+
 export async function GET(req: NextRequest) {
   try {
     const connection = await getQboConnection();
@@ -435,7 +471,7 @@ export async function POST(req: NextRequest) {
       quantity: typeof line.quantity === 'number' ? line.quantity : null,
     }));
 
-    let syncedAt: Date | null = new Date();
+    let syncedAt: Date | null = null;
     const hasSplitLines = parsedLines.some(
       (line) => Array.isArray(line.splits) && line.splits.length > 0,
     );
@@ -531,7 +567,7 @@ export async function POST(req: NextRequest) {
 
       const payload: Record<string, unknown> = {
         ...(currentBill as unknown as Record<string, unknown>),
-        PrivateNote: currentBill.PrivateNote,
+        PrivateNote: buildPrivateNoteWithPo(currentBill.PrivateNote, normalizedPoNumber),
         Line: updatedLines,
       };
 
@@ -586,7 +622,6 @@ export async function POST(req: NextRequest) {
       });
 
       persistedLines = [...nonSplitPersistedLines, ...splitPersistedLines];
-    } else {
       syncedAt = new Date();
     }
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2748,6 +2748,15 @@ test('split manufacturing bill mappings persist line-level PO numbers', () => {
   );
 });
 
+test('bill mapping route marks only QBO-mutated split saves as synced', () => {
+  const source = readFileSync('app/api/plutus/bills/route.ts', 'utf8');
+
+  assert.equal(source.includes('let syncedAt: Date | null = null;'), true);
+  assert.equal(source.includes('PrivateNote: buildPrivateNoteWithPo(currentBill.PrivateNote, normalizedPoNumber)'), true);
+  assert.equal(source.includes('PrivateNote: currentBill.PrivateNote'), false);
+  assert.equal(source.includes('} else {\n      syncedAt = new Date();\n    }'), false);
+});
+
 test('parseQboBillsToInventoryEvents scopes explicit inventory accounts by marketplace', () => {
   const bill: QboBill = {
     Id: 'B-1',


### PR DESCRIPTION
## Summary
- preserve submitted PO in QBO PrivateNote when split manufacturing bill mappings rewrite QBO bill lines
- mark only QBO-mutated split saves as synced, so unsynced non-split mappings are not overwritten by QBO pull-sync
- keep line-level PO numbers on split mapping rows

## Verification
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint
- git diff --check
