### PR TITLE
Preserve historical Plutus COGS entries

### DIFF
--- a/apps/plutus/lib/plutus/settlement-rollback.ts
+++ b/apps/plutus/lib/plutus/settlement-rollback.ts
@@ -55,19 +55,6 @@ export async function rollbackProcessedSettlementByJournalEntryId(input: {
     throw new Error(`Settlement not processed: ${input.settlementJournalEntryId}`);
   }
 
-  if (isQboJournalEntryId(existing.qboCogsJournalEntryId)) {
-    try {
-      const deleted = await deleteJournalEntry(activeConnection, existing.qboCogsJournalEntryId);
-      if (deleted.updatedConnection) activeConnection = deleted.updatedConnection;
-    } catch (error) {
-      if (!isQboNotFoundError(error)) throw error;
-      logger.warn('COGS Journal Entry already missing in QBO; skipping delete during rollback', {
-        journalEntryId: existing.qboCogsJournalEntryId,
-        settlementJournalEntryId: input.settlementJournalEntryId,
-      });
-    }
-  }
-
   if (isQboJournalEntryId(existing.qboPnlReclassJournalEntryId)) {
     try {
       const deleted = await deleteJournalEntry(activeConnection, existing.qboPnlReclassJournalEntryId);

--- a/apps/plutus/scripts/retire-legacy-cogs-journal-refs.ts
+++ b/apps/plutus/scripts/retire-legacy-cogs-journal-refs.ts
@@ -1,0 +1,160 @@
+import { db } from '@/lib/db';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { fetchJournalEntryById } from '@/lib/qbo/api';
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
+import { buildNoopJournalEntryId, isNoopJournalEntryId } from '@/lib/plutus/journal-entry-id';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  apply: boolean;
+  marketplace: string | undefined;
+  humanApproval: string | null;
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let marketplace: string | undefined;
+  let humanApproval: string | null = null;
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--marketplace') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --marketplace');
+      marketplace = next;
+      i += 2;
+      continue;
+    }
+
+    if (arg.startsWith('--marketplace=')) {
+      marketplace = arg.slice('--marketplace='.length);
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--human-approval') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+
+    if (arg.startsWith('--human-approval=')) {
+      humanApproval = arg.slice('--human-approval='.length);
+      i += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`Live Plutus settlement-state mutation requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { apply, marketplace, humanApproval };
+}
+
+function isPlutusCogsJournalEntry(journalEntry: { DocNumber?: string; PrivateNote?: string }): boolean {
+  const docNumber = journalEntry.DocNumber ?? '';
+  const privateNote = journalEntry.PrivateNote ?? '';
+  return docNumber.startsWith('C') && privateNote.startsWith('Plutus COGS |');
+}
+
+async function main(): Promise<void> {
+  loadSharedPlutusEnv();
+
+  const options = parseArgs(process.argv.slice(2));
+  const connection = await getQboConnection();
+  if (connection === null) {
+    throw new Error('Not connected to QBO (missing server connection file)');
+  }
+  let activeConnection = connection;
+
+  const rows = await db.settlementProcessing.findMany({
+    where: {
+      ...(options.marketplace === undefined ? {} : { marketplace: options.marketplace }),
+    },
+    orderBy: [{ settlementPostedDate: 'asc' }, { invoiceId: 'asc' }],
+  });
+
+  const candidates = rows.filter((row) => !isNoopJournalEntryId(row.qboCogsJournalEntryId));
+  const verifiedCandidates = [];
+
+  for (const row of candidates) {
+    const fetched = await fetchJournalEntryById(activeConnection, row.qboCogsJournalEntryId);
+    if (fetched.updatedConnection) {
+      activeConnection = fetched.updatedConnection;
+      await saveServerQboConnection(activeConnection);
+    }
+
+    if (!isPlutusCogsJournalEntry(fetched.journalEntry)) {
+      throw new Error(
+        `Refusing to retire non-Plutus COGS reference ${row.qboCogsJournalEntryId} for invoice ${row.invoiceId}`,
+      );
+    }
+
+    verifiedCandidates.push({
+      id: row.id,
+      marketplace: row.marketplace,
+      invoiceId: row.invoiceId,
+      settlementDocNumber: row.settlementDocNumber,
+      settlementPostedDate: row.settlementPostedDate.toISOString().slice(0, 10),
+      qboCogsJournalEntryId: row.qboCogsJournalEntryId,
+      qboCogsDocNumber: fetched.journalEntry.DocNumber ?? null,
+      targetNoopId: buildNoopJournalEntryId('COGS', row.invoiceId),
+    });
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        apply: options.apply,
+        marketplace: options.marketplace ?? 'ALL',
+        scanned: rows.length,
+        candidates: verifiedCandidates,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!options.apply) {
+    return;
+  }
+
+  for (const candidate of verifiedCandidates) {
+    await db.settlementProcessing.update({
+      where: { id: candidate.id },
+      data: {
+        qboCogsJournalEntryId: candidate.targetNoopId,
+      },
+    });
+
+    console.log(
+      JSON.stringify({
+        retired: true,
+        invoiceId: candidate.invoiceId,
+        preservedQboJournalEntryId: candidate.qboCogsJournalEntryId,
+        qboCogsJournalEntryId: candidate.targetNoopId,
+      }),
+    );
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/apps/plutus/scripts/rollback-settlement-processing.ts
+++ b/apps/plutus/scripts/rollback-settlement-processing.ts
@@ -160,15 +160,6 @@ async function main(): Promise<void> {
 
   for (const row of processingRows) {
     try {
-      if (isQboJournalEntryId(row.qboCogsJournalEntryId)) {
-        try {
-          const deleted = await deleteJournalEntry(activeConnection, row.qboCogsJournalEntryId);
-          if (deleted.updatedConnection) activeConnection = deleted.updatedConnection;
-        } catch (error) {
-          if (!isQboNotFoundError(error)) throw error;
-        }
-      }
-
       if (isQboJournalEntryId(row.qboPnlReclassJournalEntryId)) {
         try {
           const deleted = await deleteJournalEntry(activeConnection, row.qboPnlReclassJournalEntryId);

--- a/apps/plutus/scripts/uk-settlement-reset-spapi.ts
+++ b/apps/plutus/scripts/uk-settlement-reset-spapi.ts
@@ -301,7 +301,9 @@ async function main(): Promise<void> {
 
   const targets: DeletionTarget[] = [];
 
-  for (const r of qboSearchResults) {
+  const qboDeletionResults = qboSearchResults.filter((row) => classifyDocNumber(row.docNumber) !== 'cogs');
+
+  for (const r of qboDeletionResults) {
     targets.push({
       journalEntryId: r.id,
       txnDate: r.txnDate,
@@ -312,10 +314,10 @@ async function main(): Promise<void> {
     });
   }
 
-  const seenFromSearch = new Set(qboSearchResults.map((r) => r.id));
+  const seenFromSearch = new Set(qboDeletionResults.map((r) => r.id));
 
   for (const row of processingRows) {
-    const ids = [row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId, row.qboPnlReclassJournalEntryId];
+    const ids = [row.qboSettlementJournalEntryId, row.qboPnlReclassJournalEntryId];
     for (const id of ids) {
       if (isNoopJournalEntryId(id)) continue;
       if (seenFromSearch.has(id)) continue;
@@ -324,7 +326,7 @@ async function main(): Promise<void> {
   }
 
   for (const row of rollbackRows) {
-    const ids = [row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId, row.qboPnlReclassJournalEntryId];
+    const ids = [row.qboSettlementJournalEntryId, row.qboPnlReclassJournalEntryId];
     for (const id of ids) {
       if (isNoopJournalEntryId(id)) continue;
       if (seenFromSearch.has(id)) continue;
@@ -391,6 +393,7 @@ async function main(): Promise<void> {
           options: { startDate, endDate, resync: options.resync },
           totals: {
             qboJournalEntriesMatchedByDocNumber: qboSearchResults.length,
+            qboCogsJournalEntriesProtected: qboSearchResults.length - qboDeletionResults.length,
             qboJournalEntriesToDelete: existingTargetCount,
             qboJournalEntriesMissing: missingTargetCount,
             dbSettlementProcessingRows: processingRows.length,

--- a/apps/plutus/scripts/us-settlement-reset-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reset-spapi.ts
@@ -413,9 +413,6 @@ async function main(): Promise<void> {
 
   for (const row of processingRows) {
     qboIdsToDelete.add(row.qboSettlementJournalEntryId);
-    if (!isNoopJournalEntryId(row.qboCogsJournalEntryId)) {
-      qboIdsToDelete.add(row.qboCogsJournalEntryId);
-    }
     if (!isNoopJournalEntryId(row.qboPnlReclassJournalEntryId)) {
       qboIdsToDelete.add(row.qboPnlReclassJournalEntryId);
     }
@@ -425,9 +422,6 @@ async function main(): Promise<void> {
 
   for (const row of rollbackRows) {
     qboIdsToDelete.add(row.qboSettlementJournalEntryId);
-    if (!isNoopJournalEntryId(row.qboCogsJournalEntryId)) {
-      qboIdsToDelete.add(row.qboCogsJournalEntryId);
-    }
     if (!isNoopJournalEntryId(row.qboPnlReclassJournalEntryId)) {
       qboIdsToDelete.add(row.qboPnlReclassJournalEntryId);
     }
@@ -435,13 +429,15 @@ async function main(): Promise<void> {
     invoiceIdsToDelete.add(row.settlementDocNumber);
   }
 
-  for (const r of selectedQboSearchResults) {
+  const selectedQboDeletionResults = selectedQboSearchResults.filter((row) => classifyDocNumber(row.docNumber) !== 'cogs');
+
+  for (const r of selectedQboDeletionResults) {
     qboIdsToDelete.add(r.id);
   }
 
   const targets: DeletionTarget[] = [];
 
-  for (const r of selectedQboSearchResults) {
+  for (const r of selectedQboDeletionResults) {
     targets.push({
       journalEntryId: r.id,
       txnDate: r.txnDate,
@@ -452,10 +448,10 @@ async function main(): Promise<void> {
     });
   }
 
-  const seenFromSearch = new Set(selectedQboSearchResults.map((r) => r.id));
+  const seenFromSearch = new Set(selectedQboDeletionResults.map((r) => r.id));
 
   for (const row of processingRows) {
-    const ids = [row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId, row.qboPnlReclassJournalEntryId];
+    const ids = [row.qboSettlementJournalEntryId, row.qboPnlReclassJournalEntryId];
     for (const id of ids) {
       if (isNoopJournalEntryId(id)) continue;
       if (seenFromSearch.has(id)) continue;
@@ -464,7 +460,7 @@ async function main(): Promise<void> {
   }
 
   for (const row of rollbackRows) {
-    const ids = [row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId, row.qboPnlReclassJournalEntryId];
+    const ids = [row.qboSettlementJournalEntryId, row.qboPnlReclassJournalEntryId];
     for (const id of ids) {
       if (isNoopJournalEntryId(id)) continue;
       if (seenFromSearch.has(id)) continue;
@@ -531,6 +527,7 @@ async function main(): Promise<void> {
           options: { startDate, endDate, resync: options.resync, settlementIds: options.settlementIds },
           totals: {
             qboJournalEntriesMatchedByDocNumber: selectedQboSearchResults.length,
+            qboCogsJournalEntriesProtected: selectedQboSearchResults.length - selectedQboDeletionResults.length,
             qboJournalEntriesToDelete: existingTargetCount,
             qboJournalEntriesMissing: missingTargetCount,
             dbSettlementProcessingRows: processingRows.length,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -286,6 +286,21 @@ test('processing hash keeps SKU as evidence only', () => {
   assert.equal(left, right);
 });
 
+test('rollback/reset tools preserve historical COGS journal entries', () => {
+  const rollbackSource = read('lib/plutus/settlement-rollback.ts');
+  assert.equal(rollbackSource.includes('deleteJournalEntry(activeConnection, existing.qboCogsJournalEntryId)'), false);
+
+  for (const path of [
+    'scripts/rollback-settlement-processing.ts',
+    'scripts/us-settlement-reset-spapi.ts',
+    'scripts/uk-settlement-reset-spapi.ts',
+  ]) {
+    const source = read(path);
+    assert.equal(source.includes('deleteJournalEntry(activeConnection, row.qboCogsJournalEntryId)'), false);
+    assert.equal(source.includes('row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId'), false);
+  }
+});
+
 test('processing blocks fail closed', () => {
   assert.equal(isBlockingProcessingCode(''), false);
   assert.equal(isBlockingProcessingCode('INVOICE_CONFLICT'), true);


### PR DESCRIPTION
## Summary
- stop rollback/reset paths from deleting historical Plutus COGS journal entries
- add a verified maintenance script to retire legacy COGS references to NOOP without deleting QBO COGS
- cover the rollback/reset behavior in Plutus tests

## Verification
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint
- dry-run: US reset protects 20 COGS JEs and has 0 COGS deletion targets
- dry-run: retire legacy COGS refs verifies 20 US candidates