### PR TITLE
[codex] Populate Plutus subledger from legacy data

### DIFF
--- a/apps/plutus/lib/plutus/subledger/backfill.ts
+++ b/apps/plutus/lib/plutus/subledger/backfill.ts
@@ -35,6 +35,24 @@ export type LegacyBillLineMappingRow = {
   quantity: number | null;
 };
 
+export type LegacyOrderSaleRow = {
+  id: string;
+  marketplace: string;
+  orderId: string;
+  sku: string;
+  saleDate: Date;
+  quantity: number;
+};
+
+export type LegacyOrderReturnRow = {
+  id: string;
+  marketplace: string;
+  orderId: string;
+  sku: string;
+  returnDate: Date;
+  quantity: number;
+};
+
 export type LegacySubledgerBackfillPlan = {
   productGroups: Array<{ code: string; name: string }>;
   canonicalProducts: Array<{ key: string; name: string; productGroupCode: string }>;
@@ -65,6 +83,16 @@ export type LegacySubledgerBackfillPlan = {
     sourceQboTxnId: string;
     sourceQboLineId: string;
   }>;
+  inventoryMovements: Array<{
+    canonicalProductKey: string | null;
+    marketplace: string;
+    movementType: 'SALE' | 'RETURN';
+    quantity: number;
+    movementDate: Date;
+    sourceType: 'ORDER_SALE' | 'ORDER_RETURN';
+    sourceId: string;
+    sourceLineId: string;
+  }>;
 };
 
 export type LegacySubledgerBackfillInput = {
@@ -72,6 +100,8 @@ export type LegacySubledgerBackfillInput = {
   skus: LegacySkuRow[];
   billMappings: LegacyBillMappingRow[];
   billLineMappings: LegacyBillLineMappingRow[];
+  orderSales?: LegacyOrderSaleRow[];
+  orderReturns?: LegacyOrderReturnRow[];
 };
 
 type PurchaseOrderSource = {
@@ -131,6 +161,22 @@ function sortBillLines(lines: LegacyBillLineMappingRow[]): LegacyBillLineMapping
     if (mappingComparison !== 0) return mappingComparison;
     const qboLineComparison = compareText(left.qboLineId, right.qboLineId);
     if (qboLineComparison !== 0) return qboLineComparison;
+    return compareText(left.id, right.id);
+  });
+}
+
+function sortOrderSales(rows: LegacyOrderSaleRow[]): LegacyOrderSaleRow[] {
+  return [...rows].sort((left, right) => {
+    const dateComparison = left.saleDate.getTime() - right.saleDate.getTime();
+    if (dateComparison !== 0) return dateComparison;
+    return compareText(left.id, right.id);
+  });
+}
+
+function sortOrderReturns(rows: LegacyOrderReturnRow[]): LegacyOrderReturnRow[] {
+  return [...rows].sort((left, right) => {
+    const dateComparison = left.returnDate.getTime() - right.returnDate.getTime();
+    if (dateComparison !== 0) return dateComparison;
     return compareText(left.id, right.id);
   });
 }
@@ -331,6 +377,47 @@ export function planLegacySubledgerBackfill(
     });
   }
 
+  const inventoryMovements: LegacySubledgerBackfillPlan['inventoryMovements'] = [];
+  for (const row of sortOrderSales(input.orderSales ?? [])) {
+    if (!(Number.isFinite(row.quantity) && row.quantity > 0)) continue;
+
+    const canonicalProductKey =
+      canonicalProductKeyByMarketplaceSku.get(
+        `${row.marketplace.trim()}:${normalizeAliasLookupValue(row.sku)}`,
+      ) ?? null;
+
+    inventoryMovements.push({
+      canonicalProductKey,
+      marketplace: row.marketplace.trim(),
+      movementType: 'SALE',
+      quantity: -Math.abs(row.quantity),
+      movementDate: row.saleDate,
+      sourceType: 'ORDER_SALE',
+      sourceId: row.orderId,
+      sourceLineId: row.id,
+    });
+  }
+
+  for (const row of sortOrderReturns(input.orderReturns ?? [])) {
+    if (!(Number.isFinite(row.quantity) && row.quantity > 0)) continue;
+
+    const canonicalProductKey =
+      canonicalProductKeyByMarketplaceSku.get(
+        `${row.marketplace.trim()}:${normalizeAliasLookupValue(row.sku)}`,
+      ) ?? null;
+
+    inventoryMovements.push({
+      canonicalProductKey,
+      marketplace: row.marketplace.trim(),
+      movementType: 'RETURN',
+      quantity: Math.abs(row.quantity),
+      movementDate: row.returnDate,
+      sourceType: 'ORDER_RETURN',
+      sourceId: row.orderId,
+      sourceLineId: row.id,
+    });
+  }
+
   return {
     productGroups: Array.from(productGroupsByCode.values()).sort((left, right) =>
       compareText(left.code, right.code),
@@ -358,6 +445,13 @@ export function planLegacySubledgerBackfill(
       const qboLineComparison = compareText(left.sourceQboLineId, right.sourceQboLineId);
       if (qboLineComparison !== 0) return qboLineComparison;
       return compareText(left.component, right.component);
+    }),
+    inventoryMovements: inventoryMovements.sort((left, right) => {
+      const dateComparison = left.movementDate.getTime() - right.movementDate.getTime();
+      if (dateComparison !== 0) return dateComparison;
+      const sourceTypeComparison = compareText(left.sourceType, right.sourceType);
+      if (sourceTypeComparison !== 0) return sourceTypeComparison;
+      return compareText(left.sourceLineId, right.sourceLineId);
     }),
   };
 }

