### PR TITLE
Block Plutus COGS without trace metadata

### DIFF
--- a/apps/plutus/lib/plutus/journal-builder.ts
+++ b/apps/plutus/lib/plutus/journal-builder.ts
@@ -3,36 +3,74 @@ import type { InventoryComponent } from '@/lib/inventory/ledger';
 import type { ProcessingBlock, JournalEntryLinePreview } from './settlement-types';
 import { findRequiredSubAccountId } from './settlement-validation';
 
-function formatCents(cents: number): string {
-  const sign = cents < 0 ? '-' : '';
-  const abs = Math.abs(cents);
-  return `${sign}$${(abs / 100).toFixed(2)}`;
+export type CogsTraceLine = {
+  sku: string;
+  internalPo: string;
+  externalPi: string;
+  amountCents: number;
+};
+
+export type CogsTraceLinesByBrandComponent = Partial<Record<string, Partial<Record<InventoryComponent, CogsTraceLine[]>>>>;
+
+function componentLabels(component: InventoryComponent): {
+  invParentKey: string;
+  cogsParentKey: string;
+  invLabel: string;
+  cogsLabel: string;
+} {
+  if (component === 'manufacturing') {
+    return {
+      invParentKey: 'invManufacturing',
+      cogsParentKey: 'cogsManufacturing',
+      invLabel: 'Manufacturing',
+      cogsLabel: 'Manufacturing',
+    };
+  }
+  if (component === 'freight') {
+    return {
+      invParentKey: 'invFreight',
+      cogsParentKey: 'cogsFreight',
+      invLabel: 'Freight',
+      cogsLabel: 'Freight',
+    };
+  }
+  if (component === 'duty') {
+    return {
+      invParentKey: 'invDuty',
+      cogsParentKey: 'cogsDuty',
+      invLabel: 'Duty',
+      cogsLabel: 'Duty',
+    };
+  }
+
+  return {
+    invParentKey: 'invMfgAccessories',
+    cogsParentKey: 'cogsMfgAccessories',
+    invLabel: 'Mfg Accessories',
+    cogsLabel: 'Mfg Accessories',
+  };
 }
 
-function buildSkuBreakdownSuffix(skuBreakdown: Record<string, number> | undefined): string {
-  if (!skuBreakdown) {
-    return '';
-  }
+function hasRequiredTraceValue(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed !== '' && trimmed.toUpperCase() !== 'N/A';
+}
 
-  const entries = Object.entries(skuBreakdown).filter((entry) => entry[1] !== 0);
-  if (entries.length === 0) {
-    return '';
-  }
+function traceDescription(label: string, suffix: string, trace: CogsTraceLine): string {
+  return `${label}${suffix}; SKU: ${trace.sku.trim()}; Internal PO: ${trace.internalPo.trim()}; External PI: ${trace.externalPi.trim()}`;
+}
 
-  entries.sort((a, b) => {
-    const delta = Math.abs(b[1]) - Math.abs(a[1]);
-    if (delta !== 0) return delta;
-    return a[0].localeCompare(b[0]);
+function addTraceBlock(
+  blocks: ProcessingBlock[],
+  brand: string,
+  component: InventoryComponent,
+  details: Record<string, string | number>,
+): void {
+  blocks.push({
+    code: 'COGS_TRACE_METADATA_MISSING',
+    message: 'COGS line missing SKU PO PI trace metadata',
+    details: { brand, component, ...details },
   });
-
-  const maxShown = 4;
-  const shown = entries.slice(0, maxShown).map((entry) => `${entry[0]}:${formatCents(entry[1])}`);
-  const hiddenCount = entries.length - shown.length;
-  if (hiddenCount > 0) {
-    shown.push(`+${hiddenCount} more`);
-  }
-
-  return ` | SKUs ${shown.join(', ')}`;
 }
 
 export function buildCogsJournalLines(
@@ -42,7 +80,8 @@ export function buildCogsJournalLines(
   accounts: QboAccount[],
   _invoiceId: string,
   blocks: ProcessingBlock[],
-  skuBreakdownByBrandComponent?: Record<string, Record<InventoryComponent, Record<string, number>>>,
+  _skuBreakdownByBrandComponent?: Record<string, Record<InventoryComponent, Record<string, number>>>,
+  traceLinesByBrandComponent?: CogsTraceLinesByBrandComponent,
 ): JournalEntryLinePreview[] {
   const cogsLines: JournalEntryLinePreview[] = [];
 
@@ -54,41 +93,7 @@ export function buildCogsJournalLines(
       const cents = componentTotals[component];
       if (cents === 0) continue;
 
-      const invParentKey =
-        component === 'manufacturing'
-          ? 'invManufacturing'
-          : component === 'freight'
-            ? 'invFreight'
-            : component === 'duty'
-              ? 'invDuty'
-              : 'invMfgAccessories';
-
-      const cogsParentKey =
-        component === 'manufacturing'
-          ? 'cogsManufacturing'
-          : component === 'freight'
-            ? 'cogsFreight'
-            : component === 'duty'
-              ? 'cogsDuty'
-              : 'cogsMfgAccessories';
-
-      const invLabel =
-        component === 'manufacturing'
-          ? 'Manufacturing'
-          : component === 'freight'
-            ? 'Freight'
-            : component === 'duty'
-              ? 'Duty'
-              : 'Mfg Accessories';
-
-      const cogsLabel =
-        component === 'manufacturing'
-          ? 'Manufacturing'
-          : component === 'freight'
-            ? 'Freight'
-            : component === 'duty'
-              ? 'Duty'
-              : 'Mfg Accessories';
+      const { invParentKey, cogsParentKey, invLabel, cogsLabel } = componentLabels(component);
 
       const invSubName = `${invLabel} - ${brand}`;
       const cogsSubName = `${cogsLabel} - ${brand}`;
@@ -112,40 +117,71 @@ export function buildCogsJournalLines(
         continue;
       }
 
-      const absCents = Math.abs(cents);
-      const componentBreakdown = skuBreakdownByBrandComponent ? skuBreakdownByBrandComponent[brand] : undefined;
-      const skuBreakdown = componentBreakdown ? componentBreakdown[component] : undefined;
-      const skuSuffix = buildSkuBreakdownSuffix(skuBreakdown);
-      if (cents > 0) {
-        // Sale: Debit COGS, Credit Inventory
-        cogsLines.push({
-          accountId: cogsAccount.id,
-          accountName: cogsAccount.name,
-          accountFullyQualifiedName: cogsAccount.fullyQualifiedName,
-          accountNumber: cogsAccount.acctNum,
-          postingType: 'Debit',
-          amountCents: absCents,
-          description: `${cogsLabel} COGS${skuSuffix}`,
-        });
+      const traceByComponent = traceLinesByBrandComponent ? traceLinesByBrandComponent[brand] : undefined;
+      const traceLines = traceByComponent ? traceByComponent[component] : undefined;
+      if (!traceLines || traceLines.length === 0) {
+        addTraceBlock(blocks, brand, component, { expectedCents: cents });
+        continue;
+      }
+
+      let traceCents = 0;
+      let hasInvalidTrace = false;
+      traceLines.forEach((trace, index) => {
+        if (
+          !hasRequiredTraceValue(trace.sku) ||
+          !hasRequiredTraceValue(trace.internalPo) ||
+          !hasRequiredTraceValue(trace.externalPi) ||
+          !Number.isFinite(trace.amountCents) ||
+          !Number.isInteger(trace.amountCents) ||
+          trace.amountCents === 0
+        ) {
+          hasInvalidTrace = true;
+          addTraceBlock(blocks, brand, component, { traceIndex: index });
+        }
+        traceCents += trace.amountCents;
+      });
+      if (hasInvalidTrace) {
+        continue;
+      }
+      if (traceCents !== cents) {
+        addTraceBlock(blocks, brand, component, { expectedCents: cents, traceCents });
+        continue;
+      }
+
+      for (const trace of traceLines) {
+        const absCents = Math.abs(trace.amountCents);
+        if (trace.amountCents > 0) {
+          // Sale: Debit COGS, Credit Inventory.
+          cogsLines.push({
+            accountId: cogsAccount.id,
+            accountName: cogsAccount.name,
+            accountFullyQualifiedName: cogsAccount.fullyQualifiedName,
+            accountNumber: cogsAccount.acctNum,
+            postingType: 'Debit',
+            amountCents: absCents,
+            description: traceDescription(`${cogsLabel} COGS`, '', trace),
+          });
+          cogsLines.push({
+            accountId: invAccount.id,
+            accountName: invAccount.name,
+            accountFullyQualifiedName: invAccount.fullyQualifiedName,
+            accountNumber: invAccount.acctNum,
+            postingType: 'Credit',
+            amountCents: absCents,
+            description: traceDescription(`${invLabel} inventory`, '', trace),
+          });
+          continue;
+        }
+
+        // Return: Debit Inventory, Credit COGS.
         cogsLines.push({
           accountId: invAccount.id,
           accountName: invAccount.name,
           accountFullyQualifiedName: invAccount.fullyQualifiedName,
           accountNumber: invAccount.acctNum,
-          postingType: 'Credit',
-          amountCents: absCents,
-          description: `${invLabel} inventory${skuSuffix}`,
-        });
-      } else {
-        // Return: Debit Inventory, Credit COGS
-        cogsLines.push({
-          accountId: invAccount.id,
-          accountName: invAccount.name,
-          accountFullyQualifiedName: invAccount.fullyQualifiedName,
-          accountNumber: invAccount.acctNum,
           postingType: 'Debit',
           amountCents: absCents,
-          description: `${invLabel} inventory (return)${skuSuffix}`,
+          description: traceDescription(`${invLabel} inventory`, ' (return)', trace),
         });
         cogsLines.push({
           accountId: cogsAccount.id,
@@ -154,7 +190,7 @@ export function buildCogsJournalLines(
           accountNumber: cogsAccount.acctNum,
           postingType: 'Credit',
           amountCents: absCents,
-          description: `${cogsLabel} COGS (return)${skuSuffix}`,
+          description: traceDescription(`${cogsLabel} COGS`, ' (return)', trace),
         });
       }
     }

--- a/apps/plutus/lib/plutus/settlement-types.ts
+++ b/apps/plutus/lib/plutus/settlement-types.ts
@@ -9,6 +9,7 @@ export type ProcessingBlock =
         | 'AUDIT_NET_SCALE_SUSPECT'
         | 'MISSING_ACCOUNT_MAPPING'
         | 'MISSING_BRAND_SUBACCOUNT'
+        | 'COGS_TRACE_METADATA_MISSING'
         | 'ALREADY_PROCESSED'
         | 'INVOICE_CONFLICT'
         | 'ORDER_ALREADY_PROCESSED'

--- a/apps/plutus/lib/qbo/full-history-audit/normalize.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/normalize.ts
@@ -21,42 +21,50 @@ type QboTransfer = {
   };
 };
 
-function collectPurchasePostingAccounts(purchase: QboPurchase): string[] {
-  const accounts: string[] = [];
+type NormalizedPostingLine = NonNullable<NormalizedAuditTransaction['postingLines']>[number];
+type ExpenseLineForAudit = {
+  Description?: string;
+  AccountBasedExpenseLineDetail?: {
+    AccountRef: {
+      name?: string;
+    };
+  };
+  ItemBasedExpenseLineDetail?: {
+    AccountRef?: {
+      name?: string;
+    };
+  };
+};
 
-  for (const line of purchase.Line ?? []) {
-    const accountName =
-      line.AccountBasedExpenseLineDetail?.AccountRef.name ??
-      line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
-      null;
+function expenseLineAccountName(line: ExpenseLineForAudit): string | null {
+  return (
+    line.AccountBasedExpenseLineDetail?.AccountRef.name ??
+    line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
+    null
+  );
+}
 
+function collectExpensePostingLines(lines: ExpenseLineForAudit[]): NormalizedPostingLine[] {
+  const postingLines: NormalizedPostingLine[] = [];
+
+  for (const line of lines) {
+    const accountName = expenseLineAccountName(line);
     if (accountName !== null) {
-      accounts.push(accountName);
+      postingLines.push({
+        account: accountName,
+        description: line.Description ?? '',
+      });
     }
   }
 
-  return accounts;
+  return postingLines;
 }
 
-function collectJournalEntryPostingAccounts(journalEntry: QboJournalEntry): string[] {
-  return journalEntry.Line.map((line) => line.JournalEntryLineDetail.AccountRef.name ?? '');
-}
-
-function collectBillPostingAccounts(bill: QboBill): string[] {
-  const accounts: string[] = [];
-
-  for (const line of bill.Line ?? []) {
-    const accountName =
-      line.AccountBasedExpenseLineDetail?.AccountRef.name ??
-      line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
-      null;
-
-    if (accountName !== null) {
-      accounts.push(accountName);
-    }
-  }
-
-  return accounts;
+function collectJournalEntryPostingLines(journalEntry: QboJournalEntry): NormalizedPostingLine[] {
+  return journalEntry.Line.map((line) => ({
+    account: line.JournalEntryLineDetail.AccountRef.name ?? '',
+    description: line.Description ?? '',
+  }));
 }
 
 function collectTransferPostingAccounts(transfer: QboTransfer): string[] {
@@ -84,6 +92,8 @@ export function normalizePurchaseForAudit(
   purchase: QboPurchase,
   attachmentFileNames: string[],
 ): NormalizedAuditTransaction {
+  const postingLines = collectExpensePostingLines(purchase.Line ?? []);
+
   return {
     transactionType: 'Purchase',
     transactionId: purchase.Id,
@@ -94,8 +104,9 @@ export function normalizePurchaseForAudit(
     docNumber: purchase.DocNumber ?? null,
     privateNote: purchase.PrivateNote ?? null,
     dueDate: null,
-    postingAccounts: collectPurchasePostingAccounts(purchase),
+    postingAccounts: postingLines.map((line) => line.account),
     lineDescriptions: collectLineDescriptions(purchase.Line ?? []),
+    postingLines,
     attachmentFileNames,
     isInReconciledPeriod: null,
     lastUpdatedTime: purchase.MetaData?.LastUpdatedTime ?? null,
@@ -107,6 +118,8 @@ export function normalizeJournalEntryForAudit(
   journalEntry: QboJournalEntry,
   attachmentFileNames: string[],
 ): NormalizedAuditTransaction {
+  const postingLines = collectJournalEntryPostingLines(journalEntry);
+
   return {
     transactionType: 'JournalEntry',
     transactionId: journalEntry.Id,
@@ -117,8 +130,9 @@ export function normalizeJournalEntryForAudit(
     docNumber: journalEntry.DocNumber ?? null,
     privateNote: journalEntry.PrivateNote ?? null,
     dueDate: null,
-    postingAccounts: collectJournalEntryPostingAccounts(journalEntry),
+    postingAccounts: postingLines.map((line) => line.account),
     lineDescriptions: collectLineDescriptions(journalEntry.Line),
+    postingLines,
     attachmentFileNames,
     isInReconciledPeriod: null,
     lastUpdatedTime: journalEntry.MetaData?.LastUpdatedTime ?? null,
@@ -130,6 +144,8 @@ export function normalizeBillForAudit(
   bill: QboBill,
   attachmentFileNames: string[],
 ): NormalizedAuditTransaction {
+  const postingLines = collectExpensePostingLines(bill.Line ?? []);
+
   return {
     transactionType: 'Bill',
     transactionId: bill.Id,
@@ -140,8 +156,9 @@ export function normalizeBillForAudit(
     docNumber: bill.DocNumber ?? null,
     privateNote: bill.PrivateNote ?? null,
     dueDate: bill.DueDate ?? null,
-    postingAccounts: collectBillPostingAccounts(bill),
+    postingAccounts: postingLines.map((line) => line.account),
     lineDescriptions: collectLineDescriptions(bill.Line ?? []),
+    postingLines,
     attachmentFileNames,
     isInReconciledPeriod: null,
     lastUpdatedTime: bill.MetaData?.LastUpdatedTime ?? null,

--- a/apps/plutus/lib/qbo/full-history-audit/rules.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/rules.ts
@@ -125,6 +125,93 @@ function isBankFeeAccount(account: string): boolean {
   return ACCEPTED_FEE_ACCOUNT_CUES.some((cue) => lower.includes(cue));
 }
 
+function parseTraceFields(description: string): Map<string, string> {
+  const fields = new Map<string, string>();
+  for (const part of description.split(';')) {
+    const delimiterIndex = part.indexOf(':');
+    if (delimiterIndex === -1) {
+      continue;
+    }
+    const key = part.slice(0, delimiterIndex).trim().toLowerCase();
+    const value = part.slice(delimiterIndex + 1).trim();
+    if (key !== '') {
+      fields.set(key, value);
+    }
+  }
+  return fields;
+}
+
+function hasRequiredValue(value: string | undefined, allowNa: boolean): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    return false;
+  }
+  if (allowNa) {
+    return true;
+  }
+  return trimmed.toUpperCase() !== 'N/A';
+}
+
+function hasCogsTraceDescription(description: string): boolean {
+  const fields = parseTraceFields(description);
+  return (
+    hasRequiredValue(fields.get('sku'), false) &&
+    hasRequiredValue(fields.get('internal po'), false) &&
+    hasRequiredValue(fields.get('external pi'), false)
+  );
+}
+
+function hasWarehousingTraceDescription(description: string): boolean {
+  const fields = parseTraceFields(description);
+  return (
+    hasRequiredValue(fields.get('sku'), true) &&
+    hasRequiredValue(fields.get('internal po'), true) &&
+    hasRequiredValue(fields.get('external pi'), false) &&
+    hasRequiredValue(fields.get('service period'), false)
+  );
+}
+
+function isPlutusCogsTransaction(tx: NormalizedAuditTransaction): boolean {
+  if (tx.transactionType !== 'JournalEntry') {
+    return false;
+  }
+  if (tx.privateNote === null) {
+    return false;
+  }
+  return tx.privateNote.trim().toLowerCase().startsWith('plutus cogs |');
+}
+
+function hasMissingCogsTraceLine(tx: NormalizedAuditTransaction): boolean {
+  if (tx.lineDescriptions.length === 0) {
+    return true;
+  }
+  return tx.lineDescriptions.some((description) => !hasCogsTraceDescription(description));
+}
+
+function isWarehousingTraceAccount(account: string): boolean {
+  const lower = account.toLowerCase();
+  return ['warehousing:3pl', 'warehousing:awd', '3pl -', 'awd -'].some((cue) => lower.includes(cue));
+}
+
+function hasMissingWarehousingTraceLine(tx: NormalizedAuditTransaction): boolean {
+  const postingLines = tx.postingLines;
+  if (postingLines !== undefined && postingLines.length > 0) {
+    const warehousingLines = postingLines.filter((line) => isWarehousingTraceAccount(line.account));
+    if (warehousingLines.length === 0) {
+      return false;
+    }
+    return warehousingLines.some((line) => !hasWarehousingTraceDescription(line.description));
+  }
+
+  if (tx.lineDescriptions.length === 0) {
+    return true;
+  }
+  return tx.lineDescriptions.some((description) => !hasWarehousingTraceDescription(description));
+}
+
 function isLikelyBankCardFee(tx: NormalizedAuditTransaction): boolean {
   const text = `${tx.counterparty || ''} ${tx.privateNote || ''} ${tx.lineDescriptions.join(' ')}`.toLowerCase();
   const hasFeeCue = FEE_CUES.some((cue) => text.includes(cue));
@@ -222,6 +309,32 @@ export function classifyAuditExceptions(
         'Bill has no attachment.',
         'Attach the supporting invoice.',
         'missing',
+      );
+    }
+
+    if (isPlutusCogsTransaction(tx) && hasMissingCogsTraceLine(tx)) {
+      pushFinding(
+        findings,
+        tx,
+        'COGS_TRACE_METADATA_MISSING',
+        'traceability_controls',
+        'High',
+        'Plutus COGS journal line is missing SKU, Internal PO, or External PI trace metadata.',
+        'Regenerate from PO-layer inventory trace before posting.',
+        'not_required',
+      );
+    }
+
+    if (tx.postingAccounts.some((account) => isWarehousingTraceAccount(account)) && hasMissingWarehousingTraceLine(tx)) {
+      pushFinding(
+        findings,
+        tx,
+        'WAREHOUSING_TRACE_METADATA_MISSING',
+        'traceability_controls',
+        'High',
+        'Warehousing line is missing explicit SKU, Internal PO, External PI, or Service Period trace metadata.',
+        'Add SKU/Internal PO/External PI/Service Period trace to each warehousing line.',
+        'not_required',
       );
     }
 

--- a/apps/plutus/lib/qbo/full-history-audit/types.ts
+++ b/apps/plutus/lib/qbo/full-history-audit/types.ts
@@ -13,6 +13,8 @@ export type AuditRuleId =
   | 'OWNER_ACTIVITY_MISCLASSIFIED'
   | 'BANK_FEE_MISCLASSIFIED'
   | 'CURRENCY_COUNTERPARTY_MISMATCH'
+  | 'COGS_TRACE_METADATA_MISSING'
+  | 'WAREHOUSING_TRACE_METADATA_MISSING'
   | 'LIKELY_DUPLICATE'
   | 'UNRESOLVED_CONTROL_ACCOUNT_ACTIVITY'
   | 'POST_RECONCILE_MODIFICATION';
@@ -29,6 +31,10 @@ export interface NormalizedAuditTransaction {
   dueDate: string | null;
   postingAccounts: string[];
   lineDescriptions: string[];
+  postingLines?: Array<{
+    account: string;
+    description: string;
+  }>;
   attachmentFileNames: string[];
   isInReconciledPeriod: boolean | null;
   lastUpdatedTime: string | null;

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -2500,7 +2500,7 @@ test('buildUkSettlementDraftFromSpApiFinances still fails aggregate VAT mismatch
   );
 });
 
-test('buildCogsJournalLines includes SKU breakdown in descriptions', () => {
+test('buildCogsJournalLines blocks inventory COGS without SKU PO PI trace', () => {
   const blocks: ProcessingBlock[] = [];
   const accounts: QboAccount[] = [
     {
@@ -2565,10 +2565,99 @@ test('buildCogsJournalLines includes SKU breakdown in descriptions', () => {
     },
   );
 
-  assert.equal(lines.length, 2);
-  assert.equal(lines[0]?.description, 'Manufacturing COGS | SKUs CS-007:$82.30, CS-010:$41.15');
-  assert.equal(lines[1]?.description, 'Manufacturing inventory | SKUs CS-007:$82.30, CS-010:$41.15');
+  assert.equal(lines.length, 0);
+  assert.equal(blocks.length, 1);
+  assert.equal(blocks[0]?.code, 'COGS_TRACE_METADATA_MISSING');
+});
+
+test('buildCogsJournalLines emits one traced COGS pair per SKU PO PI layer', () => {
+  const blocks: ProcessingBlock[] = [];
+  const accounts: QboAccount[] = [
+    {
+      Id: '203',
+      SyncToken: '0',
+      Name: 'Manufacturing',
+      AccountType: 'Other Current Asset',
+      AccountSubType: 'Inventory',
+    },
+    {
+      Id: '211',
+      SyncToken: '0',
+      Name: 'Manufacturing',
+      AccountType: 'Cost of Goods Sold',
+      AccountSubType: 'SuppliesMaterialsCogs',
+    },
+    {
+      Id: '209',
+      SyncToken: '0',
+      Name: 'Manufacturing - US-PDS',
+      AccountType: 'Other Current Asset',
+      AccountSubType: 'Inventory',
+      ParentRef: { value: '203', name: 'Manufacturing' },
+    },
+    {
+      Id: '217',
+      SyncToken: '0',
+      Name: 'Manufacturing - US-PDS',
+      AccountType: 'Cost of Goods Sold',
+      AccountSubType: 'SuppliesMaterialsCogs',
+      ParentRef: { value: '211', name: 'Manufacturing' },
+    },
+  ];
+
+  const lines = buildCogsJournalLines(
+    {
+      'US-PDS': {
+        manufacturing: 12345,
+        freight: 0,
+        duty: 0,
+        mfgAccessories: 0,
+      },
+    },
+    ['US-PDS'],
+    {
+      invManufacturing: '203',
+      cogsManufacturing: '211',
+    },
+    accounts,
+    'INV-COGS-1',
+    blocks,
+    {
+      'US-PDS': {
+        manufacturing: {
+          'CS-007': 8230,
+          'CS-010': 4115,
+        },
+        freight: {},
+        duty: {},
+        mfgAccessories: {},
+      },
+    },
+    {
+      'US-PDS': {
+        manufacturing: [
+          { sku: 'CS-007', internalPo: 'PO-19-PDS', externalPi: 'PI-PDS-19', amountCents: 8230 },
+          { sku: 'CS-010', internalPo: 'PO-20-PDS', externalPi: 'PI-PDS-20', amountCents: 4115 },
+        ],
+      },
+    },
+  );
+
   assert.equal(blocks.length, 0);
+  assert.equal(lines.length, 4);
+  assert.equal(
+    lines[0]?.description,
+    'Manufacturing COGS; SKU: CS-007; Internal PO: PO-19-PDS; External PI: PI-PDS-19',
+  );
+  assert.equal(
+    lines[1]?.description,
+    'Manufacturing inventory; SKU: CS-007; Internal PO: PO-19-PDS; External PI: PI-PDS-19',
+  );
+  assert.equal(lines[2]?.amountCents, 4115);
+  assert.equal(
+    lines[2]?.description,
+    'Manufacturing COGS; SKU: CS-010; Internal PO: PO-20-PDS; External PI: PI-PDS-20',
+  );
 });
 
 test('settlement processing no longer builds brand or SKU P&L reclass lines', () => {
@@ -3989,6 +4078,136 @@ test('audit flags bank fee activity from note and line description cues', () => 
 
   const findings = classifyAuditExceptions([tx]);
   assert.deepEqual(ruleIds(findings), ['BANK_FEE_MISCLASSIFIED']);
+});
+
+test('audit flags Plutus COGS journal lines missing SKU PO PI trace', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'JournalEntry',
+    transactionId: 'COGS1',
+    txnDate: '2026-05-01',
+    amount: 123.45,
+    currency: 'USD',
+    counterparty: null,
+    docNumber: 'CUS-260501-S1',
+    privateNote: 'Plutus COGS | Invoice: US-260501-S1 | Hash: abc123',
+    dueDate: null,
+    postingAccounts: ['Manufacturing - US-PDS', 'Manufacturing - US-PDS'],
+    lineDescriptions: [
+      'Manufacturing COGS | SKUs CS-007:$82.30, CS-010:$41.15',
+      'Manufacturing inventory | SKUs CS-007:$82.30, CS-010:$41.15',
+    ],
+    attachmentFileNames: [],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-05-01T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(ruleIds(findings), ['COGS_TRACE_METADATA_MISSING']);
+});
+
+test('audit accepts traced Plutus COGS and period warehousing descriptions', () => {
+  const cogs: NormalizedAuditTransaction = {
+    transactionType: 'JournalEntry',
+    transactionId: 'COGS2',
+    txnDate: '2026-05-02',
+    amount: 82.3,
+    currency: 'USD',
+    counterparty: null,
+    docNumber: 'CUS-260502-S1',
+    privateNote: 'Plutus COGS | Invoice: US-260502-S1 | Hash: abc123',
+    dueDate: null,
+    postingAccounts: ['Manufacturing - US-PDS', 'Manufacturing - US-PDS'],
+    lineDescriptions: [
+      'Manufacturing COGS; SKU: CS-007; Internal PO: PO-19-PDS; External PI: PI-PDS-19',
+      'Manufacturing inventory; SKU: CS-007; Internal PO: PO-19-PDS; External PI: PI-PDS-19',
+    ],
+    attachmentFileNames: [],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-05-02T10:00:00Z',
+    sourceTag: null,
+  };
+  const warehousing: NormalizedAuditTransaction = {
+    transactionType: 'Bill',
+    transactionId: 'WH1',
+    txnDate: '2026-05-03',
+    amount: 77,
+    currency: 'USD',
+    counterparty: '3PL Warehouse',
+    docNumber: 'WH-2026-W17',
+    privateNote: 'Weekly 3PL charges',
+    dueDate: '2026-05-10',
+    postingAccounts: ['Warehousing:3PL:3PL - US-PDS'],
+    lineDescriptions: [
+      'SKU: N/A; Internal PO: N/A; External PI: WH-2026-W17; Service Period: W17 2026',
+    ],
+    attachmentFileNames: ['wh-2026-w17.pdf'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-05-03T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([cogs, warehousing]);
+  assert.deepEqual(ruleIds(findings), []);
+});
+
+test('audit flags warehousing lines missing explicit period trace', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Bill',
+    transactionId: 'WH2',
+    txnDate: '2026-05-04',
+    amount: 99,
+    currency: 'USD',
+    counterparty: '3PL Warehouse',
+    docNumber: 'WH-2026-W18',
+    privateNote: 'Weekly 3PL charges',
+    dueDate: '2026-05-11',
+    postingAccounts: ['Warehousing:3PL:3PL - US-PDS'],
+    lineDescriptions: ['Charges for week 18 2026'],
+    attachmentFileNames: ['wh-2026-w18.pdf'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-05-04T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(ruleIds(findings), ['WAREHOUSING_TRACE_METADATA_MISSING']);
+});
+
+test('audit validates warehousing trace only on warehousing lines in mixed bills', () => {
+  const tx: NormalizedAuditTransaction = {
+    transactionType: 'Bill',
+    transactionId: 'WH3',
+    txnDate: '2026-05-05',
+    amount: 150,
+    currency: 'USD',
+    counterparty: '3PL Warehouse',
+    docNumber: 'WH-2026-W19',
+    privateNote: 'Weekly 3PL and supplies',
+    dueDate: '2026-05-12',
+    postingAccounts: ['Warehousing:3PL:3PL - US-PDS', 'Office Supplies'],
+    lineDescriptions: [
+      'SKU: N/A; Internal PO: N/A; External PI: WH-2026-W19; Service Period: W19 2026',
+      'Tape and labels',
+    ],
+    postingLines: [
+      {
+        account: 'Warehousing:3PL:3PL - US-PDS',
+        description: 'SKU: N/A; Internal PO: N/A; External PI: WH-2026-W19; Service Period: W19 2026',
+      },
+      {
+        account: 'Office Supplies',
+        description: 'Tape and labels',
+      },
+    ],
+    attachmentFileNames: ['wh-2026-w19.pdf'],
+    isInReconciledPeriod: false,
+    lastUpdatedTime: '2026-05-05T10:00:00Z',
+    sourceTag: null,
+  };
+
+  const findings = classifyAuditExceptions([tx]);
+  assert.deepEqual(ruleIds(findings), []);
 });
 
 test('audit accepts merchant processing fee accounts', () => {


### PR DESCRIPTION
## Summary
- require SKU/Internal PO/External PI trace rows before Plutus emits inventory COGS lines
- emit one QBO COGS/inventory line pair per traced SKU/PO/PI layer
- add QBO full-history audit rules for missing Plutus COGS and warehousing trace metadata

## Verification
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint