### PR TITLE
Simplify Plutus purchase order view

### DIFF
--- a/apps/plutus/app/api/plutus/purchase-orders/route.ts
+++ b/apps/plutus/app/api/plutus/purchase-orders/route.ts
@@ -41,6 +41,20 @@ export async function GET() {
                 id: true,
                 name: true,
                 active: true,
+                aliases: {
+                  orderBy: [
+                    { marketplace: 'asc' },
+                    { aliasType: 'asc' },
+                    { value: 'asc' },
+                    { id: 'asc' },
+                  ],
+                  select: {
+                    marketplace: true,
+                    aliasType: true,
+                    value: true,
+                    active: true,
+                  },
+                },
                 productGroup: {
                   select: {
                     id: true,
@@ -61,7 +75,6 @@ export async function GET() {
       supplierRef: row.supplierRef,
       marketplace: row.marketplace,
       status: row.status,
-      totalAmountCents: row.costLayers.reduce((sum, layer) => sum + layer.amountCents, 0),
       costLayers: row.costLayers.map((layer) => ({
         id: layer.id,
         component: layer.component,

--- a/apps/plutus/components/subledger/purchase-orders-page.tsx
+++ b/apps/plutus/components/subledger/purchase-orders-page.tsx
@@ -14,13 +14,18 @@ import Typography from '@mui/material/Typography';
 
 import { PageHeader } from '@/components/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
+import {
+  buildPurchaseOrderCurrencyTotals,
+  buildPurchaseOrderProductSummaries,
+  type PurchaseOrderProductLayer,
+} from '@/lib/plutus/purchase-orders-view';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 if (basePath === undefined) {
   throw new Error('NEXT_PUBLIC_BASE_PATH is required');
 }
 
-type CostLayer = {
+type CostLayer = PurchaseOrderProductLayer & {
   id: string;
   component: string;
   quantity: number | null;
@@ -41,6 +46,12 @@ type CostLayer = {
       code: string;
       name: string;
     };
+    aliases: Array<{
+      marketplace: string;
+      aliasType: string;
+      value: string;
+      active: boolean;
+    }>;
   };
 };
 
@@ -50,7 +61,6 @@ type PurchaseOrderRow = {
   supplierRef: string | null;
   marketplace: string | null;
   status: string;
-  totalAmountCents: number;
   costLayers: CostLayer[];
 };
 
@@ -103,9 +113,9 @@ function formatCents(amountCents: number, currency: string) {
 }
 
 function formatPurchaseOrderTotal(order: PurchaseOrderRow) {
-  const firstLayer = order.costLayers[0];
-  if (firstLayer === undefined) return '-';
-  return formatCents(order.totalAmountCents, firstLayer.currency);
+  const totals = buildPurchaseOrderCurrencyTotals(order.costLayers);
+  if (totals.length === 0) return '-';
+  return totals.map((total) => formatCents(total.amountCents, total.currency)).join(' / ');
 }
 
 function StatusChip({ status }: { status: string }) {
@@ -123,38 +133,61 @@ function StatusChip({ status }: { status: string }) {
   );
 }
 
-function LayerSummary({ layer }: { layer: CostLayer }) {
-  const quantity = layer.quantity === null ? '-' : new Intl.NumberFormat('en-US').format(layer.quantity);
-
-  return (
-    <Box sx={{ display: 'grid', gridTemplateColumns: '104px minmax(160px, 1fr) 96px', gap: 1.25, alignItems: 'baseline' }}>
-      <Typography sx={{ fontSize: '0.75rem', fontWeight: 700, color: 'text.primary' }}>{layer.component}</Typography>
-      <Typography sx={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: '0.8125rem', color: 'text.primary' }}>
-        {layer.product.productGroup.code} / {layer.product.name}
-      </Typography>
-      <Typography sx={{ textAlign: 'right', fontSize: '0.8125rem', fontWeight: 600, color: 'text.primary', fontVariantNumeric: 'tabular-nums' }}>
-        {formatCents(layer.amountCents, layer.currency)}
-      </Typography>
-      <Typography sx={quietTextSx}>Qty {quantity}</Typography>
-      <Typography sx={quietTextSx}>{layer.allocationMethod}</Typography>
-      <Box />
-    </Box>
-  );
+function formatQuantity(quantity: number | null) {
+  if (quantity === null) return '-';
+  return new Intl.NumberFormat('en-US').format(quantity);
 }
 
-function QboSourceSummary({ layer }: { layer: CostLayer }) {
-  const hasQboTxn = layer.sourceQboTxnType !== null && layer.sourceQboTxnId !== null;
-  const txn = hasQboTxn ? `${layer.sourceQboTxnType} ${layer.sourceQboTxnId}` : '-';
-  const line = layer.sourceQboLineId === null ? '-' : `Line ${layer.sourceQboLineId}`;
-  const document = layer.sourceDocumentName === null ? '-' : layer.sourceDocumentName;
+function formatComponentLabel(component: string) {
+  if (component === 'mfgAccessories') return 'Accessories';
+  return component.slice(0, 1).toUpperCase() + component.slice(1);
+}
+
+function ProductSummary({ order }: { order: PurchaseOrderRow }) {
+  const products = buildPurchaseOrderProductSummaries(order.marketplace, order.costLayers);
 
   return (
-    <Box sx={{ display: 'grid', gap: 0.25 }}>
-      <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary' }}>{txn}</Typography>
-      <Typography sx={quietTextSx}>{line}</Typography>
-      <Typography title={document} sx={{ ...quietTextSx, maxWidth: 260, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-        {document}
-      </Typography>
+    <Box sx={{ display: 'grid', gap: 1.25 }}>
+      {products.map((product) => (
+        <Box
+          key={product.key}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', md: 'minmax(220px, 1fr) 120px 132px' },
+            gap: { xs: 0.5, md: 1.5 },
+            alignItems: 'start',
+          }}
+        >
+          <Box sx={{ minWidth: 0 }}>
+            <Typography sx={{ fontSize: '0.875rem', fontWeight: 700, color: 'text.primary' }}>
+              {product.groupCode} / {product.sku}
+            </Typography>
+            <Typography sx={{ ...quietTextSx, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {product.productName}
+            </Typography>
+          </Box>
+          <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary', fontVariantNumeric: 'tabular-nums' }}>
+            Qty {formatQuantity(product.quantity)}
+          </Typography>
+          <Typography sx={{ textAlign: { xs: 'left', md: 'right' }, fontSize: '0.875rem', fontWeight: 700, color: 'text.primary', fontVariantNumeric: 'tabular-nums' }}>
+            {formatCents(product.totalAmountCents, product.currency)}
+          </Typography>
+          <Box sx={{ gridColumn: { xs: 'auto', md: '1 / -1' }, display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+            {product.componentAmounts.map((component) => (
+              <Chip
+                key={component.component}
+                label={`${formatComponentLabel(component.component)} ${formatCents(component.amountCents, product.currency)}`}
+                size="small"
+                variant="outlined"
+                sx={{ borderRadius: 1, height: 22, fontSize: '0.6875rem' }}
+              />
+            ))}
+          </Box>
+        </Box>
+      ))}
+      {products.length === 0 && (
+        <Typography sx={quietTextSx}>No SKU layers</Typography>
+      )}
     </Box>
   );
 }
@@ -174,15 +207,14 @@ export function PurchaseOrdersPage() {
 
       <Box sx={tableWrapSx}>
         <Box sx={{ overflowX: 'auto' }}>
-          <Table size="small" sx={{ minWidth: 1160 }}>
+          <Table size="small" sx={{ minWidth: 960 }}>
             <TableHead>
               <TableRow>
                 <TableCell sx={headCellSx}>PO</TableCell>
-                <TableCell sx={headCellSx}>Market</TableCell>
-                <TableCell sx={headCellSx}>Status</TableCell>
+                <TableCell sx={headCellSx}>Market / Supplier Ref</TableCell>
+                <TableCell sx={headCellSx}>Products</TableCell>
                 <TableCell sx={{ ...headCellSx, textAlign: 'right' }}>Total</TableCell>
-                <TableCell sx={headCellSx}>Cost Layers</TableCell>
-                <TableCell sx={headCellSx}>QBO Source</TableCell>
+                <TableCell sx={headCellSx}>Status</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -190,7 +222,7 @@ export function PurchaseOrdersPage() {
                 <>
                   {Array.from({ length: 6 }).map((_, index) => (
                     <TableRow key={index}>
-                      <TableCell colSpan={6} sx={{ py: 1.5 }}>
+                      <TableCell colSpan={5} sx={{ py: 1.5 }}>
                         <Skeleton height={34} />
                       </TableCell>
                     </TableRow>
@@ -200,7 +232,7 @@ export function PurchaseOrdersPage() {
 
               {!isLoading && error && (
                 <TableRow>
-                  <TableCell colSpan={6} sx={{ py: 5, textAlign: 'center', color: 'error.main' }}>
+                  <TableCell colSpan={5} sx={{ py: 5, textAlign: 'center', color: 'error.main' }}>
                     {error instanceof Error ? error.message : String(error)}
                   </TableCell>
                 </TableRow>
@@ -208,7 +240,7 @@ export function PurchaseOrdersPage() {
 
               {!isLoading && !error && purchaseOrders.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={6}>
+                  <TableCell colSpan={5}>
                     <EmptyState
                       icon={<LocalShippingIcon sx={{ fontSize: 40 }} />}
                       title="No purchase orders loaded"
@@ -224,32 +256,23 @@ export function PurchaseOrdersPage() {
                       <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
                         {order.internalRef}
                       </Typography>
+                    </TableCell>
+                    <TableCell sx={bodyCellSx}>
+                      <Typography sx={{ fontSize: '0.8125rem', color: 'text.primary' }}>
+                        {order.marketplace === null ? '-' : order.marketplace}
+                      </Typography>
                       <Typography sx={quietTextSx}>
                         {order.supplierRef === null ? '-' : order.supplierRef}
                       </Typography>
                     </TableCell>
                     <TableCell sx={bodyCellSx}>
-                      {order.marketplace === null ? '-' : order.marketplace}
-                    </TableCell>
-                    <TableCell sx={bodyCellSx}>
-                      <StatusChip status={order.status} />
+                      <ProductSummary order={order} />
                     </TableCell>
                     <TableCell sx={{ ...bodyCellSx, textAlign: 'right', fontWeight: 700, color: 'text.primary', fontVariantNumeric: 'tabular-nums' }}>
                       {formatPurchaseOrderTotal(order)}
                     </TableCell>
                     <TableCell sx={bodyCellSx}>
-                      <Box sx={{ display: 'grid', gap: 1 }}>
-                        {order.costLayers.map((layer) => (
-                          <LayerSummary key={layer.id} layer={layer} />
-                        ))}
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={bodyCellSx}>
-                      <Box sx={{ display: 'grid', gap: 1 }}>
-                        {order.costLayers.map((layer) => (
-                          <QboSourceSummary key={layer.id} layer={layer} />
-                        ))}
-                      </Box>
+                      <StatusChip status={order.status} />
                     </TableCell>
                   </TableRow>
               ))}

--- a/apps/plutus/lib/plutus/purchase-orders-view.ts
+++ b/apps/plutus/lib/plutus/purchase-orders-view.ts
@@ -1,0 +1,134 @@
+export type PurchaseOrderProductAlias = {
+  marketplace: string;
+  aliasType: string;
+  value: string;
+  active: boolean;
+};
+
+export type PurchaseOrderProductLayer = {
+  id: string;
+  component: string;
+  quantity: number | null;
+  amountCents: number;
+  currency: string;
+  product: {
+    id: string;
+    name: string;
+    productGroup: {
+      code: string;
+      name: string;
+    };
+    aliases: PurchaseOrderProductAlias[];
+  };
+};
+
+export type PurchaseOrderProductSummary = {
+  key: string;
+  groupCode: string;
+  productName: string;
+  sku: string;
+  quantity: number | null;
+  currency: string;
+  totalAmountCents: number;
+  componentAmounts: Array<{
+    component: string;
+    amountCents: number;
+  }>;
+};
+
+export type PurchaseOrderCurrencyTotal = {
+  currency: string;
+  amountCents: number;
+};
+
+const COMPONENT_ORDER = ['manufacturing', 'freight', 'duty', 'mfgAccessories'] as const;
+
+function compareComponent(left: string, right: string): number {
+  const leftIndex = COMPONENT_ORDER.findIndex((component) => component === left);
+  const rightIndex = COMPONENT_ORDER.findIndex((component) => component === right);
+  if (leftIndex !== -1 && rightIndex !== -1) return leftIndex - rightIndex;
+  if (leftIndex !== -1) return -1;
+  if (rightIndex !== -1) return 1;
+  return left.localeCompare(right);
+}
+
+function resolveDisplaySku(marketplace: string | null, layer: PurchaseOrderProductLayer): string {
+  const activeSkuAliases = layer.product.aliases
+    .filter((alias) => alias.active)
+    .filter((alias) => alias.aliasType.toUpperCase() === 'SKU');
+  const marketplaceAliases =
+    marketplace === null
+      ? []
+      : activeSkuAliases.filter((alias) => alias.marketplace === marketplace);
+  const candidateAliases = marketplaceAliases.length > 0 ? marketplaceAliases : activeSkuAliases;
+  const sortedAliases = [...candidateAliases].sort((left, right) => left.value.localeCompare(right.value));
+  const firstAlias = sortedAliases[0];
+  if (firstAlias !== undefined) return firstAlias.value;
+  return layer.product.name;
+}
+
+export function buildPurchaseOrderProductSummaries(
+  marketplace: string | null,
+  layers: PurchaseOrderProductLayer[],
+): PurchaseOrderProductSummary[] {
+  const byProduct = new Map<string, PurchaseOrderProductSummary>();
+
+  for (const layer of layers) {
+    const key = `${layer.product.id}|${layer.currency}`;
+    const existing = byProduct.get(key);
+    if (existing === undefined) {
+      byProduct.set(key, {
+        key,
+        groupCode: layer.product.productGroup.code,
+        productName: layer.product.name,
+        sku: resolveDisplaySku(marketplace, layer),
+        quantity: layer.quantity,
+        currency: layer.currency,
+        totalAmountCents: layer.amountCents,
+        componentAmounts: [{ component: layer.component, amountCents: layer.amountCents }],
+      });
+      continue;
+    }
+
+    if (layer.quantity !== null) {
+      existing.quantity = (existing.quantity === null ? 0 : existing.quantity) + layer.quantity;
+    }
+    existing.totalAmountCents += layer.amountCents;
+    const component = existing.componentAmounts.find((entry) => entry.component === layer.component);
+    if (component === undefined) {
+      existing.componentAmounts.push({ component: layer.component, amountCents: layer.amountCents });
+    } else {
+      component.amountCents += layer.amountCents;
+    }
+  }
+
+  return Array.from(byProduct.values())
+    .map((summary) => ({
+      ...summary,
+      componentAmounts: [...summary.componentAmounts].sort((left, right) =>
+        compareComponent(left.component, right.component),
+      ),
+    }))
+    .sort((left, right) => {
+      const groupComparison = left.groupCode.localeCompare(right.groupCode);
+      if (groupComparison !== 0) return groupComparison;
+      const skuComparison = left.sku.localeCompare(right.sku);
+      if (skuComparison !== 0) return skuComparison;
+      return left.currency.localeCompare(right.currency);
+    });
+}
+
+export function buildPurchaseOrderCurrencyTotals(
+  layers: PurchaseOrderProductLayer[],
+): PurchaseOrderCurrencyTotal[] {
+  const totals = new Map<string, number>();
+
+  for (const layer of layers) {
+    const current = totals.get(layer.currency);
+    totals.set(layer.currency, (current === undefined ? 0 : current) + layer.amountCents);
+  }
+
+  return Array.from(totals.entries())
+    .map(([currency, amountCents]) => ({ currency, amountCents }))
+    .sort((left, right) => left.currency.localeCompare(right.currency));
+}

--- a/apps/plutus/lib/plutus/settlement-processing.ts
+++ b/apps/plutus/lib/plutus/settlement-processing.ts
@@ -474,33 +474,25 @@ export async function computeSettlementPreview(input: {
   }
 
   const setupConfig = await db.setupConfig.findFirst();
-  if (!setupConfig || setupConfig.accountsCreated !== true) {
+  const requiredMappingKeys = cogsEnabled
+    ? [
+        'invManufacturing',
+        'invFreight',
+        'invDuty',
+        'invMfgAccessories',
+        'cogsManufacturing',
+        'cogsFreight',
+        'cogsDuty',
+        'cogsMfgAccessories',
+      ]
+    : [];
+
+  const hasInventoryAccountSetup = setupConfig === null ? false : setupConfig.accountsCreated === true;
+  if (requiredMappingKeys.length > 0 && !hasInventoryAccountSetup) {
     blocks.push({
       code: 'MISSING_SETUP',
-      message: 'Setup is incomplete. Complete Accounts mapping + sub-account creation first.',
+      message: 'Setup is incomplete. Complete inventory asset and COGS account mapping first.',
     });
-  }
-
-  const requiredMappingKeys = [
-    'amazonSellerFees',
-    'amazonFbaFees',
-    'amazonStorageFees',
-    'amazonAdvertisingCosts',
-    'amazonPromotions',
-    'amazonFbaInventoryReimbursement',
-    'warehousingAwd',
-  ];
-  if (cogsEnabled) {
-    requiredMappingKeys.unshift(
-      'invManufacturing',
-      'invFreight',
-      'invDuty',
-      'invMfgAccessories',
-      'cogsManufacturing',
-      'cogsFreight',
-      'cogsDuty',
-      'cogsMfgAccessories',
-    );
   }
 
   const mapping: Record<string, string | undefined> = {};

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -110,6 +110,10 @@ import {
   fingerprintPostingLines,
 } from '../lib/plutus/subledger/qbo-trace';
 import {
+  buildPurchaseOrderCurrencyTotals,
+  buildPurchaseOrderProductSummaries,
+} from '../lib/plutus/purchase-orders-view';
+import {
   resolveCanonicalProductAlias,
 } from '../lib/plutus/subledger/sku-alias';
 import {
@@ -1349,6 +1353,120 @@ test('subledger pages are wired to route wrappers', () => {
   assert.equal(readFileSync(new URL('../app/purchase-orders/page.tsx', import.meta.url), 'utf8').includes('PurchaseOrdersPage'), true);
   assert.equal(readFileSync(new URL('../app/inventory-ledger/page.tsx', import.meta.url), 'utf8').includes('InventoryLedgerPage'), true);
   assert.equal(readFileSync(new URL('../app/qbo-audit/page.tsx', import.meta.url), 'utf8').includes('QboAuditPage'), true);
+});
+
+test('purchase order view groups cost layers by product group and SKU', () => {
+  const summaries = buildPurchaseOrderProductSummaries('amazon.com', [
+    {
+      id: 'mfg',
+      component: 'manufacturing',
+      quantity: 100,
+      amountCents: 120000,
+      currency: 'USD',
+      product: {
+        id: 'prod-1',
+        name: 'Comfort Step 7',
+        productGroup: { code: 'PDS', name: 'PDS' },
+        aliases: [
+          { marketplace: 'amazon.com', aliasType: 'SKU', value: 'CS-007', active: true },
+          { marketplace: 'amazon.co.uk', aliasType: 'SKU', value: 'CS 007', active: true },
+        ],
+      },
+    },
+    {
+      id: 'freight',
+      component: 'freight',
+      quantity: null,
+      amountCents: 15000,
+      currency: 'USD',
+      product: {
+        id: 'prod-1',
+        name: 'Comfort Step 7',
+        productGroup: { code: 'PDS', name: 'PDS' },
+        aliases: [
+          { marketplace: 'amazon.com', aliasType: 'SKU', value: 'CS-007', active: true },
+        ],
+      },
+    },
+  ]);
+
+  assert.deepEqual(summaries, [
+    {
+      key: 'prod-1|USD',
+      groupCode: 'PDS',
+      productName: 'Comfort Step 7',
+      sku: 'CS-007',
+      quantity: 100,
+      currency: 'USD',
+      totalAmountCents: 135000,
+      componentAmounts: [
+        { component: 'manufacturing', amountCents: 120000 },
+        { component: 'freight', amountCents: 15000 },
+      ],
+    },
+  ]);
+});
+
+test('purchase order view keeps mixed-currency PO product summaries separate', () => {
+  const layers = [
+    {
+      id: 'usd',
+      component: 'manufacturing',
+      quantity: 100,
+      amountCents: 120000,
+      currency: 'USD',
+      product: {
+        id: 'prod-1',
+        name: 'Comfort Step 7',
+        productGroup: { code: 'PDS', name: 'PDS' },
+        aliases: [
+          { marketplace: 'amazon.com', aliasType: 'SKU', value: 'CS-007', active: true },
+        ],
+      },
+    },
+    {
+      id: 'gbp',
+      component: 'freight',
+      quantity: null,
+      amountCents: 30000,
+      currency: 'GBP',
+      product: {
+        id: 'prod-1',
+        name: 'Comfort Step 7',
+        productGroup: { code: 'PDS', name: 'PDS' },
+        aliases: [
+          { marketplace: 'amazon.com', aliasType: 'SKU', value: 'CS-007', active: true },
+        ],
+      },
+    },
+  ];
+
+  assert.deepEqual(buildPurchaseOrderCurrencyTotals(layers), [
+    { currency: 'GBP', amountCents: 30000 },
+    { currency: 'USD', amountCents: 120000 },
+  ]);
+  assert.deepEqual(
+    buildPurchaseOrderProductSummaries('amazon.com', layers).map((summary) => ({
+      key: summary.key,
+      currency: summary.currency,
+      totalAmountCents: summary.totalAmountCents,
+      componentAmounts: summary.componentAmounts,
+    })),
+    [
+      {
+        key: 'prod-1|GBP',
+        currency: 'GBP',
+        totalAmountCents: 30000,
+        componentAmounts: [{ component: 'freight', amountCents: 30000 }],
+      },
+      {
+        key: 'prod-1|USD',
+        currency: 'USD',
+        totalAmountCents: 120000,
+        componentAmounts: [{ component: 'manufacturing', amountCents: 120000 }],
+      },
+    ],
+  );
 });
 
 test('QBO audit API exposes flattened posting source fields', () => {
@@ -2677,6 +2795,22 @@ test('settlement processing no longer builds brand or SKU P&L reclass lines', ()
   assert.equal(source.includes("docNumber: buildProcessingDocNumber('P', invoiceId)"), true);
   assert.equal(source.includes('privateNote: `Plutus P&L Reclass | Invoice: ${invoiceId} | Hash: ${hashPrefix}`'), true);
   assert.equal(source.includes('lines: [],'), true);
+});
+
+test('settlement processing no longer requires fee allocation account mappings', () => {
+  const source = readFileSync('lib/plutus/settlement-processing.ts', 'utf8');
+
+  for (const removed of [
+    "'amazonSellerFees'",
+    "'amazonFbaFees'",
+    "'amazonStorageFees'",
+    "'amazonAdvertisingCosts'",
+    "'amazonPromotions'",
+    "'amazonFbaInventoryReimbursement'",
+    "'warehousingAwd'",
+  ]) {
+    assert.equal(source.includes(removed), false, removed);
+  }
 });
 
 test('journal builder exposes only inventory COGS lines, not P&L brand reclass lines', () => {


### PR DESCRIPTION
## Summary
- Simplify the Plutus purchase orders page to show PO, market/supplier ref, product group/SKU, quantity, total, and component cost chips.
- Load product aliases in the PO API so the page can show the marketplace SKU instead of raw canonical product internals.
- Remove stale settlement processing prerequisites for fee/AWD account mappings; settlement processing now only requires inventory/COGS mappings when COGS release is enabled.

## Verification
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint
- pnpm -C apps/plutus build

Live Chrome note: https://os.targonglobal.com/plutus/purchase-orders redirects to login in the current Chrome session, so visual data verification is blocked until the session is authenticated.