--- a/apps/plutus/lib/plutus/subledger/sku-alias.ts
+++ b/apps/plutus/lib/plutus/subledger/sku-alias.ts
@@ -6,7 +6,7 @@ export type SkuAliasCandidate = {
 };
 
 export function normalizeAliasLookupValue(value: string): string {
-  return value.trim().toUpperCase();
+  return value.trim().toUpperCase().replace(/[^A-Z0-9]/g, '');
 }
 
 export function resolveCanonicalProductAlias(

--- a/apps/plutus/scripts/backfill-subledger-foundation.ts
+++ b/apps/plutus/scripts/backfill-subledger-foundation.ts
@@ -21,6 +21,8 @@ type BackfillSummary = {
   purchaseOrders: number;
   costLayers: number;
   unassignedCostLayers: number;
+  inventoryMovements: number;
+  unassignedInventoryMovements: number;
 };
 
 function parseDotenvLine(rawLine: string): { key: string; value: string } | null {
@@ -92,7 +94,7 @@ function parseArgs(argv: string[]): CliOptions {
 }
 
 async function buildBackfillPlan(db: PlutusDb): Promise<LegacySubledgerBackfillPlan> {
-  const [brands, skus, billMappings, billLineMappings] = await Promise.all([
+  const [brands, skus, billMappings, billLineMappings, orderSales, orderReturns] = await Promise.all([
     db.brand.findMany({
       select: {
         id: true,
@@ -132,6 +134,26 @@ async function buildBackfillPlan(db: PlutusDb): Promise<LegacySubledgerBackfillP
         quantity: true,
       },
     }),
+    db.orderSale.findMany({
+      select: {
+        id: true,
+        marketplace: true,
+        orderId: true,
+        sku: true,
+        saleDate: true,
+        quantity: true,
+      },
+    }),
+    db.orderReturn.findMany({
+      select: {
+        id: true,
+        marketplace: true,
+        orderId: true,
+        sku: true,
+        returnDate: true,
+        quantity: true,
+      },
+    }),
   ]);
 
   return planLegacySubledgerBackfill({
@@ -139,6 +161,8 @@ async function buildBackfillPlan(db: PlutusDb): Promise<LegacySubledgerBackfillP
     skus,
     billMappings,
     billLineMappings,
+    orderSales,
+    orderReturns,
   });
 }
 
@@ -152,6 +176,10 @@ function summarizeBackfillPlan(plan: LegacySubledgerBackfillPlan, apply: boolean
     costLayers: plan.costLayers.length,
     unassignedCostLayers: plan.costLayers.filter((layer) => layer.canonicalProductKey === null)
       .length,
+    inventoryMovements: plan.inventoryMovements.length,
+    unassignedInventoryMovements: plan.inventoryMovements.filter(
+      (movement) => movement.canonicalProductKey === null,
+    ).length,
   };
 }
 
@@ -226,6 +254,19 @@ function getRequiredMapValue(map: Map<string, string>, key: string, label: strin
 }
 
 async function applyBackfillPlan(db: PlutusDb, plan: LegacySubledgerBackfillPlan): Promise<void> {
+  const unassignedInventoryMovements = plan.inventoryMovements.filter(
+    (movement) => movement.canonicalProductKey === null,
+  );
+  if (unassignedInventoryMovements.length > 0) {
+    const sample = unassignedInventoryMovements
+      .slice(0, 10)
+      .map((movement) => `${movement.marketplace}:${movement.sourceType}:${movement.sourceId}`)
+      .join(', ');
+    throw new Error(
+      `Cannot apply subledger backfill with ${unassignedInventoryMovements.length} unassigned inventory movements. Sample: ${sample}`,
+    );
+  }
+
   await db.$transaction(async (tx) => {
     const productGroupIdByCode = new Map<string, string>();
     for (const productGroup of plan.productGroups) {
@@ -392,6 +433,35 @@ async function applyBackfillPlan(db: PlutusDb, plan: LegacySubledgerBackfillPlan
       await tx.poCostLayer.update({
         where: { id: existingLayers[0]!.id },
         data,
+      });
+    }
+
+    await tx.inventoryMovement.deleteMany({
+      where: {
+        sourceType: {
+          in: ['ORDER_SALE', 'ORDER_RETURN'],
+        },
+      },
+    });
+
+    const movementRows = plan.inventoryMovements.map((movement) => ({
+      canonicalProductId: getRequiredMapValue(
+        canonicalProductIdByKey,
+        movement.canonicalProductKey!,
+        'canonical product',
+      ),
+      marketplace: movement.marketplace,
+      movementType: movement.movementType,
+      quantity: movement.quantity,
+      movementDate: movement.movementDate,
+      sourceType: movement.sourceType,
+      sourceId: movement.sourceId,
+      sourceLineId: movement.sourceLineId,
+    }));
+
+    for (let i = 0; i < movementRows.length; i += 1000) {
+      await tx.inventoryMovement.createMany({
+        data: movementRows.slice(i, i + 1000),
       });
     }
   });

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -367,7 +367,8 @@ test('FIFO inventory movement consumes PO cost layers deterministically', () => 
 test('legacy subledger backfill groups current Brand and Sku rows without false PO merges', () => {
   assert.equal(mapLegacyBrandNameToProductGroupCode('US-PDS'), 'PDS');
   assert.equal(mapLegacyBrandNameToProductGroupCode('UK-CDS'), 'CDS');
-  assert.equal(normalizeAliasValue(' cs-007 '), 'CS-007');
+  assert.equal(normalizeAliasValue(' cs-007 '), 'CS007');
+  assert.equal(normalizeAliasValue('CS 007'), normalizeAliasValue('CS-007'));
 
   const plan = planLegacySubledgerBackfill({
     brands: [
@@ -380,6 +381,26 @@ test('legacy subledger backfill groups current Brand and Sku rows without false 
     ],
     billMappings: [],
     billLineMappings: [],
+    orderSales: [
+      {
+        id: 'sale_uk',
+        marketplace: 'amazon.co.uk',
+        orderId: 'ORDER-1',
+        sku: 'CS-007',
+        saleDate: new Date('2026-04-01T00:00:00.000Z'),
+        quantity: 2,
+      },
+    ],
+    orderReturns: [
+      {
+        id: 'return_uk',
+        marketplace: 'amazon.co.uk',
+        orderId: 'ORDER-1',
+        sku: 'CS-007',
+        returnDate: new Date('2026-04-02T00:00:00.000Z'),
+        quantity: 1,
+      },
+    ],
   });
 
   assert.deepEqual(plan.productGroups.map((group) => group.code), ['PDS']);
@@ -391,6 +412,40 @@ test('legacy subledger backfill groups current Brand and Sku rows without false 
       ['amazon.co.uk', 'SKU', 'CS 007'],
       ['amazon.com', 'ASIN', 'B09HXC3NL8'],
       ['amazon.com', 'SKU', 'CS-007'],
+    ],
+  );
+  assert.deepEqual(
+    plan.inventoryMovements.map((movement) => ({
+      canonicalProductKey: movement.canonicalProductKey,
+      marketplace: movement.marketplace,
+      movementType: movement.movementType,
+      quantity: movement.quantity,
+      movementDate: movement.movementDate.toISOString(),
+      sourceType: movement.sourceType,
+      sourceId: movement.sourceId,
+      sourceLineId: movement.sourceLineId,
+    })),
+    [
+      {
+        canonicalProductKey: 'ASIN:B09HXC3NL8',
+        marketplace: 'amazon.co.uk',
+        movementType: 'SALE',
+        quantity: -2,
+        movementDate: '2026-04-01T00:00:00.000Z',
+        sourceType: 'ORDER_SALE',
+        sourceId: 'ORDER-1',
+        sourceLineId: 'sale_uk',
+      },
+      {
+        canonicalProductKey: 'ASIN:B09HXC3NL8',
+        marketplace: 'amazon.co.uk',
+        movementType: 'RETURN',
+        quantity: 1,
+        movementDate: '2026-04-02T00:00:00.000Z',
+        sourceType: 'ORDER_RETURN',
+        sourceId: 'ORDER-1',
+        sourceLineId: 'return_uk',
+      },
     ],
   );
 });


### PR DESCRIPTION
## Summary
- populate the Plutus persistent subledger from legacy Brand/Sku/BillMapping/BillLineMapping data and historical OrderSale/OrderReturn rows
- normalize SKU aliases without punctuation so UK settlement SKUs like CS-007 match configured aliases like CS 007
- make the backfill fail closed when sale/return movements cannot map to a canonical product

## Root cause
The new Products, Purchase Orders, and Inventory Ledger pages read the persistent subledger tables, but the migration/backfill only populated product and PO cost-layer foundations. InventoryMovement rows were never generated, and separator-sensitive alias matching left historical UK sales unresolved.

## Validation
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint
- pnpm -C apps/plutus exec tsx scripts/backfill-subledger-foundation.ts
