### PR TITLE
Prefer native QBO PO links for landed cost layers

### DIFF
--- a/apps/plutus/lib/plutus/qbo-inventory-asset-lines.ts
+++ b/apps/plutus/lib/plutus/qbo-inventory-asset-lines.ts
@@ -1,5 +1,28 @@
 export type QboInventoryAssetComponent = 'manufacturing' | 'freight' | 'duty' | 'mfgAccessories';
 
+export type QboInventoryAssetPurchaseOrderSourceType = 'QBO_PURCHASE_ORDER' | 'LEGACY_INTERNAL_PO';
+
+export type QboInventoryAssetLineNativePurchaseOrderRef = {
+  qboPurchaseOrderId: string;
+  qboPurchaseOrderLineId: string | null;
+  qboPurchaseOrderDocNumber: string;
+  qboItemId: string | null;
+  qboItemName: string | null;
+  quantity: number | null;
+};
+
+export type QboInventoryAssetLineAllocation = {
+  qboPurchaseOrderId: string;
+  qboPurchaseOrderLineId: string;
+  qboPurchaseOrderDocNumber: string;
+  sellerSku: string;
+  component: QboInventoryAssetComponent;
+  amount: number;
+  quantity: number | null;
+  allocationMethod: string;
+  sourceRef: string | null;
+};
+
 export type QboInventoryAssetLineInput = {
   billId: string;
   billDocNumber?: string;
@@ -9,6 +32,11 @@ export type QboInventoryAssetLineInput = {
   accountName: string;
   amount: number;
   description?: string;
+  qboItemId?: string;
+  qboItemName?: string;
+  qboQuantity?: number;
+  nativePurchaseOrderRef?: QboInventoryAssetLineNativePurchaseOrderRef;
+  landedCostAllocation?: QboInventoryAssetLineAllocation;
 };
 
 export type ParsedQboInventoryAssetLine = {
@@ -19,6 +47,12 @@ export type ParsedQboInventoryAssetLine = {
   qboLineId: string;
   accountName: string;
   amount: number;
+  purchaseOrderSourceType: QboInventoryAssetPurchaseOrderSourceType;
+  purchaseOrderSourceId: string;
+  qboPurchaseOrderId: string | null;
+  qboPurchaseOrderLineId: string | null;
+  qboItemId: string | null;
+  qboItemName: string | null;
   component: QboInventoryAssetComponent;
   marketCode: string | null;
   descriptionKind: string;
@@ -31,12 +65,17 @@ export type ParsedQboInventoryAssetLine = {
 
 export type QboInventoryLandedCostLayer = {
   internalPo: string;
+  purchaseOrderSourceType: QboInventoryAssetPurchaseOrderSourceType;
+  purchaseOrderSourceId: string;
+  qboPurchaseOrderId: string | null;
+  qboPurchaseOrderLineIds: string[];
   sellerSku: string;
   quantity: number;
   componentAmounts: Record<QboInventoryAssetComponent, number>;
   totalAmount: number;
   unitCost: number;
   sourceRefs: string[];
+  qboSourceLineKeys: string[];
   qboBillLineRefs: string[];
 };
 
@@ -156,6 +195,13 @@ function componentForDescriptionKind(kind: string): QboInventoryAssetComponent {
   throw new Error(`Unsupported QBO inventory asset line kind: ${kind}`);
 }
 
+function descriptionKindForComponent(component: QboInventoryAssetComponent): string {
+  for (const contract of COMPONENT_ACCOUNT_CONTRACTS) {
+    if (contract.component === component) return contract.descriptionKind;
+  }
+  throw new Error(`Unsupported QBO inventory asset component: ${component}`);
+}
+
 function marketCodeFromOwner(owner: string | null): string | null {
   if (owner === null) return null;
   const normalized = owner.trim().toUpperCase();
@@ -209,6 +255,22 @@ function normalizeSku(value: string | null): string | null {
   return value.toUpperCase();
 }
 
+function nativeSku(input: QboInventoryAssetLineInput): string | null {
+  const nativeItemName = input.nativePurchaseOrderRef?.qboItemName ?? input.qboItemName;
+  return normalizeSku(nullableToken(nativeItemName));
+}
+
+function nativeItemId(input: QboInventoryAssetLineInput): string | null {
+  return nullableToken(input.nativePurchaseOrderRef?.qboItemId ?? input.qboItemId);
+}
+
+function nativeQuantity(input: QboInventoryAssetLineInput): number | null {
+  const quantity = input.nativePurchaseOrderRef?.quantity ?? input.qboQuantity;
+  if (quantity === undefined || quantity === null) return null;
+  if (!Number.isFinite(quantity)) throw new Error(`QBO inventory asset quantity is not finite: ${quantity}`);
+  return Math.trunc(quantity);
+}
+
 function parseQuantity(value: string | undefined): number | null {
   if (value === undefined) return null;
   const match = value.trim().match(/^([0-9]+)(?:\.[0-9]+)?/);
@@ -241,36 +303,80 @@ function pushUnique(values: string[], value: string | null): void {
   values.push(value);
 }
 
+function qboSourceLineKey(line: ParsedQboInventoryAssetLine): string {
+  return [
+    line.billId,
+    line.qboLineId,
+    line.purchaseOrderSourceType,
+    line.purchaseOrderSourceId,
+    line.sellerSku ?? 'NO_SKU',
+    line.component,
+  ].join(':');
+}
+
 function isInventoryAssetAccountName(accountName: string): boolean {
   return accountName === 'Inventory Asset' || accountName.startsWith('Inventory Asset:');
 }
 
 export function parseQboInventoryAssetLine(input: QboInventoryAssetLineInput): ParsedQboInventoryAssetLine {
-  const description = input.description;
-  if (description === undefined || description.trim() === '') {
+  const hasNativePo = input.nativePurchaseOrderRef !== undefined;
+  const allocation = input.landedCostAllocation;
+  if (hasNativePo && allocation !== undefined) {
+    throw new Error(`QBO inventory asset line ${input.billId}:${input.qboLineId} has both native PO and Plutus allocation`);
+  }
+
+  const description = input.description?.trim();
+  const needsDescription = !hasNativePo && allocation === undefined;
+  if (needsDescription && (description === undefined || description === '')) {
     throw new Error(`QBO inventory asset line ${input.billId}:${input.qboLineId} is missing description`);
   }
 
-  const parsedDescription = parseDescription(description);
+  const parsedDescription = description !== undefined && description !== '' ? parseDescription(description) : null;
   const account = parseComponentAccount(input.accountName);
-  const component = account.component ?? componentForDescriptionKind(parsedDescription.kind);
-  if (account.descriptionKind !== null && parsedDescription.kind !== account.descriptionKind) {
+  const component =
+    allocation?.component ??
+    account.component ??
+    (parsedDescription !== null
+      ? componentForDescriptionKind(parsedDescription.kind)
+      : hasNativePo
+        ? 'manufacturing'
+        : null);
+  if (component === null) {
+    throw new Error(`QBO inventory asset line ${input.billId}:${input.qboLineId} cannot resolve component`);
+  }
+  if (account.descriptionKind !== null && parsedDescription !== null && parsedDescription.kind !== account.descriptionKind) {
     throw new Error(
       `QBO inventory asset line ${input.billId}:${input.qboLineId} kind ${parsedDescription.kind} does not match account ${input.accountName}`,
     );
   }
+  if (account.component !== null && allocation !== undefined && account.component !== allocation.component) {
+    throw new Error(
+      `QBO inventory asset allocation ${input.billId}:${input.qboLineId} component ${allocation.component} does not match account ${input.accountName}`,
+    );
+  }
 
-  const owner = nullableToken(parsedDescription.values.get('OWNER'));
-  const explicitPo = nullableToken(parsedDescription.values.get('PO'));
+  const owner = nullableToken(parsedDescription?.values.get('OWNER'));
+  const explicitPo = nullableToken(parsedDescription?.values.get('PO'));
   const internalPo =
-    explicitPo !== null
+    input.nativePurchaseOrderRef?.qboPurchaseOrderDocNumber ??
+    allocation?.qboPurchaseOrderDocNumber ??
+    (explicitPo !== null
       ? explicitPo
       : owner !== null && owner.toUpperCase().startsWith('PO-')
         ? owner
-        : null;
+        : null);
   const skuToken = component === 'mfgAccessories'
-    ? nullableToken(parsedDescription.values.get('FOR_SKU'))
-    : nullableToken(parsedDescription.values.get('SKU'));
+    ? nullableToken(parsedDescription?.values.get('FOR_SKU'))
+    : nullableToken(parsedDescription?.values.get('SKU'));
+  const sellerSku = normalizeSku(allocation?.sellerSku ?? nativeSku(input) ?? skuToken);
+  const quantity = allocation?.quantity ?? nativeQuantity(input) ?? parseQuantity(parsedDescription?.values.get('QTY'));
+  const sourceRef = allocation?.sourceRef ?? nullableToken(parsedDescription?.values.get('SOURCE')) ?? input.billDocNumber ?? null;
+  const amount = allocation?.amount ?? input.amount;
+  const qboPurchaseOrderId = input.nativePurchaseOrderRef?.qboPurchaseOrderId ?? allocation?.qboPurchaseOrderId ?? null;
+  const qboPurchaseOrderLineId = input.nativePurchaseOrderRef?.qboPurchaseOrderLineId ?? allocation?.qboPurchaseOrderLineId ?? null;
+  const purchaseOrderSourceType: QboInventoryAssetPurchaseOrderSourceType =
+    qboPurchaseOrderId !== null ? 'QBO_PURCHASE_ORDER' : 'LEGACY_INTERNAL_PO';
+  const purchaseOrderSourceId = qboPurchaseOrderId ?? internalPo ?? `UNASSIGNED:${input.billId}:${input.qboLineId}`;
 
   return {
     billId: input.billId,
@@ -279,15 +385,21 @@ export function parseQboInventoryAssetLine(input: QboInventoryAssetLineInput): P
     ...(input.vendorName !== undefined ? { vendorName: input.vendorName } : {}),
     qboLineId: input.qboLineId,
     accountName: input.accountName,
-    amount: input.amount,
+    amount,
+    purchaseOrderSourceType,
+    purchaseOrderSourceId,
+    qboPurchaseOrderId,
+    qboPurchaseOrderLineId,
+    qboItemId: nativeItemId(input),
+    qboItemName: input.nativePurchaseOrderRef?.qboItemName ?? input.qboItemName ?? null,
     component,
     marketCode: account.marketCode ?? marketCodeFromOwner(owner),
-    descriptionKind: parsedDescription.kind,
+    descriptionKind: parsedDescription?.kind ?? descriptionKindForComponent(component),
     owner,
     internalPo,
-    sellerSku: normalizeSku(skuToken),
-    quantity: parseQuantity(parsedDescription.values.get('QTY')),
-    sourceRef: nullableToken(parsedDescription.values.get('SOURCE')),
+    sellerSku,
+    quantity,
+    sourceRef,
   };
 }
 
@@ -301,7 +413,9 @@ export function buildQboInventoryLandedCostPlan(input: {
     const account = parseComponentAccount(line.accountName);
     if (account.marketCode !== null && account.marketCode !== targetMarketCode) continue;
     const description = line.description?.trim().toUpperCase();
-    if (account.marketCode === null && !COMPONENT_ACCOUNT_CONTRACTS.some((contract) => description?.startsWith(`${contract.descriptionKind};`))) {
+    const hasStructuredDescription = COMPONENT_ACCOUNT_CONTRACTS.some((contract) => description?.startsWith(`${contract.descriptionKind};`));
+    const hasNativePurchaseEvidence = line.nativePurchaseOrderRef !== undefined || line.landedCostAllocation !== undefined;
+    if (account.marketCode === null && !hasStructuredDescription && !hasNativePurchaseEvidence) {
       continue;
     }
     parsedLines.push(parseQboInventoryAssetLine(line));
@@ -314,6 +428,7 @@ export function buildQboInventoryLandedCostPlan(input: {
   const marketLines = parsedLines.filter((line) => {
     if (line.marketCode !== null) return line.marketCode === targetMarketCode;
     if (line.owner === 'RESIDUAL') return true;
+    if (line.qboPurchaseOrderId !== null) return true;
     if (line.internalPo === null) return false;
     return marketByPo.get(line.internalPo) === targetMarketCode;
   });
@@ -323,10 +438,15 @@ export function buildQboInventoryLandedCostPlan(input: {
     string,
     {
       internalPo: string;
+      purchaseOrderSourceType: QboInventoryAssetPurchaseOrderSourceType;
+      purchaseOrderSourceId: string;
+      qboPurchaseOrderId: string | null;
+      qboPurchaseOrderLineIds: string[];
       sellerSku: string;
       manufacturingQuantity: number;
       componentAmounts: Record<QboInventoryAssetComponent, number>;
       sourceRefs: string[];
+      qboSourceLineKeys: string[];
       qboBillLineRefs: string[];
     }
   >();
@@ -359,21 +479,27 @@ export function buildQboInventoryLandedCostPlan(input: {
       continue;
     }
 
-    const key = `${line.internalPo}\u0000${line.sellerSku}`;
+    const key = `${line.purchaseOrderSourceType}\u0000${line.purchaseOrderSourceId}\u0000${line.sellerSku}`;
     let group = groupByPoSku.get(key);
     if (group === undefined) {
       group = {
         internalPo: line.internalPo,
+        purchaseOrderSourceType: line.purchaseOrderSourceType,
+        purchaseOrderSourceId: line.purchaseOrderSourceId,
+        qboPurchaseOrderId: line.qboPurchaseOrderId,
+        qboPurchaseOrderLineIds: [],
         sellerSku: line.sellerSku,
         manufacturingQuantity: 0,
         componentAmounts: createComponentAmounts(),
         sourceRefs: [],
+        qboSourceLineKeys: [],
         qboBillLineRefs: [],
       };
       groupByPoSku.set(key, group);
     }
 
     group.componentAmounts[line.component] = roundMoney(group.componentAmounts[line.component] + line.amount);
+    pushUnique(group.qboPurchaseOrderLineIds, line.qboPurchaseOrderLineId);
     if (line.component === 'manufacturing') {
       if (line.quantity === null) {
         blocks.push({ code: 'MISSING_MANUFACTURING_QUANTITY', internalPo: line.internalPo, sellerSku: line.sellerSku });
@@ -382,6 +508,7 @@ export function buildQboInventoryLandedCostPlan(input: {
       }
     }
     pushUnique(group.sourceRefs, line.sourceRef);
+    pushUnique(group.qboSourceLineKeys, qboSourceLineKey(line));
     pushUnique(group.qboBillLineRefs, `${line.billId}:${line.qboLineId}`);
   }
 
@@ -407,12 +534,17 @@ export function buildQboInventoryLandedCostPlan(input: {
     );
     layers.push({
       internalPo: group.internalPo,
+      purchaseOrderSourceType: group.purchaseOrderSourceType,
+      purchaseOrderSourceId: group.purchaseOrderSourceId,
+      qboPurchaseOrderId: group.qboPurchaseOrderId,
+      qboPurchaseOrderLineIds: group.qboPurchaseOrderLineIds.sort(),
       sellerSku: group.sellerSku,
       quantity: group.manufacturingQuantity,
       componentAmounts: group.componentAmounts,
       totalAmount,
       unitCost: roundUnitCost(totalAmount / group.manufacturingQuantity),
       sourceRefs: group.sourceRefs.sort(),
+      qboSourceLineKeys: group.qboSourceLineKeys.sort(),
       qboBillLineRefs: group.qboBillLineRefs.sort(),
     });
   }

--- a/apps/plutus/lib/qbo/api.ts
+++ b/apps/plutus/lib/qbo/api.ts
@@ -145,6 +145,7 @@ export interface QboPurchase {
     Id: string;
     Amount: number;
     Description?: string;
+    LinkedTxn?: QboLinkedTxn[];
     AccountBasedExpenseLineDetail?: {
       AccountRef: {
         value: string;
@@ -154,6 +155,51 @@ export interface QboPurchase {
     ItemBasedExpenseLineDetail?: {
       ItemRef?: { value: string; name: string };
       AccountRef?: { value: string; name: string };
+    };
+  }>;
+  MetaData?: {
+    CreateTime: string;
+    LastUpdatedTime: string;
+  };
+}
+
+export interface QboLinkedTxn {
+  TxnId: string;
+  TxnType: string;
+  TxnLineId?: string;
+}
+
+export interface QboPurchaseOrder {
+  Id: string;
+  SyncToken: string;
+  TxnDate: string;
+  DocNumber?: string;
+  PrivateNote?: string;
+  TotalAmt?: number;
+  VendorRef?: {
+    value: string;
+    name: string;
+  };
+  CurrencyRef?: {
+    value: string;
+    name?: string;
+  };
+  POStatus?: string;
+  Line?: Array<{
+    Id: string;
+    Amount?: number;
+    Description?: string;
+    LinkedTxn?: QboLinkedTxn[];
+    ItemBasedExpenseLineDetail?: {
+      ItemRef?: { value: string; name: string };
+      Qty?: number;
+      UnitPrice?: number;
+    };
+    AccountBasedExpenseLineDetail?: {
+      AccountRef: {
+        value: string;
+        name: string;
+      };
     };
   }>;
   MetaData?: {
@@ -198,6 +244,7 @@ export interface QboBill {
     Id: string;
     Amount: number;
     Description?: string;
+    LinkedTxn?: QboLinkedTxn[];
     AccountBasedExpenseLineDetail?: {
       AccountRef: {
         value: string;
@@ -219,6 +266,8 @@ export interface QboBill {
     ItemBasedExpenseLineDetail?: {
       ItemRef?: { value: string; name: string };
       AccountRef?: { value: string; name: string };
+      Qty?: number;
+      UnitPrice?: number;
     };
   }>;
   MetaData?: {
@@ -598,6 +647,7 @@ export interface QboPreferences {
 export interface QboQueryResponse {
   QueryResponse: {
     Purchase?: QboPurchase[];
+    PurchaseOrder?: QboPurchaseOrder[];
     Bill?: QboBill[];
     Invoice?: QboInvoice[];
     RecurringTransaction?: QboRecurringTransaction[];
@@ -1079,6 +1129,35 @@ export async function fetchBillById(
 
   const data = (await response.json()) as { Bill: QboBill };
   return { bill: data.Bill, updatedConnection };
+}
+
+/**
+ * Fetch a single PurchaseOrder by ID.
+ */
+export async function fetchPurchaseOrderById(
+  connection: QboConnection,
+  purchaseOrderId: string,
+): Promise<{ purchaseOrder: QboPurchaseOrder; updatedConnection?: QboConnection }> {
+  const { accessToken, updatedConnection } = await getValidToken(connection);
+  const baseUrl = getApiBaseUrl();
+
+  const url = `${baseUrl}/v3/company/${connection.realmId}/purchaseorder/${purchaseOrderId}`;
+
+  const response = await fetchWithRetry(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    logger.error('Failed to fetch purchase order', { purchaseOrderId, status: response.status, error: errorText });
+    throw new Error(`Failed to fetch purchase order: ${response.status} ${errorText}`);
+  }
+
+  const data = (await response.json()) as { PurchaseOrder: QboPurchaseOrder };
+  return { purchaseOrder: data.PurchaseOrder, updatedConnection };
 }
 
 /**

--- a/apps/plutus/prisma/migrations/20260516100000_add_qbo_landed_cost_allocations/migration.sql
+++ b/apps/plutus/prisma/migrations/20260516100000_add_qbo_landed_cost_allocations/migration.sql
@@ -1,0 +1,30 @@
+ALTER TABLE "SourceDocument"
+  ADD COLUMN "qboPurchaseOrderId" TEXT,
+  ADD COLUMN "qboPurchaseOrderLineId" TEXT;
+
+CREATE TABLE "QboLandedCostAllocation" (
+    "id" TEXT NOT NULL,
+    "qboBillId" TEXT NOT NULL,
+    "qboBillLineId" TEXT NOT NULL,
+    "qboPurchaseOrderId" TEXT NOT NULL,
+    "qboPurchaseOrderLineId" TEXT NOT NULL,
+    "qboPurchaseOrderDocNumber" TEXT NOT NULL,
+    "sellerSku" TEXT NOT NULL,
+    "component" TEXT NOT NULL,
+    "amountCents" INTEGER NOT NULL,
+    "quantity" INTEGER,
+    "allocationMethod" TEXT NOT NULL,
+    "sourceRef" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "QboLandedCostAllocation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "SourceDocument_qboPurchaseOrderId_idx" ON "SourceDocument"("qboPurchaseOrderId");
+CREATE INDEX "SourceDocument_qboPurchaseOrderLineId_idx" ON "SourceDocument"("qboPurchaseOrderLineId");
+CREATE UNIQUE INDEX "QboLandedCostAllocation_qboBillId_qboBillLineId_qboPurchaseOrderId_qboPurchaseOrderLineId_sellerSku_component_key" ON "QboLandedCostAllocation"("qboBillId", "qboBillLineId", "qboPurchaseOrderId", "qboPurchaseOrderLineId", "sellerSku", "component");
+CREATE INDEX "QboLandedCostAllocation_qboPurchaseOrderId_idx" ON "QboLandedCostAllocation"("qboPurchaseOrderId");
+CREATE INDEX "QboLandedCostAllocation_qboPurchaseOrderLineId_idx" ON "QboLandedCostAllocation"("qboPurchaseOrderLineId");
+CREATE INDEX "QboLandedCostAllocation_sellerSku_idx" ON "QboLandedCostAllocation"("sellerSku");
+CREATE INDEX "QboLandedCostAllocation_component_idx" ON "QboLandedCostAllocation"("component");

--- a/apps/plutus/prisma/schema.prisma
+++ b/apps/plutus/prisma/schema.prisma
@@ -334,6 +334,8 @@ model SourceDocument {
   qboTxnType        String
   qboTxnId          String
   qboLineId         String?
+  qboPurchaseOrderId     String?
+  qboPurchaseOrderLineId String?
   docNumber         String?
   vendorName        String?
   txnDate           String?
@@ -352,7 +354,34 @@ model SourceDocument {
   @@index([purchaseOrderId])
   @@index([landedCostBatchId])
   @@index([qboTxnType, qboTxnId])
+  @@index([qboPurchaseOrderId])
+  @@index([qboPurchaseOrderLineId])
   @@index([attachmentStatus])
+}
+
+/// QboLandedCostAllocation links non-PO landed-cost bill lines to QBO PO/SKU layers.
+model QboLandedCostAllocation {
+  id                         String @id @default(cuid())
+  qboBillId                  String
+  qboBillLineId              String
+  qboPurchaseOrderId         String
+  qboPurchaseOrderLineId     String
+  qboPurchaseOrderDocNumber  String
+  sellerSku                  String
+  component                  String
+  amountCents                Int
+  quantity                   Int?
+  allocationMethod           String
+  sourceRef                  String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([qboBillId, qboBillLineId, qboPurchaseOrderId, qboPurchaseOrderLineId, sellerSku, component])
+  @@index([qboPurchaseOrderId])
+  @@index([qboPurchaseOrderLineId])
+  @@index([sellerSku])
+  @@index([component])
 }
 
 /// LandedCostBatch groups QBO purchase, freight, duty, and packaging evidence into one costing batch.

--- a/apps/plutus/scripts/plutus-sync-exact-cost-layers-from-qbo.ts
+++ b/apps/plutus/scripts/plutus-sync-exact-cost-layers-from-qbo.ts
@@ -3,12 +3,21 @@ import crypto from 'node:crypto';
 import { db } from '@/lib/db';
 import {
   buildQboInventoryLandedCostPlan,
+  type QboInventoryAssetLineAllocation,
+  type QboInventoryAssetLineNativePurchaseOrderRef,
   type ParsedQboInventoryAssetLine,
   type QboInventoryAssetComponent,
   type QboInventoryAssetLineInput,
   type QboInventoryLandedCostLayer,
 } from '@/lib/plutus/qbo-inventory-asset-lines';
-import { fetchBills, type QboBill, type QboConnection } from '@/lib/qbo/api';
+import {
+  fetchBills,
+  fetchPurchaseOrderById,
+  type QboBill,
+  type QboConnection,
+  type QboLinkedTxn,
+  type QboPurchaseOrder,
+} from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import { loadSharedPlutusEnv } from './shared-env';
 
@@ -23,6 +32,22 @@ type SyncSummary = {
   canonicalProducts: number;
   sourceDocuments: number;
   poCostLayers: number;
+};
+
+type QboBillLine = NonNullable<QboBill['Line']>[number];
+
+type QboLandedCostAllocationRow = {
+  qboBillId: string;
+  qboBillLineId: string;
+  qboPurchaseOrderId: string;
+  qboPurchaseOrderLineId: string;
+  qboPurchaseOrderDocNumber: string;
+  sellerSku: string;
+  component: QboInventoryAssetComponent;
+  amountCents: number;
+  quantity: number | null;
+  allocationMethod: string;
+  sourceRef: string | null;
 };
 
 const PRODUCT_GROUP_CODE = 'PDS';
@@ -112,15 +137,120 @@ async function fetchAllBillsInWindow(input: {
   return { bills, updatedConnection: activeConnection };
 }
 
-function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
-  const lines: QboInventoryAssetLineInput[] = [];
+function qboLineRefFromIds(billId: string, qboLineId: string): string {
+  return `${billId}:${qboLineId}`;
+}
+
+function centsToMoney(value: number): number {
+  return value / 100;
+}
+
+function linkedPurchaseOrder(line: QboBillLine): QboLinkedTxn | null {
+  for (const linkedTxn of line.LinkedTxn ?? []) {
+    if (linkedTxn.TxnType === 'PurchaseOrder') return linkedTxn;
+  }
+  return null;
+}
+
+function collectLinkedPurchaseOrderIds(bills: QboBill[]): string[] {
+  const ids = new Set<string>();
   for (const bill of bills) {
     for (const line of bill.Line ?? []) {
-      const accountName = line.AccountBasedExpenseLineDetail?.AccountRef.name;
+      const linkedTxn = linkedPurchaseOrder(line);
+      if (linkedTxn === null) continue;
+      ids.add(linkedTxn.TxnId);
+    }
+  }
+  return Array.from(ids).sort();
+}
+
+async function fetchLinkedPurchaseOrders(input: {
+  connection: QboConnection;
+  purchaseOrderIds: string[];
+}): Promise<{ purchaseOrdersById: Map<string, QboPurchaseOrder>; updatedConnection: QboConnection }> {
+  let activeConnection = input.connection;
+  const purchaseOrdersById = new Map<string, QboPurchaseOrder>();
+  for (const purchaseOrderId of input.purchaseOrderIds) {
+    const result = await fetchPurchaseOrderById(activeConnection, purchaseOrderId);
+    if (result.updatedConnection !== undefined) {
+      activeConnection = result.updatedConnection;
+    }
+    purchaseOrdersById.set(result.purchaseOrder.Id, result.purchaseOrder);
+  }
+  return { purchaseOrdersById, updatedConnection: activeConnection };
+}
+
+function purchaseOrderLine(input: {
+  purchaseOrder: QboPurchaseOrder;
+  linkedTxn: QboLinkedTxn;
+}): NonNullable<QboPurchaseOrder['Line']>[number] | null {
+  const txnLineId = input.linkedTxn.TxnLineId;
+  if (txnLineId === undefined || txnLineId === '') return null;
+  for (const line of input.purchaseOrder.Line ?? []) {
+    if (line.Id === txnLineId) return line;
+  }
+  throw new Error(`QBO PurchaseOrder ${input.purchaseOrder.Id} does not contain linked line ${txnLineId}`);
+}
+
+function nativePurchaseOrderRef(input: {
+  line: QboBillLine;
+  purchaseOrdersById: Map<string, QboPurchaseOrder>;
+}): QboInventoryAssetLineNativePurchaseOrderRef | undefined {
+  const linkedTxn = linkedPurchaseOrder(input.line);
+  if (linkedTxn === null) return undefined;
+  const purchaseOrder = input.purchaseOrdersById.get(linkedTxn.TxnId);
+  if (purchaseOrder === undefined) {
+    throw new Error(`QBO PurchaseOrder ${linkedTxn.TxnId} was linked from bill line ${input.line.Id} but was not fetched`);
+  }
+  const docNumber = purchaseOrder.DocNumber?.trim();
+  if (docNumber === undefined || docNumber === '') {
+    throw new Error(`QBO PurchaseOrder ${purchaseOrder.Id} is missing DocNumber`);
+  }
+  const poLine = purchaseOrderLine({ purchaseOrder, linkedTxn });
+  const billItem = input.line.ItemBasedExpenseLineDetail?.ItemRef;
+  const poItem = poLine?.ItemBasedExpenseLineDetail?.ItemRef;
+  const item = poItem ?? billItem ?? null;
+  return {
+    qboPurchaseOrderId: purchaseOrder.Id,
+    qboPurchaseOrderLineId: linkedTxn.TxnLineId ?? null,
+    qboPurchaseOrderDocNumber: docNumber,
+    qboItemId: item?.value ?? null,
+    qboItemName: item?.name ?? null,
+    quantity: poLine?.ItemBasedExpenseLineDetail?.Qty ?? input.line.ItemBasedExpenseLineDetail?.Qty ?? null,
+  };
+}
+
+function allocationInput(row: QboLandedCostAllocationRow): QboInventoryAssetLineAllocation {
+  return {
+    qboPurchaseOrderId: row.qboPurchaseOrderId,
+    qboPurchaseOrderLineId: row.qboPurchaseOrderLineId,
+    qboPurchaseOrderDocNumber: row.qboPurchaseOrderDocNumber,
+    sellerSku: row.sellerSku,
+    component: row.component,
+    amount: centsToMoney(row.amountCents),
+    quantity: row.quantity,
+    allocationMethod: row.allocationMethod,
+    sourceRef: row.sourceRef,
+  };
+}
+
+function collectInventoryAssetLines(input: {
+  bills: QboBill[];
+  purchaseOrdersById: Map<string, QboPurchaseOrder>;
+  allocationsByBillLineRef: Map<string, QboLandedCostAllocationRow[]>;
+}): QboInventoryAssetLineInput[] {
+  const lines: QboInventoryAssetLineInput[] = [];
+  for (const bill of input.bills) {
+    for (const line of bill.Line ?? []) {
+      const accountName =
+        line.AccountBasedExpenseLineDetail?.AccountRef.name ??
+        line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
+        (line.ItemBasedExpenseLineDetail?.ItemRef !== undefined && linkedPurchaseOrder(line) !== null ? 'Inventory Asset' : undefined);
       if (accountName === undefined) continue;
       if (accountName !== 'Inventory Asset' && !accountName.startsWith('Inventory Asset:')) continue;
       if (line.Id === undefined) throw new Error(`QBO bill ${bill.Id} has an inventory asset line without line id`);
-      lines.push({
+      const nativeRef = nativePurchaseOrderRef({ line, purchaseOrdersById: input.purchaseOrdersById });
+      const baseLine = {
         billId: bill.Id,
         ...(bill.DocNumber !== undefined ? { billDocNumber: bill.DocNumber } : {}),
         billDate: bill.TxnDate,
@@ -129,6 +259,27 @@ function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInpu
         accountName,
         amount: line.Amount,
         ...(line.Description !== undefined ? { description: line.Description } : {}),
+        ...(line.ItemBasedExpenseLineDetail?.ItemRef?.value !== undefined
+          ? { qboItemId: line.ItemBasedExpenseLineDetail.ItemRef.value }
+          : {}),
+        ...(line.ItemBasedExpenseLineDetail?.ItemRef?.name !== undefined
+          ? { qboItemName: line.ItemBasedExpenseLineDetail.ItemRef.name }
+          : {}),
+        ...(line.ItemBasedExpenseLineDetail?.Qty !== undefined ? { qboQuantity: line.ItemBasedExpenseLineDetail.Qty } : {}),
+      };
+      const allocations = input.allocationsByBillLineRef.get(qboLineRefFromIds(bill.Id, line.Id)) ?? [];
+      if (allocations.length > 0) {
+        for (const allocation of allocations) {
+          lines.push({
+            ...baseLine,
+            landedCostAllocation: allocationInput(allocation),
+          });
+        }
+        continue;
+      }
+      lines.push({
+        ...baseLine,
+        ...(nativeRef !== undefined ? { nativePurchaseOrderRef: nativeRef } : {}),
       });
     }
   }
@@ -139,13 +290,24 @@ function qboLineRef(line: ParsedQboInventoryAssetLine): string {
   return `${line.billId}:${line.qboLineId}`;
 }
 
+function qboSourceLineKey(line: ParsedQboInventoryAssetLine): string {
+  return [
+    line.billId,
+    line.qboLineId,
+    line.purchaseOrderSourceType,
+    line.purchaseOrderSourceId,
+    line.sellerSku ?? 'NO_SKU',
+    line.component,
+  ].join(':');
+}
+
 function receiptDateForLayer(input: {
   layer: QboInventoryLandedCostLayer;
   parsedLines: ParsedQboInventoryAssetLine[];
 }): string {
-  const qboRefs = new Set(input.layer.qboBillLineRefs);
+  const qboRefs = new Set(input.layer.qboSourceLineKeys);
   const dates = input.parsedLines
-    .filter((line) => qboRefs.has(qboLineRef(line)))
+    .filter((line) => qboRefs.has(qboSourceLineKey(line)))
     .map((line) => line.billDate)
     .sort();
   const lastDate = dates[dates.length - 1];
@@ -171,10 +333,31 @@ function sourceDocumentHash(line: ParsedQboInventoryAssetLine): string {
     amount: line.amount,
     descriptionKind: line.descriptionKind,
     internalPo: line.internalPo,
+    purchaseOrderSourceType: line.purchaseOrderSourceType,
+    purchaseOrderSourceId: line.purchaseOrderSourceId,
+    qboPurchaseOrderId: line.qboPurchaseOrderId,
+    qboPurchaseOrderLineId: line.qboPurchaseOrderLineId,
+    qboItemId: line.qboItemId,
     sellerSku: line.sellerSku,
     quantity: line.quantity,
     sourceRef: line.sourceRef,
   });
+}
+
+function sourceAllocationMethod(lines: ParsedQboInventoryAssetLine[]): string {
+  const methods = new Set(
+    lines.map((line) => {
+      if (line.qboPurchaseOrderId !== null && line.qboPurchaseOrderLineId !== null) return 'QBO_NATIVE_PO_LINE';
+      if (line.qboPurchaseOrderId !== null) return 'PLUTUS_QBO_PO_ALLOCATION';
+      return 'LEGACY_DESCRIPTION';
+    }),
+  );
+  if (methods.size !== 1) {
+    throw new Error(`Cannot collapse mixed allocation methods into one cost layer component: ${Array.from(methods).sort().join(', ')}`);
+  }
+  const method = Array.from(methods)[0];
+  if (method === undefined) throw new Error('Cannot resolve allocation method for empty source lines');
+  return method;
 }
 
 async function syncQboLayer(input: {
@@ -184,7 +367,7 @@ async function syncQboLayer(input: {
   currency: string;
   productGroupId: string;
 }): Promise<SyncSummary> {
-  const layerLines = input.parsedLines.filter((line) => input.layer.qboBillLineRefs.includes(qboLineRef(line)));
+  const layerLines = input.parsedLines.filter((line) => input.layer.qboSourceLineKeys.includes(qboSourceLineKey(line)));
   if (layerLines.length === 0) {
     throw new Error(`No source bill lines found for ${input.layer.internalPo} ${input.layer.sellerSku}`);
   }
@@ -192,8 +375,8 @@ async function syncQboLayer(input: {
   const po = await db.purchaseOrder.upsert({
     where: {
       sourceType_sourceId: {
-        sourceType: 'QBO_PO',
-        sourceId: input.layer.internalPo,
+        sourceType: input.layer.purchaseOrderSourceType,
+        sourceId: input.layer.purchaseOrderSourceId,
       },
     },
     update: {
@@ -203,8 +386,8 @@ async function syncQboLayer(input: {
     },
     create: {
       internalRef: input.layer.internalPo,
-      sourceType: 'QBO_PO',
-      sourceId: input.layer.internalPo,
+      sourceType: input.layer.purchaseOrderSourceType,
+      sourceId: input.layer.purchaseOrderSourceId,
       supplierRef: input.layer.sourceRefs.join('; '),
       marketplace: input.marketplace,
       status: 'LOCKED',
@@ -287,6 +470,8 @@ async function syncQboLayer(input: {
         docNumber: line.billDocNumber ?? line.sourceRef,
         vendorName: line.vendorName,
         txnDate: line.billDate,
+        qboPurchaseOrderId: line.qboPurchaseOrderId,
+        qboPurchaseOrderLineId: line.qboPurchaseOrderLineId,
         amountCents: cents(line.amount),
         currency: input.currency,
         attachmentStatus: 'qbo',
@@ -298,6 +483,8 @@ async function syncQboLayer(input: {
         qboTxnType: 'Bill',
         qboTxnId: line.billId,
         qboLineId: line.qboLineId,
+        qboPurchaseOrderId: line.qboPurchaseOrderId,
+        qboPurchaseOrderLineId: line.qboPurchaseOrderLineId,
         docNumber: line.billDocNumber ?? line.sourceRef,
         vendorName: line.vendorName,
         txnDate: line.billDate,
@@ -319,6 +506,7 @@ async function syncQboLayer(input: {
       .map((line) => line.sourceRef ?? line.billDocNumber ?? `Bill:${line.billId}`)
       .sort()
       .join('; ');
+    const allocationMethod = sourceAllocationMethod(sourceLines);
 
     await db.poCostLayer.upsert({
       where: {
@@ -335,7 +523,7 @@ async function syncQboLayer(input: {
         quantity: input.layer.quantity,
         amountCents: cents(amount),
         currency: input.currency,
-        allocationMethod: 'QBO_BILL_LINE',
+        allocationMethod,
         receiptDate: new Date(`${receiptDateForLayer({ layer: input.layer, parsedLines: input.parsedLines })}T00:00:00Z`),
         sourceQboTxnType: sourceLines.length === 1 ? 'Bill' : null,
         sourceQboTxnId: sourceLines.length === 1 ? sourceLines[0]!.billId : null,
@@ -352,7 +540,7 @@ async function syncQboLayer(input: {
         quantity: input.layer.quantity,
         amountCents: cents(amount),
         currency: input.currency,
-        allocationMethod: 'QBO_BILL_LINE',
+        allocationMethod,
         receiptDate: new Date(`${receiptDateForLayer({ layer: input.layer, parsedLines: input.parsedLines })}T00:00:00Z`),
         sourceQboTxnType: sourceLines.length === 1 ? 'Bill' : null,
         sourceQboTxnId: sourceLines.length === 1 ? sourceLines[0]!.billId : null,
@@ -383,9 +571,31 @@ async function main(): Promise<void> {
     startDate: options.startDate,
     endDate: options.endDate,
   });
-  await saveServerQboConnection(qboBillsResult.updatedConnection);
+  const linkedPurchaseOrderIds = collectLinkedPurchaseOrderIds(qboBillsResult.bills);
+  const linkedPurchaseOrders = await fetchLinkedPurchaseOrders({
+    connection: qboBillsResult.updatedConnection,
+    purchaseOrderIds: linkedPurchaseOrderIds,
+  });
+  await saveServerQboConnection(linkedPurchaseOrders.updatedConnection);
 
-  const qboInventoryAssetLines = collectInventoryAssetLines(qboBillsResult.bills);
+  const allocations = await db.qboLandedCostAllocation.findMany({
+    where: {
+      qboBillId: { in: qboBillsResult.bills.map((bill) => bill.Id) },
+    },
+  });
+  const allocationsByBillLineRef = new Map<string, QboLandedCostAllocationRow[]>();
+  for (const allocation of allocations) {
+    const key = qboLineRefFromIds(allocation.qboBillId, allocation.qboBillLineId);
+    const existing = allocationsByBillLineRef.get(key) ?? [];
+    existing.push(allocation as QboLandedCostAllocationRow);
+    allocationsByBillLineRef.set(key, existing);
+  }
+
+  const qboInventoryAssetLines = collectInventoryAssetLines({
+    bills: qboBillsResult.bills,
+    purchaseOrdersById: linkedPurchaseOrders.purchaseOrdersById,
+    allocationsByBillLineRef,
+  });
   const qboAssetPlan = buildQboInventoryLandedCostPlan({
     marketplace: options.marketplace,
     lines: qboInventoryAssetLines,
@@ -394,7 +604,10 @@ async function main(): Promise<void> {
     throw new Error(`Cannot sync exact cost layers while QBO asset blocks exist: ${JSON.stringify(qboAssetPlan.blocks)}`);
   }
 
-  const marketAssetLines = qboAssetPlan.parsedLines.filter((line) => line.marketCode === qboAssetPlan.marketCode);
+  const marketAssetLines = qboAssetPlan.parsedLines.filter((line) => {
+    if (line.marketCode === qboAssetPlan.marketCode) return true;
+    return line.marketCode === null && line.qboPurchaseOrderId !== null;
+  });
   const productGroup = await db.productGroup.upsert({
     where: { code: PRODUCT_GROUP_CODE },
     update: {

--- a/apps/plutus/scripts/qbo-inventory-bridge-audit.ts
+++ b/apps/plutus/scripts/qbo-inventory-bridge-audit.ts
@@ -2,7 +2,10 @@ import { db } from '@/lib/db';
 import {
   buildQboInventoryAssetReclassPlan,
   buildQboInventoryLandedCostPlan,
+  type QboInventoryAssetComponent,
+  type QboInventoryAssetLineAllocation,
   type QboInventoryAssetLineInput,
+  type QboInventoryAssetLineNativePurchaseOrderRef,
   type QboInventoryLandedCostLayer,
   type ParsedQboInventoryAssetLine,
 } from '@/lib/plutus/qbo-inventory-asset-lines';
@@ -22,9 +25,12 @@ import {
   fetchAccountsByFullyQualifiedName,
   fetchBills,
   fetchJournalEntries,
+  fetchPurchaseOrderById,
   fetchQboReport,
   type QboBill,
   type QboConnection,
+  type QboLinkedTxn,
+  type QboPurchaseOrder,
 } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import { isSettlementDocNumber, normalizeSettlementDocNumber, parseSettlementDocNumber } from '@/lib/plutus/settlement-doc-number';
@@ -60,6 +66,22 @@ type QboInventoryAdjustment = {
       QtyDiff?: number;
     };
   }>;
+};
+
+type QboBillLine = NonNullable<QboBill['Line']>[number];
+
+type QboLandedCostAllocationRow = {
+  qboBillId: string;
+  qboBillLineId: string;
+  qboPurchaseOrderId: string;
+  qboPurchaseOrderLineId: string;
+  qboPurchaseOrderDocNumber: string;
+  sellerSku: string;
+  component: QboInventoryAssetComponent;
+  amountCents: number;
+  quantity: number | null;
+  allocationMethod: string;
+  sourceRef: string | null;
 };
 
 function parseArgs(argv: string[]): CliOptions {
@@ -189,13 +211,121 @@ async function fetchQboLegacyNativeInventoryAdjustments(input: { marketplace: st
     });
 }
 
+function qboLineRefFromIds(billId: string, qboLineId: string): string {
+  return `${billId}:${qboLineId}`;
+}
+
+function qboSourceLineKey(line: ParsedQboInventoryAssetLine): string {
+  return [
+    line.billId,
+    line.qboLineId,
+    line.purchaseOrderSourceType,
+    line.purchaseOrderSourceId,
+    line.sellerSku ?? 'NO_SKU',
+    line.component,
+  ].join(':');
+}
+
+function centsToMoney(value: number): number {
+  return value / 100;
+}
+
+function linkedPurchaseOrder(line: QboBillLine): QboLinkedTxn | null {
+  for (const linkedTxn of line.LinkedTxn ?? []) {
+    if (linkedTxn.TxnType === 'PurchaseOrder') return linkedTxn;
+  }
+  return null;
+}
+
+function collectLinkedPurchaseOrderIds(bills: QboBill[]): string[] {
+  const ids = new Set<string>();
+  for (const bill of bills) {
+    for (const line of bill.Line ?? []) {
+      const linkedTxn = linkedPurchaseOrder(line);
+      if (linkedTxn === null) continue;
+      ids.add(linkedTxn.TxnId);
+    }
+  }
+  return Array.from(ids).sort();
+}
+
+async function fetchLinkedPurchaseOrders(input: {
+  connection: QboConnection;
+  purchaseOrderIds: string[];
+}): Promise<{ purchaseOrdersById: Map<string, QboPurchaseOrder>; updatedConnection: QboConnection }> {
+  let activeConnection = input.connection;
+  const purchaseOrdersById = new Map<string, QboPurchaseOrder>();
+  for (const purchaseOrderId of input.purchaseOrderIds) {
+    const result = await fetchPurchaseOrderById(activeConnection, purchaseOrderId);
+    if (result.updatedConnection !== undefined) {
+      activeConnection = result.updatedConnection;
+    }
+    purchaseOrdersById.set(result.purchaseOrder.Id, result.purchaseOrder);
+  }
+  return { purchaseOrdersById, updatedConnection: activeConnection };
+}
+
+function purchaseOrderLine(input: {
+  purchaseOrder: QboPurchaseOrder;
+  linkedTxn: QboLinkedTxn;
+}): NonNullable<QboPurchaseOrder['Line']>[number] | null {
+  const txnLineId = input.linkedTxn.TxnLineId;
+  if (txnLineId === undefined || txnLineId === '') return null;
+  for (const line of input.purchaseOrder.Line ?? []) {
+    if (line.Id === txnLineId) return line;
+  }
+  throw new Error(`QBO PurchaseOrder ${input.purchaseOrder.Id} does not contain linked line ${txnLineId}`);
+}
+
+function nativePurchaseOrderRef(input: {
+  line: QboBillLine;
+  purchaseOrdersById: Map<string, QboPurchaseOrder>;
+}): QboInventoryAssetLineNativePurchaseOrderRef | undefined {
+  const linkedTxn = linkedPurchaseOrder(input.line);
+  if (linkedTxn === null) return undefined;
+  const purchaseOrder = input.purchaseOrdersById.get(linkedTxn.TxnId);
+  if (purchaseOrder === undefined) {
+    throw new Error(`QBO PurchaseOrder ${linkedTxn.TxnId} was linked from bill line ${input.line.Id} but was not fetched`);
+  }
+  const docNumber = purchaseOrder.DocNumber?.trim();
+  if (docNumber === undefined || docNumber === '') {
+    throw new Error(`QBO PurchaseOrder ${purchaseOrder.Id} is missing DocNumber`);
+  }
+  const poLine = purchaseOrderLine({ purchaseOrder, linkedTxn });
+  const billItem = input.line.ItemBasedExpenseLineDetail?.ItemRef;
+  const poItem = poLine?.ItemBasedExpenseLineDetail?.ItemRef;
+  const item = poItem ?? billItem ?? null;
+  return {
+    qboPurchaseOrderId: purchaseOrder.Id,
+    qboPurchaseOrderLineId: linkedTxn.TxnLineId ?? null,
+    qboPurchaseOrderDocNumber: docNumber,
+    qboItemId: item?.value ?? null,
+    qboItemName: item?.name ?? null,
+    quantity: poLine?.ItemBasedExpenseLineDetail?.Qty ?? input.line.ItemBasedExpenseLineDetail?.Qty ?? null,
+  };
+}
+
+function allocationInput(row: QboLandedCostAllocationRow): QboInventoryAssetLineAllocation {
+  return {
+    qboPurchaseOrderId: row.qboPurchaseOrderId,
+    qboPurchaseOrderLineId: row.qboPurchaseOrderLineId,
+    qboPurchaseOrderDocNumber: row.qboPurchaseOrderDocNumber,
+    sellerSku: row.sellerSku,
+    component: row.component,
+    amount: centsToMoney(row.amountCents),
+    quantity: row.quantity,
+    allocationMethod: row.allocationMethod,
+    sourceRef: row.sourceRef,
+  };
+}
+
 function receiptDateForLayer(input: {
   layer: QboInventoryLandedCostLayer;
   parsedLines: ParsedQboInventoryAssetLine[];
 }): string {
-  const qboRefs = new Set(input.layer.qboBillLineRefs);
+  const qboRefs = new Set(input.layer.qboSourceLineKeys);
   const dates = input.parsedLines
-    .filter((line) => qboRefs.has(`${line.billId}:${line.qboLineId}`))
+    .filter((line) => qboRefs.has(qboSourceLineKey(line)))
     .map((line) => line.billDate)
     .sort();
   const lastDate = dates[dates.length - 1];
@@ -294,15 +424,23 @@ async function fetchPostedSettlementDocNumbers(input: {
   return { docNumbers, updatedConnection: connection };
 }
 
-function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInput[] {
+function collectInventoryAssetLines(input: {
+  bills: QboBill[];
+  purchaseOrdersById: Map<string, QboPurchaseOrder>;
+  allocationsByBillLineRef: Map<string, QboLandedCostAllocationRow[]>;
+}): QboInventoryAssetLineInput[] {
   const lines: QboInventoryAssetLineInput[] = [];
-  for (const bill of bills) {
+  for (const bill of input.bills) {
     for (const line of bill.Line ?? []) {
-      const accountName = line.AccountBasedExpenseLineDetail?.AccountRef.name;
+      const accountName =
+        line.AccountBasedExpenseLineDetail?.AccountRef.name ??
+        line.ItemBasedExpenseLineDetail?.AccountRef?.name ??
+        (line.ItemBasedExpenseLineDetail?.ItemRef !== undefined && linkedPurchaseOrder(line) !== null ? 'Inventory Asset' : undefined);
       if (accountName === undefined) continue;
       if (accountName !== 'Inventory Asset' && !accountName.startsWith('Inventory Asset:')) continue;
       if (line.Id === undefined) throw new Error(`QBO bill ${bill.Id} has an inventory asset line without line id`);
-      lines.push({
+      const nativeRef = nativePurchaseOrderRef({ line, purchaseOrdersById: input.purchaseOrdersById });
+      const baseLine = {
         billId: bill.Id,
         ...(bill.DocNumber !== undefined ? { billDocNumber: bill.DocNumber } : {}),
         billDate: bill.TxnDate,
@@ -311,6 +449,27 @@ function collectInventoryAssetLines(bills: QboBill[]): QboInventoryAssetLineInpu
         accountName,
         amount: line.Amount,
         ...(line.Description !== undefined ? { description: line.Description } : {}),
+        ...(line.ItemBasedExpenseLineDetail?.ItemRef?.value !== undefined
+          ? { qboItemId: line.ItemBasedExpenseLineDetail.ItemRef.value }
+          : {}),
+        ...(line.ItemBasedExpenseLineDetail?.ItemRef?.name !== undefined
+          ? { qboItemName: line.ItemBasedExpenseLineDetail.ItemRef.name }
+          : {}),
+        ...(line.ItemBasedExpenseLineDetail?.Qty !== undefined ? { qboQuantity: line.ItemBasedExpenseLineDetail.Qty } : {}),
+      };
+      const allocations = input.allocationsByBillLineRef.get(qboLineRefFromIds(bill.Id, line.Id)) ?? [];
+      if (allocations.length > 0) {
+        for (const allocation of allocations) {
+          lines.push({
+            ...baseLine,
+            landedCostAllocation: allocationInput(allocation),
+          });
+        }
+        continue;
+      }
+      lines.push({
+        ...baseLine,
+        ...(nativeRef !== undefined ? { nativePurchaseOrderRef: nativeRef } : {}),
       });
     }
   }
@@ -350,7 +509,12 @@ async function main(): Promise<void> {
     marketplace: options.marketplace,
     startDate: '2025-12-01',
   });
-  await saveServerQboConnection(postedSettlements.updatedConnection);
+  const linkedPurchaseOrderIds = collectLinkedPurchaseOrderIds(qboBillsResult.bills);
+  const linkedPurchaseOrders = await fetchLinkedPurchaseOrders({
+    connection: postedSettlements.updatedConnection,
+    purchaseOrderIds: linkedPurchaseOrderIds,
+  });
+  await saveServerQboConnection(linkedPurchaseOrders.updatedConnection);
 
   const rowsByInvoice = new Map<string, AuditRow[]>();
   for (const row of auditRows) {
@@ -362,7 +526,24 @@ async function main(): Promise<void> {
     }
   }
 
-  const qboInventoryAssetLines = collectInventoryAssetLines(qboBillsResult.bills);
+  const allocations = await db.qboLandedCostAllocation.findMany({
+    where: {
+      qboBillId: { in: qboBillsResult.bills.map((bill) => bill.Id) },
+    },
+  });
+  const allocationsByBillLineRef = new Map<string, QboLandedCostAllocationRow[]>();
+  for (const allocation of allocations) {
+    const key = qboLineRefFromIds(allocation.qboBillId, allocation.qboBillLineId);
+    const existing = allocationsByBillLineRef.get(key) ?? [];
+    existing.push(allocation as QboLandedCostAllocationRow);
+    allocationsByBillLineRef.set(key, existing);
+  }
+
+  const qboInventoryAssetLines = collectInventoryAssetLines({
+    bills: qboBillsResult.bills,
+    purchaseOrdersById: linkedPurchaseOrders.purchaseOrdersById,
+    allocationsByBillLineRef,
+  });
   const qboAssetPlan = buildQboInventoryLandedCostPlan({
     marketplace: options.marketplace,
     lines: qboInventoryAssetLines,
@@ -371,7 +552,10 @@ async function main(): Promise<void> {
     marketplace: options.marketplace,
     lines: qboInventoryAssetLines,
   });
-  const marketAssetLines = qboAssetPlan.parsedLines.filter((line) => line.marketCode === qboAssetPlan.marketCode);
+  const marketAssetLines = qboAssetPlan.parsedLines.filter((line) => {
+    if (line.marketCode === qboAssetPlan.marketCode) return true;
+    return line.marketCode === null && line.qboPurchaseOrderId !== null;
+  });
   const exactCostLayers = exactLayersFromQbo({
     marketplace: options.marketplace,
     layers: qboAssetPlan.layers,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -107,6 +107,7 @@ test('Prisma schema models exact Plutus PO cost layers and consumption records',
     'model SkuAlias',
     'model PurchaseOrder',
     'model SourceDocument',
+    'model QboLandedCostAllocation',
     'model LandedCostBatch',
     'model PoCostLayer',
     'model InventoryMovement',
@@ -458,6 +459,12 @@ test('QBO inventory asset line parser enforces the bill-line description contrac
       qboLineId: '5',
       accountName: 'Inventory Asset:Manufacturing - US-PDS',
       amount: 17310.72,
+      purchaseOrderSourceType: 'LEGACY_INTERNAL_PO',
+      purchaseOrderSourceId: 'PO-19-PDS',
+      qboPurchaseOrderId: null,
+      qboPurchaseOrderLineId: null,
+      qboItemId: null,
+      qboItemName: null,
       component: 'manufacturing',
       marketCode: 'US-PDS',
       descriptionKind: 'MFG',
@@ -482,6 +489,52 @@ test('QBO inventory asset line parser enforces the bill-line description contrac
         'DUTY; OWNER=US-PDS; PO=PO-19-PDS; SKU=CS-007; ENTRY=N/A; SHIP=FBA19523CMQ9; SERVICE=CUSTOMS DUTY; ALLOC=FOB_VALUE; SOURCE=FSHY2509087198',
     }).component,
     'duty',
+  );
+
+  assert.deepEqual(
+    parseQboInventoryAssetLine({
+      billId: '701',
+      billDocNumber: 'PH260521',
+      billDate: '2026-05-21',
+      vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+      qboLineId: '1',
+      accountName: 'Inventory Asset',
+      amount: 1200,
+      qboItemId: '4',
+      qboItemName: 'CS-007',
+      qboQuantity: 2000,
+      nativePurchaseOrderRef: {
+        qboPurchaseOrderId: 'PO_QBO_21',
+        qboPurchaseOrderLineId: '3',
+        qboPurchaseOrderDocNumber: 'PO-21-PDS',
+        qboItemId: '4',
+        qboItemName: 'CS-007',
+        quantity: 2000,
+      },
+    }),
+    {
+      billId: '701',
+      billDocNumber: 'PH260521',
+      billDate: '2026-05-21',
+      vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+      qboLineId: '1',
+      accountName: 'Inventory Asset',
+      amount: 1200,
+      purchaseOrderSourceType: 'QBO_PURCHASE_ORDER',
+      purchaseOrderSourceId: 'PO_QBO_21',
+      qboPurchaseOrderId: 'PO_QBO_21',
+      qboPurchaseOrderLineId: '3',
+      qboItemId: '4',
+      qboItemName: 'CS-007',
+      component: 'manufacturing',
+      marketCode: null,
+      descriptionKind: 'MFG',
+      owner: null,
+      internalPo: 'PO-21-PDS',
+      sellerSku: 'CS-007',
+      quantity: 2000,
+      sourceRef: 'PH260521',
+    },
   );
 
   assert.deepEqual(
@@ -594,6 +647,10 @@ test('QBO landed cost plan aggregates US asset bills by internal PO and SKU', ()
   assert.deepEqual(plan.layers, [
     {
       internalPo: 'PO-19-PDS',
+      purchaseOrderSourceType: 'LEGACY_INTERNAL_PO',
+      purchaseOrderSourceId: 'PO-19-PDS',
+      qboPurchaseOrderId: null,
+      qboPurchaseOrderLineIds: [],
       sellerSku: 'CS-007',
       quantity: 29440,
       componentAmounts: {
@@ -605,12 +662,94 @@ test('QBO landed cost plan aggregates US asset bills by internal PO and SKU', ()
       totalAmount: 24765.78,
       unitCost: 0.841229,
       sourceRefs: ['FSHY2509087198', 'PH250940', 'PI-250804BOXB', 'PI-2508204A'],
+      qboSourceLineKeys: [
+        '44:1:LEGACY_INTERNAL_PO:PO-19-PDS:CS-007:mfgAccessories',
+        '46:16:LEGACY_INTERNAL_PO:PO-19-PDS:CS-007:mfgAccessories',
+        '49:5:LEGACY_INTERNAL_PO:PO-19-PDS:CS-007:manufacturing',
+        '51:1:LEGACY_INTERNAL_PO:PO-19-PDS:CS-007:freight',
+        '51:5:LEGACY_INTERNAL_PO:PO-19-PDS:CS-007:duty',
+      ],
       qboBillLineRefs: ['44:1', '46:16', '49:5', '51:1', '51:5'],
     },
   ]);
   assert.deepEqual(plan.blocks, [
     { code: 'RESIDUAL_ASSET_LINE', billId: '46', qboLineId: '18', owner: 'RESIDUAL', sellerSku: 'CS-007' },
     { code: 'NON_SKU_ASSET_LINE', billId: '48', qboLineId: '1', owner: 'US-PDS' },
+  ]);
+});
+
+test('QBO landed cost plan prefers native PO links and Plutus allocations over description tokens', () => {
+  const plan = buildQboInventoryLandedCostPlan({
+    marketplace: 'amazon.com',
+    lines: [
+      {
+        billId: '701',
+        billDocNumber: 'PH260521',
+        billDate: '2026-05-21',
+        vendorName: 'JIANGSU ZHEWEI ELECTROMECHANICAL CO., LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset',
+        amount: 1200,
+        qboItemId: '4',
+        qboItemName: 'CS-007',
+        qboQuantity: 2000,
+        nativePurchaseOrderRef: {
+          qboPurchaseOrderId: 'PO_QBO_21',
+          qboPurchaseOrderLineId: '3',
+          qboPurchaseOrderDocNumber: 'PO-21-PDS',
+          qboItemId: '4',
+          qboItemName: 'CS-007',
+          quantity: 2000,
+        },
+      },
+      {
+        billId: '702',
+        billDocNumber: 'FRT260521',
+        billDate: '2026-05-22',
+        vendorName: 'FOREST SHIPPING WORLDWIDE LTD',
+        qboLineId: '1',
+        accountName: 'Inventory Asset:Freight - US-PDS',
+        amount: 300,
+        landedCostAllocation: {
+          qboPurchaseOrderId: 'PO_QBO_21',
+          qboPurchaseOrderLineId: '3',
+          qboPurchaseOrderDocNumber: 'PO-21-PDS',
+          sellerSku: 'CS-007',
+          component: 'freight',
+          amount: 300,
+          quantity: null,
+          allocationMethod: 'MANUAL_SKU_SPLIT',
+          sourceRef: 'FRT260521',
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(plan.blocks, []);
+  assert.deepEqual(plan.layers, [
+    {
+      internalPo: 'PO-21-PDS',
+      purchaseOrderSourceType: 'QBO_PURCHASE_ORDER',
+      purchaseOrderSourceId: 'PO_QBO_21',
+      qboPurchaseOrderId: 'PO_QBO_21',
+      qboPurchaseOrderLineIds: ['3'],
+      sellerSku: 'CS-007',
+      quantity: 2000,
+      componentAmounts: {
+        manufacturing: 1200,
+        freight: 300,
+        duty: 0,
+        mfgAccessories: 0,
+      },
+      totalAmount: 1500,
+      unitCost: 0.75,
+      sourceRefs: ['FRT260521', 'PH260521'],
+      qboSourceLineKeys: [
+        '701:1:QBO_PURCHASE_ORDER:PO_QBO_21:CS-007:manufacturing',
+        '702:1:QBO_PURCHASE_ORDER:PO_QBO_21:CS-007:freight',
+      ],
+      qboBillLineRefs: ['701:1', '702:1'],
+    },
   ]);
 });
 


### PR DESCRIPTION
## Summary
- prefer native QBO PurchaseOrder links for future landed-cost layer identity
- add explicit QBO landed-cost allocation records for freight/duty/packaging bills that are not native PO item lines
- keep legacy description-token parsing only for historical repair/backfill
- align exact-cost sync and audit around QBO PO ids, PO line ids, and split allocation source keys

## Verification
- pnpm -C apps/plutus test
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus lint
- pnpm -C apps/plutus build
- git diff --check