### PR TITLE
Clean Plutus bridge settlement handling

### DIFF
--- a/apps/plutus/components/subledger/qbo-audit-page.tsx
+++ b/apps/plutus/components/subledger/qbo-audit-page.tsx
@@ -190,7 +190,7 @@ export function QboAuditPage() {
 
   return (
     <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
-      <PageHeader title="QBO Audit" kicker="Subledger" />
+      <PageHeader title="QBO Audit" kicker="Bridge" />
 
       <Box sx={tableWrapSx}>
         <Box sx={{ overflowX: 'auto' }}>
@@ -233,7 +233,7 @@ export function QboAuditPage() {
                     <EmptyState
                       icon={<FactCheckIcon sx={{ fontSize: 40 }} />}
                       title="No QBO postings tracked"
-                      description="Posting drift and attachment state will appear after QBO traces are recorded."
+                      description="Bridge posting drift and attachment state will appear after QBO traces are recorded."
                     />
                   </TableCell>
                 </TableRow>

--- a/apps/plutus/lib/amazon-finances/fund-transfer-status.ts
+++ b/apps/plutus/lib/amazon-finances/fund-transfer-status.ts
@@ -1,0 +1,4 @@
+export function isPostableFundTransferStatus(value: unknown): boolean {
+  if (typeof value !== 'string') return true;
+  return value.trim().toLowerCase() !== 'processing';
+}

--- a/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/uk-settlement-sync.ts
@@ -1,5 +1,6 @@
 import { buildQboJournalEntriesFromUkSettlementDraft, buildUkSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/uk-settlement-builder';
 import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '@/lib/amazon-finances/settlement-cash-account-guardrails';
+import { isPostableFundTransferStatus } from '@/lib/amazon-finances/fund-transfer-status';
 import {
   normalizeSettlementOperatingMemo,
   settlementParentAccountKeyForMemo,
@@ -151,6 +152,7 @@ function computeGroupStartedAfterIso(startDate: string): string {
 function isClosedFinancialEventGroup(group: any): boolean {
   if (!group || typeof group !== 'object') return false;
   if (group.ProcessingStatus !== 'Closed') return false;
+  if (!isPostableFundTransferStatus(group.FundTransferStatus)) return false;
   const start = group.FinancialEventGroupStart;
   const end = group.FinancialEventGroupEnd;
   if (typeof start !== 'string' || start.trim() === '') return false;

--- a/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
+++ b/apps/plutus/lib/amazon-finances/us-settlement-sync.ts
@@ -1,5 +1,6 @@
 import { buildQboJournalEntriesFromUsSettlementDraft, buildUsSettlementDraftFromSpApiFinances } from '@/lib/amazon-finances/us-settlement-builder';
 import { assertSettlementCashMappingDoesNotUseRealBankMovement } from '@/lib/amazon-finances/settlement-cash-account-guardrails';
+import { isPostableFundTransferStatus } from '@/lib/amazon-finances/fund-transfer-status';
 import {
   normalizeSettlementOperatingMemo,
   settlementParentAccountKeyForMemo,
@@ -146,6 +147,7 @@ function computeGroupStartedAfterIso(startDate: string): string {
 function isClosedFinancialEventGroup(group: any): boolean {
   if (!group || typeof group !== 'object') return false;
   if (group.ProcessingStatus !== 'Closed') return false;
+  if (!isPostableFundTransferStatus(group.FundTransferStatus)) return false;
   const start = group.FinancialEventGroupStart;
   const end = group.FinancialEventGroupEnd;
   if (typeof start !== 'string' || start.trim() === '') return false;

--- a/apps/plutus/scripts/settlement-sync-worker.ts
+++ b/apps/plutus/scripts/settlement-sync-worker.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 
 import { buildSyntheticUkSettlementId } from '@/lib/amazon-finances/uk-settlement-id';
 import { parseSettlementSyncWorkerPostMode } from '@/lib/amazon-finances/settlement-sync-post-mode';
+import { isPostableFundTransferStatus } from '@/lib/amazon-finances/fund-transfer-status';
 import {
   isSettlementDocNumber,
   normalizeSettlementDocNumber,
@@ -206,6 +207,7 @@ function isClosedFinancialEventGroup(group: unknown): group is {
 
   const candidate = group as Record<string, unknown>;
   if (candidate.ProcessingStatus !== 'Closed') return false;
+  if (!isPostableFundTransferStatus(candidate.FundTransferStatus)) return false;
   if (typeof candidate.FinancialEventGroupId !== 'string' || candidate.FinancialEventGroupId.trim() === '') return false;
   if (typeof candidate.FinancialEventGroupStart !== 'string' || candidate.FinancialEventGroupStart.trim() === '') return false;
   if (typeof candidate.FinancialEventGroupEnd !== 'string' || candidate.FinancialEventGroupEnd.trim() === '') return false;

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -10,6 +10,7 @@ import {
   buildUkSettlementDraftFromSpApiFinances,
 } from '../lib/amazon-finances/uk-settlement-builder';
 import { normalizeSettlementOperatingMemo } from '../lib/amazon-finances/settlement-memo-normalization';
+import { isPostableFundTransferStatus } from '../lib/amazon-finances/fund-transfer-status';
 import { isBlockingProcessingCode } from '../lib/plutus/settlement-types';
 import { computeProcessingHash } from '../lib/plutus/settlement-utils';
 
@@ -104,6 +105,20 @@ test('package scripts do not expose inventory ownership workflows', () => {
   ]) {
     assert.equal(pkg.includes(forbidden), false, `${forbidden} should not be callable`);
   }
+});
+
+test('QBO audit page uses bridge language, not subledger language', () => {
+  const source = read('components/subledger/qbo-audit-page.tsx');
+  assert.equal(source.includes('kicker="Subledger"'), false);
+  assert.equal(source.includes('Posting drift and attachment state will appear after QBO traces are recorded.'), false);
+});
+
+test('SP-API settlements with processing fund transfers are not postable', () => {
+  assert.equal(isPostableFundTransferStatus('Succeeded'), true);
+  assert.equal(isPostableFundTransferStatus('Failed'), true);
+  assert.equal(isPostableFundTransferStatus('Unknown'), true);
+  assert.equal(isPostableFundTransferStatus('Processing'), false);
+  assert.equal(isPostableFundTransferStatus(' processing '), false);
 });
 
 test('US SP-API settlement build does not require SKU brand mapping', () => {


### PR DESCRIPTION
## Summary
- treat Amazon SP-API FundTransferStatus=Processing as not postable for US/UK settlement sync and the sync worker
- rename QBO Audit page language from Subledger to Bridge
- add Plutus regression coverage for bridge-only audit copy and Processing fund-transfer status

## Verification
- pnpm -C apps/plutus test
- pnpm -C apps/plutus exec tsc --noEmit
- pnpm -C apps/plutus build
- live QBO repair dry-run for US-260501-260508-S2 returns no remaining journal changes