### PR TITLE
[codex] Repair Plutus exact COGS posting flow

### DIFF
--- a/apps/plutus/package.json
+++ b/apps/plutus/package.json
@@ -23,6 +23,8 @@
     "inventory:qbo:audit": "tsx scripts/qbo-inventory-bridge-audit.ts",
     "inventory:exact:sync": "tsx scripts/plutus-sync-exact-cost-layers-from-qbo.ts",
     "inventory:exact:cogs:sync": "tsx scripts/plutus-sync-exact-cogs-from-audit.ts",
+    "inventory:exact:cogs:post": "tsx scripts/plutus-post-exact-cogs-to-qbo.ts",
+    "inventory:native:retire": "tsx scripts/plutus-retire-native-inventory-adjustments.ts",
     "inventory:exact:audit": "tsx scripts/plutus-exact-cost-layer-audit.ts",
     "settlements:backfill-docnumbers": "tsx scripts/backfill-settlement-doc-numbers.ts",
     "settlements:backfill-fx": "tsx scripts/backfill-settlement-exchange-rates.ts",

--- a/apps/plutus/scripts/plutus-post-exact-cogs-to-qbo.ts
+++ b/apps/plutus/scripts/plutus-post-exact-cogs-to-qbo.ts
@@ -1,0 +1,335 @@
+import { db } from '@/lib/db';
+import {
+  createJournalEntry,
+  fetchAccounts,
+  fetchJournalEntries,
+  type QboAccount,
+  type QboConnection,
+} from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import type { QboInventoryAssetComponent } from '@/lib/plutus/qbo-inventory-asset-lines';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  marketplace: string;
+  settlementDocNumbers: string[];
+  post: boolean;
+};
+
+type ComponentAmounts = Record<QboInventoryAssetComponent, number>;
+
+type CogsBatchRow = {
+  id: string;
+  marketplace: string;
+  settlementDocNumber: string;
+  txnDate: string;
+  currency: string;
+  status: string;
+  qboJournalEntryId: string | null;
+  qboDocNumber: string | null;
+  consumptions: Array<{
+    internalPo: string;
+    sellerSku: string;
+    quantity: number;
+    amountCents: number;
+    componentAmounts: unknown;
+  }>;
+};
+
+const COMPONENTS: QboInventoryAssetComponent[] = ['manufacturing', 'freight', 'duty', 'mfgAccessories'];
+
+const COMPONENT_LABELS: Record<QboInventoryAssetComponent, string> = {
+  manufacturing: 'Manufacturing',
+  freight: 'Freight',
+  duty: 'Duty',
+  mfgAccessories: 'Mfg Accessories',
+};
+
+const COMPONENT_ACCOUNT_NAMES: Record<QboInventoryAssetComponent, string> = {
+  manufacturing: 'Manufacturing',
+  freight: 'Freight & Custom Duty',
+  duty: 'Freight & Custom Duty',
+  mfgAccessories: 'Mfg Accessories',
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  let marketplace = 'amazon.com';
+  let settlementDocNumbers: string[] = [];
+  let post = false;
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--marketplace') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --marketplace');
+      marketplace = next;
+      i += 2;
+      continue;
+    }
+    if (arg === '--settlement-doc-number') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --settlement-doc-number');
+      settlementDocNumbers = settlementDocNumbers.concat(
+        next
+          .split(',')
+          .map((value) => value.trim())
+          .filter((value) => value !== ''),
+      );
+      i += 2;
+      continue;
+    }
+    if (arg === '--post') {
+      post = true;
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (settlementDocNumbers.length === 0) {
+    throw new Error('Usage: pnpm inventory:exact:cogs:post --settlement-doc-number <doc[,doc...]> [--post]');
+  }
+
+  return {
+    marketplace,
+    settlementDocNumbers: Array.from(new Set(settlementDocNumbers)).sort(),
+    post,
+  };
+}
+
+function centsToDollars(cents: number): number {
+  return Math.round(cents) / 100;
+}
+
+function roundMoney(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function requireComponentAmounts(value: unknown): ComponentAmounts {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('COGS consumption is missing componentAmounts');
+  }
+  const raw = value as Record<string, unknown>;
+  const result = {} as ComponentAmounts;
+  for (const component of COMPONENTS) {
+    const amount = raw[component];
+    if (typeof amount !== 'number' || !Number.isFinite(amount) || amount < 0) {
+      throw new Error(`COGS consumption has invalid ${component} amount`);
+    }
+    result[component] = roundMoney(amount);
+  }
+  return result;
+}
+
+function requireOneActiveAccountByName(accounts: QboAccount[], name: string): string {
+  const matches = accounts.filter((account) => account.Active !== false && account.Name.trim() === name);
+  if (matches.length !== 1) {
+    throw new Error(`Expected exactly one active QBO account named "${name}", found ${matches.length}`);
+  }
+  return matches[0]!.Id;
+}
+
+async function findExistingJournalEntryIdByDocNumber(input: {
+  connection: QboConnection;
+  docNumber: string;
+}): Promise<{ id: string | null; updatedConnection?: QboConnection }> {
+  const result = await fetchJournalEntries(input.connection, {
+    docNumberContains: input.docNumber,
+    maxResults: 10,
+    startPosition: 1,
+  });
+  const exactMatches = result.journalEntries.filter((entry) => entry.DocNumber === input.docNumber);
+  if (exactMatches.length > 1) {
+    throw new Error(`Multiple QBO journal entries already exist for ${input.docNumber}`);
+  }
+  return {
+    id: exactMatches[0]?.Id ?? null,
+    updatedConnection: result.updatedConnection,
+  };
+}
+
+function buildJournalEntry(input: {
+  batch: CogsBatchRow;
+  componentAccountIds: Record<QboInventoryAssetComponent, string>;
+  inventoryAssetAccountId: string;
+}): {
+  docNumber: string;
+  txnDate: string;
+  privateNote: string;
+  lines: Array<{ accountId: string; postingType: 'Debit' | 'Credit'; amount: number; description: string }>;
+} {
+  const docNumber = `C-${input.batch.settlementDocNumber}`;
+  const lines: Array<{ accountId: string; postingType: 'Debit' | 'Credit'; amount: number; description: string }> = [];
+
+  for (const consumption of input.batch.consumptions) {
+    const componentAmounts = requireComponentAmounts(consumption.componentAmounts);
+    for (const component of COMPONENTS) {
+      const amount = componentAmounts[component];
+      if (amount === 0) continue;
+      const unitCost = roundMoney(amount / consumption.quantity).toFixed(6);
+      lines.push({
+        accountId: input.componentAccountIds[component],
+        postingType: 'Debit',
+        amount,
+        description: `${COMPONENT_LABELS[component]} COGS; SKU=${consumption.sellerSku}; PO=${consumption.internalPo}; QTY=${consumption.quantity}; UNIT=${unitCost}`,
+      });
+    }
+    const totalAmount = centsToDollars(consumption.amountCents);
+    lines.push({
+      accountId: input.inventoryAssetAccountId,
+      postingType: 'Credit',
+      amount: totalAmount,
+      description: `Inventory Asset release; SKU=${consumption.sellerSku}; PO=${consumption.internalPo}; QTY=${consumption.quantity}; UNIT=${roundMoney(
+        totalAmount / consumption.quantity,
+      ).toFixed(6)}`,
+    });
+  }
+
+  const debits = roundMoney(lines.filter((line) => line.postingType === 'Debit').reduce((sum, line) => sum + line.amount, 0));
+  const credits = roundMoney(lines.filter((line) => line.postingType === 'Credit').reduce((sum, line) => sum + line.amount, 0));
+  if (Math.abs(debits - credits) > 0.01) {
+    throw new Error(`Exact COGS journal ${docNumber} is not balanced: debits=${debits}, credits=${credits}`);
+  }
+
+  return {
+    docNumber,
+    txnDate: input.batch.txnDate,
+    privateNote: `Plutus exact COGS | Settlement: ${input.batch.settlementDocNumber} | Marketplace: ${input.batch.marketplace}`,
+    lines,
+  };
+}
+
+async function main(): Promise<void> {
+  loadSharedPlutusEnv();
+  const options = parseArgs(process.argv.slice(2));
+
+  const batches = await db.cogsPostingBatch.findMany({
+    where: {
+      marketplace: options.marketplace,
+      settlementDocNumber: { in: options.settlementDocNumbers },
+    },
+    include: {
+      consumptions: {
+        orderBy: [{ internalPo: 'asc' }, { sellerSku: 'asc' }],
+      },
+    },
+    orderBy: [{ txnDate: 'asc' }, { settlementDocNumber: 'asc' }],
+  });
+  if (batches.length !== options.settlementDocNumbers.length) {
+    const found = new Set(batches.map((batch) => batch.settlementDocNumber));
+    const missing = options.settlementDocNumbers.filter((docNumber) => !found.has(docNumber));
+    throw new Error(`Missing exact COGS batch for settlement(s): ${missing.join(', ')}`);
+  }
+
+  const maybeConnection = await getQboConnection();
+  if (maybeConnection === null) throw new Error('QBO connection is not configured');
+  let connection = maybeConnection;
+
+  const accountsResult = await fetchAccounts(connection, { includeInactive: true });
+  if (accountsResult.updatedConnection !== undefined) connection = accountsResult.updatedConnection;
+  const accounts = accountsResult.accounts;
+  const componentAccountIds: Record<QboInventoryAssetComponent, string> = {
+    manufacturing: requireOneActiveAccountByName(accounts, COMPONENT_ACCOUNT_NAMES.manufacturing),
+    freight: requireOneActiveAccountByName(accounts, COMPONENT_ACCOUNT_NAMES.freight),
+    duty: requireOneActiveAccountByName(accounts, COMPONENT_ACCOUNT_NAMES.duty),
+    mfgAccessories: requireOneActiveAccountByName(accounts, COMPONENT_ACCOUNT_NAMES.mfgAccessories),
+  };
+  const inventoryAssetAccountId = requireOneActiveAccountByName(accounts, 'Inventory Asset');
+
+  const runSummary: Array<Record<string, unknown>> = [];
+
+  for (const batch of batches) {
+    if (batch.consumptions.length === 0) {
+      runSummary.push({
+        settlementDocNumber: batch.settlementDocNumber,
+        action: 'skipped',
+        reason: 'No COGS consumption lines',
+      });
+      continue;
+    }
+
+    const journalEntry = buildJournalEntry({
+      batch,
+      componentAccountIds,
+      inventoryAssetAccountId,
+    });
+    const existing = await findExistingJournalEntryIdByDocNumber({ connection, docNumber: journalEntry.docNumber });
+    if (existing.updatedConnection !== undefined) connection = existing.updatedConnection;
+
+    if (existing.id !== null) {
+      await db.cogsPostingBatch.update({
+        where: { id: batch.id },
+        data: {
+          status: 'posted',
+          qboJournalEntryId: existing.id,
+          qboDocNumber: journalEntry.docNumber,
+        },
+      });
+      await db.sellerboardCogsExport.updateMany({
+        where: { cogsPostingBatchId: batch.id },
+        data: { status: 'ready' },
+      });
+      runSummary.push({
+        settlementDocNumber: batch.settlementDocNumber,
+        action: 'existing',
+        qboJournalEntryId: existing.id,
+        docNumber: journalEntry.docNumber,
+      });
+      continue;
+    }
+
+    if (!options.post) {
+      runSummary.push({
+        settlementDocNumber: batch.settlementDocNumber,
+        action: 'dry_run',
+        docNumber: journalEntry.docNumber,
+        lines: journalEntry.lines.length,
+        totalAmount: roundMoney(
+          journalEntry.lines.filter((line) => line.postingType === 'Credit').reduce((sum, line) => sum + line.amount, 0),
+        ),
+      });
+      continue;
+    }
+
+    const posted = await createJournalEntry(connection, {
+      txnDate: journalEntry.txnDate,
+      docNumber: journalEntry.docNumber,
+      privateNote: journalEntry.privateNote,
+      currencyCode: batch.currency,
+      lines: journalEntry.lines,
+    });
+    if (posted.updatedConnection !== undefined) connection = posted.updatedConnection;
+
+    await db.cogsPostingBatch.update({
+      where: { id: batch.id },
+      data: {
+        status: 'posted',
+        qboJournalEntryId: posted.journalEntry.Id,
+        qboDocNumber: journalEntry.docNumber,
+      },
+    });
+    await db.sellerboardCogsExport.updateMany({
+      where: { cogsPostingBatchId: batch.id },
+      data: { status: 'ready' },
+    });
+
+    runSummary.push({
+      settlementDocNumber: batch.settlementDocNumber,
+      action: 'posted',
+      qboJournalEntryId: posted.journalEntry.Id,
+      docNumber: journalEntry.docNumber,
+    });
+  }
+
+  await saveServerQboConnection(connection);
+  console.log(JSON.stringify({ options, runSummary }, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  })
+  .finally(async () => {
+    await db.$disconnect();
+  });

--- a/apps/plutus/scripts/plutus-retire-native-inventory-adjustments.ts
+++ b/apps/plutus/scripts/plutus-retire-native-inventory-adjustments.ts
@@ -1,0 +1,268 @@
+import { HUMAN_APPROVAL_PHRASE } from '@/lib/plutus/human-approval';
+import { getApiBaseUrl } from '@/lib/qbo/client';
+import { getValidToken, type QboConnection } from '@/lib/qbo/api';
+import { saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { getActiveQboConnection, qboQueryAll } from '@/lib/qbo/full-history-audit/fetch';
+import { loadSharedPlutusEnv } from './shared-env';
+
+type CliOptions = {
+  apply: boolean;
+  humanApproval: string | null;
+  marketplace: 'amazon.com';
+};
+
+type QboInventoryAdjustment = {
+  Id?: string;
+  SyncToken?: string;
+  DocNumber?: string;
+  TxnDate?: string;
+  PrivateNote?: string;
+  Line?: Array<{
+    ItemAdjustmentLineDetail?: {
+      ItemRef?: { value?: string; name?: string };
+      QtyDiff?: number;
+    };
+  }>;
+};
+
+type PlutusNativeInventoryAdjustment = {
+  id: string;
+  syncToken: string;
+  docNumber: string;
+  txnDate: string;
+  settlementDocNumber: string;
+  marketplace: 'amazon.com';
+  quantityDelta: number;
+  lines: Array<{ itemName: string; quantityDelta: number }>;
+  privateNote: string;
+};
+
+function parseArgs(argv: string[]): CliOptions {
+  let apply = false;
+  let humanApproval: string | null = null;
+  const marketplace = 'amazon.com';
+
+  for (let i = 0; i < argv.length; ) {
+    const arg = argv[i]!;
+    if (arg === '--apply') {
+      apply = true;
+      i += 1;
+      continue;
+    }
+    if (arg === '--human-approval') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --human-approval');
+      humanApproval = next;
+      i += 2;
+      continue;
+    }
+    if (arg === '--marketplace') {
+      const next = argv[i + 1];
+      if (next === undefined) throw new Error('Missing value for --marketplace');
+      if (next !== marketplace) throw new Error(`Unsupported marketplace for native inventory retirement: ${next}`);
+      i += 2;
+      continue;
+    }
+    if (arg.startsWith('--marketplace=')) {
+      const next = arg.slice('--marketplace='.length);
+      if (next !== marketplace) throw new Error(`Unsupported marketplace for native inventory retirement: ${next}`);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (apply && humanApproval !== HUMAN_APPROVAL_PHRASE) {
+    throw new Error(`Native inventory retirement requires --human-approval "${HUMAN_APPROVAL_PHRASE}"`);
+  }
+
+  return { apply, humanApproval, marketplace };
+}
+
+function parsePlutusAdjustment(adjustment: QboInventoryAdjustment): {
+  settlementDocNumber: string;
+  marketplace: 'amazon.com';
+} | null {
+  const privateNote = adjustment.PrivateNote?.trim();
+  if (privateNote === undefined || privateNote === '') return null;
+
+  const match = /^Plutus inventory movement \| Settlement: (US-\d{6}-\d{6}-S\d+) \| Marketplace: (amazon\.com)$/.exec(
+    privateNote,
+  );
+  if (match === null) return null;
+
+  return {
+    settlementDocNumber: match[1]!,
+    marketplace: 'amazon.com',
+  };
+}
+
+function requirePlutusNativeInventoryAdjustment(
+  adjustment: QboInventoryAdjustment,
+): PlutusNativeInventoryAdjustment | null {
+  const parsed = parsePlutusAdjustment(adjustment);
+  if (parsed === null) return null;
+
+  if (adjustment.Id === undefined || adjustment.Id.trim() === '') {
+    throw new Error(`Plutus InventoryAdjustment for ${parsed.settlementDocNumber} is missing Id`);
+  }
+  if (adjustment.SyncToken === undefined || adjustment.SyncToken.trim() === '') {
+    throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} is missing SyncToken`);
+  }
+  if (adjustment.DocNumber === undefined || !adjustment.DocNumber.startsWith('IA-')) {
+    throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} has unsupported DocNumber ${adjustment.DocNumber ?? ''}`);
+  }
+  if (adjustment.TxnDate === undefined || adjustment.TxnDate.trim() === '') {
+    throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} is missing TxnDate`);
+  }
+  if (adjustment.PrivateNote === undefined || adjustment.PrivateNote.trim() === '') {
+    throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} is missing PrivateNote`);
+  }
+
+  const lines = (adjustment.Line ?? []).map((line) => {
+    const itemName = line.ItemAdjustmentLineDetail?.ItemRef?.name;
+    const qtyDiff = line.ItemAdjustmentLineDetail?.QtyDiff;
+    if (itemName === undefined || itemName.trim() === '') {
+      throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} has a line without ItemRef.name`);
+    }
+    if (qtyDiff === undefined || !Number.isInteger(qtyDiff) || qtyDiff === 0) {
+      throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} has invalid QtyDiff for ${itemName}`);
+    }
+    return {
+      itemName,
+      quantityDelta: qtyDiff,
+    };
+  });
+  if (lines.length === 0) {
+    throw new Error(`Plutus InventoryAdjustment ${adjustment.Id} has no item adjustment lines`);
+  }
+
+  return {
+    id: adjustment.Id,
+    syncToken: adjustment.SyncToken,
+    docNumber: adjustment.DocNumber,
+    txnDate: adjustment.TxnDate,
+    settlementDocNumber: parsed.settlementDocNumber,
+    marketplace: parsed.marketplace,
+    quantityDelta: lines.reduce((sum, line) => sum + line.quantityDelta, 0),
+    lines,
+    privateNote: adjustment.PrivateNote,
+  };
+}
+
+async function fetchPlutusNativeInventoryAdjustments(
+  marketplace: 'amazon.com',
+): Promise<{ connection: QboConnection; adjustments: PlutusNativeInventoryAdjustment[] }> {
+  const activeConnection = await getActiveQboConnection();
+  const result = await qboQueryAll(activeConnection, 'SELECT * FROM InventoryAdjustment');
+  const adjustments = (result.rows as QboInventoryAdjustment[])
+    .map(requirePlutusNativeInventoryAdjustment)
+    .filter((adjustment) => adjustment !== null)
+    .filter((adjustment) => adjustment.marketplace === marketplace)
+    .sort((left, right) => {
+      const dateCompare = left.txnDate.localeCompare(right.txnDate);
+      if (dateCompare !== 0) return dateCompare;
+      return left.docNumber.localeCompare(right.docNumber);
+    });
+
+  return {
+    connection: activeConnection.connection,
+    adjustments,
+  };
+}
+
+async function deleteInventoryAdjustment(
+  connection: QboConnection,
+  adjustment: PlutusNativeInventoryAdjustment,
+): Promise<{ deletedId: string; updatedConnection?: QboConnection }> {
+  const tokenResult = await getValidToken(connection);
+  const activeConnection = tokenResult.updatedConnection ?? connection;
+  const url = new URL(`${getApiBaseUrl()}/v3/company/${activeConnection.realmId}/inventoryadjustment`);
+  url.searchParams.set('operation', 'delete');
+  url.searchParams.set('minorversion', '75');
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${tokenResult.accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      Id: adjustment.id,
+      SyncToken: adjustment.syncToken,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to delete QBO InventoryAdjustment ${adjustment.id} ${adjustment.docNumber}: ${response.status} ${errorText}`,
+    );
+  }
+
+  return {
+    deletedId: adjustment.id,
+    updatedConnection: activeConnection === connection ? undefined : activeConnection,
+  };
+}
+
+async function main(): Promise<void> {
+  loadSharedPlutusEnv();
+  const options = parseArgs(process.argv.slice(2));
+  const fetched = await fetchPlutusNativeInventoryAdjustments(options.marketplace);
+
+  const summary = {
+    mode: options.apply ? 'apply' : 'dry-run',
+    marketplace: options.marketplace,
+    count: fetched.adjustments.length,
+    totalQuantityDelta: fetched.adjustments.reduce((sum, adjustment) => sum + adjustment.quantityDelta, 0),
+    adjustments: fetched.adjustments.map((adjustment) => ({
+      id: adjustment.id,
+      syncToken: adjustment.syncToken,
+      docNumber: adjustment.docNumber,
+      txnDate: adjustment.txnDate,
+      settlementDocNumber: adjustment.settlementDocNumber,
+      quantityDelta: adjustment.quantityDelta,
+      lines: adjustment.lines,
+    })),
+  };
+  console.log(JSON.stringify(summary, null, 2));
+
+  if (!options.apply) return;
+
+  let connection = fetched.connection;
+  const deleted: Array<{ id: string; docNumber: string; settlementDocNumber: string }> = [];
+  for (const adjustment of fetched.adjustments) {
+    const result = await deleteInventoryAdjustment(connection, adjustment);
+    if (result.updatedConnection !== undefined) {
+      connection = result.updatedConnection;
+      await saveServerQboConnection(connection);
+    }
+    deleted.push({
+      id: result.deletedId,
+      docNumber: adjustment.docNumber,
+      settlementDocNumber: adjustment.settlementDocNumber,
+    });
+  }
+  await saveServerQboConnection(connection);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        marketplace: options.marketplace,
+        deletedCount: deleted.length,
+        deleted,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/apps/plutus/scripts/plutus-sync-exact-cogs-from-audit.ts
+++ b/apps/plutus/scripts/plutus-sync-exact-cogs-from-audit.ts
@@ -10,6 +10,9 @@ import {
   type ExactSoldUnitInput,
 } from '@/lib/plutus/exact-cost-layer-subledger';
 import type { QboInventoryAssetComponent } from '@/lib/plutus/qbo-inventory-asset-lines';
+import { fetchJournalEntries, type QboConnection } from '@/lib/qbo/api';
+import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { isSettlementDocNumber, normalizeSettlementDocNumber, parseSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
 import { loadSharedPlutusEnv } from './shared-env';
 
 type CliOptions = {
@@ -221,6 +224,47 @@ function buildLayers(rows: CostLayerRow[]): {
   return { layers, metadataByLayerId };
 }
 
+async function fetchPostedSettlementDocNumbers(input: {
+  connection: QboConnection;
+  marketplace: string;
+  startDate: string;
+}): Promise<{ docNumbers: Set<string>; updatedConnection: QboConnection }> {
+  const docNumberContains = input.marketplace === 'amazon.com' ? 'US-' : 'UK-';
+  const pageSize = 100;
+  let startPosition = 1;
+  let connection = input.connection;
+  const docNumbers = new Set<string>();
+
+  while (true) {
+    const page = await fetchJournalEntries(connection, {
+      docNumberContains,
+      startDate: input.startDate,
+      maxResults: pageSize,
+      startPosition,
+    });
+    if (page.updatedConnection !== undefined) {
+      connection = page.updatedConnection;
+    }
+
+    for (const entry of page.journalEntries) {
+      const docNumber = entry.DocNumber?.trim();
+      if (docNumber === undefined || docNumber === '') continue;
+      if (docNumber.toUpperCase().startsWith('COGS-')) continue;
+      if (docNumber.toUpperCase().startsWith('C-')) continue;
+      if (!isSettlementDocNumber(docNumber)) continue;
+      const parsed = parseSettlementDocNumber(docNumber);
+      if (parsed.marketplace.id !== input.marketplace) continue;
+      docNumbers.add(normalizeSettlementDocNumber(docNumber));
+    }
+
+    if (page.journalEntries.length === 0) break;
+    startPosition += page.journalEntries.length;
+    if (startPosition > page.totalCount) break;
+  }
+
+  return { docNumbers, updatedConnection: connection };
+}
+
 async function main(): Promise<void> {
   loadSharedPlutusEnv();
   const options = parseArgs(process.argv.slice(2));
@@ -268,13 +312,31 @@ async function main(): Promise<void> {
     }),
   ]);
 
+  const qboConnection = await getQboConnection();
+  if (qboConnection === null) throw new Error('QBO connection is not configured');
+  const postedSettlements = await fetchPostedSettlementDocNumbers({
+    connection: qboConnection,
+    marketplace: options.marketplace,
+    startDate: '2025-12-01',
+  });
+  await saveServerQboConnection(postedSettlements.updatedConnection);
+  const postedSettlementDocNumbers = Array.from(postedSettlements.docNumbers).sort();
+
   const { layers, metadataByLayerId } = buildLayers(layerRows);
   if (layers.length === 0) {
     throw new Error(`No exact cost layers exist for ${options.marketplace}`);
   }
 
+  await db.cogsPostingBatch.deleteMany({
+    where: {
+      marketplace: options.marketplace,
+      settlementDocNumber: { notIn: postedSettlementDocNumbers },
+    },
+  });
+
   const rowsByInvoice = new Map<string, AuditRow[]>();
   for (const row of auditRows) {
+    if (!postedSettlements.docNumbers.has(row.invoiceId)) continue;
     const existing = rowsByInvoice.get(row.invoiceId);
     if (existing === undefined) {
       rowsByInvoice.set(row.invoiceId, [row]);
@@ -312,6 +374,23 @@ async function main(): Promise<void> {
       throw new Error(`Exact COGS blocked for ${invoiceId}: ${JSON.stringify(plan.blocks)}`);
     }
 
+    const existingBatch = await db.cogsPostingBatch.findUnique({
+      where: {
+        marketplace_settlementDocNumber: {
+          marketplace: options.marketplace,
+          settlementDocNumber: invoiceId,
+        },
+      },
+      select: {
+        status: true,
+        qboJournalEntryId: true,
+        qboDocNumber: true,
+      },
+    });
+    const preservePostedBatch = existingBatch?.status === 'posted';
+    if (preservePostedBatch && existingBatch.qboJournalEntryId === null) {
+      throw new Error(`Exact COGS batch ${invoiceId} is posted without qboJournalEntryId`);
+    }
     const batch = await db.cogsPostingBatch.upsert({
       where: {
         marketplace_settlementDocNumber: {
@@ -322,8 +401,9 @@ async function main(): Promise<void> {
       update: {
         txnDate: settlementTxnDate(rows),
         currency,
-        status: 'draft',
-        qboDocNumber: plan.qboJournalEntryDraft?.docNumber ?? null,
+        status: preservePostedBatch ? 'posted' : 'processed',
+        qboJournalEntryId: preservePostedBatch ? existingBatch.qboJournalEntryId : null,
+        qboDocNumber: preservePostedBatch ? existingBatch.qboDocNumber : plan.qboJournalEntryDraft?.docNumber ?? null,
         sourceHash: hashJson(rows),
         postingHash: hashJson(plan.qboJournalEntryDraft),
       },
@@ -332,7 +412,8 @@ async function main(): Promise<void> {
         settlementDocNumber: invoiceId,
         txnDate: settlementTxnDate(rows),
         currency,
-        status: 'draft',
+        status: 'processed',
+        qboJournalEntryId: null,
         qboDocNumber: plan.qboJournalEntryDraft?.docNumber ?? null,
         sourceHash: hashJson(rows),
         postingHash: hashJson(plan.qboJournalEntryDraft),
@@ -398,7 +479,7 @@ async function main(): Promise<void> {
           quantity: consumption.quantity,
           amountCents,
           currency,
-          status: 'draft',
+          status: 'ready',
         },
         create: {
           cogsPostingBatchId: batch.id,
@@ -410,7 +491,7 @@ async function main(): Promise<void> {
           quantity: consumption.quantity,
           amountCents,
           currency,
-          status: 'draft',
+          status: 'ready',
         },
       });
       sellerboardRows += 1;
@@ -434,6 +515,7 @@ async function main(): Promise<void> {
         ok: true,
         marketplace: options.marketplace,
         exactLayers: layers.length,
+        postedSettlements: postedSettlementDocNumbers.length,
         settlements: rowsByInvoice.size,
         batches,
         consumptionRows,

--- a/apps/plutus/scripts/qbo-inventory-bridge-audit.ts
+++ b/apps/plutus/scripts/qbo-inventory-bridge-audit.ts
@@ -21,11 +21,14 @@ import { normalizeSettlementOperatingMemo } from '@/lib/amazon-finances/settleme
 import {
   fetchAccountsByFullyQualifiedName,
   fetchBills,
+  fetchJournalEntries,
   fetchQboReport,
   type QboBill,
   type QboConnection,
 } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { isSettlementDocNumber, normalizeSettlementDocNumber, parseSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
+import { getActiveQboConnection, qboQueryAll } from '@/lib/qbo/full-history-audit/fetch';
 import { loadSharedPlutusEnv } from './shared-env';
 
 type CliOptions = {
@@ -43,6 +46,20 @@ type AuditRow = {
   quantity: number;
   description: string;
   net: number;
+};
+
+type QboInventoryAdjustment = {
+  Id?: string;
+  SyncToken?: string;
+  DocNumber?: string;
+  TxnDate?: string;
+  PrivateNote?: string;
+  Line?: Array<{
+    ItemAdjustmentLineDetail?: {
+      ItemRef?: { value?: string; name?: string };
+      QtyDiff?: number;
+    };
+  }>;
 };
 
 function parseArgs(argv: string[]): CliOptions {
@@ -124,6 +141,54 @@ function soldUnitsFromRows(rows: AuditRow[]): ExactSoldUnitInput[] {
     .map(([sellerSku, quantity]) => ({ sellerSku, quantity }));
 }
 
+function parsePlutusNativeInventoryAdjustment(
+  adjustment: QboInventoryAdjustment,
+): { settlementDocNumber: string; marketplace: string } | null {
+  const note = adjustment.PrivateNote?.trim();
+  if (note === undefined || note === '') return null;
+
+  const match = /^Plutus inventory movement \| Settlement: (US-\d{6}-\d{6}-S\d+) \| Marketplace: (amazon\.com)$/.exec(note);
+  if (match === null) return null;
+
+  return {
+    settlementDocNumber: match[1]!,
+    marketplace: match[2]!,
+  };
+}
+
+function nativeInventoryAdjustmentQuantity(adjustment: QboInventoryAdjustment): number {
+  return (adjustment.Line ?? []).reduce((sum, line) => {
+    const qty = line.ItemAdjustmentLineDetail?.QtyDiff;
+    if (qty === undefined) return sum;
+    return sum + qty;
+  }, 0);
+}
+
+async function fetchQboLegacyNativeInventoryAdjustments(input: { marketplace: string }) {
+  const activeConnection = await getActiveQboConnection();
+  const result = await qboQueryAll(activeConnection, 'SELECT * FROM InventoryAdjustment');
+  return (result.rows as QboInventoryAdjustment[])
+    .map((adjustment) => {
+      const parsed = parsePlutusNativeInventoryAdjustment(adjustment);
+      if (parsed === null) return null;
+      if (parsed.marketplace !== input.marketplace) return null;
+      return {
+        id: adjustment.Id ?? null,
+        docNumber: adjustment.DocNumber ?? null,
+        txnDate: adjustment.TxnDate ?? null,
+        settlementDocNumber: parsed.settlementDocNumber,
+        quantityDelta: nativeInventoryAdjustmentQuantity(adjustment),
+        privateNote: adjustment.PrivateNote ?? null,
+      };
+    })
+    .filter((row) => row !== null)
+    .sort((left, right) => {
+      const dateCompare = (left.txnDate ?? '').localeCompare(right.txnDate ?? '');
+      if (dateCompare !== 0) return dateCompare;
+      return (left.docNumber ?? '').localeCompare(right.docNumber ?? '');
+    });
+}
+
 function receiptDateForLayer(input: {
   layer: QboInventoryLandedCostLayer;
   parsedLines: ParsedQboInventoryAssetLine[];
@@ -188,6 +253,47 @@ async function fetchAllBillsInWindow(input: {
   return { bills, updatedConnection: activeConnection };
 }
 
+async function fetchPostedSettlementDocNumbers(input: {
+  connection: QboConnection;
+  marketplace: string;
+  startDate: string;
+}): Promise<{ docNumbers: Set<string>; updatedConnection: QboConnection }> {
+  const docNumberContains = input.marketplace === 'amazon.com' ? 'US-' : 'UK-';
+  const pageSize = 100;
+  let startPosition = 1;
+  let connection = input.connection;
+  const docNumbers = new Set<string>();
+
+  while (true) {
+    const page = await fetchJournalEntries(connection, {
+      docNumberContains,
+      startDate: input.startDate,
+      maxResults: pageSize,
+      startPosition,
+    });
+    if (page.updatedConnection !== undefined) {
+      connection = page.updatedConnection;
+    }
+
+    for (const entry of page.journalEntries) {
+      const docNumber = entry.DocNumber?.trim();
+      if (docNumber === undefined || docNumber === '') continue;
+      if (docNumber.toUpperCase().startsWith('COGS-')) continue;
+      if (docNumber.toUpperCase().startsWith('C-')) continue;
+      if (!isSettlementDocNumber(docNumber)) continue;
+      const parsed = parseSettlementDocNumber(docNumber);
+      if (parsed.marketplace.id !== input.marketplace) continue;
+      docNumbers.add(normalizeSettlementDocNumber(docNumber));
+    }
+
+    if (page.journalEntries.length === 0) break;
+    startPosition += page.journalEntries.length;
+    if (startPosition > page.totalCount) break;
+  }
+
+  return { docNumbers, updatedConnection: connection };
+}
+
 function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
   const lines: QboInventoryAssetLineInput[] = [];
   for (const bill of bills) {
@@ -239,7 +345,12 @@ async function main(): Promise<void> {
       endDate: options.assetEndDate,
     }),
   ]);
-  await saveServerQboConnection(qboBillsResult.updatedConnection);
+  const postedSettlements = await fetchPostedSettlementDocNumbers({
+    connection: qboBillsResult.updatedConnection,
+    marketplace: options.marketplace,
+    startDate: '2025-12-01',
+  });
+  await saveServerQboConnection(postedSettlements.updatedConnection);
 
   const rowsByInvoice = new Map<string, AuditRow[]>();
   for (const row of auditRows) {
@@ -267,21 +378,21 @@ async function main(): Promise<void> {
     parsedLines: marketAssetLines,
   });
 
-  const exactConsumptions: ExactCostLayerConsumptionInput[] = [];
-  const plutusExactCogsPreview = Array.from(rowsByInvoice.entries())
-    .sort((left, right) => {
+  const previewExactConsumptions: ExactCostLayerConsumptionInput[] = [];
+  const sortedInvoiceRows = Array.from(rowsByInvoice.entries()).sort((left, right) => {
       const dateCompare = settlementTxnDate(left[1]).localeCompare(settlementTxnDate(right[1]));
       if (dateCompare !== 0) return dateCompare;
       return left[0].localeCompare(right[0]);
-    })
-    .map(([invoiceId, rows]) => {
+  });
+
+  const plutusExactCogsPreview = sortedInvoiceRows.map(([invoiceId, rows]) => {
       const plan = buildExactCogsPlan({
         marketplace: options.marketplace,
         settlementDocNumber: invoiceId,
         txnDate: settlementTxnDate(rows),
         soldUnits: soldUnitsFromRows(rows),
         layers: exactCostLayers,
-        priorConsumptions: exactConsumptions,
+        priorConsumptions: previewExactConsumptions,
         componentAccountIds: {
           manufacturing: 'QBO_COGS_MANUFACTURING_ACCOUNT_REQUIRED',
           freight: 'QBO_COGS_FREIGHT_ACCOUNT_REQUIRED',
@@ -291,7 +402,50 @@ async function main(): Promise<void> {
         inventoryAssetAccountId: 'QBO_INVENTORY_ASSET_PLUTUS_ACCOUNT_REQUIRED',
       });
       if (plan.ok) {
-        exactConsumptions.push(
+        const mappedConsumptions = plan.consumptions.map((consumption) => ({
+          layerId: consumption.layerId,
+          settlementDocNumber: consumption.settlementDocNumber,
+          sellerSku: consumption.sellerSku,
+          quantity: consumption.quantity,
+          componentAmounts: consumption.componentAmounts,
+          totalAmount: consumption.totalAmount,
+        }));
+        previewExactConsumptions.push(...mappedConsumptions);
+      }
+      return {
+        settlementDocNumber: invoiceId,
+        txnDate: settlementTxnDate(rows),
+        ok: plan.ok,
+        soldUnits: soldUnitsFromRows(rows),
+        blocks: plan.blocks,
+        consumptionCount: plan.consumptions.length,
+        componentTotals: plan.componentTotals,
+        totalCogsAmount: plan.consumptions.reduce((sum, consumption) => sum + consumption.totalAmount, 0),
+        qboJournalEntryDraft: plan.qboJournalEntryDraft,
+      };
+    });
+
+  const processedExactConsumptions: ExactCostLayerConsumptionInput[] = [];
+  const plutusExactPostedCogsPreview = sortedInvoiceRows
+    .filter(([invoiceId]) => postedSettlements.docNumbers.has(invoiceId))
+    .map(([invoiceId, rows]) => {
+      const plan = buildExactCogsPlan({
+        marketplace: options.marketplace,
+        settlementDocNumber: invoiceId,
+        txnDate: settlementTxnDate(rows),
+        soldUnits: soldUnitsFromRows(rows),
+        layers: exactCostLayers,
+        priorConsumptions: processedExactConsumptions,
+        componentAccountIds: {
+          manufacturing: 'QBO_COGS_MANUFACTURING_ACCOUNT_REQUIRED',
+          freight: 'QBO_COGS_FREIGHT_ACCOUNT_REQUIRED',
+          duty: 'QBO_COGS_DUTY_ACCOUNT_REQUIRED',
+          mfgAccessories: 'QBO_COGS_ACCESSORIES_ACCOUNT_REQUIRED',
+        },
+        inventoryAssetAccountId: 'QBO_INVENTORY_ASSET_PLUTUS_ACCOUNT_REQUIRED',
+      });
+      if (plan.ok) {
+        processedExactConsumptions.push(
           ...plan.consumptions.map((consumption) => ({
             layerId: consumption.layerId,
             settlementDocNumber: consumption.settlementDocNumber,
@@ -316,7 +470,7 @@ async function main(): Promise<void> {
     });
   const plutusExactInventoryValuation = buildPlutusInventoryValuation({
     layers: exactCostLayers,
-    consumptions: exactConsumptions,
+    consumptions: processedExactConsumptions,
   });
 
   let activeConnection = qboBillsResult.updatedConnection;
@@ -349,18 +503,23 @@ async function main(): Promise<void> {
     inventoryValuationAssetValue: qboInventoryValuation.totalAssetValue,
   });
   const qboVsPlutusExactInventoryTieout = {
-    ok: Math.abs(qboInventoryValuation.totalAssetValue - plutusExactInventoryValuation.totalRemainingAmount) <= 0.01,
-    qboInventoryValuationAssetValue: qboInventoryValuation.totalAssetValue,
+    ok: Math.abs(inventoryAssetBalance - plutusExactInventoryValuation.totalRemainingAmount) <= 0.01,
+    qboInventoryAssetBalance: inventoryAssetBalance,
     plutusExactRemainingAmount: plutusExactInventoryValuation.totalRemainingAmount,
-    delta: Number((qboInventoryValuation.totalAssetValue - plutusExactInventoryValuation.totalRemainingAmount).toFixed(2)),
+    delta: Number((inventoryAssetBalance - plutusExactInventoryValuation.totalRemainingAmount).toFixed(2)),
     tolerance: 0.01,
   };
+  const qboLegacyNativeInventoryAdjustments = await fetchQboLegacyNativeInventoryAdjustments({
+    marketplace: options.marketplace,
+  });
 
   const ok =
     qboAssetPlan.blocks.length === 0 &&
     plutusExactCogsPreview.every((preview) => preview.ok) &&
+    plutusExactPostedCogsPreview.every((preview) => preview.ok) &&
     qboInventoryAssetReclassPlan.lines.length === 0 &&
-    qboInventoryValuationTieout.ok;
+    qboLegacyNativeInventoryAdjustments.length === 0 &&
+    qboVsPlutusExactInventoryTieout.ok;
 
   console.log(
     JSON.stringify(
@@ -373,11 +532,14 @@ async function main(): Promise<void> {
           startDate: options.assetStartDate,
           endDate: options.assetEndDate,
         },
+        postedSettlementCount: postedSettlements.docNumbers.size,
         qboInventoryAssetLines: marketAssetLines.length,
         qboLandedCostLayers: qboAssetPlan.layers,
         qboInventoryAssetBlocks: qboAssetPlan.blocks,
+        qboLegacyNativeInventoryAdjustments,
         plutusExactInventoryValuation,
         plutusExactCogsPreview,
+        plutusExactPostedCogsPreview,
         qboInventoryAssetReclassPlan,
         qboInventoryValuation,
         qboInventoryValuationTieout,

--- a/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
+++ b/apps/plutus/scripts/us-settlement-reconcile-spapi.ts
@@ -5,7 +5,7 @@ import { buildQboJournalEntriesFromUsSettlementDraft, buildUsSettlementDraftFrom
 import { normalizeSettlementOperatingMemo } from '@/lib/amazon-finances/settlement-memo-normalization';
 import {
   fetchAllFinancialEventsByGroupId,
-  findFinancialEventGroupIdForSettlementId,
+  listSettlementEventGroupsFromTransactions,
   listAllFinancialEventGroups,
 } from '@/lib/amazon-finances/sp-api-finances';
 import { isSettlementDocNumber, parseSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
@@ -233,6 +233,8 @@ async function fetchUsSettlementJournalEntries(input: {
       const docNumber = entry.DocNumber;
       if (typeof docNumber !== 'string') return false;
       const trimmed = docNumber.trim();
+      if (trimmed.toUpperCase().startsWith('C-')) return false;
+      if (trimmed.toUpperCase().startsWith('COGS-')) return false;
       if (!isSettlementDocNumber(trimmed)) return false;
       const meta = parseSettlementDocNumber(trimmed);
       return meta.marketplace.id === 'amazon.com';
@@ -300,6 +302,11 @@ async function main(): Promise<void> {
     startedAfterIso: postedAfterIso,
     startedBeforeIso: postedBeforeIso,
   });
+  const settlementEventGroupIds = await listSettlementEventGroupsFromTransactions({
+    tenantCode: 'US',
+    postedAfterIso,
+    postedBeforeIso,
+  });
 
   const groupById = new Map<string, any>();
   for (const g of eventGroups) {
@@ -316,12 +323,10 @@ async function main(): Promise<void> {
     const settlementJournals = journalsBySettlement.get(settlementId);
     if (!settlementJournals) continue;
 
-    const eventGroupId = await findFinancialEventGroupIdForSettlementId({
-      tenantCode: 'US',
-      settlementId,
-      postedAfterIso,
-      postedBeforeIso,
-    });
+    const eventGroupId = settlementEventGroupIds.get(settlementId);
+    if (eventGroupId === undefined) {
+      throw new Error(`No SP-API transactions found for settlementId ${settlementId}`);
+    }
 
     const eventGroup = groupById.get(eventGroupId);
     if (!eventGroup) {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -169,11 +169,17 @@ test('package exposes QBO inventory bridge audit workflow', () => {
   assert.equal(pkg.includes('scripts/plutus-sync-exact-cost-layers-from-qbo.ts'), true);
   assert.equal(pkg.includes('"inventory:exact:cogs:sync"'), true);
   assert.equal(pkg.includes('scripts/plutus-sync-exact-cogs-from-audit.ts'), true);
+  assert.equal(pkg.includes('"inventory:exact:cogs:post"'), true);
+  assert.equal(pkg.includes('scripts/plutus-post-exact-cogs-to-qbo.ts'), true);
+  assert.equal(pkg.includes('"inventory:native:retire"'), true);
+  assert.equal(pkg.includes('scripts/plutus-retire-native-inventory-adjustments.ts'), true);
   assert.equal(pkg.includes('"inventory:exact:audit"'), true);
   assert.equal(pkg.includes('scripts/plutus-exact-cost-layer-audit.ts'), true);
   assert.equal(existsSync('scripts/qbo-inventory-bridge-audit.ts'), true);
   assert.equal(existsSync('scripts/plutus-sync-exact-cost-layers-from-qbo.ts'), true);
   assert.equal(existsSync('scripts/plutus-sync-exact-cogs-from-audit.ts'), true);
+  assert.equal(existsSync('scripts/plutus-post-exact-cogs-to-qbo.ts'), true);
+  assert.equal(existsSync('scripts/plutus-retire-native-inventory-adjustments.ts'), true);
   assert.equal(existsSync('scripts/plutus-exact-cost-layer-audit.ts'), true);
 });
 
@@ -186,13 +192,56 @@ test('QBO inventory audit reports exact Plutus cost-layer evidence', () => {
   assert.equal(source.includes('parseQboInventoryValuationSummary'), true);
   assert.equal(source.includes('plutusExactInventoryValuation'), true);
   assert.equal(source.includes('plutusExactCogsPreview'), true);
+  assert.equal(source.includes('plutusExactPostedCogsPreview'), true);
   assert.equal(source.includes('qboInventoryValuationTieout'), true);
   assert.equal(source.includes('qboInventoryAssetLines'), true);
   assert.equal(source.includes('qboLandedCostLayers'), true);
   assert.equal(source.includes('qboInventoryAssetBlocks'), true);
+  assert.equal(source.includes('qboLegacyNativeInventoryAdjustments'), true);
   assert.equal(source.includes('qboVsPlutusExactInventoryTieout'), true);
+  assert.equal(source.includes('postedSettlementCount'), true);
+  assert.equal(source.includes('qboInventoryAssetBalance'), true);
   assert.equal(source.includes('buildSettlementInventoryMovementPlan'), false);
   assert.equal(source.includes('qboNativeInventoryMigration'), false);
+});
+
+test('exact COGS sync only consumes processed settlements', () => {
+  const source = read('scripts/plutus-sync-exact-cogs-from-audit.ts');
+  assert.equal(source.includes('fetchPostedSettlementDocNumbers'), true);
+  assert.equal(source.includes('postedSettlements.docNumbers.has(row.invoiceId)'), true);
+  assert.equal(source.includes('settlementDocNumber: { notIn: postedSettlementDocNumbers }'), true);
+  assert.equal(source.includes('existingBatch?.status === \'posted\''), true);
+  assert.equal(source.includes("status: 'ready'"), true);
+});
+
+test('native QBO inventory adjustment retirement is explicit and scoped to Plutus US movements', () => {
+  const source = read('scripts/plutus-retire-native-inventory-adjustments.ts');
+  assert.equal(source.includes('InventoryAdjustment'), true);
+  assert.equal(source.includes('Plutus inventory movement \\| Settlement:'), true);
+  assert.equal(source.includes('--apply'), true);
+  assert.equal(source.includes('HUMAN_APPROVAL_PHRASE'), true);
+  assert.equal(source.includes("url.searchParams.set('operation', 'delete')"), true);
+  assert.equal(source.includes("marketplace: 'amazon.com'"), true);
+});
+
+test('exact COGS QBO posting uses parent accounts and idempotent doc numbers', () => {
+  const source = read('scripts/plutus-post-exact-cogs-to-qbo.ts');
+  assert.equal(source.includes("manufacturing: 'Manufacturing'"), true);
+  assert.equal(source.includes("freight: 'Freight & Custom Duty'"), true);
+  assert.equal(source.includes("duty: 'Freight & Custom Duty'"), true);
+  assert.equal(source.includes("mfgAccessories: 'Mfg Accessories'"), true);
+  assert.equal(source.includes("requireOneActiveAccountByName(accounts, 'Inventory Asset')"), true);
+  assert.equal(source.includes('findExistingJournalEntryIdByDocNumber'), true);
+  assert.equal(source.includes('createJournalEntry'), true);
+  assert.equal(source.includes('C-${input.batch.settlementDocNumber}'), true);
+});
+
+test('US SP-API reconcile ignores exact COGS journals', () => {
+  const source = read('scripts/us-settlement-reconcile-spapi.ts');
+  assert.equal(source.includes("trimmed.toUpperCase().startsWith('C-')"), true);
+  assert.equal(source.includes("trimmed.toUpperCase().startsWith('COGS-')"), true);
+  assert.equal(source.includes('listSettlementEventGroupsFromTransactions'), true);
+  assert.equal(source.includes('findFinancialEventGroupIdForSettlementId'), false);
 });
 
 test('QBO audit page explains Plutus exact subledger controls', () => {


### PR DESCRIPTION
## Summary
- retires Plutus-created native QBO InventoryAdjustment rows so QBO no longer carries average-cost COGS releases
- posts exact PO/SKU COGS JEs with QBO-safe `C-US-...` doc numbers and preserves posted batch references on resync
- tightens QBO inventory audit to detect legacy native adjustments and compare Inventory Asset to the Plutus exact subledger
- keeps settlement reconcile focused on financial settlement JEs, excluding exact COGS docs from the SP-API tieout

## Live QBO repair performed
- Deleted 22 Plutus native QBO InventoryAdjustment rows for `amazon.com`.
- Posted 21 exact COGS JEs totaling $9,167.58.
- Left 2 zero-consumption COGS batches unposted.

## Verification
- `pnpm -C apps/plutus test`
- `pnpm -C apps/plutus type-check`
- `pnpm -C apps/plutus lint`
- `pnpm -C apps/plutus build`
- `pnpm -C apps/plutus inventory:exact:cogs:sync --marketplace amazon.com`
- `pnpm -C apps/plutus inventory:exact:audit`
- `pnpm -C apps/plutus inventory:qbo:audit --marketplace amazon.com --asset-start-date 2025-01-01`
- `pnpm -C apps/plutus settlements:us:reconcile:spapi`

## Evidence
- Exact subledger: 11 layers, 67 consumption rows, remaining inventory $76,770.48.
- QBO exact tieout: Inventory Asset $76,770.48, Plutus exact remaining $76,770.48, delta $0.00.
- Legacy native QBO inventory adjustments: 0.
- US SP-API settlement reconcile: 25 segments, 25 ok, 0 mismatched.
