### PR TITLE
[codex] Promote Plutus settlement parent postings

### DIFF
--- a/apps/plutus/lib/amazon-finances/settlement-memo-normalization.ts
+++ b/apps/plutus/lib/amazon-finances/settlement-memo-normalization.ts
@@ -1,0 +1,42 @@
+const SETTLEMENT_OPERATING_ACCOUNT_PREFIXES = [
+  'Amazon Sales',
+  'Amazon Refunds',
+  'Amazon FBA Fees',
+  'Amazon Seller Fees',
+  'Amazon Storage Fees',
+  'Amazon Advertising Costs',
+  'Amazon Promotions',
+  'Amazon FBA Inventory Reimbursement',
+] as const;
+
+const MEMOS_WITH_LEGACY_BRAND_SUFFIX = new Set(['Amazon Sales', 'Amazon Refunds']);
+
+export type SettlementParentAccountKey = 'amazonSales' | 'amazonRefunds';
+
+export function normalizeSettlementOperatingMemo(memo: string): string {
+  const trimmed = memo.trim();
+  const parts = trimmed.split(' - ');
+  if (parts.length < 3) return trimmed;
+
+  const parent = parts[0];
+  if (!MEMOS_WITH_LEGACY_BRAND_SUFFIX.has(parent)) return trimmed;
+
+  return parts.slice(0, -1).join(' - ');
+}
+
+export function settlementParentAccountKeyForMemo(memo: string): SettlementParentAccountKey | null {
+  const normalized = normalizeSettlementOperatingMemo(memo);
+  if (normalized.startsWith('Amazon Sales - ')) return 'amazonSales';
+  if (normalized.startsWith('Amazon Refunds - ')) return 'amazonRefunds';
+  return null;
+}
+
+export function isSettlementOperatingBrandAccountName(accountName: string): boolean {
+  const trimmed = accountName.trim();
+  if (trimmed === '') return false;
+
+  const leaf = trimmed.split(':').at(-1)?.trim();
+  if (!leaf) return false;
+
+  return SETTLEMENT_OPERATING_ACCOUNT_PREFIXES.some((prefix) => leaf.startsWith(`${prefix} - `));
+}

