### PR TITLE
Make QBO inventory the Plutus source of truth

### DIFF
--- a/apps/plutus/lib/plutus/qbo-inventory-asset-lines.ts
+++ b/apps/plutus/lib/plutus/qbo-inventory-asset-lines.ts
@@ -1,0 +1,495 @@
+export type QboInventoryAssetComponent = 'manufacturing' | 'freight' | 'duty' | 'mfgAccessories';
+
+export type QboInventoryAssetLineInput = {
+  billId: string;
+  billDocNumber?: string;
+  billDate: string;
+  vendorName?: string;
+  qboLineId: string;
+  accountName: string;
+  amount: number;
+  description?: string;
+};
+
+export type ParsedQboInventoryAssetLine = {
+  billId: string;
+  billDocNumber?: string;
+  billDate: string;
+  vendorName?: string;
+  qboLineId: string;
+  accountName: string;
+  amount: number;
+  component: QboInventoryAssetComponent;
+  marketCode: string | null;
+  descriptionKind: string;
+  owner: string | null;
+  internalPo: string | null;
+  sellerSku: string | null;
+  quantity: number | null;
+  sourceRef: string | null;
+};
+
+export type QboInventoryLandedCostLayer = {
+  internalPo: string;
+  sellerSku: string;
+  quantity: number;
+  componentAmounts: Record<QboInventoryAssetComponent, number>;
+  totalAmount: number;
+  unitCost: number;
+  sourceRefs: string[];
+  qboBillLineRefs: string[];
+};
+
+export type QboInventoryAssetBlock =
+  | {
+      code: 'NON_SKU_ASSET_LINE';
+      billId: string;
+      qboLineId: string;
+      owner: string | null;
+    }
+  | {
+      code: 'RESIDUAL_ASSET_LINE';
+      billId: string;
+      qboLineId: string;
+      owner: string;
+      sellerSku: string;
+    }
+  | {
+      code: 'MISSING_INTERNAL_PO';
+      billId: string;
+      qboLineId: string;
+      owner: string | null;
+      sellerSku: string;
+    }
+  | {
+      code: 'MISSING_MANUFACTURING_QUANTITY';
+      internalPo: string;
+      sellerSku: string;
+    };
+
+export type QboInventoryLandedCostPlan = {
+  marketplace: string;
+  marketCode: string;
+  parsedLines: ParsedQboInventoryAssetLine[];
+  layers: QboInventoryLandedCostLayer[];
+  blocks: QboInventoryAssetBlock[];
+};
+
+export type QboInventoryAssetReclassReason =
+  | 'NON_TARGET_MARKET_ASSET_LINE'
+  | 'NON_SKU_ASSET_LINE'
+  | 'RESIDUAL_ASSET_LINE'
+  | 'MISSING_INTERNAL_PO'
+  | 'UNPARSEABLE_ASSET_LINE';
+
+export type QboInventoryAssetReclassLine = QboInventoryAssetLineInput & {
+  reason: QboInventoryAssetReclassReason;
+};
+
+export type QboInventoryAssetReclassPlan = {
+  marketplace: string;
+  marketCode: string;
+  lines: QboInventoryAssetReclassLine[];
+  totalAmount: number;
+};
+
+type ComponentAccountContract = {
+  component: QboInventoryAssetComponent;
+  leafPrefix: string;
+  descriptionKind: string;
+};
+
+const COMPONENT_ACCOUNT_CONTRACTS: ComponentAccountContract[] = [
+  { component: 'manufacturing', leafPrefix: 'Manufacturing - ', descriptionKind: 'MFG' },
+  { component: 'freight', leafPrefix: 'Freight - ', descriptionKind: 'FREIGHT' },
+  { component: 'duty', leafPrefix: 'Duty - ', descriptionKind: 'DUTY' },
+  { component: 'mfgAccessories', leafPrefix: 'Mfg Accessories - ', descriptionKind: 'PKG' },
+];
+
+const COMPONENTS: QboInventoryAssetComponent[] = ['manufacturing', 'freight', 'duty', 'mfgAccessories'];
+
+function marketCodeForMarketplace(marketplace: string): string {
+  if (marketplace === 'amazon.com') return 'US-PDS';
+  if (marketplace === 'amazon.co.uk') return 'UK-PDS';
+  throw new Error(`Unsupported QBO inventory marketplace: ${marketplace}`);
+}
+
+function accountLeaf(accountName: string): string {
+  const parts = accountName.split(':');
+  const leaf = parts[parts.length - 1];
+  if (leaf === undefined) throw new Error(`Cannot parse QBO account leaf: ${accountName}`);
+  return leaf.trim();
+}
+
+function parseComponentAccount(accountName: string): {
+  component: QboInventoryAssetComponent | null;
+  marketCode: string | null;
+  descriptionKind: string | null;
+} {
+  const leaf = accountLeaf(accountName);
+  if (leaf === 'Inventory Asset') {
+    return {
+      component: null,
+      marketCode: null,
+      descriptionKind: null,
+    };
+  }
+
+  for (const contract of COMPONENT_ACCOUNT_CONTRACTS) {
+    if (!leaf.startsWith(contract.leafPrefix)) continue;
+    const marketCode = leaf.slice(contract.leafPrefix.length).trim();
+    if (marketCode === '') throw new Error(`QBO inventory asset account is missing market code: ${accountName}`);
+    return {
+      component: contract.component,
+      marketCode,
+      descriptionKind: contract.descriptionKind,
+    };
+  }
+
+  throw new Error(`Unsupported QBO inventory asset account: ${accountName}`);
+}
+
+function componentForDescriptionKind(kind: string): QboInventoryAssetComponent {
+  for (const contract of COMPONENT_ACCOUNT_CONTRACTS) {
+    if (contract.descriptionKind === kind) return contract.component;
+  }
+  throw new Error(`Unsupported QBO inventory asset line kind: ${kind}`);
+}
+
+function marketCodeFromOwner(owner: string | null): string | null {
+  if (owner === null) return null;
+  const normalized = owner.trim().toUpperCase();
+  if (normalized === 'US' || normalized === 'US-PDS') return 'US-PDS';
+  if (normalized === 'UK' || normalized === 'UK-PDS') return 'UK-PDS';
+  return null;
+}
+
+function normalizeTokenValue(value: string): string {
+  return value.trim();
+}
+
+function parseDescription(description: string): { kind: string; values: Map<string, string> } {
+  const segments = description
+    .split(';')
+    .map((segment) => segment.trim())
+    .filter((segment) => segment !== '');
+
+  const firstSegment = segments[0];
+  if (firstSegment === undefined) throw new Error('QBO inventory asset line description is empty');
+  if (firstSegment.includes('=')) throw new Error(`QBO inventory asset line kind is missing: ${description}`);
+
+  const values = new Map<string, string>();
+  for (const segment of segments.slice(1)) {
+    const equalsIndex = segment.indexOf('=');
+    if (equalsIndex === -1) {
+      throw new Error(`QBO inventory asset line segment is not KEY=VALUE: ${segment}`);
+    }
+    const key = segment.slice(0, equalsIndex).trim().toUpperCase();
+    const value = normalizeTokenValue(segment.slice(equalsIndex + 1));
+    if (key === '') throw new Error(`QBO inventory asset line segment has empty key: ${segment}`);
+    values.set(key, value);
+  }
+
+  return {
+    kind: firstSegment.trim().toUpperCase(),
+    values,
+  };
+}
+
+function nullableToken(value: string | undefined): string | null {
+  if (value === undefined) return null;
+  const normalized = value.trim();
+  if (normalized === '') return null;
+  if (normalized.toUpperCase() === 'N/A') return null;
+  return normalized;
+}
+
+function normalizeSku(value: string | null): string | null {
+  if (value === null) return null;
+  return value.toUpperCase();
+}
+
+function parseQuantity(value: string | undefined): number | null {
+  if (value === undefined) return null;
+  const match = value.trim().match(/^([0-9]+)(?:\.[0-9]+)?/);
+  if (match === null) throw new Error(`QBO inventory asset quantity is not numeric: ${value}`);
+  const numericValue = Number(match[1]);
+  if (!Number.isFinite(numericValue)) throw new Error(`QBO inventory asset quantity is not finite: ${value}`);
+  return numericValue;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function roundUnitCost(value: number): number {
+  return Math.round(value * 1000000) / 1000000;
+}
+
+function createComponentAmounts(): Record<QboInventoryAssetComponent, number> {
+  return {
+    manufacturing: 0,
+    freight: 0,
+    duty: 0,
+    mfgAccessories: 0,
+  };
+}
+
+function pushUnique(values: string[], value: string | null): void {
+  if (value === null) return;
+  if (values.includes(value)) return;
+  values.push(value);
+}
+
+function isInventoryAssetAccountName(accountName: string): boolean {
+  return accountName === 'Inventory Asset' || accountName.startsWith('Inventory Asset:');
+}
+
+export function parseQboInventoryAssetLine(input: QboInventoryAssetLineInput): ParsedQboInventoryAssetLine {
+  const description = input.description;
+  if (description === undefined || description.trim() === '') {
+    throw new Error(`QBO inventory asset line ${input.billId}:${input.qboLineId} is missing description`);
+  }
+
+  const parsedDescription = parseDescription(description);
+  const account = parseComponentAccount(input.accountName);
+  const component = account.component ?? componentForDescriptionKind(parsedDescription.kind);
+  if (account.descriptionKind !== null && parsedDescription.kind !== account.descriptionKind) {
+    throw new Error(
+      `QBO inventory asset line ${input.billId}:${input.qboLineId} kind ${parsedDescription.kind} does not match account ${input.accountName}`,
+    );
+  }
+
+  const owner = nullableToken(parsedDescription.values.get('OWNER'));
+  const explicitPo = nullableToken(parsedDescription.values.get('PO'));
+  const internalPo =
+    explicitPo !== null
+      ? explicitPo
+      : owner !== null && owner.toUpperCase().startsWith('PO-')
+        ? owner
+        : null;
+  const skuToken = component === 'mfgAccessories'
+    ? nullableToken(parsedDescription.values.get('FOR_SKU'))
+    : nullableToken(parsedDescription.values.get('SKU'));
+
+  return {
+    billId: input.billId,
+    ...(input.billDocNumber !== undefined ? { billDocNumber: input.billDocNumber } : {}),
+    billDate: input.billDate,
+    ...(input.vendorName !== undefined ? { vendorName: input.vendorName } : {}),
+    qboLineId: input.qboLineId,
+    accountName: input.accountName,
+    amount: input.amount,
+    component,
+    marketCode: account.marketCode ?? marketCodeFromOwner(owner),
+    descriptionKind: parsedDescription.kind,
+    owner,
+    internalPo,
+    sellerSku: normalizeSku(skuToken),
+    quantity: parseQuantity(parsedDescription.values.get('QTY')),
+    sourceRef: nullableToken(parsedDescription.values.get('SOURCE')),
+  };
+}
+
+export function buildQboInventoryLandedCostPlan(input: {
+  marketplace: string;
+  lines: QboInventoryAssetLineInput[];
+}): QboInventoryLandedCostPlan {
+  const targetMarketCode = marketCodeForMarketplace(input.marketplace);
+  const parsedLines: ParsedQboInventoryAssetLine[] = [];
+  for (const line of input.lines) {
+    const account = parseComponentAccount(line.accountName);
+    if (account.marketCode !== null && account.marketCode !== targetMarketCode) continue;
+    const description = line.description?.trim().toUpperCase();
+    if (account.marketCode === null && !COMPONENT_ACCOUNT_CONTRACTS.some((contract) => description?.startsWith(`${contract.descriptionKind};`))) {
+      continue;
+    }
+    parsedLines.push(parseQboInventoryAssetLine(line));
+  }
+  const marketByPo = new Map<string, string>();
+  for (const line of parsedLines) {
+    if (line.internalPo === null || line.marketCode === null) continue;
+    marketByPo.set(line.internalPo, line.marketCode);
+  }
+  const marketLines = parsedLines.filter((line) => {
+    if (line.marketCode !== null) return line.marketCode === targetMarketCode;
+    if (line.owner === 'RESIDUAL') return true;
+    if (line.internalPo === null) return false;
+    return marketByPo.get(line.internalPo) === targetMarketCode;
+  });
+
+  const blocks: QboInventoryAssetBlock[] = [];
+  const groupByPoSku = new Map<
+    string,
+    {
+      internalPo: string;
+      sellerSku: string;
+      manufacturingQuantity: number;
+      componentAmounts: Record<QboInventoryAssetComponent, number>;
+      sourceRefs: string[];
+      qboBillLineRefs: string[];
+    }
+  >();
+
+  for (const line of marketLines) {
+    if (line.sellerSku === null) {
+      blocks.push({ code: 'NON_SKU_ASSET_LINE', billId: line.billId, qboLineId: line.qboLineId, owner: line.owner });
+      continue;
+    }
+
+    if (line.owner === 'RESIDUAL') {
+      blocks.push({
+        code: 'RESIDUAL_ASSET_LINE',
+        billId: line.billId,
+        qboLineId: line.qboLineId,
+        owner: line.owner,
+        sellerSku: line.sellerSku,
+      });
+      continue;
+    }
+
+    if (line.internalPo === null) {
+      blocks.push({
+        code: 'MISSING_INTERNAL_PO',
+        billId: line.billId,
+        qboLineId: line.qboLineId,
+        owner: line.owner,
+        sellerSku: line.sellerSku,
+      });
+      continue;
+    }
+
+    const key = `${line.internalPo}\u0000${line.sellerSku}`;
+    let group = groupByPoSku.get(key);
+    if (group === undefined) {
+      group = {
+        internalPo: line.internalPo,
+        sellerSku: line.sellerSku,
+        manufacturingQuantity: 0,
+        componentAmounts: createComponentAmounts(),
+        sourceRefs: [],
+        qboBillLineRefs: [],
+      };
+      groupByPoSku.set(key, group);
+    }
+
+    group.componentAmounts[line.component] = roundMoney(group.componentAmounts[line.component] + line.amount);
+    if (line.component === 'manufacturing') {
+      if (line.quantity === null) {
+        blocks.push({ code: 'MISSING_MANUFACTURING_QUANTITY', internalPo: line.internalPo, sellerSku: line.sellerSku });
+      } else {
+        group.manufacturingQuantity += line.quantity;
+      }
+    }
+    pushUnique(group.sourceRefs, line.sourceRef);
+    pushUnique(group.qboBillLineRefs, `${line.billId}:${line.qboLineId}`);
+  }
+
+  const layers: QboInventoryLandedCostLayer[] = [];
+  const groups = Array.from(groupByPoSku.values()).sort((left, right) => {
+    const poCompare = left.internalPo.localeCompare(right.internalPo);
+    if (poCompare !== 0) return poCompare;
+    return left.sellerSku.localeCompare(right.sellerSku);
+  });
+
+  for (const group of groups) {
+    if (group.manufacturingQuantity <= 0) {
+      blocks.push({
+        code: 'MISSING_MANUFACTURING_QUANTITY',
+        internalPo: group.internalPo,
+        sellerSku: group.sellerSku,
+      });
+      continue;
+    }
+
+    const totalAmount = roundMoney(
+      COMPONENTS.reduce((sum, component) => sum + group.componentAmounts[component], 0),
+    );
+    layers.push({
+      internalPo: group.internalPo,
+      sellerSku: group.sellerSku,
+      quantity: group.manufacturingQuantity,
+      componentAmounts: group.componentAmounts,
+      totalAmount,
+      unitCost: roundUnitCost(totalAmount / group.manufacturingQuantity),
+      sourceRefs: group.sourceRefs.sort(),
+      qboBillLineRefs: group.qboBillLineRefs.sort(),
+    });
+  }
+
+  return {
+    marketplace: input.marketplace,
+    marketCode: targetMarketCode,
+    parsedLines,
+    layers,
+    blocks,
+  };
+}
+
+export function buildQboInventoryAssetReclassPlan(input: {
+  marketplace: string;
+  lines: QboInventoryAssetLineInput[];
+}): QboInventoryAssetReclassPlan {
+  const targetMarketCode = marketCodeForMarketplace(input.marketplace);
+  const parsedLines: Array<{ source: QboInventoryAssetLineInput; parsed: ParsedQboInventoryAssetLine }> = [];
+  const linesToMove: QboInventoryAssetReclassLine[] = [];
+
+  for (const line of input.lines) {
+    if (!isInventoryAssetAccountName(line.accountName)) continue;
+
+    try {
+      parsedLines.push({ source: line, parsed: parseQboInventoryAssetLine(line) });
+    } catch {
+      linesToMove.push({ ...line, reason: 'UNPARSEABLE_ASSET_LINE' });
+    }
+  }
+
+  const marketByPo = new Map<string, string>();
+  for (const { parsed } of parsedLines) {
+    if (parsed.internalPo === null || parsed.marketCode === null) continue;
+    marketByPo.set(parsed.internalPo, parsed.marketCode);
+  }
+
+  for (const { source, parsed } of parsedLines) {
+    if (parsed.marketCode !== null && parsed.marketCode !== targetMarketCode) {
+      linesToMove.push({ ...source, reason: 'NON_TARGET_MARKET_ASSET_LINE' });
+      continue;
+    }
+
+    if (parsed.owner === 'RESIDUAL') {
+      linesToMove.push({ ...source, reason: 'RESIDUAL_ASSET_LINE' });
+      continue;
+    }
+
+    if (parsed.sellerSku === null) {
+      linesToMove.push({ ...source, reason: 'NON_SKU_ASSET_LINE' });
+      continue;
+    }
+
+    if (parsed.internalPo === null) {
+      linesToMove.push({ ...source, reason: 'MISSING_INTERNAL_PO' });
+      continue;
+    }
+
+    if (parsed.marketCode === null && marketByPo.get(parsed.internalPo) !== targetMarketCode) {
+      linesToMove.push({ ...source, reason: 'NON_TARGET_MARKET_ASSET_LINE' });
+    }
+  }
+
+  linesToMove.sort((left, right) => {
+    const billCompare = Number(left.billId) - Number(right.billId);
+    if (Number.isFinite(billCompare) && billCompare !== 0) return billCompare;
+    const lexicalBillCompare = left.billId.localeCompare(right.billId);
+    if (lexicalBillCompare !== 0) return lexicalBillCompare;
+    const lineCompare = Number(left.qboLineId) - Number(right.qboLineId);
+    if (Number.isFinite(lineCompare) && lineCompare !== 0) return lineCompare;
+    return left.qboLineId.localeCompare(right.qboLineId);
+  });
+
+  return {
+    marketplace: input.marketplace,
+    marketCode: targetMarketCode,
+    lines: linesToMove,
+    totalAmount: roundMoney(linesToMove.reduce((sum, line) => sum + line.amount, 0)),
+  };
+}

--- a/apps/plutus/lib/plutus/qbo-inventory-movements.ts
+++ b/apps/plutus/lib/plutus/qbo-inventory-movements.ts
@@ -1,0 +1,112 @@
+import { buildQboInventoryAdjustmentPayload, type QboInventoryAdjustmentPayload } from '@/lib/qbo/inventory-adjustments';
+import { normalizeSettlementOperatingMemo } from '@/lib/amazon-finances/settlement-memo-normalization';
+
+type AuditRow = {
+  invoiceId: string;
+  market: string;
+  date: string;
+  orderId: string;
+  sku: string;
+  quantity: number;
+  description: string;
+};
+
+export type QboInventoryItemMapping = {
+  marketplace: string;
+  sellerSku: string;
+  qboItemId: string;
+};
+
+export type InventoryMovementBlock = {
+  code: 'MISSING_QBO_ITEM_MAPPING';
+  sellerSku: string;
+};
+
+export type InventoryAdjustmentLinePlan = {
+  sellerSku: string;
+  qboItemId: string;
+  qtyDiff: number;
+};
+
+export type SettlementInventoryMovementPlan = {
+  ok: boolean;
+  blocks: InventoryMovementBlock[];
+  adjustmentLines: InventoryAdjustmentLinePlan[];
+  qboInventoryAdjustmentPayload: QboInventoryAdjustmentPayload | null;
+};
+
+function normalizeSellerSku(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function isSoldPrincipalRow(row: AuditRow): boolean {
+  return row.quantity > 0 && normalizeSettlementOperatingMemo(row.description) === 'Amazon Sales - Principal';
+}
+
+function qboInventoryAdjustmentDocNumber(settlementDocNumber: string): string {
+  const match = settlementDocNumber.match(/^(US|UK)-(\d{6})-(\d{6})-(S\d+(?:-[A-Z])?)$/);
+  if (match === null) {
+    throw new Error(`Unsupported settlement doc number for QBO inventory adjustment: ${settlementDocNumber}`);
+  }
+  const marketPrefix = match[1] === 'US' ? '' : `${match[1]!}-`;
+  return `IA-${marketPrefix}${match[2]!}-${match[3]!.slice(4)}-${match[4]!}`;
+}
+
+export function buildSettlementInventoryMovementPlan(input: {
+  marketplace: string;
+  settlementDocNumber: string;
+  txnDate: string;
+  adjustmentAccountId: string;
+  auditRows: AuditRow[];
+  itemMappings: QboInventoryItemMapping[];
+}): SettlementInventoryMovementPlan {
+  const mappingBySku = new Map<string, QboInventoryItemMapping>();
+  for (const mapping of input.itemMappings) {
+    if (mapping.marketplace !== input.marketplace) continue;
+    mappingBySku.set(normalizeSellerSku(mapping.sellerSku), mapping);
+  }
+
+  const soldQtyBySku = new Map<string, number>();
+  for (const row of input.auditRows) {
+    if (!isSoldPrincipalRow(row)) continue;
+    const sellerSku = normalizeSellerSku(row.sku);
+    if (sellerSku === '') continue;
+    soldQtyBySku.set(sellerSku, (soldQtyBySku.get(sellerSku) ?? 0) + row.quantity);
+  }
+
+  const blocks: InventoryMovementBlock[] = [];
+  const adjustmentLines: InventoryAdjustmentLinePlan[] = [];
+  for (const [sellerSku, soldQty] of soldQtyBySku.entries()) {
+    const mapping = mappingBySku.get(sellerSku);
+    if (mapping === undefined) {
+      blocks.push({ code: 'MISSING_QBO_ITEM_MAPPING', sellerSku });
+      continue;
+    }
+    adjustmentLines.push({
+      sellerSku,
+      qboItemId: mapping.qboItemId,
+      qtyDiff: -soldQty,
+    });
+  }
+
+  const qboInventoryAdjustmentPayload =
+    blocks.length === 0 && adjustmentLines.length > 0
+      ? buildQboInventoryAdjustmentPayload({
+          adjustmentAccountId: input.adjustmentAccountId,
+          txnDate: input.txnDate,
+          docNumber: qboInventoryAdjustmentDocNumber(input.settlementDocNumber),
+          privateNote: `Plutus inventory movement | Settlement: ${input.settlementDocNumber} | Marketplace: ${input.marketplace}`,
+          lines: adjustmentLines.map((line) => ({
+            qboItemId: line.qboItemId,
+            qtyDiff: line.qtyDiff,
+          })),
+        })
+      : null;
+
+  return {
+    ok: blocks.length === 0,
+    blocks,
+    adjustmentLines,
+    qboInventoryAdjustmentPayload,
+  };
+}

--- a/apps/plutus/lib/plutus/qbo-inventory-valuation.ts
+++ b/apps/plutus/lib/plutus/qbo-inventory-valuation.ts
@@ -1,0 +1,98 @@
+export type QboInventoryValuationRow = {
+  itemId: string | null;
+  name: string;
+  sku: string | null;
+  quantity: number;
+  assetValue: number;
+  averageCost: number;
+};
+
+export type QboInventoryValuationSummary = {
+  rows: QboInventoryValuationRow[];
+  totalAssetValue: number;
+};
+
+export type QboInventoryValuationTieout = {
+  ok: boolean;
+  inventoryAssetBalance: number;
+  inventoryValuationAssetValue: number;
+  delta: number;
+  tolerance: number;
+};
+
+type QboReportColData = {
+  value?: string;
+  id?: string;
+};
+
+type QboReportRow = {
+  ColData?: QboReportColData[];
+  group?: string;
+};
+
+type QboReport = {
+  Rows?: {
+    Row?: QboReportRow[];
+  };
+};
+
+function parseMoney(value: string | undefined): number {
+  if (value === undefined || value.trim() === '') return 0;
+  const numeric = Number(value.replace(/,/g, ''));
+  if (!Number.isFinite(numeric)) throw new Error(`QBO inventory valuation amount is not finite: ${value}`);
+  return numeric;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+export function parseQboInventoryValuationSummary(report: QboReport): QboInventoryValuationSummary {
+  const rows: QboInventoryValuationRow[] = [];
+  let totalAssetValue: number | null = null;
+
+  for (const row of report.Rows?.Row ?? []) {
+    const colData = row.ColData ?? [];
+    const itemName = colData[0]?.value?.trim();
+    if (itemName === undefined || itemName === '') continue;
+
+    if (row.group === 'GrandTotal' || itemName.toUpperCase() === 'TOTAL') {
+      totalAssetValue = parseMoney(colData[3]?.value);
+      continue;
+    }
+
+    rows.push({
+      itemId: colData[0]?.id ?? null,
+      name: itemName,
+      sku: colData[1]?.value?.trim() || null,
+      quantity: parseMoney(colData[2]?.value),
+      assetValue: parseMoney(colData[3]?.value),
+      averageCost: parseMoney(colData[4]?.value),
+    });
+  }
+
+  return {
+    rows,
+    totalAssetValue:
+      totalAssetValue === null ? roundMoney(rows.reduce((sum, row) => sum + row.assetValue, 0)) : totalAssetValue,
+  };
+}
+
+export function assessQboInventoryValuationTieout(input: {
+  inventoryAssetBalance: number;
+  inventoryValuationAssetValue: number;
+  tolerance?: number;
+}): QboInventoryValuationTieout {
+  const tolerance = input.tolerance ?? 0.01;
+  const inventoryAssetBalance = roundMoney(input.inventoryAssetBalance);
+  const inventoryValuationAssetValue = roundMoney(input.inventoryValuationAssetValue);
+  const delta = roundMoney(inventoryAssetBalance - inventoryValuationAssetValue);
+
+  return {
+    ok: Math.abs(delta) <= tolerance,
+    inventoryAssetBalance,
+    inventoryValuationAssetValue,
+    delta,
+    tolerance,
+  };
+}

--- a/apps/plutus/lib/qbo/api.ts
+++ b/apps/plutus/lib/qbo/api.ts
@@ -1599,7 +1599,7 @@ export async function fetchAccounts(
   const baseUrl = getApiBaseUrl();
 
   const query = includeInactive
-    ? `SELECT * FROM Account MAXRESULTS 1000`
+    ? `SELECT * FROM Account WHERE Active IN (true, false) MAXRESULTS 1000`
     : `SELECT * FROM Account WHERE Active = true MAXRESULTS 1000`;
   const queryUrl = `${baseUrl}/v3/company/${connection.realmId}/query?query=${encodeURIComponent(query)}`;
 
@@ -1655,6 +1655,37 @@ export async function fetchAccountsByFullyQualifiedName(
   const data = (await response.json()) as QboQueryResponse;
   const accounts = data.QueryResponse.Account;
   return { accounts: accounts ? accounts : [], updatedConnection };
+}
+
+export async function fetchQboReport(
+  connection: QboConnection,
+  reportName: string,
+  params: Record<string, string> = {},
+): Promise<{ report: unknown; updatedConnection?: QboConnection }> {
+  if (reportName.trim() === '') throw new Error('QBO report name is required');
+
+  const { accessToken, updatedConnection } = await getValidToken(connection);
+  const baseUrl = getApiBaseUrl();
+  const searchParams = new URLSearchParams(params);
+  searchParams.set('minorversion', '75');
+
+  const url = `${baseUrl}/v3/company/${connection.realmId}/reports/${reportName}?${searchParams.toString()}`;
+  logger.info('Fetching QBO report', { reportName, params });
+
+  const response = await fetchWithRetry(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error('Failed to fetch QBO report', { reportName, status: response.status, error: errorText });
+    throw new Error(`Failed to fetch QBO report ${reportName}: ${response.status} ${errorText}`);
+  }
+
+  return { report: await response.json(), updatedConnection };
 }
 
 export async function createAccount(
@@ -1746,6 +1777,9 @@ export async function updateAccountActive(
   }
 
   const data = await response.json();
+  invalidateCache(`accounts:${connection.realmId}:all`);
+  invalidateCache(`accounts:${connection.realmId}:active`);
+  invalidateCache(`accounts:${connection.realmId}`);
   return { account: data.Account, updatedConnection };
 }
 

--- a/apps/plutus/lib/qbo/inventory-adjustments.ts
+++ b/apps/plutus/lib/qbo/inventory-adjustments.ts
@@ -1,0 +1,63 @@
+export type QboInventoryAdjustmentPayload = {
+  AdjustAccountRef: { value: string };
+  domain: 'QBO';
+  sparse: false;
+  TxnDate: string;
+  DocNumber?: string;
+  PrivateNote?: string;
+  Line: Array<{
+    Id: string;
+    DetailType: 'ItemAdjustmentLineDetail';
+    ItemAdjustmentLineDetail: {
+      ItemRef: { value: string };
+      QtyDiff: number;
+    };
+  }>;
+};
+
+export function buildQboInventoryAdjustmentPayload(input: {
+  adjustmentAccountId: string;
+  txnDate: string;
+  docNumber?: string;
+  privateNote?: string;
+  lines: Array<{
+    qboItemId: string;
+    qtyDiff: number;
+  }>;
+}): QboInventoryAdjustmentPayload {
+  if (input.adjustmentAccountId.trim() === '') {
+    throw new Error('QBO inventory adjustment requires adjustmentAccountId');
+  }
+  if (input.txnDate.trim() === '') {
+    throw new Error('QBO inventory adjustment requires txnDate');
+  }
+  if (input.lines.length === 0) {
+    throw new Error('QBO inventory adjustment requires at least one line');
+  }
+
+  return {
+    AdjustAccountRef: { value: input.adjustmentAccountId },
+    domain: 'QBO',
+    sparse: false,
+    TxnDate: input.txnDate,
+    ...(input.docNumber !== undefined && input.docNumber.trim() !== '' ? { DocNumber: input.docNumber } : {}),
+    ...(input.privateNote !== undefined && input.privateNote.trim() !== '' ? { PrivateNote: input.privateNote } : {}),
+    Line: input.lines.map((line, index) => {
+      if (line.qboItemId.trim() === '') {
+        throw new Error('QBO inventory adjustment line requires qboItemId');
+      }
+      if (!Number.isInteger(line.qtyDiff) || line.qtyDiff === 0) {
+        throw new Error(`QBO inventory adjustment line requires non-zero integer qtyDiff for item ${line.qboItemId}`);
+      }
+
+      return {
+        Id: String(index + 1),
+        DetailType: 'ItemAdjustmentLineDetail',
+        ItemAdjustmentLineDetail: {
+          ItemRef: { value: line.qboItemId },
+          QtyDiff: line.qtyDiff,
+        },
+      };
+    }),
+  };
+}

--- a/apps/plutus/lib/qbo/inventory-documents.ts
+++ b/apps/plutus/lib/qbo/inventory-documents.ts
@@ -1,0 +1,124 @@
+type ItemLineInput = {
+  qboItemId: string;
+  description?: string;
+  quantity: number;
+  unitCost: number;
+};
+
+type QboItemBasedLinePayload = {
+  DetailType: 'ItemBasedExpenseLineDetail';
+  Amount: number;
+  Description?: string;
+  ItemBasedExpenseLineDetail: {
+    ItemRef: { value: string };
+    Qty: number;
+    UnitPrice: number;
+  };
+};
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function buildItemBasedLines(lines: ItemLineInput[]): QboItemBasedLinePayload[] {
+  if (lines.length === 0) {
+    throw new Error('QBO item document requires at least one item line');
+  }
+
+  return lines.map((line) => {
+    if (line.qboItemId.trim() === '') {
+      throw new Error('QBO item document line requires qboItemId');
+    }
+    if (!Number.isInteger(line.quantity) || line.quantity <= 0) {
+      throw new Error(`QBO item document line requires positive integer quantity for item ${line.qboItemId}`);
+    }
+    if (!Number.isFinite(line.unitCost) || line.unitCost < 0) {
+      throw new Error(`QBO item document line requires non-negative unitCost for item ${line.qboItemId}`);
+    }
+
+    return {
+      DetailType: 'ItemBasedExpenseLineDetail',
+      Amount: roundMoney(line.quantity * line.unitCost),
+      ...(line.description !== undefined && line.description.trim() !== '' ? { Description: line.description } : {}),
+      ItemBasedExpenseLineDetail: {
+        ItemRef: { value: line.qboItemId },
+        Qty: line.quantity,
+        UnitPrice: line.unitCost,
+      },
+    };
+  });
+}
+
+export function buildQboInventoryItemPayload(input: {
+  name: string;
+  sku: string;
+  inventoryStartDate: string;
+  initialQuantityOnHand: number;
+  assetAccountId: string;
+  incomeAccountId: string;
+  expenseAccountId: string;
+  purchaseCost?: number;
+  unitPrice?: number;
+}) {
+  if (input.name.trim() === '') throw new Error('QBO inventory item requires name');
+  if (input.sku.trim() === '') throw new Error('QBO inventory item requires sku');
+  if (input.inventoryStartDate.trim() === '') throw new Error('QBO inventory item requires inventoryStartDate');
+  if (!Number.isInteger(input.initialQuantityOnHand) || input.initialQuantityOnHand < 0) {
+    throw new Error('QBO inventory item requires non-negative integer initialQuantityOnHand');
+  }
+  if (input.assetAccountId.trim() === '') throw new Error('QBO inventory item requires assetAccountId');
+  if (input.incomeAccountId.trim() === '') throw new Error('QBO inventory item requires incomeAccountId');
+  if (input.expenseAccountId.trim() === '') throw new Error('QBO inventory item requires expenseAccountId');
+
+  return {
+    Name: input.name,
+    Sku: input.sku,
+    Type: 'Inventory',
+    TrackQtyOnHand: true,
+    QtyOnHand: input.initialQuantityOnHand,
+    InvStartDate: input.inventoryStartDate,
+    AssetAccountRef: { value: input.assetAccountId },
+    IncomeAccountRef: { value: input.incomeAccountId },
+    ExpenseAccountRef: { value: input.expenseAccountId },
+    ...(input.purchaseCost !== undefined ? { PurchaseCost: input.purchaseCost } : {}),
+    ...(input.unitPrice !== undefined ? { UnitPrice: input.unitPrice } : {}),
+  };
+}
+
+export function buildQboPurchaseOrderPayload(input: {
+  vendorId: string;
+  txnDate: string;
+  docNumber?: string;
+  privateNote?: string;
+  lines: ItemLineInput[];
+}) {
+  if (input.vendorId.trim() === '') throw new Error('QBO purchase order requires vendorId');
+  if (input.txnDate.trim() === '') throw new Error('QBO purchase order requires txnDate');
+
+  return {
+    VendorRef: { value: input.vendorId },
+    TxnDate: input.txnDate,
+    ...(input.docNumber !== undefined && input.docNumber.trim() !== '' ? { DocNumber: input.docNumber } : {}),
+    ...(input.privateNote !== undefined && input.privateNote.trim() !== '' ? { PrivateNote: input.privateNote } : {}),
+    Line: buildItemBasedLines(input.lines),
+  };
+}
+
+export function buildQboItemBasedBillPayload(input: {
+  vendorId: string;
+  txnDate: string;
+  docNumber?: string;
+  privateNote?: string;
+  lines: ItemLineInput[];
+}) {
+  if (input.vendorId.trim() === '') throw new Error('QBO item-based bill requires vendorId');
+  if (input.txnDate.trim() === '') throw new Error('QBO item-based bill requires txnDate');
+
+  return {
+    VendorRef: { value: input.vendorId },
+    TxnDate: input.txnDate,
+    ...(input.docNumber !== undefined && input.docNumber.trim() !== '' ? { DocNumber: input.docNumber } : {}),
+    ...(input.privateNote !== undefined && input.privateNote.trim() !== '' ? { PrivateNote: input.privateNote } : {}),
+    Line: buildItemBasedLines(input.lines),
+  };
+}

--- a/apps/plutus/package.json
+++ b/apps/plutus/package.json
@@ -20,6 +20,8 @@
     "settlements:reclass:repair": "tsx scripts/settlement-reclass-repair.ts",
     "settlements:us:reconcile:spapi": "tsx scripts/us-settlement-reconcile-spapi.ts",
     "settlements:us:ingest:spapi": "tsx scripts/us-settlement-ingest-spapi.ts",
+    "inventory:qbo:audit": "tsx scripts/qbo-inventory-bridge-audit.ts",
+    "inventory:qbo:repair": "tsx scripts/qbo-repair-inventory-valuation-tieout.ts",
     "settlements:backfill-docnumbers": "tsx scripts/backfill-settlement-doc-numbers.ts",
     "settlements:backfill-fx": "tsx scripts/backfill-settlement-exchange-rates.ts",
     "db:generate": "prisma generate --schema prisma/schema.prisma",

--- a/apps/plutus/prisma/migrations/20260515223000_add_qbo_inventory_bridge/migration.sql
+++ b/apps/plutus/prisma/migrations/20260515223000_add_qbo_inventory_bridge/migration.sql
@@ -1,0 +1,43 @@
+CREATE TABLE "QboInventoryItemMapping" (
+    "id" TEXT NOT NULL,
+    "marketplace" TEXT NOT NULL,
+    "sellerSku" TEXT NOT NULL,
+    "normalizedSellerSku" TEXT NOT NULL,
+    "qboItemId" TEXT NOT NULL,
+    "qboItemName" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QboInventoryItemMapping_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "QboInventoryMovementPosting" (
+    "id" TEXT NOT NULL,
+    "marketplace" TEXT NOT NULL,
+    "settlementDocNumber" TEXT NOT NULL,
+    "sellerSku" TEXT NOT NULL,
+    "qboItemId" TEXT NOT NULL,
+    "qboInventoryAdjustmentId" TEXT NOT NULL,
+    "quantityDelta" INTEGER NOT NULL,
+    "movementDate" TEXT NOT NULL,
+    "sourceHash" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'posted',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QboInventoryMovementPosting_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "QboInventoryItemMapping_marketplace_sellerSku_key" ON "QboInventoryItemMapping"("marketplace", "sellerSku");
+CREATE UNIQUE INDEX "QboInventoryItemMapping_marketplace_normalizedSellerSku_key" ON "QboInventoryItemMapping"("marketplace", "normalizedSellerSku");
+CREATE INDEX "QboInventoryItemMapping_marketplace_idx" ON "QboInventoryItemMapping"("marketplace");
+CREATE INDEX "QboInventoryItemMapping_qboItemId_idx" ON "QboInventoryItemMapping"("qboItemId");
+CREATE INDEX "QboInventoryItemMapping_active_idx" ON "QboInventoryItemMapping"("active");
+
+CREATE UNIQUE INDEX "QboInventoryMovementPosting_marketplace_settlementDocNumber_sellerSku_key" ON "QboInventoryMovementPosting"("marketplace", "settlementDocNumber", "sellerSku");
+CREATE INDEX "QboInventoryMovementPosting_marketplace_idx" ON "QboInventoryMovementPosting"("marketplace");
+CREATE INDEX "QboInventoryMovementPosting_settlementDocNumber_idx" ON "QboInventoryMovementPosting"("settlementDocNumber");
+CREATE INDEX "QboInventoryMovementPosting_qboInventoryAdjustmentId_idx" ON "QboInventoryMovementPosting"("qboInventoryAdjustmentId");
+CREATE INDEX "QboInventoryMovementPosting_qboItemId_idx" ON "QboInventoryMovementPosting"("qboItemId");
+CREATE INDEX "QboInventoryMovementPosting_status_idx" ON "QboInventoryMovementPosting"("status");

--- a/apps/plutus/prisma/schema.prisma
+++ b/apps/plutus/prisma/schema.prisma
@@ -241,6 +241,54 @@ model QboPostingLineFingerprint {
   @@index([driftStatus])
 }
 
+/// QboInventoryItemMapping maps marketplace seller SKUs to QBO inventory Item ids.
+/// QBO owns the item master; Plutus stores only the bridge needed to post proven quantity movements.
+model QboInventoryItemMapping {
+  id String @id @default(cuid())
+
+  marketplace          String
+  sellerSku            String
+  normalizedSellerSku  String
+  qboItemId            String
+  qboItemName          String?
+  active               Boolean @default(true)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([marketplace, sellerSku])
+  @@unique([marketplace, normalizedSellerSku])
+  @@index([marketplace])
+  @@index([qboItemId])
+  @@index([active])
+}
+
+/// QboInventoryMovementPosting records QBO Inventory Adjustment postings created from Amazon evidence.
+/// It is an audit bridge only; QBO remains the inventory quantity/value/COGS source of truth.
+model QboInventoryMovementPosting {
+  id String @id @default(cuid())
+
+  marketplace               String
+  settlementDocNumber       String
+  sellerSku                 String
+  qboItemId                 String
+  qboInventoryAdjustmentId  String
+  quantityDelta             Int
+  movementDate              String
+  sourceHash                String
+  status                    String @default("posted")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([marketplace, settlementDocNumber, sellerSku])
+  @@index([marketplace])
+  @@index([settlementDocNumber])
+  @@index([qboInventoryAdjustmentId])
+  @@index([qboItemId])
+  @@index([status])
+}
+
 /// AwdDataUpload tracks AWD monthly fee report uploads used for deterministic AWD fee allocation.
 model AwdDataUpload {
   id         String   @id @default(cuid())

--- a/apps/plutus/scripts/qbo-collapse-brand-level-accounts.ts
+++ b/apps/plutus/scripts/qbo-collapse-brand-level-accounts.ts
@@ -1,0 +1,493 @@
+import { getApiBaseUrl } from '@/lib/qbo/client';
+import { getActiveQboConnection, fetchAuditSourceData } from '@/lib/qbo/full-history-audit/fetch';
+import {
+  fetchAccounts,
+  fetchBillById,
+  fetchJournalEntryById,
+  fetchPurchaseById,
+  updateAccountActive,
+  updateBillWithPayload,
+  updateJournalEntryWithPayload,
+  updatePurchaseWithPayload,
+  type QboAccount,
+  type QboBill,
+  type QboJournalEntry,
+  type QboPurchase,
+} from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  apply: boolean;
+  humanApproval: string | null;
+};
+
+type AccountMove = {
+  fromAccountId: string;
+  fromAccountName: string;
+  fromAccountFqn: string;
+  toAccountId: string;
+  toAccountName: string;
+  toAccountFqn: string;
+};
+
+type LineChange = {
+  transactionType: 'Bill' | 'JournalEntry' | 'Purchase';
+  transactionId: string;
+  docNumber: string | null;
+  txnDate: string | null;
+  lineId: string;
+  amount: number;
+  description: string | null;
+  fromAccountId: string;
+  fromAccountName: string;
+  toAccountId: string;
+  toAccountName: string;
+};
+
+type UnsupportedReference = {
+  transactionType: string;
+  transactionId: string;
+  accountId: string;
+  accountName: string;
+};
+
+type RawSourceData = Awaited<ReturnType<typeof fetchAuditSourceData>>;
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let humanApproval: string | null = null;
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+    if (arg === '--human-approval') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`Brand-level QBO account collapse requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { apply, humanApproval };
+}
+
+function accountDisplayName(account: QboAccount): string {
+  return account.FullyQualifiedName ?? account.Name;
+}
+
+function isBrandLevelLeafAccount(account: QboAccount): boolean {
+  if (account.Active === false) return false;
+  return / - (US|UK)-(PDS|CDS)$/.test(account.Name.trim());
+}
+
+function buildAccountMoves(accounts: QboAccount[]): AccountMove[] {
+  const accountById = new Map(accounts.map((account) => [account.Id, account]));
+  const moves: AccountMove[] = [];
+
+  for (const account of accounts) {
+    if (!isBrandLevelLeafAccount(account)) continue;
+    const parentId = account.ParentRef?.value;
+    if (parentId === undefined || parentId.trim() === '') {
+      throw new Error(`Brand-level account has no parent: ${accountDisplayName(account)} (${account.Id})`);
+    }
+    const parent = accountById.get(parentId);
+    if (parent === undefined) {
+      throw new Error(`Missing parent account ${parentId} for ${accountDisplayName(account)} (${account.Id})`);
+    }
+    if (parent.Active === false) {
+      throw new Error(`Parent account is inactive for ${accountDisplayName(account)} (${account.Id})`);
+    }
+
+    moves.push({
+      fromAccountId: account.Id,
+      fromAccountName: account.Name,
+      fromAccountFqn: accountDisplayName(account),
+      toAccountId: parent.Id,
+      toAccountName: parent.Name,
+      toAccountFqn: accountDisplayName(parent),
+    });
+  }
+
+  return moves.sort((left, right) => left.fromAccountFqn.localeCompare(right.fromAccountFqn));
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+function nullableNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function findLineChanges(input: {
+  sourceData: RawSourceData;
+  movesByAccountId: Map<string, AccountMove>;
+}): { lineChanges: LineChange[]; unsupportedReferences: UnsupportedReference[] } {
+  const lineChanges: LineChange[] = [];
+  const unsupportedReferences: UnsupportedReference[] = [];
+
+  for (const bill of input.sourceData.bills.rows) {
+    for (const line of bill.Line ?? []) {
+      const accountId = line.AccountBasedExpenseLineDetail?.AccountRef?.value ?? line.ItemBasedExpenseLineDetail?.AccountRef?.value;
+      if (typeof accountId !== 'string') continue;
+      const move = input.movesByAccountId.get(accountId);
+      if (move === undefined) continue;
+      lineChanges.push({
+        transactionType: 'Bill',
+        transactionId: String(bill.Id),
+        docNumber: nullableString(bill.DocNumber),
+        txnDate: nullableString(bill.TxnDate),
+        lineId: String(line.Id),
+        amount: nullableNumber(line.Amount),
+        description: nullableString(line.Description),
+        fromAccountId: move.fromAccountId,
+        fromAccountName: move.fromAccountFqn,
+        toAccountId: move.toAccountId,
+        toAccountName: move.toAccountFqn,
+      });
+    }
+  }
+
+  for (const journalEntry of input.sourceData.journalEntries.rows) {
+    for (const line of journalEntry.Line ?? []) {
+      const accountId = line.JournalEntryLineDetail?.AccountRef?.value;
+      if (typeof accountId !== 'string') continue;
+      const move = input.movesByAccountId.get(accountId);
+      if (move === undefined) continue;
+      lineChanges.push({
+        transactionType: 'JournalEntry',
+        transactionId: String(journalEntry.Id),
+        docNumber: nullableString(journalEntry.DocNumber),
+        txnDate: nullableString(journalEntry.TxnDate),
+        lineId: String(line.Id),
+        amount: nullableNumber(line.Amount),
+        description: nullableString(line.Description),
+        fromAccountId: move.fromAccountId,
+        fromAccountName: move.fromAccountFqn,
+        toAccountId: move.toAccountId,
+        toAccountName: move.toAccountFqn,
+      });
+    }
+  }
+
+  for (const purchase of input.sourceData.purchases.rows) {
+    const purchaseAccountId = purchase.AccountRef?.value;
+    if (typeof purchaseAccountId === 'string') {
+      const move = input.movesByAccountId.get(purchaseAccountId);
+      if (move !== undefined) {
+        unsupportedReferences.push({
+          transactionType: 'PurchaseAccount',
+          transactionId: String(purchase.Id),
+          accountId: move.fromAccountId,
+          accountName: move.fromAccountFqn,
+        });
+      }
+    }
+
+    for (const line of purchase.Line ?? []) {
+      const accountId = line.AccountBasedExpenseLineDetail?.AccountRef?.value ?? line.ItemBasedExpenseLineDetail?.AccountRef?.value;
+      if (typeof accountId !== 'string') continue;
+      const move = input.movesByAccountId.get(accountId);
+      if (move === undefined) continue;
+      lineChanges.push({
+        transactionType: 'Purchase',
+        transactionId: String(purchase.Id),
+        docNumber: nullableString(purchase.DocNumber),
+        txnDate: nullableString(purchase.TxnDate),
+        lineId: String(line.Id),
+        amount: nullableNumber(line.Amount),
+        description: nullableString(line.Description),
+        fromAccountId: move.fromAccountId,
+        fromAccountName: move.fromAccountFqn,
+        toAccountId: move.toAccountId,
+        toAccountName: move.toAccountFqn,
+      });
+    }
+  }
+
+  for (const transfer of input.sourceData.transfers.rows) {
+    const fromAccountId = transfer.FromAccountRef?.value;
+    if (typeof fromAccountId === 'string') {
+      const move = input.movesByAccountId.get(fromAccountId);
+      if (move !== undefined) {
+        unsupportedReferences.push({
+          transactionType: 'TransferFrom',
+          transactionId: String(transfer.Id),
+          accountId: move.fromAccountId,
+          accountName: move.fromAccountFqn,
+        });
+      }
+    }
+
+    const toAccountId = transfer.ToAccountRef?.value;
+    if (typeof toAccountId === 'string') {
+      const move = input.movesByAccountId.get(toAccountId);
+      if (move !== undefined) {
+        unsupportedReferences.push({
+          transactionType: 'TransferTo',
+          transactionId: String(transfer.Id),
+          accountId: move.fromAccountId,
+          accountName: move.fromAccountFqn,
+        });
+      }
+    }
+  }
+
+  return { lineChanges, unsupportedReferences };
+}
+
+function groupLineChangesByTransaction(changes: LineChange[]): Map<string, LineChange[]> {
+  const grouped = new Map<string, LineChange[]>();
+  for (const change of changes) {
+    const key = `${change.transactionType}:${change.transactionId}`;
+    const existing = grouped.get(key);
+    if (existing === undefined) {
+      grouped.set(key, [change]);
+      continue;
+    }
+    existing.push(change);
+  }
+  return grouped;
+}
+
+function updateBillPayload(input: { bill: QboBill; changes: LineChange[] }): QboBill {
+  const changesByLineId = new Map(input.changes.map((change) => [change.lineId, change]));
+  return {
+    ...input.bill,
+    Line: (input.bill.Line ?? []).map((line) => {
+      const change = changesByLineId.get(line.Id);
+      if (change === undefined) return line;
+
+      if (line.AccountBasedExpenseLineDetail !== undefined) {
+        return {
+          ...line,
+          AccountBasedExpenseLineDetail: {
+            ...line.AccountBasedExpenseLineDetail,
+            AccountRef: {
+              value: change.toAccountId,
+              name: change.toAccountName,
+            },
+          },
+        };
+      }
+
+      if (line.ItemBasedExpenseLineDetail !== undefined) {
+        return {
+          ...line,
+          ItemBasedExpenseLineDetail: {
+            ...line.ItemBasedExpenseLineDetail,
+            AccountRef: {
+              value: change.toAccountId,
+              name: change.toAccountName,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Bill ${input.bill.Id} line ${line.Id} has no updatable account detail`);
+    }),
+  };
+}
+
+function updateJournalEntryPayload(input: { journalEntry: QboJournalEntry; changes: LineChange[] }): QboJournalEntry {
+  const changesByLineId = new Map(input.changes.map((change) => [change.lineId, change]));
+  return {
+    ...input.journalEntry,
+    Line: input.journalEntry.Line.map((line) => {
+      const lineId = line.Id;
+      if (lineId === undefined) return line;
+      const change = changesByLineId.get(lineId);
+      if (change === undefined) return line;
+      return {
+        ...line,
+        JournalEntryLineDetail: {
+          ...line.JournalEntryLineDetail,
+          AccountRef: {
+            value: change.toAccountId,
+            name: change.toAccountName,
+          },
+        },
+      };
+    }),
+  };
+}
+
+function updatePurchasePayload(input: { purchase: QboPurchase; changes: LineChange[] }): QboPurchase {
+  const changesByLineId = new Map(input.changes.map((change) => [change.lineId, change]));
+  return {
+    ...input.purchase,
+    Line: (input.purchase.Line ?? []).map((line) => {
+      const change = changesByLineId.get(line.Id);
+      if (change === undefined) return line;
+
+      if (line.AccountBasedExpenseLineDetail !== undefined) {
+        return {
+          ...line,
+          AccountBasedExpenseLineDetail: {
+            ...line.AccountBasedExpenseLineDetail,
+            AccountRef: {
+              value: change.toAccountId,
+              name: change.toAccountName,
+            },
+          },
+        };
+      }
+
+      if (line.ItemBasedExpenseLineDetail !== undefined) {
+        return {
+          ...line,
+          ItemBasedExpenseLineDetail: {
+            ...line.ItemBasedExpenseLineDetail,
+            AccountRef: {
+              value: change.toAccountId,
+              name: change.toAccountName,
+            },
+          },
+        };
+      }
+
+      throw new Error(`Purchase ${input.purchase.Id} line ${line.Id} has no updatable account detail`);
+    }),
+  };
+}
+
+function summarizeChangesByAccount(changes: LineChange[]): Array<{
+  fromAccountId: string;
+  fromAccountName: string;
+  toAccountId: string;
+  toAccountName: string;
+  lineCount: number;
+  amount: number;
+}> {
+  const summaryByAccount = new Map<string, ReturnType<typeof summarizeChangesByAccount>[number]>();
+  for (const change of changes) {
+    const key = change.fromAccountId;
+    const summary =
+      summaryByAccount.get(key) ??
+      {
+        fromAccountId: change.fromAccountId,
+        fromAccountName: change.fromAccountName,
+        toAccountId: change.toAccountId,
+        toAccountName: change.toAccountName,
+        lineCount: 0,
+        amount: 0,
+      };
+    summary.lineCount += 1;
+    summary.amount = Math.round((summary.amount + change.amount) * 100) / 100;
+    summaryByAccount.set(key, summary);
+  }
+  return Array.from(summaryByAccount.values()).sort((left, right) =>
+    left.fromAccountName.localeCompare(right.fromAccountName),
+  );
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  loadSharedPlutusEnv();
+
+  const activeConnection = await getActiveQboConnection();
+  let qboConnection = activeConnection.connection;
+  const accountsResult = await fetchAccounts(qboConnection, { includeInactive: true });
+  if (accountsResult.updatedConnection !== undefined) {
+    qboConnection = accountsResult.updatedConnection;
+    await saveServerQboConnection(qboConnection);
+  }
+
+  const accountMoves = buildAccountMoves(accountsResult.accounts);
+  const movesByAccountId = new Map(accountMoves.map((move) => [move.fromAccountId, move]));
+  const sourceData = await fetchAuditSourceData(activeConnection.accessToken, qboConnection.realmId, getApiBaseUrl());
+  const { lineChanges, unsupportedReferences } = findLineChanges({ sourceData, movesByAccountId });
+  const groupedChanges = groupLineChangesByTransaction(lineChanges);
+
+  const dryRunPayload = {
+    mode: options.apply ? 'apply' : 'dry-run',
+    activeBrandLevelAccounts: accountMoves.length,
+    transactionLineChanges: lineChanges.length,
+    transactionsToUpdate: groupedChanges.size,
+    changesByAccount: summarizeChangesByAccount(lineChanges),
+    accountsToDeactivate: accountMoves.map((move) => ({
+      accountId: move.fromAccountId,
+      accountName: move.fromAccountFqn,
+      targetAccountId: move.toAccountId,
+      targetAccountName: move.toAccountFqn,
+    })),
+    unsupportedReferences,
+  };
+
+  console.log(JSON.stringify(dryRunPayload, null, 2));
+
+  if (unsupportedReferences.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!options.apply) {
+    return;
+  }
+
+  for (const [key, changes] of groupedChanges.entries()) {
+    const [transactionType, transactionId] = key.split(':') as ['Bill' | 'JournalEntry' | 'Purchase', string];
+    if (transactionType === 'Bill') {
+      const fetched = await fetchBillById(qboConnection, transactionId);
+      if (fetched.updatedConnection !== undefined) qboConnection = fetched.updatedConnection;
+      const updatedPayload = updateBillPayload({ bill: fetched.bill, changes });
+      const updated = await updateBillWithPayload(qboConnection, updatedPayload as unknown as Record<string, unknown>);
+      if (updated.updatedConnection !== undefined) qboConnection = updated.updatedConnection;
+      continue;
+    }
+
+    if (transactionType === 'JournalEntry') {
+      const fetched = await fetchJournalEntryById(qboConnection, transactionId);
+      if (fetched.updatedConnection !== undefined) qboConnection = fetched.updatedConnection;
+      const updatedPayload = updateJournalEntryPayload({ journalEntry: fetched.journalEntry, changes });
+      const updated = await updateJournalEntryWithPayload(qboConnection, updatedPayload);
+      if (updated.updatedConnection !== undefined) qboConnection = updated.updatedConnection;
+      continue;
+    }
+
+    if (transactionType === 'Purchase') {
+      const fetched = await fetchPurchaseById(qboConnection, transactionId);
+      if (fetched.updatedConnection !== undefined) qboConnection = fetched.updatedConnection;
+      const updatedPayload = updatePurchasePayload({ purchase: fetched.purchase, changes });
+      const updated = await updatePurchaseWithPayload(qboConnection, updatedPayload as unknown as Record<string, unknown>);
+      if (updated.updatedConnection !== undefined) qboConnection = updated.updatedConnection;
+      continue;
+    }
+
+    throw new Error(`Unsupported transaction type: ${transactionType}`);
+  }
+
+  const refreshedActiveConnection = await getQboConnection();
+  if (refreshedActiveConnection === null) throw new Error('QBO connection disappeared after transaction updates');
+  qboConnection = refreshedActiveConnection;
+  const refreshedAccounts = await fetchAccounts(qboConnection, { includeInactive: true });
+  if (refreshedAccounts.updatedConnection !== undefined) qboConnection = refreshedAccounts.updatedConnection;
+  const refreshedById = new Map(refreshedAccounts.accounts.map((account) => [account.Id, account]));
+
+  for (const move of accountMoves) {
+    const account = refreshedById.get(move.fromAccountId);
+    if (account === undefined) throw new Error(`Cannot deactivate missing account ${move.fromAccountId}`);
+    if (account.Active === false) continue;
+    const updated = await updateAccountActive(qboConnection, account.Id, account.SyncToken, account.Name, false);
+    if (updated.updatedConnection !== undefined) qboConnection = updated.updatedConnection;
+  }
+
+  await saveServerQboConnection(qboConnection);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/apps/plutus/scripts/qbo-complete-inventory-migration.ts
+++ b/apps/plutus/scripts/qbo-complete-inventory-migration.ts
@@ -1,0 +1,684 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+import { normalizeSettlementOperatingMemo } from '@/lib/amazon-finances/settlement-memo-normalization';
+import { db } from '@/lib/db';
+import { buildQboInventoryLandedCostPlan, type QboInventoryAssetLineInput } from '@/lib/plutus/qbo-inventory-asset-lines';
+import { buildSettlementInventoryMovementPlan, type QboInventoryItemMapping } from '@/lib/plutus/qbo-inventory-movements';
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
+import { computeProcessingHash } from '@/lib/plutus/settlement-utils';
+import {
+  deleteJournalEntry,
+  fetchAccounts,
+  fetchBills,
+  fetchJournalEntries,
+  getValidToken,
+  type QboAccount,
+  type QboBill,
+  type QboConnection,
+  type QboJournalEntry,
+} from '@/lib/qbo/api';
+import { getApiBaseUrl } from '@/lib/qbo/client';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { getActiveQboConnection, qboQueryAll } from '@/lib/qbo/full-history-audit/fetch';
+import { buildQboItemBasedBillPayload } from '@/lib/qbo/inventory-documents';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  apply: boolean;
+  humanApproval: string | null;
+};
+
+type QboItem = {
+  Id: string;
+  Name: string;
+  Sku?: string;
+  Type?: string;
+  Active?: boolean;
+};
+
+type QboDocNumberRow = {
+  DocNumber?: string;
+};
+
+type QboVendorCredit = {
+  Id: string;
+  DocNumber?: string;
+};
+
+type QboInventoryAdjustment = {
+  Id: string;
+  DocNumber?: string;
+};
+
+type AuditRow = {
+  invoiceId: string;
+  market: string;
+  date: string;
+  orderId: string;
+  sku: string;
+  quantity: number;
+  description: string;
+  net: number;
+};
+
+type CreatedObject = {
+  id: string;
+  docNumber: string;
+};
+
+const MARKETPLACE = 'amazon.com';
+const MARKET = 'us';
+const SKU_ORDER = ['CS-007', 'CS-010', 'CS-12LD-7M', 'CS-1SD-32M'];
+const RECEIPT_DOC_PREFIX = 'MIG-R-';
+const VENDOR_CREDIT_DOC_PREFIX = 'MIG-VC-';
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let humanApproval: string | null = null;
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+    if (arg === '--human-approval') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`QBO inventory migration requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { apply, humanApproval };
+}
+
+function requireAccount(accounts: QboAccount[], fullyQualifiedName: string): QboAccount {
+  const matches = accounts.filter((account) => account.Active !== false && account.FullyQualifiedName === fullyQualifiedName);
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one active QBO account named ${fullyQualifiedName}; found ${matches.length}`);
+  }
+  return matches[0]!;
+}
+
+function normalizeSku(value: string | undefined): string {
+  return value === undefined ? '' : value.trim().toUpperCase();
+}
+
+function buildInventoryItemBySku(items: QboItem[]): Map<string, QboItem> {
+  const bySku = new Map<string, QboItem>();
+  for (const item of items) {
+    if (item.Active === false) continue;
+    if (item.Type !== 'Inventory') continue;
+    const key = normalizeSku(item.Sku ?? item.Name);
+    if (key === '') continue;
+    bySku.set(key, item);
+  }
+  return bySku;
+}
+
+async function postQboObject(input: {
+  connection: QboConnection;
+  entityPath: 'bill' | 'vendorcredit' | 'inventoryadjustment';
+  responseKey: 'Bill' | 'VendorCredit' | 'InventoryAdjustment';
+  payload: Record<string, unknown>;
+}): Promise<{ object: Record<string, unknown>; updatedConnection?: QboConnection }> {
+  const tokenResult = await getValidToken(input.connection);
+  const activeConnection = tokenResult.updatedConnection ?? input.connection;
+  const entityUrl = new URL(`${getApiBaseUrl()}/v3/company/${activeConnection.realmId}/${input.entityPath}`);
+  if (input.entityPath === 'inventoryadjustment') {
+    entityUrl.searchParams.set('minorversion', '75');
+  }
+  const response = await fetch(entityUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokenResult.accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(input.payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to create QBO ${input.entityPath}: ${response.status} ${errorText}; payload=${JSON.stringify(input.payload)}`,
+    );
+  }
+
+  const data = (await response.json()) as Record<string, unknown>;
+  const created = data[input.responseKey];
+  if (typeof created !== 'object' || created === null) {
+    throw new Error(`QBO ${input.entityPath} create response did not include ${input.responseKey}`);
+  }
+  return { object: created as Record<string, unknown>, updatedConnection: tokenResult.updatedConnection };
+}
+
+async function fetchAllBills(input: { connection: QboConnection; startDate: string; endDate: string }): Promise<QboBill[]> {
+  const maxResults = 1000;
+  let startPosition = 1;
+  let activeConnection = input.connection;
+  const bills: QboBill[] = [];
+
+  while (true) {
+    const result = await fetchBills(activeConnection, {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      maxResults,
+      startPosition,
+      includeTotalCount: false,
+    });
+    if (result.updatedConnection !== undefined) {
+      activeConnection = result.updatedConnection;
+    }
+
+    bills.push(...result.bills);
+    if (result.bills.length < maxResults) break;
+    startPosition += result.bills.length;
+  }
+
+  if (activeConnection !== input.connection) {
+    await saveServerQboConnection(activeConnection);
+  }
+  return bills;
+}
+
+function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
+  const lines: QboInventoryAssetLineInput[] = [];
+  for (const bill of bills) {
+    for (const line of bill.Line ?? []) {
+      const accountName = line.AccountBasedExpenseLineDetail?.AccountRef.name;
+      if (accountName === undefined) continue;
+      if (accountName !== 'Inventory Asset' && !accountName.startsWith('Inventory Asset:')) continue;
+      if (line.Id === undefined) throw new Error(`QBO bill ${bill.Id} has an inventory asset line without line id`);
+      lines.push({
+        billId: bill.Id,
+        ...(bill.DocNumber !== undefined ? { billDocNumber: bill.DocNumber } : {}),
+        billDate: bill.TxnDate,
+        ...(bill.VendorRef?.name !== undefined ? { vendorName: bill.VendorRef.name } : {}),
+        qboLineId: line.Id,
+        accountName,
+        amount: line.Amount,
+        ...(line.Description !== undefined ? { description: line.Description } : {}),
+      });
+    }
+  }
+  return lines;
+}
+
+function findManufacturingBillVendorByPo(input: {
+  bills: QboBill[];
+}): Map<string, { vendorId: string; vendorName: string; txnDate: string; sourceRefs: Set<string> }> {
+  const vendorByPo = new Map<string, { vendorId: string; vendorName: string; txnDate: string; sourceRefs: Set<string> }>();
+  for (const bill of input.bills) {
+    const vendorId = bill.VendorRef?.value;
+    const vendorName = bill.VendorRef?.name;
+    if (vendorId === undefined || vendorName === undefined) continue;
+    for (const line of bill.Line ?? []) {
+      const description = line.Description ?? '';
+      if (!description.startsWith('MFG;')) continue;
+      const poMatch = description.match(/(?:^|; )PO=([^;]+)/);
+      if (poMatch === null) continue;
+      const internalPo = poMatch[1]!.trim();
+      const sourceMatch = description.match(/(?:^|; )SOURCE=([^;]+)/);
+      const sourceRef = sourceMatch === null ? bill.DocNumber ?? null : sourceMatch[1]!.trim();
+      const existing = vendorByPo.get(internalPo);
+      if (existing === undefined) {
+        vendorByPo.set(internalPo, {
+          vendorId,
+          vendorName,
+          txnDate: bill.TxnDate,
+          sourceRefs: new Set(sourceRef === null ? [] : [sourceRef]),
+        });
+        continue;
+      }
+      if (existing.vendorId !== vendorId) {
+        throw new Error(`PO ${internalPo} has multiple manufacturing vendors: ${existing.vendorName} and ${vendorName}`);
+      }
+      if (sourceRef !== null) existing.sourceRefs.add(sourceRef);
+      if (bill.TxnDate < existing.txnDate) existing.txnDate = bill.TxnDate;
+    }
+  }
+  return vendorByPo;
+}
+
+function receiptDocNumber(internalPo: string): string {
+  return `${RECEIPT_DOC_PREFIX}${internalPo}`;
+}
+
+function vendorCreditDocNumber(internalPo: string): string {
+  return `${VENDOR_CREDIT_DOC_PREFIX}${internalPo}`;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function buildVendorCreditPayload(input: {
+  vendorId: string;
+  txnDate: string;
+  docNumber: string;
+  privateNote: string;
+  accountId: string;
+  amount: number;
+}) {
+  return {
+    VendorRef: { value: input.vendorId },
+    TxnDate: input.txnDate,
+    DocNumber: input.docNumber,
+    PrivateNote: input.privateNote,
+    Line: [
+      {
+        DetailType: 'AccountBasedExpenseLineDetail',
+        Amount: input.amount,
+        Description: input.privateNote,
+        AccountBasedExpenseLineDetail: {
+          AccountRef: { value: input.accountId },
+        },
+      },
+    ],
+  };
+}
+
+function isLegacyManualCogsJournalEntry(entry: QboJournalEntry): boolean {
+  return entry.Line.some((line) => {
+    const description = line.Description ?? '';
+    return (
+      description.startsWith('Manufacturing COGS |') ||
+      description.startsWith('Freight COGS |') ||
+      description.startsWith('Duty COGS |') ||
+      description.startsWith('Mfg Accessories COGS |')
+    );
+  });
+}
+
+async function fetchAllJournalEntries(input: { connection: QboConnection }): Promise<QboJournalEntry[]> {
+  const maxResults = 1000;
+  let startPosition = 1;
+  let connection = input.connection;
+  const entries: QboJournalEntry[] = [];
+  while (true) {
+    const result = await fetchJournalEntries(connection, {
+      maxResults,
+      startPosition,
+      includeTotalCount: false,
+    });
+    if (result.updatedConnection !== undefined) connection = result.updatedConnection;
+    entries.push(...result.journalEntries);
+    if (result.journalEntries.length < maxResults) break;
+    startPosition += result.journalEntries.length;
+  }
+  await saveServerQboConnection(connection);
+  return entries;
+}
+
+function sourceHashForRows(rows: AuditRow[]): string {
+  return createHash('sha256').update(JSON.stringify(rows)).digest('hex');
+}
+
+function settlementTxnDate(rows: AuditRow[]): string {
+  const dates = rows.map((row) => row.date).sort();
+  const last = dates[dates.length - 1];
+  if (last === undefined) throw new Error('Cannot determine settlement txn date without rows');
+  return last;
+}
+
+async function upsertInventoryMappings(input: { mappings: QboInventoryItemMapping[] }): Promise<void> {
+  for (const mapping of input.mappings) {
+    const id = randomUUID();
+    await db.$executeRaw`
+      INSERT INTO "QboInventoryItemMapping"
+        ("id", "marketplace", "sellerSku", "normalizedSellerSku", "qboItemId", "qboItemName", "active", "createdAt", "updatedAt")
+      VALUES
+        (${id}, ${mapping.marketplace}, ${mapping.sellerSku}, ${mapping.sellerSku.trim().toUpperCase()}, ${mapping.qboItemId}, ${mapping.sellerSku}, true, now(), now())
+      ON CONFLICT ("marketplace", "normalizedSellerSku")
+      DO UPDATE SET
+        "sellerSku" = EXCLUDED."sellerSku",
+        "qboItemId" = EXCLUDED."qboItemId",
+        "qboItemName" = EXCLUDED."qboItemName",
+        "active" = true,
+        "updatedAt" = now()
+    `;
+  }
+}
+
+async function recordInventoryMovementPostings(input: {
+  marketplace: string;
+  settlementDocNumber: string;
+  movementDate: string;
+  sourceHash: string;
+  adjustmentId: string;
+  adjustmentLines: Array<{ sellerSku: string; qboItemId: string; qtyDiff: number }>;
+}): Promise<void> {
+  for (const line of input.adjustmentLines) {
+    const id = randomUUID();
+    await db.$executeRaw`
+      INSERT INTO "QboInventoryMovementPosting"
+        ("id", "marketplace", "settlementDocNumber", "sellerSku", "qboItemId", "qboInventoryAdjustmentId", "quantityDelta", "movementDate", "sourceHash", "status", "createdAt", "updatedAt")
+      VALUES
+        (${id}, ${input.marketplace}, ${input.settlementDocNumber}, ${line.sellerSku}, ${line.qboItemId}, ${input.adjustmentId}, ${line.qtyDiff}, ${input.movementDate}, ${input.sourceHash}, 'posted', now(), now())
+      ON CONFLICT ("marketplace", "settlementDocNumber", "sellerSku")
+      DO UPDATE SET
+        "qboItemId" = EXCLUDED."qboItemId",
+        "qboInventoryAdjustmentId" = EXCLUDED."qboInventoryAdjustmentId",
+        "quantityDelta" = EXCLUDED."quantityDelta",
+        "movementDate" = EXCLUDED."movementDate",
+        "sourceHash" = EXCLUDED."sourceHash",
+        "status" = 'posted',
+        "updatedAt" = now()
+    `;
+  }
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  loadSharedPlutusEnv();
+
+  let connection = await getQboConnection();
+  if (connection === null) throw new Error('QBO connection is not configured');
+  const activeConnection = await getActiveQboConnection();
+  connection = activeConnection.connection;
+
+  const accountsResult = await fetchAccounts(connection, { includeInactive: true });
+  if (accountsResult.updatedConnection !== undefined) {
+    connection = accountsResult.updatedConnection;
+    await saveServerQboConnection(connection);
+  }
+  const inventoryAsset = requireAccount(accountsResult.accounts, 'Inventory Asset');
+  const inventoryAdjustmentCogs = requireAccount(accountsResult.accounts, 'Inventory COGS Release');
+
+  const [itemsResult, billDocsResult, vendorCreditsResult, adjustmentResult, bills, journalEntries, auditRows] =
+    await Promise.all([
+      qboQueryAll(activeConnection, 'SELECT * FROM Item WHERE Active IN (true, false)'),
+      qboQueryAll(activeConnection, 'SELECT * FROM Bill'),
+      qboQueryAll(activeConnection, 'SELECT * FROM VendorCredit'),
+      qboQueryAll(activeConnection, 'SELECT * FROM InventoryAdjustment'),
+      fetchAllBills({ connection, startDate: '2025-01-01', endDate: new Date().toISOString().slice(0, 10) }),
+      fetchAllJournalEntries({ connection }),
+      db.auditDataRow.findMany({
+        where: { market: { equals: MARKET, mode: 'insensitive' } },
+        select: {
+          invoiceId: true,
+          market: true,
+          date: true,
+          orderId: true,
+          sku: true,
+          quantity: true,
+          description: true,
+          net: true,
+        },
+        orderBy: [{ date: 'asc' }, { invoiceId: 'asc' }, { sku: 'asc' }],
+      }),
+    ]);
+
+  const itemBySku = buildInventoryItemBySku(itemsResult.rows as QboItem[]);
+  const missingSkus = SKU_ORDER.filter((sku) => itemBySku.get(sku) === undefined);
+  if (missingSkus.length > 0) throw new Error(`Missing QBO inventory item mappings for: ${missingSkus.join(', ')}`);
+
+  const mappings: QboInventoryItemMapping[] = SKU_ORDER.map((sku) => ({
+    marketplace: MARKETPLACE,
+    sellerSku: sku,
+    qboItemId: itemBySku.get(sku)!.Id,
+  }));
+
+  const landedPlan = buildQboInventoryLandedCostPlan({
+    marketplace: MARKETPLACE,
+    lines: collectInventoryAssetLines(bills),
+  });
+  const vendorByPo = findManufacturingBillVendorByPo({ bills });
+  const layersByPo = new Map<string, typeof landedPlan.layers>();
+  for (const layer of landedPlan.layers) {
+    const existing = layersByPo.get(layer.internalPo);
+    if (existing === undefined) {
+      layersByPo.set(layer.internalPo, [layer]);
+    } else {
+      existing.push(layer);
+    }
+  }
+
+  const existingBillDocs = new Set(
+    (billDocsResult.rows as QboDocNumberRow[]).map((bill) => bill.DocNumber).filter(Boolean),
+  );
+  const existingVendorCreditDocs = new Set(
+    (vendorCreditsResult.rows as QboVendorCredit[]).map((credit) => credit.DocNumber).filter(Boolean),
+  );
+  const existingAdjustmentDocs = new Set(
+    (adjustmentResult.rows as QboInventoryAdjustment[]).map((adjustment) => adjustment.DocNumber).filter(Boolean),
+  );
+
+  const receiptPlans = Array.from(layersByPo.entries())
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([internalPo, layers]) => {
+      const vendor = vendorByPo.get(internalPo);
+      if (vendor === undefined) throw new Error(`Missing manufacturing vendor for ${internalPo}`);
+      const sortedLayers = layers.slice().sort((left, right) => SKU_ORDER.indexOf(left.sellerSku) - SKU_ORDER.indexOf(right.sellerSku));
+      const sourceRefs = Array.from(new Set(sortedLayers.flatMap((layer) => layer.sourceRefs))).sort();
+      const totalAmount = roundMoney(sortedLayers.reduce((sum, layer) => sum + layer.totalAmount, 0));
+      return {
+        internalPo,
+        receiptDocNumber: receiptDocNumber(internalPo),
+        vendorCreditDocNumber: vendorCreditDocNumber(internalPo),
+        vendorId: vendor.vendorId,
+        vendorName: vendor.vendorName,
+        txnDate: vendor.txnDate,
+        sourceRefs,
+        totalAmount,
+        lines: sortedLayers.map((layer) => ({
+          qboItemId: itemBySku.get(layer.sellerSku)!.Id,
+          sellerSku: layer.sellerSku,
+          quantity: layer.quantity,
+          unitCost: layer.unitCost,
+          amount: layer.totalAmount,
+          description: [
+            `INTERNAL PO: ${layer.internalPo}`,
+            `SKU: ${layer.sellerSku}`,
+            `QTY: ${layer.quantity}`,
+            `LANDED_TOTAL: ${layer.totalAmount.toFixed(2)}`,
+            `SOURCES: ${layer.sourceRefs.join(',')}`,
+            `QBO_BILL_LINES: ${layer.qboBillLineRefs.join(',')}`,
+          ].join('; '),
+        })),
+      };
+    });
+
+  const legacyManualCogsEntries = journalEntries.filter(isLegacyManualCogsJournalEntry);
+  const rowsByInvoice = new Map<string, AuditRow[]>();
+  for (const row of auditRows as AuditRow[]) {
+    const existing = rowsByInvoice.get(row.invoiceId);
+    if (existing === undefined) rowsByInvoice.set(row.invoiceId, [row]);
+    else existing.push(row);
+  }
+
+  const movementPlans = Array.from(rowsByInvoice.entries())
+    .sort((left, right) => settlementTxnDate(left[1]).localeCompare(settlementTxnDate(right[1])))
+    .map(([invoiceId, rows]) => ({
+      invoiceId,
+      rows,
+      plan: buildSettlementInventoryMovementPlan({
+        marketplace: MARKETPLACE,
+        settlementDocNumber: invoiceId,
+        txnDate: settlementTxnDate(rows),
+        adjustmentAccountId: inventoryAdjustmentCogs.Id,
+        auditRows: rows,
+        itemMappings: mappings,
+      }),
+    }))
+    .filter((entry) => entry.plan.adjustmentLines.length > 0);
+
+  const blockingMovementPlans = movementPlans.filter((entry) => !entry.plan.ok);
+  if (blockingMovementPlans.length > 0) {
+    throw new Error(
+      `Inventory movement plans blocked: ${blockingMovementPlans
+        .map((entry) => `${entry.invoiceId}:${entry.plan.blocks.map((block) => block.code).join(',')}`)
+        .join('; ')}`,
+    );
+  }
+
+  const dryRun = {
+    mode: options.apply ? 'apply' : 'dry-run',
+    mappings,
+    receiptPlans: receiptPlans.map((plan) => ({
+      internalPo: plan.internalPo,
+      receiptDocNumber: plan.receiptDocNumber,
+      receiptExists: existingBillDocs.has(plan.receiptDocNumber),
+      vendorCreditDocNumber: plan.vendorCreditDocNumber,
+      vendorCreditExists: existingVendorCreditDocs.has(plan.vendorCreditDocNumber),
+      vendorName: plan.vendorName,
+      txnDate: plan.txnDate,
+      totalAmount: plan.totalAmount,
+      lines: plan.lines.map((line) => ({
+        sellerSku: line.sellerSku,
+        qboItemId: line.qboItemId,
+        quantity: line.quantity,
+        unitCost: line.unitCost,
+        amount: line.amount,
+      })),
+    })),
+    legacyManualCogsEntries: legacyManualCogsEntries.map((entry) => ({
+      id: entry.Id,
+      docNumber: entry.DocNumber,
+      txnDate: entry.TxnDate,
+      totalDebit: roundMoney(
+        entry.Line.filter((line) => line.JournalEntryLineDetail.PostingType === 'Debit').reduce(
+          (sum, line) => sum + (line.Amount ?? 0),
+          0,
+        ),
+      ),
+    })),
+    movementPlans: movementPlans.map((entry) => ({
+      invoiceId: entry.invoiceId,
+      txnDate: settlementTxnDate(entry.rows),
+      docNumber: entry.plan.qboInventoryAdjustmentPayload?.DocNumber ?? null,
+      exists:
+        entry.plan.qboInventoryAdjustmentPayload?.DocNumber === undefined
+          ? false
+          : existingAdjustmentDocs.has(entry.plan.qboInventoryAdjustmentPayload.DocNumber),
+      lines: entry.plan.adjustmentLines,
+    })),
+  };
+  console.log(JSON.stringify(dryRun, null, 2));
+
+  if (!options.apply) return;
+
+  await upsertInventoryMappings({ mappings });
+
+  const createdReceiptBills: CreatedObject[] = [];
+  const createdVendorCredits: CreatedObject[] = [];
+  for (const plan of receiptPlans) {
+    if (!existingBillDocs.has(plan.receiptDocNumber)) {
+      const created = await postQboObject({
+        connection,
+        entityPath: 'bill',
+        responseKey: 'Bill',
+        payload: buildQboItemBasedBillPayload({
+          vendorId: plan.vendorId,
+          txnDate: plan.txnDate,
+          docNumber: plan.receiptDocNumber,
+          privateNote: [
+            `QBO INVENTORY MIGRATION RECEIPT`,
+            `INTERNAL PO: ${plan.internalPo}`,
+            `SOURCES: ${plan.sourceRefs.join(',')}`,
+          ].join('; '),
+          lines: plan.lines.map((line) => ({
+            qboItemId: line.qboItemId,
+            description: line.description,
+            quantity: line.quantity,
+            unitCost: line.unitCost,
+          })),
+        }) as Record<string, unknown>,
+      });
+      if (created.updatedConnection !== undefined) connection = created.updatedConnection;
+      const bill = created.object as { Id?: string; DocNumber?: string };
+      if (bill.Id === undefined) throw new Error(`Created receipt bill ${plan.receiptDocNumber} returned no Id`);
+      createdReceiptBills.push({ id: bill.Id, docNumber: bill.DocNumber ?? plan.receiptDocNumber });
+    }
+
+    if (!existingVendorCreditDocs.has(plan.vendorCreditDocNumber)) {
+      const created = await postQboObject({
+        connection,
+        entityPath: 'vendorcredit',
+        responseKey: 'VendorCredit',
+        payload: buildVendorCreditPayload({
+          vendorId: plan.vendorId,
+          txnDate: plan.txnDate,
+          docNumber: plan.vendorCreditDocNumber,
+          privateNote: [
+            `QBO INVENTORY MIGRATION OFFSET`,
+            `INTERNAL PO: ${plan.internalPo}`,
+            `OFFSETS RECEIPT: ${plan.receiptDocNumber}`,
+          ].join('; '),
+          accountId: inventoryAsset.Id,
+          amount: plan.totalAmount,
+        }),
+      });
+      if (created.updatedConnection !== undefined) connection = created.updatedConnection;
+      const vendorCredit = created.object as { Id?: string; DocNumber?: string };
+      if (vendorCredit.Id === undefined) throw new Error(`Created vendor credit ${plan.vendorCreditDocNumber} returned no Id`);
+      createdVendorCredits.push({ id: vendorCredit.Id, docNumber: vendorCredit.DocNumber ?? plan.vendorCreditDocNumber });
+    }
+  }
+  await saveServerQboConnection(connection);
+
+  const deletedLegacyCogsEntries: CreatedObject[] = [];
+  for (const entry of legacyManualCogsEntries) {
+    const deleted = await deleteJournalEntry(connection, entry.Id);
+    if (deleted.updatedConnection !== undefined) connection = deleted.updatedConnection;
+    deletedLegacyCogsEntries.push({ id: deleted.deletedJournalEntryId, docNumber: entry.DocNumber ?? entry.Id });
+  }
+  await saveServerQboConnection(connection);
+
+  const createdInventoryAdjustments: CreatedObject[] = [];
+  for (const entry of movementPlans) {
+    const payload = entry.plan.qboInventoryAdjustmentPayload;
+    if (payload === null) continue;
+    if (payload.DocNumber !== undefined && existingAdjustmentDocs.has(payload.DocNumber)) continue;
+    const created = await postQboObject({
+      connection,
+      entityPath: 'inventoryadjustment',
+      responseKey: 'InventoryAdjustment',
+      payload: payload as unknown as Record<string, unknown>,
+    });
+    if (created.updatedConnection !== undefined) connection = created.updatedConnection;
+    const adjustment = created.object as { Id?: string; DocNumber?: string };
+    if (adjustment.Id === undefined) throw new Error(`Created inventory adjustment ${payload.DocNumber} returned no Id`);
+    createdInventoryAdjustments.push({ id: adjustment.Id, docNumber: adjustment.DocNumber ?? payload.DocNumber ?? adjustment.Id });
+    await recordInventoryMovementPostings({
+      marketplace: MARKETPLACE,
+      settlementDocNumber: entry.invoiceId,
+      movementDate: payload.TxnDate,
+      sourceHash: `${computeProcessingHash(entry.rows)}:${sourceHashForRows(entry.rows)}`,
+      adjustmentId: adjustment.Id,
+      adjustmentLines: entry.plan.adjustmentLines,
+    });
+  }
+  await saveServerQboConnection(connection);
+
+  console.log(
+    JSON.stringify(
+      {
+        createdReceiptBills,
+        createdVendorCredits,
+        deletedLegacyCogsEntries,
+        createdInventoryAdjustments,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/apps/plutus/scripts/qbo-create-inventory-purchase-orders.ts
+++ b/apps/plutus/scripts/qbo-create-inventory-purchase-orders.ts
@@ -1,0 +1,418 @@
+import { buildQboInventoryLandedCostPlan, type QboInventoryAssetLineInput } from '@/lib/plutus/qbo-inventory-asset-lines';
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
+import { getApiBaseUrl } from '@/lib/qbo/client';
+import { getActiveQboConnection, qboQueryAll } from '@/lib/qbo/full-history-audit/fetch';
+import { buildQboInventoryItemPayload, buildQboPurchaseOrderPayload } from '@/lib/qbo/inventory-documents';
+import { fetchAccounts, fetchBills, getValidToken, type QboAccount, type QboBill, type QboConnection } from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  apply: boolean;
+  humanApproval: string | null;
+};
+
+type QboItem = {
+  Id: string;
+  Name: string;
+  Sku?: string;
+  Type?: string;
+  Active?: boolean;
+};
+
+type QboPurchaseOrder = {
+  Id: string;
+  DocNumber?: string;
+  POStatus?: string;
+};
+
+type CreatedQboObject = {
+  id: string;
+  docNumber?: string;
+  name?: string;
+};
+
+const MARKETPLACE = 'amazon.com';
+const SKU_ORDER = ['CS-007', 'CS-010', 'CS-12LD-7M', 'CS-1SD-32M'];
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let humanApproval: string | null = null;
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+    if (arg === '--human-approval') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`QBO inventory PO creation requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { apply, humanApproval };
+}
+
+function requireAccount(accounts: QboAccount[], fullyQualifiedName: string): QboAccount {
+  const matches = accounts.filter((account) => account.Active !== false && account.FullyQualifiedName === fullyQualifiedName);
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one active QBO account named ${fullyQualifiedName}; found ${matches.length}`);
+  }
+  return matches[0]!;
+}
+
+async function fetchAllBills(input: { connection: QboConnection; startDate: string; endDate: string }): Promise<QboBill[]> {
+  const maxResults = 1000;
+  let startPosition = 1;
+  let activeConnection = input.connection;
+  const bills: QboBill[] = [];
+
+  while (true) {
+    const result = await fetchBills(activeConnection, {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      maxResults,
+      startPosition,
+      includeTotalCount: false,
+    });
+    if (result.updatedConnection !== undefined) {
+      activeConnection = result.updatedConnection;
+    }
+
+    bills.push(...result.bills);
+    if (result.bills.length < maxResults) break;
+    startPosition += result.bills.length;
+  }
+
+  if (activeConnection !== input.connection) {
+    await saveServerQboConnection(activeConnection);
+  }
+  return bills;
+}
+
+function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
+  const lines: QboInventoryAssetLineInput[] = [];
+  for (const bill of bills) {
+    for (const line of bill.Line ?? []) {
+      const accountName = line.AccountBasedExpenseLineDetail?.AccountRef.name;
+      if (accountName === undefined) continue;
+      if (accountName !== 'Inventory Asset' && !accountName.startsWith('Inventory Asset:')) continue;
+      if (line.Id === undefined) throw new Error(`QBO bill ${bill.Id} has an inventory asset line without line id`);
+      lines.push({
+        billId: bill.Id,
+        ...(bill.DocNumber !== undefined ? { billDocNumber: bill.DocNumber } : {}),
+        billDate: bill.TxnDate,
+        ...(bill.VendorRef?.name !== undefined ? { vendorName: bill.VendorRef.name } : {}),
+        qboLineId: line.Id,
+        accountName,
+        amount: line.Amount,
+        ...(line.Description !== undefined ? { description: line.Description } : {}),
+      });
+    }
+  }
+  return lines;
+}
+
+function findManufacturingBillVendorByPo(input: {
+  bills: QboBill[];
+}): Map<string, { vendorId: string; vendorName: string; txnDate: string; sourceRefs: Set<string> }> {
+  const vendorByPo = new Map<string, { vendorId: string; vendorName: string; txnDate: string; sourceRefs: Set<string> }>();
+  for (const bill of input.bills) {
+    const vendorId = bill.VendorRef?.value;
+    const vendorName = bill.VendorRef?.name;
+    if (vendorId === undefined || vendorName === undefined) continue;
+    for (const line of bill.Line ?? []) {
+      const description = line.Description ?? '';
+      if (!description.startsWith('MFG;')) continue;
+      const poMatch = description.match(/(?:^|; )PO=([^;]+)/);
+      if (poMatch === null) continue;
+      const po = poMatch[1]!.trim();
+      const sourceMatch = description.match(/(?:^|; )SOURCE=([^;]+)/);
+      const sourceRef = sourceMatch === null ? bill.DocNumber ?? null : sourceMatch[1]!.trim();
+      const existing = vendorByPo.get(po);
+      if (existing === undefined) {
+        vendorByPo.set(po, {
+          vendorId,
+          vendorName,
+          txnDate: bill.TxnDate,
+          sourceRefs: new Set(sourceRef === null ? [] : [sourceRef]),
+        });
+        continue;
+      }
+      if (existing.vendorId !== vendorId) {
+        throw new Error(`PO ${po} has multiple manufacturing vendors: ${existing.vendorName} and ${vendorName}`);
+      }
+      if (sourceRef !== null) existing.sourceRefs.add(sourceRef);
+      if (bill.TxnDate < existing.txnDate) existing.txnDate = bill.TxnDate;
+    }
+  }
+  return vendorByPo;
+}
+
+function isLandedPo(componentAmounts: { freight: number; duty: number }): boolean {
+  return componentAmounts.freight > 0 && componentAmounts.duty > 0;
+}
+
+function normalizeSku(value: string | undefined): string {
+  return value === undefined ? '' : value.trim().toUpperCase();
+}
+
+function buildInventoryItemBySku(items: QboItem[]): Map<string, QboItem> {
+  const bySku = new Map<string, QboItem>();
+  for (const item of items) {
+    if (item.Active === false) continue;
+    if (item.Type !== 'Inventory') continue;
+    const key = normalizeSku(item.Sku ?? item.Name);
+    if (key === '') continue;
+    bySku.set(key, item);
+  }
+  return bySku;
+}
+
+async function postQboObject(input: {
+  connection: QboConnection;
+  entityPath: 'item' | 'purchaseorder';
+  responseKey: 'Item' | 'PurchaseOrder';
+  payload: Record<string, unknown>;
+}): Promise<{ object: Record<string, unknown>; updatedConnection?: QboConnection }> {
+  const tokenResult = await getValidToken(input.connection);
+  const activeConnection = tokenResult.updatedConnection ?? input.connection;
+  const response = await fetch(`${getApiBaseUrl()}/v3/company/${activeConnection.realmId}/${input.entityPath}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokenResult.accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(input.payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to create QBO ${input.entityPath}: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as Record<string, unknown>;
+  const created = data[input.responseKey];
+  if (typeof created !== 'object' || created === null) {
+    throw new Error(`QBO ${input.entityPath} create response did not include ${input.responseKey}`);
+  }
+
+  return {
+    object: created as Record<string, unknown>,
+    updatedConnection: tokenResult.updatedConnection,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2));
+  loadSharedPlutusEnv();
+
+  let connection = await getQboConnection();
+  if (connection === null) throw new Error('QBO connection is not configured');
+
+  const activeConnection = await getActiveQboConnection();
+  connection = activeConnection.connection;
+
+  const accountsResult = await fetchAccounts(connection, { includeInactive: true });
+  if (accountsResult.updatedConnection !== undefined) {
+    connection = accountsResult.updatedConnection;
+    await saveServerQboConnection(connection);
+  }
+
+  const inventoryAsset = requireAccount(accountsResult.accounts, 'Inventory Asset');
+  const amazonSales = requireAccount(accountsResult.accounts, 'Amazon Sales');
+  const cogs = requireAccount(accountsResult.accounts, 'Cost of goods sold');
+
+  const [itemsResult, purchaseOrdersResult, bills] = await Promise.all([
+    qboQueryAll(activeConnection, 'SELECT * FROM Item WHERE Active IN (true, false)'),
+    qboQueryAll(activeConnection, 'SELECT * FROM PurchaseOrder'),
+    fetchAllBills({ connection, startDate: '2025-01-01', endDate: new Date().toISOString().slice(0, 10) }),
+  ]);
+
+  const items = itemsResult.rows as QboItem[];
+  const purchaseOrders = purchaseOrdersResult.rows as QboPurchaseOrder[];
+  const activeItemBySku = buildInventoryItemBySku(items);
+  const purchaseOrderByDocNumber = new Map(
+    purchaseOrders
+      .filter((purchaseOrder) => purchaseOrder.DocNumber !== undefined)
+      .map((purchaseOrder) => [purchaseOrder.DocNumber!, purchaseOrder]),
+  );
+
+  const landedPlan = buildQboInventoryLandedCostPlan({
+    marketplace: MARKETPLACE,
+    lines: collectInventoryAssetLines(bills),
+  });
+  const manufacturingVendorByPo = findManufacturingBillVendorByPo({ bills });
+
+  const layersByPo = new Map<string, typeof landedPlan.layers>();
+  for (const layer of landedPlan.layers) {
+    const existing = layersByPo.get(layer.internalPo);
+    if (existing === undefined) {
+      layersByPo.set(layer.internalPo, [layer]);
+      continue;
+    }
+    existing.push(layer);
+  }
+
+  const missingItems = SKU_ORDER.filter((sku) => activeItemBySku.get(sku) === undefined);
+  const itemCreatePlans = missingItems.map((sku) => ({
+    sku,
+    payload: buildQboInventoryItemPayload({
+      name: sku,
+      sku,
+      inventoryStartDate: '2025-01-01',
+      initialQuantityOnHand: 0,
+      assetAccountId: inventoryAsset.Id,
+      incomeAccountId: amazonSales.Id,
+      expenseAccountId: cogs.Id,
+    }),
+  }));
+
+  const poCreatePlans = Array.from(layersByPo.entries())
+    .sort(([leftPo], [rightPo]) => leftPo.localeCompare(rightPo))
+    .map(([internalPo, layers]) => {
+      const existingPo = purchaseOrderByDocNumber.get(internalPo);
+      const vendor = manufacturingVendorByPo.get(internalPo);
+      if (vendor === undefined) throw new Error(`Missing manufacturing vendor for ${internalPo}`);
+      const lines = layers
+        .slice()
+        .sort((left, right) => SKU_ORDER.indexOf(left.sellerSku) - SKU_ORDER.indexOf(right.sellerSku))
+        .map((layer) => {
+          const item = activeItemBySku.get(layer.sellerSku);
+          return {
+            layer,
+            qboItemId: item?.Id ?? `CREATE:${layer.sellerSku}`,
+          };
+        });
+      const allSourceRefs = Array.from(new Set(layers.flatMap((layer) => layer.sourceRefs))).sort();
+      const hasLandedEvidence = layers.every((layer) => isLandedPo(layer.componentAmounts));
+      return {
+        internalPo,
+        existingPoId: existingPo?.Id ?? null,
+        status: hasLandedEvidence ? 'Closed' : 'Open',
+        vendorId: vendor.vendorId,
+        vendorName: vendor.vendorName,
+        txnDate: vendor.txnDate,
+        sourceRefs: allSourceRefs,
+        linePlans: lines.map(({ layer, qboItemId }) => ({
+          qboItemId,
+          sellerSku: layer.sellerSku,
+          quantity: layer.quantity,
+          unitCost: layer.unitCost,
+          totalAmount: layer.totalAmount,
+          qboBillLineRefs: layer.qboBillLineRefs,
+          description: [
+            `INTERNAL PO: ${layer.internalPo}`,
+            `SKU: ${layer.sellerSku}`,
+            `QTY: ${layer.quantity}`,
+            `LANDED_TOTAL: ${layer.totalAmount.toFixed(2)}`,
+            `SOURCES: ${layer.sourceRefs.join(',')}`,
+            `QBO_BILL_LINES: ${layer.qboBillLineRefs.join(',')}`,
+          ].join('; '),
+        })),
+      };
+    });
+
+  const dryRun = {
+    mode: options.apply ? 'apply' : 'dry-run',
+    itemCreatePlans: itemCreatePlans.map((plan) => ({ sku: plan.sku, payload: plan.payload })),
+    purchaseOrderCreatePlans: poCreatePlans.map((plan) => ({
+      internalPo: plan.internalPo,
+      existingPoId: plan.existingPoId,
+      status: plan.status,
+      vendorName: plan.vendorName,
+      txnDate: plan.txnDate,
+      sourceRefs: plan.sourceRefs,
+      lines: plan.linePlans.map((line) => ({
+        sellerSku: line.sellerSku,
+        qboItemId: line.qboItemId,
+        quantity: line.quantity,
+        unitCost: line.unitCost,
+        totalAmount: line.totalAmount,
+      })),
+    })),
+    qboInventoryAssetBlocks: landedPlan.blocks,
+  };
+
+  console.log(JSON.stringify(dryRun, null, 2));
+
+  if (!options.apply) return;
+
+  const createdItems: CreatedQboObject[] = [];
+  for (const plan of itemCreatePlans) {
+    const created = await postQboObject({
+      connection,
+      entityPath: 'item',
+      responseKey: 'Item',
+      payload: plan.payload,
+    });
+    if (created.updatedConnection !== undefined) {
+      connection = created.updatedConnection;
+      await saveServerQboConnection(connection);
+    }
+    const item = created.object as { Id?: string; Name?: string; Sku?: string };
+    if (item.Id === undefined) throw new Error(`Created QBO item for ${plan.sku} did not return Id`);
+    createdItems.push({ id: item.Id, name: item.Name, docNumber: item.Sku });
+    activeItemBySku.set(plan.sku, { Id: item.Id, Name: item.Name ?? plan.sku, Sku: item.Sku ?? plan.sku, Type: 'Inventory' });
+  }
+
+  const createdPurchaseOrders: CreatedQboObject[] = [];
+  for (const plan of poCreatePlans) {
+    if (plan.existingPoId !== null) continue;
+    const payload = buildQboPurchaseOrderPayload({
+      vendorId: plan.vendorId,
+      txnDate: plan.txnDate,
+      docNumber: plan.internalPo,
+      privateNote: [
+        `INTERNAL PO: ${plan.internalPo}`,
+        `BASIS: QBO inventory asset bill lines`,
+        `SOURCES: ${plan.sourceRefs.join(',')}`,
+      ].join('; '),
+      lines: plan.linePlans.map((line) => {
+        const qboItemId = activeItemBySku.get(line.sellerSku)?.Id;
+        if (qboItemId === undefined) throw new Error(`Missing QBO item id for ${line.sellerSku}`);
+        return {
+          qboItemId,
+          description: line.description,
+          quantity: line.quantity,
+          unitCost: line.unitCost,
+        };
+      }),
+    });
+    const created = await postQboObject({
+      connection,
+      entityPath: 'purchaseorder',
+      responseKey: 'PurchaseOrder',
+      payload: {
+        ...payload,
+        POStatus: plan.status,
+      },
+    });
+    if (created.updatedConnection !== undefined) {
+      connection = created.updatedConnection;
+      await saveServerQboConnection(connection);
+    }
+    const purchaseOrder = created.object as { Id?: string; DocNumber?: string };
+    if (purchaseOrder.Id === undefined) throw new Error(`Created QBO purchase order ${plan.internalPo} did not return Id`);
+    createdPurchaseOrders.push({ id: purchaseOrder.Id, docNumber: purchaseOrder.DocNumber ?? plan.internalPo });
+  }
+
+  await saveServerQboConnection(connection);
+  console.log(JSON.stringify({ createdItems, createdPurchaseOrders }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/apps/plutus/scripts/qbo-inventory-bridge-audit.ts
+++ b/apps/plutus/scripts/qbo-inventory-bridge-audit.ts
@@ -1,0 +1,318 @@
+import { db } from '@/lib/db';
+import {
+  buildQboInventoryAssetReclassPlan,
+  buildQboInventoryLandedCostPlan,
+  type QboInventoryAssetLineInput,
+} from '@/lib/plutus/qbo-inventory-asset-lines';
+import {
+  assessQboInventoryValuationTieout,
+  parseQboInventoryValuationSummary,
+} from '@/lib/plutus/qbo-inventory-valuation';
+import { buildSettlementInventoryMovementPlan, type QboInventoryItemMapping } from '@/lib/plutus/qbo-inventory-movements';
+import {
+  fetchAccountsByFullyQualifiedName,
+  fetchBills,
+  fetchQboReport,
+  type QboBill,
+  type QboConnection,
+} from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  marketplace: string;
+  assetStartDate: string;
+  assetEndDate: string;
+};
+
+type MappingRow = {
+  marketplace: string;
+  sellerSku: string;
+  qboItemId: string;
+};
+
+type AuditRow = {
+  invoiceId: string;
+  market: string;
+  date: string;
+  orderId: string;
+  sku: string;
+  quantity: number;
+  description: string;
+  net: number;
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  let marketplace = 'amazon.com';
+  let assetStartDate = '2025-01-01';
+  let assetEndDate = new Date().toISOString().slice(0, 10);
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--marketplace') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --marketplace');
+      marketplace = next;
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--marketplace=')) {
+      marketplace = arg.slice('--marketplace='.length);
+      i += 1;
+      continue;
+    }
+    if (arg === '--asset-start-date') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --asset-start-date');
+      assetStartDate = next;
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--asset-start-date=')) {
+      assetStartDate = arg.slice('--asset-start-date='.length);
+      i += 1;
+      continue;
+    }
+    if (arg === '--asset-end-date') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --asset-end-date');
+      assetEndDate = next;
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--asset-end-date=')) {
+      assetEndDate = arg.slice('--asset-end-date='.length);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { marketplace, assetStartDate, assetEndDate };
+}
+
+function marketForMarketplace(marketplace: string): string {
+  if (marketplace === 'amazon.com') return 'us';
+  if (marketplace === 'amazon.co.uk') return 'uk';
+  throw new Error(`Unsupported marketplace for QBO inventory bridge audit: ${marketplace}`);
+}
+
+function settlementTxnDate(rows: AuditRow[]): string {
+  const dates = rows.map((row) => row.date).sort();
+  const last = dates[dates.length - 1];
+  if (last === undefined) throw new Error('Cannot determine settlement txn date without audit rows');
+  return last;
+}
+
+async function fetchMappings(marketplace: string): Promise<QboInventoryItemMapping[]> {
+  const rows = await db.$queryRawUnsafe<MappingRow[]>(
+    'SELECT "marketplace", "sellerSku", "qboItemId" FROM "QboInventoryItemMapping" WHERE "marketplace" = $1 AND "active" = true ORDER BY "sellerSku"',
+    marketplace,
+  );
+  return rows.map((row) => ({
+    marketplace: row.marketplace,
+    sellerSku: row.sellerSku,
+    qboItemId: row.qboItemId,
+  }));
+}
+
+async function fetchAllBillsInWindow(input: {
+  connection: QboConnection;
+  startDate: string;
+  endDate: string;
+}): Promise<{ bills: QboBill[]; updatedConnection: QboConnection }> {
+  const maxResults = 1000;
+  let startPosition = 1;
+  let activeConnection = input.connection;
+  const bills: QboBill[] = [];
+
+  while (true) {
+    const page = await fetchBills(activeConnection, {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      maxResults,
+      startPosition,
+      includeTotalCount: false,
+    });
+    if (page.updatedConnection !== undefined) {
+      activeConnection = page.updatedConnection;
+    }
+
+    bills.push(...page.bills);
+    if (page.bills.length < maxResults) break;
+    startPosition += page.bills.length;
+  }
+
+  return { bills, updatedConnection: activeConnection };
+}
+
+function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
+  const lines: QboInventoryAssetLineInput[] = [];
+  for (const bill of bills) {
+    for (const line of bill.Line ?? []) {
+      const accountName = line.AccountBasedExpenseLineDetail?.AccountRef.name;
+      if (accountName === undefined) continue;
+      if (accountName !== 'Inventory Asset' && !accountName.startsWith('Inventory Asset:')) continue;
+      if (line.Id === undefined) throw new Error(`QBO bill ${bill.Id} has an inventory asset line without line id`);
+      lines.push({
+        billId: bill.Id,
+        ...(bill.DocNumber !== undefined ? { billDocNumber: bill.DocNumber } : {}),
+        billDate: bill.TxnDate,
+        ...(bill.VendorRef?.name !== undefined ? { vendorName: bill.VendorRef.name } : {}),
+        qboLineId: line.Id,
+        accountName,
+        amount: line.Amount,
+        ...(line.Description !== undefined ? { description: line.Description } : {}),
+      });
+    }
+  }
+  return lines;
+}
+
+async function main(): Promise<void> {
+  loadSharedPlutusEnv();
+  const options = parseArgs(process.argv.slice(2));
+  const market = marketForMarketplace(options.marketplace);
+  const qboConnection = await getQboConnection();
+  if (qboConnection === null) throw new Error('QBO connection is not configured');
+
+  const [mappings, auditRows, qboBillsResult] = await Promise.all([
+    fetchMappings(options.marketplace),
+    db.auditDataRow.findMany({
+      where: { market: { equals: market, mode: 'insensitive' } },
+      select: {
+        invoiceId: true,
+        market: true,
+        date: true,
+        orderId: true,
+        sku: true,
+        quantity: true,
+        description: true,
+        net: true,
+      },
+      orderBy: [{ invoiceId: 'asc' }, { date: 'asc' }, { sku: 'asc' }],
+    }),
+    fetchAllBillsInWindow({
+      connection: qboConnection,
+      startDate: options.assetStartDate,
+      endDate: options.assetEndDate,
+    }),
+  ]);
+  await saveServerQboConnection(qboBillsResult.updatedConnection);
+
+  const rowsByInvoice = new Map<string, AuditRow[]>();
+  for (const row of auditRows) {
+    const existing = rowsByInvoice.get(row.invoiceId);
+    if (existing === undefined) {
+      rowsByInvoice.set(row.invoiceId, [row]);
+    } else {
+      existing.push(row);
+    }
+  }
+
+  const plans = Array.from(rowsByInvoice.entries()).map(([invoiceId, rows]) =>
+    buildSettlementInventoryMovementPlan({
+      marketplace: options.marketplace,
+      settlementDocNumber: invoiceId,
+      txnDate: settlementTxnDate(rows),
+      adjustmentAccountId: 'QBO_COGS_ADJUSTMENT_ACCOUNT_REQUIRED',
+      auditRows: rows,
+      itemMappings: mappings,
+    }),
+  );
+
+  const missingMappings = new Set<string>();
+  for (const plan of plans) {
+    for (const block of plan.blocks) {
+      if (block.code === 'MISSING_QBO_ITEM_MAPPING') missingMappings.add(block.sellerSku);
+    }
+  }
+  const qboInventoryAssetLines = collectInventoryAssetLines(qboBillsResult.bills);
+  const qboAssetPlan = buildQboInventoryLandedCostPlan({
+    marketplace: options.marketplace,
+    lines: qboInventoryAssetLines,
+  });
+  const qboInventoryAssetReclassPlan = buildQboInventoryAssetReclassPlan({
+    marketplace: options.marketplace,
+    lines: qboInventoryAssetLines,
+  });
+  const marketAssetLines = qboAssetPlan.parsedLines.filter((line) => line.marketCode === qboAssetPlan.marketCode);
+
+  let activeConnection = qboBillsResult.updatedConnection;
+  const valuationReportResult = await fetchQboReport(activeConnection, 'InventoryValuationSummary', {
+    report_date: options.assetEndDate,
+  });
+  if (valuationReportResult.updatedConnection !== undefined) {
+    activeConnection = valuationReportResult.updatedConnection;
+  }
+  const qboInventoryValuation = parseQboInventoryValuationSummary(
+    valuationReportResult.report as Parameters<typeof parseQboInventoryValuationSummary>[0],
+  );
+
+  const inventoryAssetAccountResult = await fetchAccountsByFullyQualifiedName(activeConnection, 'Inventory Asset');
+  if (inventoryAssetAccountResult.updatedConnection !== undefined) {
+    activeConnection = inventoryAssetAccountResult.updatedConnection;
+  }
+  await saveServerQboConnection(activeConnection);
+
+  const inventoryAssetAccount = inventoryAssetAccountResult.accounts.find((account) => account.Active !== false);
+  if (inventoryAssetAccount === undefined) {
+    throw new Error('Active QBO account not found: Inventory Asset');
+  }
+  const inventoryAssetBalance = inventoryAssetAccount.CurrentBalanceWithSubAccounts ?? inventoryAssetAccount.CurrentBalance;
+  if (inventoryAssetBalance === undefined) {
+    throw new Error('QBO Inventory Asset account is missing current balance');
+  }
+  const qboInventoryValuationTieout = assessQboInventoryValuationTieout({
+    inventoryAssetBalance,
+    inventoryValuationAssetValue: qboInventoryValuation.totalAssetValue,
+  });
+
+  const ok =
+    plans.every((plan) => plan.ok) &&
+    missingMappings.size === 0 &&
+    qboAssetPlan.blocks.length === 0 &&
+    qboInventoryAssetReclassPlan.lines.length === 0 &&
+    qboInventoryValuationTieout.ok;
+
+  console.log(
+    JSON.stringify(
+      {
+        ok,
+        marketplace: options.marketplace,
+        market,
+        invoicesScanned: rowsByInvoice.size,
+        qboItemMappings: mappings.length,
+        movementPlans: plans.length,
+        blockedPlans: plans.filter((plan) => !plan.ok).length,
+        adjustmentLines: plans.reduce((sum, plan) => sum + plan.adjustmentLines.length, 0),
+        missingMappings: Array.from(missingMappings).sort(),
+        qboInventoryAssetWindow: {
+          startDate: options.assetStartDate,
+          endDate: options.assetEndDate,
+        },
+        qboInventoryAssetLines: marketAssetLines.length,
+        qboLandedCostLayers: qboAssetPlan.layers,
+        qboInventoryAssetBlocks: qboAssetPlan.blocks,
+        qboInventoryAssetReclassPlan,
+        qboInventoryValuation,
+        qboInventoryValuationTieout,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!ok) {
+    process.exitCode = 1;
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/apps/plutus/scripts/qbo-repair-inventory-valuation-tieout.ts
+++ b/apps/plutus/scripts/qbo-repair-inventory-valuation-tieout.ts
@@ -1,0 +1,390 @@
+import {
+  buildQboInventoryAssetReclassPlan,
+  type QboInventoryAssetLineInput,
+  type QboInventoryAssetReclassPlan,
+} from '@/lib/plutus/qbo-inventory-asset-lines';
+import {
+  assessQboInventoryValuationTieout,
+  parseQboInventoryValuationSummary,
+  type QboInventoryValuationTieout,
+} from '@/lib/plutus/qbo-inventory-valuation';
+import {
+  createAccount,
+  fetchAccounts,
+  fetchAccountsByFullyQualifiedName,
+  fetchBills,
+  fetchQboReport,
+  updateAccountActive,
+  updateBillLineAccounts,
+  type QboAccount,
+  type QboBill,
+  type QboConnection,
+} from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  apply: boolean;
+  marketplace: string;
+  assetStartDate: string;
+  assetEndDate: string;
+};
+
+const INVENTORY_ASSET_ACCOUNT_NAME = 'Inventory Asset';
+const INVENTORY_CLEARING_ACCOUNT_NAME = 'Inventory Clearing';
+const INVENTORY_COGS_RELEASE_ACCOUNT_NAME = 'Inventory COGS Release';
+const LEGACY_INVENTORY_SHRINKAGE_ACCOUNT_NAME = 'Inventory Shrinkage';
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let marketplace = 'amazon.com';
+  let assetStartDate = '2025-01-01';
+  let assetEndDate = new Date().toISOString().slice(0, 10);
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+    if (arg === '--marketplace') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --marketplace');
+      marketplace = next;
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--marketplace=')) {
+      marketplace = arg.slice('--marketplace='.length);
+      i += 1;
+      continue;
+    }
+    if (arg === '--asset-start-date') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --asset-start-date');
+      assetStartDate = next;
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--asset-start-date=')) {
+      assetStartDate = arg.slice('--asset-start-date='.length);
+      i += 1;
+      continue;
+    }
+    if (arg === '--asset-end-date') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --asset-end-date');
+      assetEndDate = next;
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--asset-end-date=')) {
+      assetEndDate = arg.slice('--asset-end-date='.length);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { apply, marketplace, assetStartDate, assetEndDate };
+}
+
+async function fetchAllBillsInWindow(input: {
+  connection: QboConnection;
+  startDate: string;
+  endDate: string;
+}): Promise<{ bills: QboBill[]; updatedConnection: QboConnection }> {
+  const maxResults = 1000;
+  let startPosition = 1;
+  let activeConnection = input.connection;
+  const bills: QboBill[] = [];
+
+  while (true) {
+    const page = await fetchBills(activeConnection, {
+      startDate: input.startDate,
+      endDate: input.endDate,
+      maxResults,
+      startPosition,
+      includeTotalCount: false,
+    });
+    if (page.updatedConnection !== undefined) {
+      activeConnection = page.updatedConnection;
+    }
+
+    bills.push(...page.bills);
+    if (page.bills.length < maxResults) break;
+    startPosition += page.bills.length;
+  }
+
+  return { bills, updatedConnection: activeConnection };
+}
+
+function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
+  const lines: QboInventoryAssetLineInput[] = [];
+  for (const bill of bills) {
+    for (const line of bill.Line ?? []) {
+      const accountName = line.AccountBasedExpenseLineDetail?.AccountRef.name;
+      if (accountName === undefined) continue;
+      if (accountName !== INVENTORY_ASSET_ACCOUNT_NAME && !accountName.startsWith(`${INVENTORY_ASSET_ACCOUNT_NAME}:`)) continue;
+      if (line.Id === undefined) throw new Error(`QBO bill ${bill.Id} has an inventory asset line without line id`);
+      lines.push({
+        billId: bill.Id,
+        ...(bill.DocNumber !== undefined ? { billDocNumber: bill.DocNumber } : {}),
+        billDate: bill.TxnDate,
+        ...(bill.VendorRef?.name !== undefined ? { vendorName: bill.VendorRef.name } : {}),
+        qboLineId: line.Id,
+        accountName,
+        amount: line.Amount,
+        ...(line.Description !== undefined ? { description: line.Description } : {}),
+      });
+    }
+  }
+  return lines;
+}
+
+function activeExactAccount(accounts: QboAccount[], name: string): QboAccount | null {
+  const match = accounts.find((account) => account.Active !== false && account.FullyQualifiedName === name);
+  return match ?? null;
+}
+
+async function ensureInventoryClearingAccount(input: {
+  connection: QboConnection;
+  accounts: QboAccount[];
+  apply: boolean;
+}): Promise<{ connection: QboConnection; account: QboAccount | null; action: string }> {
+  const existing = activeExactAccount(input.accounts, INVENTORY_CLEARING_ACCOUNT_NAME);
+  if (existing !== null) {
+    return { connection: input.connection, account: existing, action: 'exists' };
+  }
+
+  if (!input.apply) {
+    return { connection: input.connection, account: null, action: 'would_create' };
+  }
+
+  const created = await createAccount(input.connection, {
+    name: INVENTORY_CLEARING_ACCOUNT_NAME,
+    accountType: 'Other Current Asset',
+    accountSubType: 'OtherCurrentAssets',
+  });
+  return {
+    connection: created.updatedConnection ?? input.connection,
+    account: created.account,
+    action: 'created',
+  };
+}
+
+async function ensureInventoryCogsReleaseAccount(input: {
+  connection: QboConnection;
+  accounts: QboAccount[];
+  apply: boolean;
+}): Promise<{ connection: QboConnection; account: QboAccount | null; action: string }> {
+  const existing = activeExactAccount(input.accounts, INVENTORY_COGS_RELEASE_ACCOUNT_NAME);
+  if (existing !== null) {
+    return { connection: input.connection, account: existing, action: 'exists' };
+  }
+
+  const legacy = activeExactAccount(input.accounts, LEGACY_INVENTORY_SHRINKAGE_ACCOUNT_NAME);
+  if (legacy === null) {
+    throw new Error(`QBO account not found: ${INVENTORY_COGS_RELEASE_ACCOUNT_NAME}`);
+  }
+
+  if (!input.apply) {
+    return { connection: input.connection, account: legacy, action: 'would_rename_legacy_inventory_shrinkage' };
+  }
+
+  const renamed = await updateAccountActive(
+    input.connection,
+    legacy.Id,
+    legacy.SyncToken,
+    INVENTORY_COGS_RELEASE_ACCOUNT_NAME,
+    true,
+  );
+  return {
+    connection: renamed.updatedConnection ?? input.connection,
+    account: renamed.account,
+    action: 'renamed_legacy_inventory_shrinkage',
+  };
+}
+
+async function fetchInventoryValuationTieout(input: {
+  connection: QboConnection;
+  assetEndDate: string;
+}): Promise<{ connection: QboConnection; tieout: QboInventoryValuationTieout }> {
+  let activeConnection = input.connection;
+  const valuationReportResult = await fetchQboReport(activeConnection, 'InventoryValuationSummary', {
+    report_date: input.assetEndDate,
+  });
+  if (valuationReportResult.updatedConnection !== undefined) {
+    activeConnection = valuationReportResult.updatedConnection;
+  }
+  const valuation = parseQboInventoryValuationSummary(
+    valuationReportResult.report as Parameters<typeof parseQboInventoryValuationSummary>[0],
+  );
+
+  const inventoryAssetAccountResult = await fetchAccountsByFullyQualifiedName(activeConnection, INVENTORY_ASSET_ACCOUNT_NAME);
+  if (inventoryAssetAccountResult.updatedConnection !== undefined) {
+    activeConnection = inventoryAssetAccountResult.updatedConnection;
+  }
+  const account = inventoryAssetAccountResult.accounts.find((candidate) => candidate.Active !== false);
+  if (account === undefined) throw new Error(`Active QBO account not found: ${INVENTORY_ASSET_ACCOUNT_NAME}`);
+  const balance = account.CurrentBalanceWithSubAccounts ?? account.CurrentBalance;
+  if (balance === undefined) throw new Error(`${INVENTORY_ASSET_ACCOUNT_NAME} is missing current balance`);
+
+  return {
+    connection: activeConnection,
+    tieout: assessQboInventoryValuationTieout({
+      inventoryAssetBalance: balance,
+      inventoryValuationAssetValue: valuation.totalAssetValue,
+    }),
+  };
+}
+
+function summarizeReclassPlan(plan: QboInventoryAssetReclassPlan) {
+  return {
+    marketplace: plan.marketplace,
+    marketCode: plan.marketCode,
+    totalAmount: plan.totalAmount,
+    lineCount: plan.lines.length,
+    lines: plan.lines.map((line) => ({
+      billId: line.billId,
+      billDocNumber: line.billDocNumber ?? null,
+      qboLineId: line.qboLineId,
+      billDate: line.billDate,
+      vendorName: line.vendorName ?? null,
+      amount: line.amount,
+      reason: line.reason,
+      fromAccount: line.accountName,
+      toAccount: INVENTORY_CLEARING_ACCOUNT_NAME,
+      description: line.description ?? null,
+    })),
+  };
+}
+
+async function main(): Promise<void> {
+  loadSharedPlutusEnv();
+  const options = parseArgs(process.argv.slice(2));
+  const qboConnection = await getQboConnection();
+  if (qboConnection === null) throw new Error('QBO connection is not configured');
+
+  let activeConnection = qboConnection;
+  const accountsResult = await fetchAccounts(activeConnection, { includeInactive: true });
+  if (accountsResult.updatedConnection !== undefined) {
+    activeConnection = accountsResult.updatedConnection;
+  }
+
+  const beforeTieout = await fetchInventoryValuationTieout({
+    connection: activeConnection,
+    assetEndDate: options.assetEndDate,
+  });
+  activeConnection = beforeTieout.connection;
+
+  const qboBillsResult = await fetchAllBillsInWindow({
+    connection: activeConnection,
+    startDate: options.assetStartDate,
+    endDate: options.assetEndDate,
+  });
+  activeConnection = qboBillsResult.updatedConnection;
+
+  const reclassPlan = buildQboInventoryAssetReclassPlan({
+    marketplace: options.marketplace,
+    lines: collectInventoryAssetLines(qboBillsResult.bills),
+  });
+
+  const clearingAccountResult = await ensureInventoryClearingAccount({
+    connection: activeConnection,
+    accounts: accountsResult.accounts,
+    apply: options.apply,
+  });
+  activeConnection = clearingAccountResult.connection;
+
+  const cogsReleaseAccountResult = await ensureInventoryCogsReleaseAccount({
+    connection: activeConnection,
+    accounts: accountsResult.accounts,
+    apply: options.apply,
+  });
+  activeConnection = cogsReleaseAccountResult.connection;
+
+  const updatedBills: Array<{ billId: string; docNumber: string | null; movedLineIds: string[] }> = [];
+  if (options.apply && reclassPlan.lines.length > 0) {
+    if (clearingAccountResult.account === null) {
+      throw new Error(`${INVENTORY_CLEARING_ACCOUNT_NAME} account was not created`);
+    }
+
+    const billsById = new Map(qboBillsResult.bills.map((bill) => [bill.Id, bill]));
+    const linesByBillId = new Map<string, typeof reclassPlan.lines>();
+    for (const line of reclassPlan.lines) {
+      const existing = linesByBillId.get(line.billId);
+      if (existing === undefined) {
+        linesByBillId.set(line.billId, [line]);
+      } else {
+        existing.push(line);
+      }
+    }
+
+    for (const [billId, lines] of Array.from(linesByBillId.entries()).sort(([left], [right]) => left.localeCompare(right))) {
+      const bill = billsById.get(billId);
+      if (bill === undefined) throw new Error(`Fetched bill not found for reclass plan: ${billId}`);
+      const updated = await updateBillLineAccounts(
+        activeConnection,
+        bill.Id,
+        bill.SyncToken,
+        lines.map((line) => ({
+          lineId: line.qboLineId,
+          accountId: clearingAccountResult.account!.Id,
+          accountName: INVENTORY_CLEARING_ACCOUNT_NAME,
+        })),
+      );
+      activeConnection = updated.updatedConnection ?? activeConnection;
+      updatedBills.push({
+        billId,
+        docNumber: updated.bill.DocNumber ?? null,
+        movedLineIds: lines.map((line) => line.qboLineId),
+      });
+    }
+  }
+
+  const afterTieout = options.apply
+    ? await fetchInventoryValuationTieout({
+        connection: activeConnection,
+        assetEndDate: options.assetEndDate,
+      })
+    : null;
+  if (afterTieout !== null) {
+    activeConnection = afterTieout.connection;
+  }
+  await saveServerQboConnection(activeConnection);
+
+  console.log(
+    JSON.stringify(
+      {
+        mode: options.apply ? 'apply' : 'dry-run',
+        beforeTieout: beforeTieout.tieout,
+        clearingAccount: {
+          name: INVENTORY_CLEARING_ACCOUNT_NAME,
+          action: clearingAccountResult.action,
+          id: clearingAccountResult.account?.Id ?? null,
+        },
+        cogsReleaseAccount: {
+          name: INVENTORY_COGS_RELEASE_ACCOUNT_NAME,
+          action: cogsReleaseAccountResult.action,
+          id: cogsReleaseAccountResult.account?.Id ?? null,
+        },
+        reclassPlan: summarizeReclassPlan(reclassPlan),
+        updatedBills,
+        afterTieout: afterTieout?.tieout ?? null,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (options.apply && afterTieout !== null && !afterTieout.tieout.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -13,6 +13,19 @@ import { normalizeSettlementOperatingMemo } from '../lib/amazon-finances/settlem
 import { isPostableFundTransferStatus } from '../lib/amazon-finances/fund-transfer-status';
 import { isBlockingProcessingCode } from '../lib/plutus/settlement-types';
 import { computeProcessingHash } from '../lib/plutus/settlement-utils';
+import { buildQboInventoryAdjustmentPayload } from '../lib/qbo/inventory-adjustments';
+import {
+  buildQboInventoryItemPayload,
+  buildQboItemBasedBillPayload,
+  buildQboPurchaseOrderPayload,
+} from '../lib/qbo/inventory-documents';
+import { buildSettlementInventoryMovementPlan } from '../lib/plutus/qbo-inventory-movements';
+import {
+  buildQboInventoryLandedCostPlan,
+  buildQboInventoryAssetReclassPlan,
+  parseQboInventoryAssetLine,
+} from '../lib/plutus/qbo-inventory-asset-lines';
+import { assessQboInventoryValuationTieout, parseQboInventoryValuationSummary } from '../lib/plutus/qbo-inventory-valuation';
 
 const tests: Array<{ name: string; fn: () => void | Promise<void> }> = [];
 
@@ -94,6 +107,22 @@ test('Prisma schema no longer models Plutus-owned inventory', () => {
   }
 });
 
+test('Prisma schema tracks QBO inventory bridge mappings and movement postings only', () => {
+  const schema = read('prisma/schema.prisma');
+  for (const required of [
+    'model QboInventoryItemMapping',
+    'model QboInventoryMovementPosting',
+    'sellerSku',
+    'qboItemId',
+    'qboInventoryAdjustmentId',
+    'quantityDelta',
+    '@@unique([marketplace, sellerSku])',
+    '@@unique([marketplace, settlementDocNumber, sellerSku])',
+  ]) {
+    assert.equal(schema.includes(required), true, `${required} should exist in schema`);
+  }
+});
+
 test('package scripts do not expose inventory ownership workflows', () => {
   const pkg = read('package.json');
   for (const forbidden of [
@@ -104,6 +133,60 @@ test('package scripts do not expose inventory ownership workflows', () => {
     'reprocess-invoice-conflicts',
   ]) {
     assert.equal(pkg.includes(forbidden), false, `${forbidden} should not be callable`);
+  }
+});
+
+test('package exposes QBO inventory bridge audit workflow', () => {
+  const pkg = read('package.json');
+  assert.equal(pkg.includes('"inventory:qbo:audit"'), true);
+  assert.equal(pkg.includes('scripts/qbo-inventory-bridge-audit.ts'), true);
+  assert.equal(pkg.includes('"inventory:qbo:repair"'), true);
+  assert.equal(pkg.includes('scripts/qbo-repair-inventory-valuation-tieout.ts'), true);
+  assert.equal(existsSync('scripts/qbo-inventory-bridge-audit.ts'), true);
+  assert.equal(existsSync('scripts/qbo-repair-inventory-valuation-tieout.ts'), true);
+});
+
+test('QBO inventory bridge audit reports live asset bill landed-cost evidence', () => {
+  const source = read('scripts/qbo-inventory-bridge-audit.ts');
+  assert.equal(source.includes('buildQboInventoryLandedCostPlan'), true);
+  assert.equal(source.includes('buildQboInventoryAssetReclassPlan'), true);
+  assert.equal(source.includes('parseQboInventoryValuationSummary'), true);
+  assert.equal(source.includes('qboInventoryValuationTieout'), true);
+  assert.equal(source.includes('qboInventoryAssetLines'), true);
+  assert.equal(source.includes('qboLandedCostLayers'), true);
+  assert.equal(source.includes('qboInventoryAssetBlocks'), true);
+  assert.equal(source.includes('qboNativeInventoryMigration'), false);
+});
+
+test('QBO inventory repair script moves only valuation drift lines to clearing', () => {
+  const source = read('scripts/qbo-repair-inventory-valuation-tieout.ts');
+  assert.equal(source.includes("const INVENTORY_ASSET_ACCOUNT_NAME = 'Inventory Asset'"), true);
+  assert.equal(source.includes("const INVENTORY_CLEARING_ACCOUNT_NAME = 'Inventory Clearing'"), true);
+  assert.equal(source.includes("const INVENTORY_COGS_RELEASE_ACCOUNT_NAME = 'Inventory COGS Release'"), true);
+  assert.equal(source.includes('buildQboInventoryAssetReclassPlan'), true);
+  assert.equal(source.includes('updateBillLineAccounts'), true);
+  assert.equal(source.includes('afterTieout'), true);
+});
+
+test('QBO inventory migration uses explicit COGS release adjustment account', () => {
+  const source = read('scripts/qbo-complete-inventory-migration.ts');
+  assert.equal(source.includes("requireAccount(accountsResult.accounts, 'Inventory COGS Release')"), true);
+  assert.equal(source.includes("requireAccount(accountsResult.accounts, 'Inventory Shrinkage')"), false);
+});
+
+test('QBO inventory setup scripts only reuse inventory-tracked SKU items', () => {
+  for (const path of ['scripts/qbo-create-inventory-purchase-orders.ts', 'scripts/qbo-complete-inventory-migration.ts']) {
+    const source = read(path);
+    assert.equal(source.includes("if (item.Type !== 'Inventory') continue;"), true, `${path} should require inventory items`);
+  }
+});
+
+test('QBO inventory migration scripts paginate bill fetches', () => {
+  for (const path of ['scripts/qbo-create-inventory-purchase-orders.ts', 'scripts/qbo-complete-inventory-migration.ts']) {
+    const source = read(path);
+    assert.equal(source.includes('let startPosition = 1;'), true, `${path} should start paginated bill reads`);
+    assert.equal(source.includes('startPosition += result.bills.length;'), true, `${path} should advance paginated bill reads`);
+    assert.equal(source.includes('if (result.bills.length < maxResults) break;'), true, `${path} should stop at the final page`);
   }
 });
 
@@ -299,6 +382,642 @@ test('rollback/reset tools preserve historical COGS journal entries', () => {
     assert.equal(source.includes('deleteJournalEntry(activeConnection, row.qboCogsJournalEntryId)'), false);
     assert.equal(source.includes('row.qboSettlementJournalEntryId, row.qboCogsJournalEntryId'), false);
   }
+});
+
+test('QBO inventory adjustment payload carries quantities only', () => {
+  const payload = buildQboInventoryAdjustmentPayload({
+    adjustmentAccountId: 'cogs-account',
+    txnDate: '2026-05-08',
+    docNumber: 'IA-260501-08-S2',
+    privateNote: 'Plutus inventory movement | Settlement: US-260501-260508-S2',
+    lines: [
+      { qboItemId: 'item-cs007', qtyDiff: -3 },
+      { qboItemId: 'item-cs010', qtyDiff: 1 },
+    ],
+  });
+
+  assert.deepEqual(payload, {
+    AdjustAccountRef: { value: 'cogs-account' },
+    domain: 'QBO',
+    sparse: false,
+    TxnDate: '2026-05-08',
+    DocNumber: 'IA-260501-08-S2',
+    PrivateNote: 'Plutus inventory movement | Settlement: US-260501-260508-S2',
+    Line: [
+      {
+        Id: '1',
+        DetailType: 'ItemAdjustmentLineDetail',
+        ItemAdjustmentLineDetail: {
+          ItemRef: { value: 'item-cs007' },
+          QtyDiff: -3,
+        },
+      },
+      {
+        Id: '2',
+        DetailType: 'ItemAdjustmentLineDetail',
+        ItemAdjustmentLineDetail: {
+          ItemRef: { value: 'item-cs010' },
+          QtyDiff: 1,
+        },
+      },
+    ],
+  });
+  assert.equal(JSON.stringify(payload).includes('Amount'), false);
+  assert.equal(JSON.stringify(payload).includes('UnitPrice'), false);
+});
+
+test('QBO inventory item payload creates inventory-tracked SKU item', () => {
+  const payload = buildQboInventoryItemPayload({
+    name: 'CS-007',
+    sku: 'CS-007',
+    inventoryStartDate: '2025-12-01',
+    initialQuantityOnHand: 0,
+    assetAccountId: 'inventory-asset',
+    incomeAccountId: 'sales',
+    expenseAccountId: 'cogs',
+    purchaseCost: 0.84,
+    unitPrice: 9.99,
+  });
+
+  assert.deepEqual(payload, {
+    Name: 'CS-007',
+    Sku: 'CS-007',
+    Type: 'Inventory',
+    TrackQtyOnHand: true,
+    QtyOnHand: 0,
+    InvStartDate: '2025-12-01',
+    AssetAccountRef: { value: 'inventory-asset' },
+    IncomeAccountRef: { value: 'sales' },
+    ExpenseAccountRef: { value: 'cogs' },
+    PurchaseCost: 0.84,
+    UnitPrice: 9.99,
+  });
+});
+
+test('QBO PO and item-based bill payloads carry item quantities and landed unit costs', () => {
+  const lines = [
+    {
+      qboItemId: 'item-cs007',
+      description: 'INTERNAL PO: 19; SUPPLIER REF: PH250940; SKU: CS-007',
+      quantity: 29440,
+      unitCost: 0.841229,
+    },
+  ];
+
+  assert.deepEqual(
+    buildQboPurchaseOrderPayload({
+      vendorId: 'jiangsu',
+      txnDate: '2025-09-29',
+      docNumber: 'PO-19-PDS',
+      privateNote: 'INTERNAL PO: 19; SUPPLIER REF: PH250940',
+      lines,
+    }),
+    {
+      VendorRef: { value: 'jiangsu' },
+      TxnDate: '2025-09-29',
+      DocNumber: 'PO-19-PDS',
+      PrivateNote: 'INTERNAL PO: 19; SUPPLIER REF: PH250940',
+      Line: [
+        {
+          DetailType: 'ItemBasedExpenseLineDetail',
+          Amount: 24765.78,
+          Description: 'INTERNAL PO: 19; SUPPLIER REF: PH250940; SKU: CS-007',
+          ItemBasedExpenseLineDetail: {
+            ItemRef: { value: 'item-cs007' },
+            Qty: 29440,
+            UnitPrice: 0.841229,
+          },
+        },
+      ],
+    },
+  );
+
+  assert.deepEqual(
+    buildQboItemBasedBillPayload({
+      vendorId: 'jiangsu',
+      txnDate: '2025-09-29',
+      docNumber: 'PH250940',
+      privateNote: 'INTERNAL PO: 19; SUPPLIER REF: PH250940',
+      lines,
+    }),
+    {
+      VendorRef: { value: 'jiangsu' },
+      TxnDate: '2025-09-29',
+      DocNumber: 'PH250940',
+      PrivateNote: 'INTERNAL PO: 19; SUPPLIER REF: PH250940',
+      Line: [
+        {
+          DetailType: 'ItemBasedExpenseLineDetail',
+          Amount: 24765.78,
+          Description: 'INTERNAL PO: 19; SUPPLIER REF: PH250940; SKU: CS-007',
+          ItemBasedExpenseLineDetail: {
+            ItemRef: { value: 'item-cs007' },
+            Qty: 29440,
+            UnitPrice: 0.841229,
+          },
+        },
+      ],
+    },
+  );
+});
+
+test('QBO inventory asset line parser enforces the bill-line description contract', () => {
+  assert.deepEqual(
+    parseQboInventoryAssetLine({
+      billId: '49',
+      billDocNumber: 'PH250940',
+      billDate: '2025-09-29',
+      vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+      qboLineId: '5',
+      accountName: 'Inventory Asset:Manufacturing - US-PDS',
+      amount: 17310.72,
+      description: 'MFG; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; QTY=29440; UNIT_COST=0.588; SOURCE=PH250940',
+    }),
+    {
+      billId: '49',
+      billDocNumber: 'PH250940',
+      billDate: '2025-09-29',
+      vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+      qboLineId: '5',
+      accountName: 'Inventory Asset:Manufacturing - US-PDS',
+      amount: 17310.72,
+      component: 'manufacturing',
+      marketCode: 'US-PDS',
+      descriptionKind: 'MFG',
+      owner: 'US-PDS',
+      internalPo: 'PO-19-PDS',
+      sellerSku: 'CS-007',
+      quantity: 29440,
+      sourceRef: 'PH250940',
+    },
+  );
+
+  assert.deepEqual(
+    parseQboInventoryAssetLine({
+      billId: '51',
+      billDocNumber: 'FSHY2509087198',
+      billDate: '2025-10-07',
+      vendorName: 'FOREST SHIPPING WORLDWIDE LTD',
+      qboLineId: '5',
+      accountName: 'Inventory Asset',
+      amount: 2514.18,
+      description:
+        'DUTY; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; ENTRY=N/A; SHIP=FBA19523CMQ9; SERVICE=CUSTOMS DUTY; ALLOC=FOB_VALUE; SOURCE=FSHY2509087198',
+    }).component,
+    'duty',
+  );
+
+  assert.deepEqual(
+    parseQboInventoryAssetLine({
+      billId: '48',
+      billDocNumber: 'ABC20250923007',
+      billDate: '2025-09-23',
+      vendorName: 'Huizhou Anboson Technology Co., Ltd',
+      qboLineId: '1',
+      accountName: 'Inventory Asset:Mfg Accessories - US-PDS',
+      amount: 560,
+      description:
+        'PKG; OWNER=US-PDS; ITEM=NITRILE_GLOVES; QTY=196 boxes; FOR_SKU=N/A; SOURCE=ABC20250923007; NOTES=item $490 plus shipping $70',
+    }).sellerSku,
+    null,
+  );
+});
+
+test('QBO landed cost plan aggregates US asset bills by internal PO and SKU', () => {
+  const plan = buildQboInventoryLandedCostPlan({
+    marketplace: 'amazon.com',
+    lines: [
+      {
+        billId: '49',
+        billDocNumber: 'PH250940',
+        billDate: '2025-09-29',
+        vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+        qboLineId: '5',
+        accountName: 'Inventory Asset',
+        amount: 17310.72,
+        description: 'MFG; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; QTY=29440; UNIT_COST=0.588; SOURCE=PH250940',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '16',
+        accountName: 'Inventory Asset',
+        amount: 2266.88,
+        description: 'PKG; OWNER=PO-19-PDS; ITEM=CS-007-BOX; QTY=29440; FOR_SKU=CS-007; PO=PO-19-PDS; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '44',
+        billDocNumber: 'PI-2508204A',
+        billDate: '2025-08-20',
+        vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset',
+        amount: 971.52,
+        description: 'PKG; OWNER=PO-19-PDS; ITEM=CS-007-BOX-PRESSING; QTY=29440; FOR_SKU=CS-007; PO=PO-19-PDS; SOURCE=PI-2508204A',
+      },
+      {
+        billId: '51',
+        billDocNumber: 'FSHY2509087198',
+        billDate: '2025-10-07',
+        vendorName: 'FOREST SHIPPING WORLDWIDE LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset:Freight - US-PDS',
+        amount: 1702.48,
+        description:
+          'FREIGHT; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; SERVICE=FOREST SHIPPING; SHIP=FBA19523CMQ9; ALLOC=CBM; SOURCE=FSHY2509087198',
+      },
+      {
+        billId: '51',
+        billDocNumber: 'FSHY2509087198',
+        billDate: '2025-10-07',
+        vendorName: 'FOREST SHIPPING WORLDWIDE LTD',
+        qboLineId: '5',
+        accountName: 'Inventory Asset:Duty - US-PDS',
+        amount: 2514.18,
+        description:
+          'DUTY; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; ENTRY=N/A; SHIP=FBA19523CMQ9; SERVICE=CUSTOMS DUTY; ALLOC=FOB_VALUE; SOURCE=FSHY2509087198',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '18',
+        accountName: 'Inventory Asset:Mfg Accessories - US-PDS',
+        amount: 1.23,
+        description: 'PKG; OWNER=RESIDUAL; ITEM=CS-007-BOX; QTY=16; FOR_SKU=CS-007; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '48',
+        billDocNumber: 'ABC20250923007',
+        billDate: '2025-09-23',
+        vendorName: 'Huizhou Anboson Technology Co., Ltd',
+        qboLineId: '1',
+        accountName: 'Inventory Asset:Mfg Accessories - US-PDS',
+        amount: 560,
+        description:
+          'PKG; OWNER=US-PDS; ITEM=NITRILE_GLOVES; QTY=196 boxes; FOR_SKU=N/A; SOURCE=ABC20250923007; NOTES=item $490 plus shipping $70',
+      },
+      {
+        billId: '605',
+        billDocNumber: 'FSHY2512091572',
+        billDate: '2026-02-24',
+        vendorName: 'FOREST SHIPPING WORLDWIDE LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset:Freight - UK-PDS',
+        amount: 6694.15,
+        description: 'Freight invoice FSHY2512091572 - awaiting goods receipt for future UK-PDS shipment',
+      },
+    ],
+  });
+
+  assert.equal(plan.marketCode, 'US-PDS');
+  assert.deepEqual(plan.layers, [
+    {
+      internalPo: 'PO-19-PDS',
+      sellerSku: 'CS-007',
+      quantity: 29440,
+      componentAmounts: {
+        manufacturing: 17310.72,
+        freight: 1702.48,
+        duty: 2514.18,
+        mfgAccessories: 3238.4,
+      },
+      totalAmount: 24765.78,
+      unitCost: 0.841229,
+      sourceRefs: ['FSHY2509087198', 'PH250940', 'PI-250804BOXB', 'PI-2508204A'],
+      qboBillLineRefs: ['44:1', '46:16', '49:5', '51:1', '51:5'],
+    },
+  ]);
+  assert.deepEqual(plan.blocks, [
+    { code: 'RESIDUAL_ASSET_LINE', billId: '46', qboLineId: '18', owner: 'RESIDUAL', sellerSku: 'CS-007' },
+    { code: 'NON_SKU_ASSET_LINE', billId: '48', qboLineId: '1', owner: 'US-PDS' },
+  ]);
+});
+
+test('QBO inventory asset reclass plan moves only non-item valuation drift lines', () => {
+  const plan = buildQboInventoryAssetReclassPlan({
+    marketplace: 'amazon.com',
+    lines: [
+      {
+        billId: '49',
+        billDocNumber: 'PH250940',
+        billDate: '2025-09-29',
+        vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+        qboLineId: '5',
+        accountName: 'Inventory Asset',
+        amount: 17310.72,
+        description: 'MFG; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; QTY=29440; UNIT_COST=0.588; SOURCE=PH250940',
+      },
+      {
+        billId: '44',
+        billDocNumber: 'PI-2508204A',
+        billDate: '2025-08-20',
+        vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset',
+        amount: 971.52,
+        description: 'PKG; OWNER=PO-19-PDS; ITEM=CS-007-BOX-PRESSING; QTY=29440; FOR_SKU=CS-007; PO=PO-19-PDS; SOURCE=PI-2508204A',
+      },
+      {
+        billId: '44',
+        billDocNumber: 'PI-2508204A',
+        billDate: '2025-08-20',
+        vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+        qboLineId: '2',
+        accountName: 'Inventory Asset',
+        amount: 413.95,
+        description: 'PKG; OWNER=UK-PDS; ITEM=CS-007-BOX-PRESSING; QTY=12544; FOR_SKU=CS-007; SOURCE=PI-2508204A',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '17',
+        accountName: 'Inventory Asset',
+        amount: 965.89,
+        description: 'PKG; OWNER=UK; ITEM=CS-007-BOX; QTY=12544; FOR_SKU=CS-007; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '18',
+        accountName: 'Inventory Asset',
+        amount: 1.23,
+        description: 'PKG; OWNER=RESIDUAL; ITEM=CS-007-BOX; QTY=16; FOR_SKU=CS-007; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '21',
+        accountName: 'Inventory Asset',
+        amount: 2,
+        description: 'PKG; OWNER=RESIDUAL; ITEM=CS-12LD-7M-BOX; QTY=20; FOR_SKU=CS-12LD-7M; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '24',
+        accountName: 'Inventory Asset',
+        amount: 0.77,
+        description: 'PKG; OWNER=RESIDUAL; ITEM=CS-1SD-32M-BOX; QTY=10; FOR_SKU=CS-1SD-32M; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '46',
+        billDocNumber: 'PI-250804BOXB',
+        billDate: '2025-08-04',
+        vendorName: 'VICTOR HERO HOLDINGS LIMITED',
+        qboLineId: '27',
+        accountName: 'Inventory Asset',
+        amount: 0.95,
+        description: 'PKG; OWNER=RESIDUAL; ITEM=CS-010-BOX; QTY=10; FOR_SKU=CS-010; SOURCE=PI-250804BOXB',
+      },
+      {
+        billId: '48',
+        billDocNumber: 'ABC20250923007',
+        billDate: '2025-09-23',
+        vendorName: 'Huizhou Anboson Technology Co., Ltd',
+        qboLineId: '1',
+        accountName: 'Inventory Asset',
+        amount: 560,
+        description:
+          'PKG; OWNER=US-PDS; ITEM=NITRILE_GLOVES; QTY=196 boxes; FOR_SKU=N/A; SOURCE=ABC20250923007; NOTES=item $490 plus shipping $70',
+      },
+      {
+        billId: '605',
+        billDocNumber: 'FSHY2512091572',
+        billDate: '2026-02-24',
+        vendorName: 'FOREST SHIPPING WORLDWIDE LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset',
+        amount: 6694.15,
+        description: 'Freight invoice FSHY2512091572 - awaiting goods receipt for future UK-PDS shipment',
+      },
+    ],
+  });
+
+  assert.equal(plan.totalAmount, 8638.94);
+  assert.deepEqual(
+    plan.lines.map((line) => [line.billId, line.qboLineId, line.reason, line.amount]),
+    [
+      ['44', '2', 'NON_TARGET_MARKET_ASSET_LINE', 413.95],
+      ['46', '17', 'NON_TARGET_MARKET_ASSET_LINE', 965.89],
+      ['46', '18', 'RESIDUAL_ASSET_LINE', 1.23],
+      ['46', '21', 'RESIDUAL_ASSET_LINE', 2],
+      ['46', '24', 'RESIDUAL_ASSET_LINE', 0.77],
+      ['46', '27', 'RESIDUAL_ASSET_LINE', 0.95],
+      ['48', '1', 'NON_SKU_ASSET_LINE', 560],
+      ['605', '1', 'UNPARSEABLE_ASSET_LINE', 6694.15],
+    ],
+  );
+});
+
+test('QBO inventory valuation tieout compares item valuation to Inventory Asset GL', () => {
+  assert.deepEqual(
+    assessQboInventoryValuationTieout({
+      inventoryAssetBalance: 84134.69,
+      inventoryValuationAssetValue: 75495.75,
+    }),
+    {
+      ok: false,
+      inventoryAssetBalance: 84134.69,
+      inventoryValuationAssetValue: 75495.75,
+      delta: 8638.94,
+      tolerance: 0.01,
+    },
+  );
+
+  assert.equal(
+    assessQboInventoryValuationTieout({
+      inventoryAssetBalance: 75495.75,
+      inventoryValuationAssetValue: 75495.75,
+    }).ok,
+    true,
+  );
+});
+
+test('QBO inventory valuation summary parser reads item rows and report total', () => {
+  const parsed = parseQboInventoryValuationSummary({
+    Rows: {
+      Row: [
+        {
+          ColData: [
+            { value: 'CS-007', id: '4' },
+            { value: 'CS-007' },
+            { value: '54634.00' },
+            { value: '38218.18' },
+            { value: '0.70' },
+          ],
+        },
+        {
+          ColData: [{ value: 'TOTAL' }, { value: ' ' }, { value: '' }, { value: '75495.75' }, { value: '' }],
+          group: 'GrandTotal',
+        },
+      ],
+    },
+  });
+
+  assert.equal(parsed.totalAssetValue, 75495.75);
+  assert.deepEqual(parsed.rows, [
+    {
+      itemId: '4',
+      name: 'CS-007',
+      sku: 'CS-007',
+      quantity: 54634,
+      assetValue: 38218.18,
+      averageCost: 0.7,
+    },
+  ]);
+});
+
+test('inventory movement planning blocks missing QBO item mappings and ignores refund stockbacks without proof', () => {
+  const plan = buildSettlementInventoryMovementPlan({
+    marketplace: 'amazon.com',
+    settlementDocNumber: 'US-260501-260508-S2',
+    txnDate: '2026-05-08',
+    adjustmentAccountId: 'cogs-account',
+    itemMappings: [{ marketplace: 'amazon.com', sellerSku: 'CS-007', qboItemId: 'item-cs007' }],
+    auditRows: [
+      {
+        invoiceId: 'US-260501-260508-S2',
+        market: 'us',
+        date: '2026-05-01',
+        orderId: 'ORDER-1',
+        sku: 'CS-007',
+        quantity: 3,
+        description: 'Amazon Sales - Principal - US-PDS',
+        net: 3000,
+      },
+      {
+        invoiceId: 'US-260501-260508-S2',
+        market: 'us',
+        date: '2026-05-02',
+        orderId: 'ORDER-2',
+        sku: 'CS-007',
+        quantity: -1,
+        description: 'Amazon Refunds - Refunded Principal',
+        net: -1000,
+      },
+      {
+        invoiceId: 'US-260501-260508-S2',
+        market: 'us',
+        date: '2026-05-03',
+        orderId: 'ORDER-3',
+        sku: 'CS-010',
+        quantity: 2,
+        description: 'Amazon Sales - Principal - US-PDS',
+        net: 2000,
+      },
+    ],
+  });
+
+  assert.equal(plan.ok, false);
+  assert.deepEqual(plan.blocks, [{ code: 'MISSING_QBO_ITEM_MAPPING', sellerSku: 'CS-010' }]);
+  assert.deepEqual(plan.adjustmentLines, [{ sellerSku: 'CS-007', qboItemId: 'item-cs007', qtyDiff: -3 }]);
+});
+
+test('inventory movement planning emits QBO adjustment when every sold SKU is mapped', () => {
+  const plan = buildSettlementInventoryMovementPlan({
+    marketplace: 'amazon.com',
+    settlementDocNumber: 'US-260501-260508-S2',
+    txnDate: '2026-05-08',
+    adjustmentAccountId: 'cogs-account',
+    itemMappings: [
+      { marketplace: 'amazon.com', sellerSku: 'CS-007', qboItemId: 'item-cs007' },
+      { marketplace: 'amazon.com', sellerSku: 'CS-010', qboItemId: 'item-cs010' },
+    ],
+    auditRows: [
+      {
+        invoiceId: 'US-260501-260508-S2',
+        market: 'us',
+        date: '2026-05-01',
+        orderId: 'ORDER-1',
+        sku: 'CS-007',
+        quantity: 3,
+        description: 'Amazon Sales - Principal',
+        net: 3000,
+      },
+      {
+        invoiceId: 'US-260501-260508-S2',
+        market: 'us',
+        date: '2026-05-03',
+        orderId: 'ORDER-3',
+        sku: 'CS-010',
+        quantity: 2,
+        description: 'Amazon Sales - Principal',
+        net: 2000,
+      },
+    ],
+  });
+
+  assert.equal(plan.ok, true);
+  assert.deepEqual(plan.blocks, []);
+  assert.deepEqual(plan.qboInventoryAdjustmentPayload, {
+    AdjustAccountRef: { value: 'cogs-account' },
+    domain: 'QBO',
+    sparse: false,
+    TxnDate: '2026-05-08',
+    DocNumber: 'IA-260501-08-S2',
+    PrivateNote: 'Plutus inventory movement | Settlement: US-260501-260508-S2 | Marketplace: amazon.com',
+    Line: [
+      {
+        Id: '1',
+        DetailType: 'ItemAdjustmentLineDetail',
+        ItemAdjustmentLineDetail: {
+          ItemRef: { value: 'item-cs007' },
+          QtyDiff: -3,
+        },
+      },
+      {
+        Id: '2',
+        DetailType: 'ItemAdjustmentLineDetail',
+        ItemRef: undefined,
+        ItemAdjustmentLineDetail: {
+          ItemRef: { value: 'item-cs010' },
+          QtyDiff: -2,
+        },
+      },
+    ].map((line) => {
+      const next = { ...line };
+      delete (next as { ItemRef?: unknown }).ItemRef;
+      return next;
+    }),
+  });
+});
+
+test('inventory movement planning supports UK settlement adjustment doc numbers', () => {
+  const plan = buildSettlementInventoryMovementPlan({
+    marketplace: 'amazon.co.uk',
+    settlementDocNumber: 'UK-260501-260508-S2',
+    txnDate: '2026-05-08',
+    adjustmentAccountId: 'cogs-account',
+    itemMappings: [{ marketplace: 'amazon.co.uk', sellerSku: 'CS-007', qboItemId: 'item-cs007' }],
+    auditRows: [
+      {
+        invoiceId: 'UK-260501-260508-S2',
+        market: 'uk',
+        date: '2026-05-01',
+        orderId: 'ORDER-UK-1',
+        sku: 'CS-007',
+        quantity: 4,
+        description: 'Amazon Sales - Principal - UK-PDS',
+        net: 4000,
+      },
+    ],
+  });
+
+  assert.equal(plan.ok, true);
+  assert.equal(plan.qboInventoryAdjustmentPayload?.DocNumber, 'IA-UK-260501-08-S2');
+  assert.equal(plan.qboInventoryAdjustmentPayload?.Line[0]?.ItemAdjustmentLineDetail.QtyDiff, -4);
 });
 
 test('processing blocks fail closed', () => {


### PR DESCRIPTION
## Summary
- replace Plutus-owned inventory state with QBO item/PO/inventory-adjustment bridge records
- add QBO item/PO/migration/audit/repair scripts for inventory source-of-truth migration
- enforce QBO Inventory Asset GL to Inventory Valuation tieout and move non-item drift into Inventory Clearing
- require Inventory COGS Release as the QBO adjustment account

## Live QBO verification
- Inventory Asset: ,495.75
- Inventory Valuation Summary: ,495.75
- Delta: /bin/zsh.00
- inventory:qbo:audit: ok=true

## Tests
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus inventory:qbo:audit