--- a/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-builder.ts
@@ -106,20 +106,18 @@ function orderScopeFromMarketplaceName(marketplaceName: unknown): OrderScope {
 
 function salesMemo(input: {
   kind: 'Principal' | 'Shipping' | 'Shipping Promotion' | 'Promotional Discounts';
-  brandLabel: string;
   marketplaceVatResponsible: boolean;
 }): string {
   const suffix = input.marketplaceVatResponsible ? ' (Marketplace VAT Responsible)' : '';
-  return `Amazon Sales - ${input.kind}${suffix} - ${input.brandLabel}`;
+  return `Amazon Sales - ${input.kind}${suffix}`;
 }
 
 function refundMemo(input: {
   kind: 'Refunded Principal' | 'Refunded Shipping' | 'Refunded Shipping Promotion' | 'Refunded Promotional Discounts';
-  brandLabel: string;
   marketplaceVatResponsible: boolean;
 }): string {
   const suffix = input.marketplaceVatResponsible ? ' (Marketplace VAT Responsible)' : '';
-  return `Amazon Refunds - ${input.kind}${suffix} - ${input.brandLabel}`;
+  return `Amazon Refunds - ${input.kind}${suffix}`;
 }
 
 function feeTypeMemoForShipment(input: { feeType: string; scope: OrderScope }): string | null {
@@ -537,7 +535,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
       }
 
       if (principalNetCents !== 0) {
-        const memo = salesMemo({ kind: 'Principal', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible });
+        const memo = salesMemo({ kind: 'Principal', marketplaceVatResponsible: orderMarketplaceVatResponsible });
         addCents(segment.memoTotalsCents, memo, principalNetCents);
         segment.auditRows.push({
           invoiceId: segment.docNumber,
@@ -552,7 +550,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
       }
 
       if (shippingNetCents !== 0) {
-        const memo = salesMemo({ kind: 'Shipping', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible });
+        const memo = salesMemo({ kind: 'Shipping', marketplaceVatResponsible: orderMarketplaceVatResponsible });
         addCents(segment.memoTotalsCents, memo, shippingNetCents);
       }
 
@@ -564,7 +562,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
           if (split.shippingPromoCents !== 0) {
             addCents(
               segment.memoTotalsCents,
-              salesMemo({ kind: 'Shipping Promotion', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible }),
+              salesMemo({ kind: 'Shipping Promotion', marketplaceVatResponsible: orderMarketplaceVatResponsible }),
               split.shippingPromoCents,
             );
           }
@@ -572,7 +570,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
           if (split.discountPromoCents !== 0) {
             addCents(
               segment.memoTotalsCents,
-              salesMemo({ kind: 'Promotional Discounts', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible }),
+              salesMemo({ kind: 'Promotional Discounts', marketplaceVatResponsible: orderMarketplaceVatResponsible }),
               split.discountPromoCents,
             );
           }
@@ -704,7 +702,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
       }
 
       if (principalNetCents !== 0) {
-        const memo = refundMemo({ kind: 'Refunded Principal', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible });
+        const memo = refundMemo({ kind: 'Refunded Principal', marketplaceVatResponsible: orderMarketplaceVatResponsible });
         addCents(segment.memoTotalsCents, memo, principalNetCents);
         segment.auditRows.push({
           invoiceId: segment.docNumber,
@@ -719,7 +717,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
       }
 
       if (shippingNetCents !== 0) {
-        const memo = refundMemo({ kind: 'Refunded Shipping', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible });
+        const memo = refundMemo({ kind: 'Refunded Shipping', marketplaceVatResponsible: orderMarketplaceVatResponsible });
         addCents(segment.memoTotalsCents, memo, shippingNetCents);
       }
 
@@ -731,7 +729,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
           if (split.shippingPromoCents !== 0) {
             addCents(
               segment.memoTotalsCents,
-              refundMemo({ kind: 'Refunded Shipping Promotion', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible }),
+              refundMemo({ kind: 'Refunded Shipping Promotion', marketplaceVatResponsible: orderMarketplaceVatResponsible }),
               split.shippingPromoCents,
             );
           }
@@ -739,7 +737,7 @@ export function buildUkSettlementDraftFromSpApiFinances(input: {
           if (split.discountPromoCents !== 0) {
             addCents(
               segment.memoTotalsCents,
-              refundMemo({ kind: 'Refunded Promotional Discounts', brandLabel: itemData.brandLabel, marketplaceVatResponsible: orderMarketplaceVatResponsible }),
+              refundMemo({ kind: 'Refunded Promotional Discounts', marketplaceVatResponsible: orderMarketplaceVatResponsible }),
               split.discountPromoCents,
             );
           }

--- a/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
@@ -1,6 +1,11 @@
 import { buildQboJournalEntriesFromUkSettlementDraft, buildUkSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/uk-settlement-builder';
 import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '@/lib/amazon-finances/settlement-cash-account-guardrails';
 import {
+  normalizeSettlementOperatingMemo,
+  settlementParentAccountKeyForMemo,
+  type SettlementParentAccountKey,
+} from '@/lib/amazon-finances/settlement-memo-normalization';
+import {
   fetchAllFinancialEventsByGroupId,
   findFinancialEventGroupIdForSettlementId,
   listAllFinancialEventGroups,
@@ -243,6 +248,17 @@ async function ensureJournalEntryHasSettlementEvidenceAttachments(
 
 type MemoMappingEntry = { accountId: string; taxCodeId: string | null };
 
+function requireSetupSettlementParentAccount(
+  setupConfig: Record<string, unknown>,
+  key: SettlementParentAccountKey,
+): string {
+  const value = setupConfig[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing SetupConfig.${key}`);
+  }
+  return value.trim();
+}
+
 function requireMemoMapping(value: unknown): Record<string, MemoMappingEntry> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error('Settlement memo mapping must be an object');
@@ -306,11 +322,19 @@ async function loadUkSettlementPostingMapping(input: {
   const paymentAccountId = config.paymentAccountId ? config.paymentAccountId.trim() : '';
 
   const memoMapping = requireMemoMapping(config.accountIdByMemo);
+  const setupConfig = await db.setupConfig.findFirst();
+  if (setupConfig === null) {
+    throw new Error('Missing SetupConfig');
+  }
+  const setupConfigRecord = setupConfig as Record<string, unknown>;
   const accountIdByMemo = new Map<string, string>();
   const taxCodeIdByMemo = new Map<string, string | null>();
   for (const [memo, entry] of Object.entries(memoMapping)) {
-    accountIdByMemo.set(memo, entry.accountId);
-    taxCodeIdByMemo.set(memo, entry.taxCodeId);
+    const normalizedMemo = normalizeSettlementOperatingMemo(memo);
+    const parentKey = settlementParentAccountKeyForMemo(normalizedMemo);
+    const accountId = parentKey ? requireSetupSettlementParentAccount(setupConfigRecord, parentKey) : entry.accountId;
+    accountIdByMemo.set(normalizedMemo, accountId);
+    taxCodeIdByMemo.set(normalizedMemo, entry.taxCodeId);
   }
 
   const missingMemos = Array.from(input.requiredMemos).filter((memo) => !accountIdByMemo.has(memo)).sort();

--- a/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-builder.ts
@@ -99,24 +99,18 @@ function brandNameForSku(skuRaw: string, skuToBrandName: Map<string, string>): s
   return brandName;
 }
 
-function brandLabelForName(brandName: string, brandLabelByBrandName?: Map<string, string>): string {
-  if (!brandLabelByBrandName) return brandName;
-  const label = brandLabelByBrandName.get(brandName);
-  return label ? label : brandName;
-}
-
-function chargeTypeMemoForShipment(input: { chargeType: string; brandLabel: string }): string | null {
-  if (input.chargeType === 'Principal') return `Amazon Sales - Principal - ${input.brandLabel}`;
-  if (input.chargeType === 'ShippingCharge') return `Amazon Sales - Shipping - ${input.brandLabel}`;
-  if (input.chargeType === 'Tax') return 'Amazon Sales Tax - Sales Tax (Principal)';
-  if (input.chargeType === 'ShippingTax') return 'Amazon Sales Tax - Sales Tax (Shipping)';
-  if (input.chargeType === 'GiftWrap') return null;
-  if (input.chargeType === 'GiftWrapTax') return null;
+function chargeTypeMemoForShipment(chargeType: string): string | null {
+  if (chargeType === 'Principal') return 'Amazon Sales - Principal';
+  if (chargeType === 'ShippingCharge') return 'Amazon Sales - Shipping';
+  if (chargeType === 'Tax') return 'Amazon Sales Tax - Sales Tax (Principal)';
+  if (chargeType === 'ShippingTax') return 'Amazon Sales Tax - Sales Tax (Shipping)';
+  if (chargeType === 'GiftWrap') return null;
+  if (chargeType === 'GiftWrapTax') return null;
   return null;
 }
 
-function promotionMemoForShipment(brandLabel: string): string {
-  return `Amazon Sales - Shipping Promotion - ${brandLabel}`;
+function promotionMemoForShipment(): string {
+  return 'Amazon Sales - Shipping Promotion';
 }
 
 function feeTypeMemoForShipment(feeType: string): string | null {
@@ -157,19 +151,19 @@ function withheldChargeMemo(chargeType: string, context: 'shipment' | 'refund'):
   return null;
 }
 
-function chargeTypeMemoForRefund(input: { chargeType: string; brandLabel: string }): string | null {
-  if (input.chargeType === 'Principal') return `Amazon Refunds - Refunded Principal - ${input.brandLabel}`;
-  if (input.chargeType === 'RestockingFee') return `Amazon Refunds - Refunded Principal - ${input.brandLabel}`;
-  if (input.chargeType === 'ShippingCharge') return `Amazon Refunds - Refunded Shipping - ${input.brandLabel}`;
-  if (input.chargeType === 'Tax') return 'Amazon Sales Tax - Refund - Item Price - Tax';
-  if (input.chargeType === 'ShippingTax') return 'Amazon Sales Tax - Refund - Item Price - Tax';
-  if (input.chargeType === 'GiftWrap') return null;
-  if (input.chargeType === 'GiftWrapTax') return null;
+function chargeTypeMemoForRefund(chargeType: string): string | null {
+  if (chargeType === 'Principal') return 'Amazon Refunds - Refunded Principal';
+  if (chargeType === 'RestockingFee') return 'Amazon Refunds - Refunded Principal';
+  if (chargeType === 'ShippingCharge') return 'Amazon Refunds - Refunded Shipping';
+  if (chargeType === 'Tax') return 'Amazon Sales Tax - Refund - Item Price - Tax';
+  if (chargeType === 'ShippingTax') return 'Amazon Sales Tax - Refund - Item Price - Tax';
+  if (chargeType === 'GiftWrap') return null;
+  if (chargeType === 'GiftWrapTax') return null;
   return null;
 }
 
-function promotionMemoForRefund(brandLabel: string): string {
-  return `Amazon Refunds - Refunded Shipping Promotion - ${brandLabel}`;
+function promotionMemoForRefund(): string {
+  return 'Amazon Refunds - Refunded Shipping Promotion';
 }
 
 function feeTypeMemoForRefund(feeType: string): string | null {
@@ -307,8 +301,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
     for (const item of items) {
       const skuRaw = typeof item.SellerSKU === 'string' ? item.SellerSKU : '';
       const qty = typeof item.QuantityShipped === 'number' && Number.isInteger(item.QuantityShipped) ? item.QuantityShipped : 0;
-      const brandName = skuRaw === '' ? '' : brandNameForSku(skuRaw, input.skuToBrandName);
-      const brandLabel = brandName === '' ? '' : brandLabelForName(brandName, input.brandLabelByBrandName);
+      if (skuRaw !== '') brandNameForSku(skuRaw, input.skuToBrandName);
 
       for (const charge of toChargeComponents(item.ItemChargeList)) {
         const chargeType = typeof charge.ChargeType === 'string' ? charge.ChargeType : '';
@@ -317,7 +310,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
         const cents = moneyToCents(chargeAmount, `Shipment charge ${chargeType}`);
         if (cents === 0) continue;
 
-        const memo = chargeTypeMemoForShipment({ chargeType, brandLabel });
+        const memo = chargeTypeMemoForShipment(chargeType);
         if (!memo) {
           throw new Error(`Unhandled shipment charge type: ${chargeType}`);
         }
@@ -345,7 +338,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
         promoCents += moneyToCents(amount, 'Shipment promotion');
       }
       if (promoCents !== 0) {
-        const memo = promotionMemoForShipment(brandLabel);
+        const memo = promotionMemoForShipment();
         addCents(segment.memoTotalsCents, memo, promoCents);
       }
 
@@ -407,8 +400,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
       const skuRaw = typeof item.SellerSKU === 'string' ? item.SellerSKU : '';
       const qtyRaw = typeof item.QuantityShipped === 'number' && Number.isInteger(item.QuantityShipped) ? item.QuantityShipped : 0;
       const qty = qtyRaw === 0 ? 0 : -qtyRaw;
-      const brandName = skuRaw === '' ? '' : brandNameForSku(skuRaw, input.skuToBrandName);
-      const brandLabel = brandName === '' ? '' : brandLabelForName(brandName, input.brandLabelByBrandName);
+      if (skuRaw !== '') brandNameForSku(skuRaw, input.skuToBrandName);
 
       for (const charge of toChargeComponents(item.ItemChargeAdjustmentList)) {
         const chargeType = typeof charge.ChargeType === 'string' ? charge.ChargeType : '';
@@ -417,7 +409,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
         const cents = moneyToCents(chargeAmount, `Refund charge ${chargeType}`);
         if (cents === 0) continue;
 
-        const memo = chargeTypeMemoForRefund({ chargeType, brandLabel });
+        const memo = chargeTypeMemoForRefund(chargeType);
         if (!memo) {
           throw new Error(`Unhandled refund charge type: ${chargeType}`);
         }
@@ -445,7 +437,7 @@ export function buildUsSettlementDraftFromSpApiFinances(input: {
         promoCents += moneyToCents(amount, 'Refund promotion');
       }
       if (promoCents !== 0) {
-        const memo = promotionMemoForRefund(brandLabel);
+        const memo = promotionMemoForRefund();
         addCents(segment.memoTotalsCents, memo, promoCents);
       }
 

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -1,6 +1,11 @@
 import { buildQboJournalEntriesFromUsSettlementDraft, buildUsSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/us-settlement-builder';
 import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '@/lib/amazon-finances/settlement-cash-account-guardrails';
 import {
+  normalizeSettlementOperatingMemo,
+  settlementParentAccountKeyForMemo,
+  type SettlementParentAccountKey,
+} from '@/lib/amazon-finances/settlement-memo-normalization';
+import {
   fetchAllFinancialEventsByGroupId,
   findFinancialEventGroupIdForSettlementId,
   listAllFinancialEventGroups,
@@ -238,6 +243,17 @@ async function ensureJournalEntryHasSettlementEvidenceAttachments(
 
 type MemoMappingEntry = { accountId: string; taxCodeId: string | null };
 
+function requireSetupSettlementParentAccount(
+  setupConfig: Record<string, unknown>,
+  key: SettlementParentAccountKey,
+): string {
+  const value = setupConfig[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing SetupConfig.${key}`);
+  }
+  return value.trim();
+}
+
 function requireMemoMapping(value: unknown): Record<string, MemoMappingEntry> {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) {
     throw new Error('US settlement memo mapping must be an object');
@@ -303,11 +319,19 @@ async function loadUsSettlementPostingMapping(input: {
   const paymentAccountId = config.paymentAccountId ? config.paymentAccountId.trim() : '';
 
   const memoMapping = requireMemoMapping(config.accountIdByMemo);
+  const setupConfig = await db.setupConfig.findFirst();
+  if (setupConfig === null) {
+    throw new Error('Missing SetupConfig');
+  }
+  const setupConfigRecord = setupConfig as Record<string, unknown>;
   const accountIdByMemo = new Map<string, string>();
   const taxCodeIdByMemo = new Map<string, string | null>();
   for (const [memo, entry] of Object.entries(memoMapping)) {
-    accountIdByMemo.set(memo, entry.accountId);
-    taxCodeIdByMemo.set(memo, entry.taxCodeId);
+    const normalizedMemo = normalizeSettlementOperatingMemo(memo);
+    const parentKey = settlementParentAccountKeyForMemo(normalizedMemo);
+    const accountId = parentKey ? requireSetupSettlementParentAccount(setupConfigRecord, parentKey) : entry.accountId;
+    accountIdByMemo.set(normalizedMemo, accountId);
+    taxCodeIdByMemo.set(normalizedMemo, entry.taxCodeId);
   }
 
   const missingMemos = Array.from(input.requiredMemos).filter((memo) => !accountIdByMemo.has(memo)).sort();

--- a/apps/plutus/lib/qbo/api.ts
+++ b/apps/plutus/lib/qbo/api.ts
@@ -1366,6 +1366,50 @@ export async function updateJournalEntry(
   };
 }
 
+export async function updateJournalEntryWithPayload(
+  connection: QboConnection,
+  payload: QboJournalEntry,
+): Promise<{ journalEntry: QboJournalEntry; updatedConnection?: QboConnection }> {
+  if (!payload.Id || !payload.SyncToken) {
+    throw new Error('updateJournalEntryWithPayload requires Id and SyncToken');
+  }
+
+  let activeConnection = connection;
+  const { accessToken, updatedConnection } = await getValidToken(activeConnection);
+  if (updatedConnection) {
+    activeConnection = updatedConnection;
+  }
+
+  const baseUrl = getApiBaseUrl();
+  const updateUrl = `${baseUrl}/v3/company/${activeConnection.realmId}/journalentry?operation=update`;
+
+  const response = await fetchWithRetry(updateUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error('Failed to update journal entry with payload', {
+      journalEntryId: payload.Id,
+      status: response.status,
+      error: errorText,
+    });
+    throw new Error(`Failed to update journal entry with payload: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as { JournalEntry: QboJournalEntry };
+  return {
+    journalEntry: data.JournalEntry,
+    updatedConnection: activeConnection === connection ? undefined : activeConnection,
+  };
+}
+
 /**
  * Delete a single JournalEntry by ID.
  *

--- a/apps/plutus/scripts/create-settlement-je-from-audit.ts
+++ b/apps/plutus/scripts/create-settlement-je-from-audit.ts
@@ -1,5 +1,10 @@
 import { promises as fs } from 'node:fs';
 
+import {
+  normalizeSettlementOperatingMemo,
+  settlementParentAccountKeyForMemo,
+  type SettlementParentAccountKey,
+} from '@/lib/amazon-finances/settlement-memo-normalization';
 import { buildPlutusSettlementDocNumber, normalizeSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
 import type { QboConnection } from '@/lib/qbo/api';
 import { createJournalEntry, fetchAccounts, fetchExchangeRate, fetchJournalEntries, fetchPreferences } from '@/lib/qbo/api';
@@ -154,6 +159,35 @@ function requireMemoMapping(value: unknown): Record<string, MemoMappingEntry> {
   return result;
 }
 
+function requireSetupSettlementParentAccount(
+  setupConfig: Record<string, unknown>,
+  key: SettlementParentAccountKey,
+): string {
+  const value = setupConfig[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing SetupConfig.${key}`);
+  }
+  return value.trim();
+}
+
+function normalizeMemoMapping(input: {
+  setupConfig: Record<string, unknown>;
+  memoMapping: Record<string, MemoMappingEntry>;
+}): Record<string, MemoMappingEntry> {
+  const result: Record<string, MemoMappingEntry> = {};
+
+  for (const [memo, entry] of Object.entries(input.memoMapping)) {
+    const normalizedMemo = normalizeSettlementOperatingMemo(memo);
+    const parentKey = settlementParentAccountKeyForMemo(normalizedMemo);
+    result[normalizedMemo] = {
+      accountId: parentKey ? requireSetupSettlementParentAccount(input.setupConfig, parentKey) : entry.accountId,
+      taxCodeId: entry.taxCodeId,
+    };
+  }
+
+  return result;
+}
+
 function postingForNonBank(cents: number): { postingType: 'Debit' | 'Credit'; amount: number } {
   const abs = Math.abs(cents);
   const amount = abs / 100;
@@ -239,7 +273,7 @@ async function main(): Promise<void> {
   for (const row of auditRows) {
     const marketplaceId = normalizeAuditMarketToMarketplaceId(row.market);
     if (marketplaceId !== options.marketplace) continue;
-    const memo = row.description.trim();
+    const memo = normalizeSettlementOperatingMemo(row.description);
     if (memo === '') continue;
     const current = memoTotals.get(memo);
     memoTotals.set(memo, (current === undefined ? 0 : current) + row.net);
@@ -259,7 +293,15 @@ async function main(): Promise<void> {
     throw new Error(`Missing settlement posting config for marketplace=${options.marketplace}`);
   }
 
-  const memoMapping = requireMemoMapping(postingConfig.accountIdByMemo);
+  const setupConfig = await db.setupConfig.findFirst();
+  if (!setupConfig) {
+    throw new Error('Missing SetupConfig');
+  }
+
+  const memoMapping = normalizeMemoMapping({
+    setupConfig: setupConfig as Record<string, unknown>,
+    memoMapping: requireMemoMapping(postingConfig.accountIdByMemo),
+  });
 
   const missingMemos = Array.from(memoTotals.keys()).filter((memo) => memoMapping[memo] === undefined).sort();
   if (missingMemos.length > 0) {

--- a/apps/plutus/scripts/repair-settlement-parent-pnl-accounts.ts
+++ b/apps/plutus/scripts/repair-settlement-parent-pnl-accounts.ts
@@ -1,0 +1,478 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { db } from '@/lib/db';
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
+import { isQboJournalEntryId } from '@/lib/plutus/journal-entry-id';
+import type { QboAccount, QboConnection, QboJournalEntry, QboJournalEntryLine } from '@/lib/qbo/api';
+import { fetchAccounts, fetchJournalEntryById, updateJournalEntryWithPayload } from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import {
+  isSettlementOperatingBrandAccountName,
+  normalizeSettlementOperatingMemo,
+  settlementParentAccountKeyForMemo,
+} from '@/lib/amazon-finances/settlement-memo-normalization';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type MarketSelection = 'ALL' | 'US' | 'UK';
+type Marketplace = 'amazon.com' | 'amazon.co.uk';
+
+type CliOptions = {
+  apply: boolean;
+  humanApproval: string | null;
+  market: MarketSelection;
+  invoiceId: string | null;
+};
+
+type MemoMappingEntry = { accountId: string; taxCodeId: string | null };
+type MemoMapping = Record<string, MemoMappingEntry>;
+
+type ConfigPlan = {
+  marketplace: Marketplace;
+  currentMapping: MemoMapping;
+  targetMapping: MemoMapping;
+  changedKeys: string[];
+};
+
+type JournalPlan = {
+  marketplace: Marketplace;
+  invoiceId: string;
+  journalEntryId: string;
+  docNumber: string | null;
+  changedLines: Array<{
+    lineIndex: number;
+    fromDescription: string;
+    toDescription: string;
+    fromAccountId: string;
+    toAccountId: string;
+    toAccountName: string;
+  }>;
+  unresolvedBrandAccounts: Array<{
+    lineIndex: number;
+    description: string;
+    accountId: string;
+    accountName: string;
+  }>;
+  targetEntry: QboJournalEntry;
+};
+
+function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
+  let line = rawLine.trim();
+  if (line === '') return null;
+  if (line.startsWith('#')) return null;
+
+  if (line.startsWith('export ')) {
+    line = line.slice('export '.length).trim();
+  }
+
+  const equalsIndex = line.indexOf('=');
+  if (equalsIndex === -1) return null;
+
+  const key = line.slice(0, equalsIndex).trim();
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return null;
+
+  let value = line.slice(equalsIndex + 1).trim();
+  if (value.startsWith("'") && value.endsWith("'")) value = value.slice(1, -1);
+  if (value.startsWith('"') && value.endsWith('"')) value = value.slice(1, -1);
+
+  return { key, value };
+}
+
+async function loadEnvFile(filePath: string): Promise<void> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError.code === 'ENOENT') return;
+    throw error;
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    const parsed = parseDotenvLine(line);
+    if (!parsed) continue;
+    if (process.env[parsed.key] !== undefined) continue;
+    process.env[parsed.key] = parsed.value;
+  }
+}
+
+async function loadPlutusEnv(): Promise<void> {
+  const cwd = process.cwd();
+  await loadEnvFile(path.join(cwd, '.env.local'));
+  await loadEnvFile(path.join(cwd, '.env'));
+  await loadEnvFile(path.join(cwd, '.env.dev.ci'));
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let humanApproval: string | null = null;
+  let market: MarketSelection = 'ALL';
+  let invoiceId: string | null = null;
+
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--human-approval') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+
+    if (arg === '--market') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('Missing value for --market');
+      const upper = next.trim().toUpperCase();
+      if (upper !== 'ALL' && upper !== 'US' && upper !== 'UK') throw new Error(`Invalid --market value: ${next}`);
+      market = upper;
+      i += 2;
+      continue;
+    }
+
+    if (arg === '--invoice-id') {
+      const next = argv[i + 1];
+      if (!next) throw new Error('Missing value for --invoice-id');
+      invoiceId = next.trim();
+      i += 2;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`Settlement QBO/account-config repair requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { apply, humanApproval, market, invoiceId };
+}
+
+function marketplacesForSelection(selection: MarketSelection): Marketplace[] {
+  if (selection === 'US') return ['amazon.com'];
+  if (selection === 'UK') return ['amazon.co.uk'];
+  return ['amazon.com', 'amazon.co.uk'];
+}
+
+function requireMemoMapping(value: unknown): MemoMapping {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('Settlement memo mapping must be an object');
+  }
+
+  const result: MemoMapping = {};
+  for (const [memo, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof raw === 'string') {
+      const accountId = raw.trim();
+      if (accountId === '') throw new Error(`Invalid account id for memo mapping: ${memo}`);
+      result[memo] = { accountId, taxCodeId: null };
+      continue;
+    }
+
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      throw new Error(`Invalid memo mapping entry: ${memo}`);
+    }
+
+    const entry = raw as Record<string, unknown>;
+    const accountIdRaw = entry.accountId;
+    if (typeof accountIdRaw !== 'string' || accountIdRaw.trim() === '') {
+      throw new Error(`Invalid memo mapping accountId: ${memo}`);
+    }
+
+    const taxCodeIdRaw = entry.taxCodeId;
+    result[memo] = {
+      accountId: accountIdRaw.trim(),
+      taxCodeId: typeof taxCodeIdRaw === 'string' && taxCodeIdRaw.trim() !== '' ? taxCodeIdRaw.trim() : null,
+    };
+  }
+
+  return result;
+}
+
+function sortMapping(mapping: MemoMapping): MemoMapping {
+  const sorted: MemoMapping = {};
+  for (const key of Object.keys(mapping).sort()) {
+    sorted[key] = mapping[key]!;
+  }
+  return sorted;
+}
+
+function requireSetupAccount(setupConfig: Record<string, unknown>, key: 'amazonSales' | 'amazonRefunds'): string {
+  const value = setupConfig[key];
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Missing SetupConfig.${key}`);
+  }
+  return value.trim();
+}
+
+function accountIdForNormalizedMemo(input: {
+  setupConfig: Record<string, unknown>;
+  normalizedMemo: string;
+  entry: MemoMappingEntry;
+}): string {
+  const setupKey = settlementParentAccountKeyForMemo(input.normalizedMemo);
+  if (setupKey) return requireSetupAccount(input.setupConfig, setupKey);
+  return input.entry.accountId;
+}
+
+function planConfig(input: {
+  marketplace: Marketplace;
+  setupConfig: Record<string, unknown>;
+  currentMapping: MemoMapping;
+}): ConfigPlan {
+  const targetMapping: MemoMapping = {};
+
+  for (const [memo, entry] of Object.entries(input.currentMapping)) {
+    const normalizedMemo = normalizeSettlementOperatingMemo(memo);
+    targetMapping[normalizedMemo] = {
+      accountId: accountIdForNormalizedMemo({
+        setupConfig: input.setupConfig,
+        normalizedMemo,
+        entry,
+      }),
+      taxCodeId: entry.taxCodeId,
+    };
+  }
+
+  const currentSorted = sortMapping(input.currentMapping);
+  const targetSorted = sortMapping(targetMapping);
+  const keys = new Set([...Object.keys(currentSorted), ...Object.keys(targetSorted)]);
+  const changedKeys = Array.from(keys)
+    .filter((key) => JSON.stringify(currentSorted[key]) !== JSON.stringify(targetSorted[key]))
+    .sort();
+
+  return {
+    marketplace: input.marketplace,
+    currentMapping: currentSorted,
+    targetMapping: targetSorted,
+    changedKeys,
+  };
+}
+
+function buildAccountIndex(accounts: QboAccount[]): Map<string, QboAccount> {
+  return new Map(accounts.map((account) => [account.Id, account]));
+}
+
+function accountDisplayName(account: QboAccount | undefined, fallback: string | undefined): string {
+  return account?.FullyQualifiedName?.trim() || fallback?.trim() || account?.Name?.trim() || '';
+}
+
+function compactJournalEntryForUpdate(entry: QboJournalEntry, lines: QboJournalEntryLine[]): QboJournalEntry {
+  return {
+    Id: entry.Id,
+    SyncToken: entry.SyncToken,
+    TxnDate: entry.TxnDate,
+    DocNumber: entry.DocNumber,
+    PrivateNote: entry.PrivateNote,
+    CurrencyRef: entry.CurrencyRef,
+    ExchangeRate: entry.ExchangeRate,
+    Line: lines,
+  };
+}
+
+function planJournalRepair(input: {
+  marketplace: Marketplace;
+  invoiceId: string;
+  entry: QboJournalEntry;
+  targetMapping: MemoMapping;
+  accountById: Map<string, QboAccount>;
+}): JournalPlan {
+  const changedLines: JournalPlan['changedLines'] = [];
+  const unresolvedBrandAccounts: JournalPlan['unresolvedBrandAccounts'] = [];
+
+  const lines = input.entry.Line.map((line, index) => {
+    const currentAccountId = line.JournalEntryLineDetail?.AccountRef?.value;
+    const currentAccountName = accountDisplayName(
+      typeof currentAccountId === 'string' ? input.accountById.get(currentAccountId) : undefined,
+      line.JournalEntryLineDetail?.AccountRef?.name,
+    );
+    const fromDescription = typeof line.Description === 'string' ? line.Description.trim() : '';
+    const toDescription = normalizeSettlementOperatingMemo(fromDescription);
+    const target = input.targetMapping[toDescription];
+
+    if (!target) {
+      if (currentAccountId && isSettlementOperatingBrandAccountName(currentAccountName)) {
+        unresolvedBrandAccounts.push({
+          lineIndex: index,
+          description: fromDescription,
+          accountId: currentAccountId,
+          accountName: currentAccountName,
+        });
+      }
+      return line;
+    }
+
+    const targetAccount = input.accountById.get(target.accountId);
+    if (!targetAccount) {
+      throw new Error(`Missing QBO account ${target.accountId} for memo ${toDescription}`);
+    }
+
+    const toAccountName = accountDisplayName(targetAccount, targetAccount.Name);
+    if (currentAccountId === target.accountId && fromDescription === toDescription) return line;
+
+    changedLines.push({
+      lineIndex: index,
+      fromDescription,
+      toDescription,
+      fromAccountId: currentAccountId ?? '',
+      toAccountId: target.accountId,
+      toAccountName,
+    });
+
+    return {
+      ...line,
+      Description: toDescription,
+      JournalEntryLineDetail: {
+        ...line.JournalEntryLineDetail,
+        AccountRef: {
+          value: target.accountId,
+          name: toAccountName,
+        },
+      },
+    };
+  });
+
+  return {
+    marketplace: input.marketplace,
+    invoiceId: input.invoiceId,
+    journalEntryId: input.entry.Id,
+    docNumber: typeof input.entry.DocNumber === 'string' ? input.entry.DocNumber : null,
+    changedLines,
+    unresolvedBrandAccounts,
+    targetEntry: compactJournalEntryForUpdate(input.entry, lines),
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  loadSharedPlutusEnv();
+  await loadPlutusEnv();
+
+  const connectionMaybe = await getQboConnection();
+  if (connectionMaybe === null) throw new Error('Not connected to QBO');
+  let connection: QboConnection = connectionMaybe;
+
+  const setupConfig = await db.setupConfig.findFirst();
+  if (setupConfig === null) throw new Error('Missing SetupConfig');
+
+  const accountsRes = await fetchAccounts(connection, { includeInactive: true });
+  if (accountsRes.updatedConnection) connection = accountsRes.updatedConnection;
+  const accountById = buildAccountIndex(accountsRes.accounts);
+
+  const marketplaces = marketplacesForSelection(options.market);
+  const configPlans: ConfigPlan[] = [];
+  const targetMappingsByMarketplace = new Map<Marketplace, MemoMapping>();
+
+  for (const marketplace of marketplaces) {
+    const config = await db.settlementPostingConfig.findUnique({ where: { marketplace } });
+    if (!config) throw new Error(`Missing settlement posting config for ${marketplace}`);
+
+    const currentMapping = requireMemoMapping(config.accountIdByMemo);
+    const configPlan = planConfig({ marketplace, setupConfig: setupConfig as Record<string, unknown>, currentMapping });
+    configPlans.push(configPlan);
+    targetMappingsByMarketplace.set(marketplace, configPlan.targetMapping);
+  }
+
+  const processingRows = await db.settlementProcessing.findMany({
+    where: {
+      marketplace: { in: marketplaces },
+      ...(options.invoiceId === null ? {} : { invoiceId: options.invoiceId }),
+    },
+    orderBy: { createdAt: 'asc' },
+    select: {
+      marketplace: true,
+      invoiceId: true,
+      qboSettlementJournalEntryId: true,
+    },
+  });
+
+  const journalPlans: JournalPlan[] = [];
+  for (const row of processingRows) {
+    if (!isQboJournalEntryId(row.qboSettlementJournalEntryId)) continue;
+
+    const fetched = await fetchJournalEntryById(connection, row.qboSettlementJournalEntryId);
+    if (fetched.updatedConnection) connection = fetched.updatedConnection;
+
+    const marketplace = row.marketplace as Marketplace;
+    const targetMapping = targetMappingsByMarketplace.get(marketplace);
+    if (!targetMapping) throw new Error(`Missing target mapping for ${marketplace}`);
+
+    const journalPlan = planJournalRepair({
+      marketplace,
+      invoiceId: row.invoiceId,
+      entry: fetched.journalEntry,
+      targetMapping,
+      accountById,
+    });
+
+    if (journalPlan.changedLines.length > 0 || journalPlan.unresolvedBrandAccounts.length > 0) {
+      journalPlans.push(journalPlan);
+    }
+  }
+
+  const configChanges = configPlans.filter((plan) => plan.changedKeys.length > 0);
+  const journalChanges = journalPlans.filter((plan) => plan.changedLines.length > 0);
+  const unresolved = journalPlans.flatMap((plan) =>
+    plan.unresolvedBrandAccounts.map((line) => ({
+      marketplace: plan.marketplace,
+      invoiceId: plan.invoiceId,
+      journalEntryId: plan.journalEntryId,
+      ...line,
+    })),
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: options.apply ? 'apply' : 'dry-run',
+        scannedSettlementRows: processingRows.length,
+        configChanges: configChanges.map((plan) => ({ marketplace: plan.marketplace, changedKeys: plan.changedKeys })),
+        journalChanges: journalChanges.map((plan) => ({
+          marketplace: plan.marketplace,
+          invoiceId: plan.invoiceId,
+          journalEntryId: plan.journalEntryId,
+          docNumber: plan.docNumber,
+          changedLines: plan.changedLines,
+        })),
+        unresolved,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (unresolved.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options.apply) {
+    await saveServerQboConnection(connection);
+    return;
+  }
+
+  for (const plan of configChanges) {
+    await db.settlementPostingConfig.update({
+      where: { marketplace: plan.marketplace },
+      data: { accountIdByMemo: plan.targetMapping },
+    });
+  }
+
+  for (const plan of journalChanges) {
+    const updated = await updateJournalEntryWithPayload(connection, plan.targetEntry);
+    if (updated.updatedConnection) connection = updated.updatedConnection;
+  }
+
+  await saveServerQboConnection(connection);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/apps/plutus/scripts/settlement-processing-audit.ts
+++ b/apps/plutus/scripts/settlement-processing-audit.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import { isSettlementOperatingBrandAccountName } from '@/lib/amazon-finances/settlement-memo-normalization';
 import type { SettlementAuditRow } from '@/lib/plutus/settlement-audit';
 import { isNoopJournalEntryId, isQboJournalEntryId } from '@/lib/plutus/journal-entry-id';
 import { buildCogsJournalLines } from '@/lib/plutus/journal-builder';
@@ -51,6 +52,12 @@ type JeCompareResult = {
   txnDate?: { expected: string; actual: string | null; ok: boolean };
 };
 
+type SettlementBrandAccountViolation = {
+  accountId: string;
+  accountName: string;
+  description: string;
+};
+
 type SettlementAuditResult = {
   marketplace: string;
   invoiceId: string;
@@ -64,6 +71,7 @@ type SettlementAuditResult = {
   auditUpload?: { id: string; filename: string; uploadedAt: string };
 
   settlementJe: { status: 'ok' | 'missing' | 'mismatch'; docNumber: string | null; txnDate: string | null };
+  settlementBrandAccountViolations: SettlementBrandAccountViolation[];
   cogsJe: JeCompareResult;
   pnlJe: JeCompareResult;
   deterministicPnlOk: boolean;
@@ -224,6 +232,33 @@ function extractLinesFromJe(je: QboJournalEntry): LineSummary[] {
   }
 
   return result;
+}
+
+function findSettlementBrandAccountViolations(je: QboJournalEntry, accounts: QboAccount[]): SettlementBrandAccountViolation[] {
+  const accountById = new Map(accounts.map((account) => [account.Id, account]));
+  const violations: SettlementBrandAccountViolation[] = [];
+
+  for (const line of je.Line) {
+    const accountId = line.JournalEntryLineDetail?.AccountRef?.value;
+    if (typeof accountId !== 'string' || accountId.trim() === '') continue;
+
+    const account = accountById.get(accountId);
+    const accountName =
+      account?.FullyQualifiedName?.trim() ||
+      line.JournalEntryLineDetail?.AccountRef?.name?.trim() ||
+      account?.Name?.trim() ||
+      accountId;
+
+    if (!isSettlementOperatingBrandAccountName(accountName)) continue;
+
+    violations.push({
+      accountId,
+      accountName,
+      description: typeof line.Description === 'string' ? line.Description.trim() : '',
+    });
+  }
+
+  return violations;
 }
 
 function compareJeLines(input: { expected: LineSummary[]; actual: LineSummary[] }): { mismatches: Array<{ key: string; expectedCents: number; actualCents: number }> } {
@@ -391,10 +426,16 @@ async function auditSettlementProcessingRow(input: {
 
   const settlementDocOk = settlementDocNumber === expectedSettlementDocNumber;
   const settlementDateOk = settlementTxnDate === expectedSettlementTxnDate;
+  const settlementBrandAccountViolations = findSettlementBrandAccountViolations(settlementRes.journalEntry, input.accounts);
 
   let settlementStatus: 'ok' | 'mismatch' = 'ok';
-  if (!settlementDocOk || !settlementDateOk) {
+  if (!settlementDocOk || !settlementDateOk || settlementBrandAccountViolations.length > 0) {
     settlementStatus = 'mismatch';
+  }
+  for (const violation of settlementBrandAccountViolations) {
+    warnings.push(
+      `Settlement JE uses branded operating P&L account ${violation.accountName} on "${violation.description || 'blank description'}"`,
+    );
   }
 
   const requiredMappingKeys = [
@@ -673,6 +714,7 @@ async function auditSettlementProcessingRow(input: {
       docNumber: settlementDocNumber,
       txnDate: settlementTxnDate,
     },
+    settlementBrandAccountViolations,
     cogsJe: cogsJeResult,
     pnlJe: pnlJeResult,
       warnings,

--- a/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import { loadSharedPlutusEnv } from './shared-env';
 
 import { buildQboJournalEntriesFromUsSettlementDraft, buildUsSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/us-settlement-builder';
+import { normalizeSettlementOperatingMemo } from '@/lib/amazon-finances/settlement-memo-normalization';
 import {
   fetchAllFinancialEventsByGroupId,
   findFinancialEventGroupIdForSettlementId,
@@ -122,7 +123,7 @@ function extractLinesFromJe(je: QboJournalEntry): QboLine[] {
     const amount = line.Amount;
     if (typeof amount !== 'number' || !Number.isFinite(amount) || amount === 0) continue;
 
-    const description = typeof line.Description === 'string' ? line.Description : '';
+    const description = normalizeSettlementOperatingMemo(typeof line.Description === 'string' ? line.Description : '');
     result.push({ accountId, postingType, amount: normalizeAmount(amount), description });
   }
 
@@ -137,37 +138,6 @@ function requireSettlementIdFromPrivateNote(input: { docNumber: string; privateN
   }
 
   throw new Error(`Missing SP-API settlementId in PrivateNote for ${input.docNumber}`);
-}
-
-function extractBrandLabelFromMemo(description: string): string | null {
-  const prefixes = [
-    'Amazon Sales - Principal - ',
-    'Amazon Sales - Shipping - ',
-    'Amazon Sales - Shipping Promotion - ',
-    'Amazon Refunds - Refunded Principal - ',
-    'Amazon Refunds - Refunded Shipping - ',
-    'Amazon Refunds - Refunded Shipping Promotion - ',
-  ];
-
-  for (const prefix of prefixes) {
-    if (!description.startsWith(prefix)) continue;
-    const label = description.slice(prefix.length).trim();
-    return label === '' ? null : label;
-  }
-
-  return null;
-}
-
-function collectBrandLabelsFromJournalEntries(journalEntries: QboJournalEntry[]): Set<string> {
-  const result = new Set<string>();
-  for (const je of journalEntries) {
-    const lines = extractLinesFromJe(je);
-    for (const line of lines) {
-      const label = extractBrandLabelFromMemo(line.description);
-      if (label) result.add(label);
-    }
-  }
-  return result;
 }
 
 function requireSkuBrandName(skuRaw: string, skuToBrandName: Map<string, string>): string {
@@ -199,51 +169,6 @@ function collectBrandNamesFromEvents(events: SpApiFinancialEvents, skuToBrandNam
   }
 
   return result;
-}
-
-function buildBrandLabelByBrandName(input: {
-  brandNamesUsed: Set<string>;
-  journalBrandLabels: Set<string>;
-}): Map<string, string> | undefined {
-  if (input.brandNamesUsed.size === 0 && input.journalBrandLabels.size === 0) return undefined;
-
-  if (input.brandNamesUsed.size === 0) {
-    throw new Error(`Journal uses brand labels, but no brands were detected from SP-API events: ${Array.from(input.journalBrandLabels).join(', ')}`);
-  }
-
-  if (input.journalBrandLabels.size === 0) {
-    throw new Error(`SP-API events use brands (${Array.from(input.brandNamesUsed).join(', ')}), but journal entry has no brand-labeled memos`);
-  }
-
-  const brandNames = Array.from(input.brandNamesUsed).sort();
-  const labels = Array.from(input.journalBrandLabels).sort();
-
-  const mapping = new Map<string, string>();
-
-  for (const brandName of brandNames) {
-    if (input.journalBrandLabels.has(brandName)) {
-      mapping.set(brandName, brandName);
-    }
-  }
-
-  const usedLabels = new Set(mapping.values());
-  const unmappedBrandNames = brandNames.filter((b) => !mapping.has(b));
-  const remainingLabels = labels.filter((l) => !usedLabels.has(l));
-
-  if (unmappedBrandNames.length === 0 && remainingLabels.length === 0) {
-    return mapping;
-  }
-
-  if (unmappedBrandNames.length === 1 && remainingLabels.length === 1) {
-    mapping.set(unmappedBrandNames[0]!, remainingLabels[0]!);
-    return mapping;
-  }
-
-  if (brandNames.length !== labels.length) {
-    throw new Error(`Brand mismatch: SP-API brands (${brandNames.join(', ')}) vs QBO brand labels (${labels.join(', ')})`);
-  }
-
-  throw new Error(`Ambiguous brand label mapping: SP-API brands (${brandNames.join(', ')}) vs QBO labels (${labels.join(', ')})`);
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -451,9 +376,7 @@ async function main(): Promise<void> {
 
     const events = await fetchAllFinancialEventsByGroupId({ tenantCode: 'US', eventGroupId });
 
-    const journalBrandLabels = collectBrandLabelsFromJournalEntries(settlementJournals);
-    const brandNamesUsed = collectBrandNamesFromEvents(events, skuToBrandName);
-    const brandLabelByBrandName = buildBrandLabelByBrandName({ brandNamesUsed, journalBrandLabels });
+    collectBrandNamesFromEvents(events, skuToBrandName);
 
     const draft = buildUsSettlementDraftFromSpApiFinances({
       settlementId,
@@ -461,7 +384,6 @@ async function main(): Promise<void> {
       eventGroup,
       events,
       skuToBrandName,
-      brandLabelByBrandName,
     });
 
     const journalsByDocNumber = new Map<string, QboJournalEntry>();

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -1826,6 +1826,15 @@ test('US settlement SP-API reconcile no longer requires real bank transfer lines
   assert.equal(source.includes("throw new Error(`Missing 'Payment to Amazon' line"), false);
 });
 
+test('US settlement SP-API reconcile supports parent sales and refund memos', () => {
+  const source = readFileSync(new URL('../scripts/us-settlement-reconcile-spapi.ts', import.meta.url), 'utf8');
+
+  assert.equal(source.includes('normalizeSettlementOperatingMemo'), true);
+  assert.equal(source.includes('extractBrandLabelFromMemo'), false);
+  assert.equal(source.includes('brandLabelByBrandName'), false);
+  assert.equal(source.includes('journal entry has no brand-labeled memos'), false);
+});
+
 test('buildUsSettlementDraftFromSpApiFinances maps low value goods withheld tax', () => {
   const draft = buildUsSettlementDraftFromSpApiFinances({
     settlementId: 'SETTLEMENT-LVG-1',

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -66,6 +66,10 @@ import {
 } from '../lib/amazon-finances/settlement-evidence';
 import { settlementJournalEntryMatchesSource } from '../lib/amazon-finances/settlement-sync-existing';
 import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '../lib/amazon-finances/settlement-cash-account-guardrails';
+import {
+  isSettlementOperatingBrandAccountName,
+  normalizeSettlementOperatingMemo,
+} from '../lib/amazon-finances/settlement-memo-normalization';
 import { isBlockingProcessingCode } from '../lib/plutus/settlement-types';
 import { buildPrincipalGroupsByDate, matchRefundsToSales } from '../lib/plutus/settlement-validation';
 import {
@@ -1100,6 +1104,16 @@ test('settlement reclass repair is approval-gated and protects source settlement
   assert.equal(source.includes("const BANK_ACCOUNT_TYPES = new Set(['Bank', 'Credit Card']);"), true);
 });
 
+test('settlement parent account repair is approval-gated and targets settlement JEs only by payload', () => {
+  const source = readFileSync('scripts/repair-settlement-parent-pnl-accounts.ts', 'utf8');
+
+  assert.equal(source.includes('HUMAN_APPROVAL_PHRASE'), true);
+  assert.equal(source.includes('updateJournalEntryWithPayload'), true);
+  assert.equal(source.includes('qboSettlementJournalEntryId'), true);
+  assert.equal(source.includes('qboCogsJournalEntryId'), false);
+  assert.equal(source.includes('qboPnlReclassJournalEntryId'), false);
+});
+
 test('plutus primary nav exposes settlement and subledger accounting scope', () => {
   const source = readFileSync('components/app-header.tsx', 'utf8');
 
@@ -1562,11 +1576,11 @@ test('buildSettlementMtdDailySummaryCsvBytes builds daily totals by memo', () =>
     startIsoDay: '2026-01-16',
     endIsoDay: '2026-01-17',
     accountIdByMemo: new Map([
-      ['Amazon Sales - Principal - UK-PDS', '188'],
+      ['Amazon Sales - Principal', '188'],
       ['Amazon Seller Fees - Commission', '183'],
     ]),
     taxCodeIdByMemo: new Map([
-      ['Amazon Sales - Principal - UK-PDS', null],
+      ['Amazon Sales - Principal', null],
       ['Amazon Seller Fees - Commission', null],
     ]),
     rows: [
@@ -1577,7 +1591,7 @@ test('buildSettlementMtdDailySummaryCsvBytes builds daily totals by memo', () =>
         orderId: 'o-1',
         sku: 'SKU-1',
         quantity: 1,
-        description: 'Amazon Sales - Principal - UK-PDS',
+        description: 'Amazon Sales - Principal',
         netCents: 1000,
       },
       {
@@ -1587,7 +1601,7 @@ test('buildSettlementMtdDailySummaryCsvBytes builds daily totals by memo', () =>
         orderId: 'o-2',
         sku: 'SKU-2',
         quantity: 1,
-        description: 'Amazon Sales - Principal - UK-PDS',
+        description: 'Amazon Sales - Principal',
         netCents: 500,
       },
       {
@@ -1608,11 +1622,89 @@ test('buildSettlementMtdDailySummaryCsvBytes builds daily totals by memo', () =>
     'Marketplace,Amazon.co.uk,Currency,GBP,Start Date,2026-01-16,End Date,2026-01-17',
     '',
     'Description,Tax Code,Account Code,Total,2026-01-16,2026-01-17',
-    'Amazon Sales - Principal - UK-PDS,No Tax Rate Applicable,188,15.00,10.00,5.00',
+    'Amazon Sales - Principal,No Tax Rate Applicable,188,15.00,10.00,5.00',
     'Amazon Seller Fees - Commission,No Tax Rate Applicable,183,-2.50,0.00,-2.50',
   ].join('\n');
 
   assert.equal(csv, expected);
+});
+
+test('normalizeSettlementOperatingMemo removes legacy brand suffixes from sales and refunds only', () => {
+  assert.equal(normalizeSettlementOperatingMemo('Amazon Sales - Principal - US-PDS'), 'Amazon Sales - Principal');
+  assert.equal(
+    normalizeSettlementOperatingMemo('Amazon Sales - Principal (Marketplace VAT Responsible) - UK-PDS'),
+    'Amazon Sales - Principal (Marketplace VAT Responsible)',
+  );
+  assert.equal(
+    normalizeSettlementOperatingMemo('Amazon Refunds - Refunded Shipping Promotion - US-PDS'),
+    'Amazon Refunds - Refunded Shipping Promotion',
+  );
+  assert.equal(normalizeSettlementOperatingMemo('Amazon Seller Fees - Commission'), 'Amazon Seller Fees - Commission');
+});
+
+test('isSettlementOperatingBrandAccountName flags branded settlement P&L accounts', () => {
+  assert.equal(isSettlementOperatingBrandAccountName('Amazon Sales:Amazon Sales - US-PDS'), true);
+  assert.equal(isSettlementOperatingBrandAccountName('Amazon Refunds:Amazon Refunds - UK-PDS'), true);
+  assert.equal(isSettlementOperatingBrandAccountName('Amazon FBA Fees:Amazon FBA Fees - US-PDS'), true);
+  assert.equal(isSettlementOperatingBrandAccountName('Amazon Sales'), false);
+  assert.equal(isSettlementOperatingBrandAccountName('Inventory Asset:Manufacturing - US-PDS'), false);
+});
+
+test('buildUsSettlementDraftFromSpApiFinances emits parent sales and refund memos', () => {
+  const draft = buildUsSettlementDraftFromSpApiFinances({
+    settlementId: 'US-SET-PARENT-1',
+    eventGroupId: 'US-GROUP-PARENT-1',
+    eventGroup: {
+      FinancialEventGroupStart: '2026-04-16T00:00:00.000Z',
+      FinancialEventGroupEnd: '2026-04-30T23:59:59.000Z',
+      FundTransferStatus: 'Unknown',
+      OriginalTotal: { CurrencyCode: 'USD', CurrencyAmount: 8 },
+    },
+    events: {
+      ShipmentEventList: [
+        {
+          PostedDate: '2026-04-20T12:00:00.000Z',
+          AmazonOrderId: 'ORDER-US-1',
+          ShipmentItemList: [
+            {
+              SellerSKU: 'SKU-US-1',
+              QuantityShipped: 1,
+              ItemChargeList: [
+                { ChargeType: 'Principal', ChargeAmount: { CurrencyCode: 'USD', CurrencyAmount: 10 } },
+                { ChargeType: 'ShippingCharge', ChargeAmount: { CurrencyCode: 'USD', CurrencyAmount: 2 } },
+              ],
+            },
+          ],
+        },
+      ],
+      RefundEventList: [
+        {
+          PostedDate: '2026-04-21T12:00:00.000Z',
+          AmazonOrderId: 'ORDER-US-2',
+          ShipmentItemAdjustmentList: [
+            {
+              SellerSKU: 'SKU-US-1',
+              QuantityShipped: 1,
+              ItemChargeAdjustmentList: [
+                { ChargeType: 'Principal', ChargeAmount: { CurrencyCode: 'USD', CurrencyAmount: -3 } },
+                { ChargeType: 'ShippingCharge', ChargeAmount: { CurrencyCode: 'USD', CurrencyAmount: -1 } },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    skuToBrandName: new Map([['SKU-US-1', 'US-PDS']]),
+    brandLabelByBrandName: new Map([['US-PDS', 'US-PDS']]),
+  });
+
+  const totals = draft.segments[0]!.memoTotalsCents;
+  assert.equal(totals.get('Amazon Sales - Principal'), 1000);
+  assert.equal(totals.get('Amazon Sales - Shipping'), 200);
+  assert.equal(totals.get('Amazon Refunds - Refunded Principal'), -300);
+  assert.equal(totals.get('Amazon Refunds - Refunded Shipping'), -100);
+  assert.equal(totals.has('Amazon Sales - Principal - US-PDS'), false);
+  assert.equal(totals.has('Amazon Refunds - Refunded Principal - US-PDS'), false);
 });
 
 test('buildUsSettlementDraftFromSpApiFinances splits cross-month settlement periods by default', () => {
@@ -2232,7 +2324,7 @@ test('buildUkSettlementDraftFromSpApiFinances validates marketplace VAT at order
     skuToBrandName: new Map([['SKU-1', 'UK-BRAND']]),
   });
 
-  const principalMemo = 'Amazon Sales - Principal (Marketplace VAT Responsible) - UK-BRAND';
+  const principalMemo = 'Amazon Sales - Principal (Marketplace VAT Responsible)';
   const principalCents = draft.segments[0]?.memoTotalsCents.get(principalMemo);
   assert.equal(principalCents, 3000);
 });
@@ -2288,7 +2380,7 @@ test('buildUkSettlementDraftFromSpApiFinances validates marketplace VAT at order
     skuToBrandName: new Map([['SKU-2', 'UK-BRAND']]),
   });
 
-  const principalMemo = 'Amazon Refunds - Refunded Principal (Marketplace VAT Responsible) - UK-BRAND';
+  const principalMemo = 'Amazon Refunds - Refunded Principal (Marketplace VAT Responsible)';
   const principalCents = draft.segments[0]?.memoTotalsCents.get(principalMemo);
   assert.equal(principalCents, -3000);
 });
@@ -4468,7 +4560,7 @@ test('successful US settlement payouts post to settlement control instead of ban
           endIsoDay: '2026-04-30',
           txnDate: '2026-04-30',
           docNumber: 'US-260416-260430-S1',
-          memoTotalsCents: new Map([['Amazon Sales - Principal - US-PDS', 11934]]),
+          memoTotalsCents: new Map([['Amazon Sales - Principal', 11934]]),
           auditRows: [],
         },
       ],
@@ -4477,7 +4569,7 @@ test('successful US settlement payouts post to settlement control instead of ban
     settlementControlAccountId: 'control',
     bankAccountId: 'bank',
     paymentAccountId: 'payment',
-    accountIdByMemo: new Map([['Amazon Sales - Principal - US-PDS', 'sales']]),
+    accountIdByMemo: new Map([['Amazon Sales - Principal', 'sales']]),
   });
 
   assert.equal(entries[0]!.lines.some((line) => line.accountId === 'bank'), false);
@@ -4509,7 +4601,7 @@ test('successful UK settlement payouts post to settlement control instead of ban
           endIsoDay: '2026-04-21',
           txnDate: '2026-04-21',
           docNumber: 'UK-260401-260421-S1',
-          memoTotalsCents: new Map([['Amazon Sales - Principal - UK-PDS', 1394696]]),
+          memoTotalsCents: new Map([['Amazon Sales - Principal', 1394696]]),
           auditRows: [],
         },
       ],
@@ -4518,7 +4610,7 @@ test('successful UK settlement payouts post to settlement control instead of ban
     settlementControlAccountId: 'control',
     bankAccountId: 'bank',
     paymentAccountId: 'payment',
-    accountIdByMemo: new Map([['Amazon Sales - Principal - UK-PDS', 'sales']]),
+    accountIdByMemo: new Map([['Amazon Sales - Principal', 'sales']]),
   });
 
   assert.equal(entries[0]!.lines.some((line) => line.accountId === 'bank'), false);


### PR DESCRIPTION
## Summary
- promote the Plutus settlement P&L simplification merged into dev in #5447
- carries parent-account settlement sales/refund posting, branded-account audit guard, and approval-gated historical repair tooling

## Verification already completed
- PR #5447 CI passed on dev
- live repair dry-run after apply: configChanges=[], journalChanges=[], unresolved=[]
- live settlement audit: processed=38, ok=38, notOk=0, deterministicNotOk=0
- local: pnpm -C apps/plutus test
- local: pnpm -C apps/plutus type-check
- local: pnpm -C apps/plutus lint
