### PR TITLE
Promote Plutus COGS doc-number fix

### DIFF
--- a/apps/plutus/lib/plutus/fresh-start-fifo-cogs.ts
+++ b/apps/plutus/lib/plutus/fresh-start-fifo-cogs.ts
@@ -93,6 +93,14 @@ function roundUnitCost(value: number): number {
   return Math.round(value * 1000000) / 1000000;
 }
 
+export function buildFreshCogsDocNumber(settlementId: string): string {
+  const docNumber = `C-${settlementId}`;
+  if (docNumber.length > 21) {
+    throw new Error(`QBO COGS doc number exceeds 21 characters: ${docNumber}`);
+  }
+  return docNumber;
+}
+
 function requirePositiveInteger(value: number, label: string): void {
   if (!Number.isInteger(value) || value <= 0) throw new Error(`${label} must be a positive integer`);
 }
@@ -190,7 +198,7 @@ export function buildFreshStartCogsPlan(input: {
     cogsTotal,
     qboCogsJournalDraft: {
       txnDate: input.txnDate,
-      docNumber: `COGS-${input.settlementId}`,
+      docNumber: buildFreshCogsDocNumber(input.settlementId),
       privateNote: `Plutus FIFO COGS | Settlement ${input.settlementId}`,
       lines: [
         {

--- a/apps/plutus/scripts/plutus-post-fresh-cogs-to-qbo.ts
+++ b/apps/plutus/scripts/plutus-post-fresh-cogs-to-qbo.ts
@@ -1,5 +1,6 @@
 import { createJournalEntry, fetchAccounts, type QboAccount } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
+import { buildFreshCogsDocNumber } from '@/lib/plutus/fresh-start-fifo-cogs';
 import { db } from '@/lib/db';
 
 type CliOptions = {
@@ -71,7 +72,7 @@ async function main() {
 
   const payload = {
     txnDate: posting.txnDate,
-    docNumber: posting.qboDocNumber ?? `COGS-${posting.settlementId}`,
+    docNumber: posting.qboDocNumber ?? buildFreshCogsDocNumber(posting.settlementId),
     privateNote: `Plutus FIFO COGS | Settlement ${posting.settlementId}`,
     currencyCode: posting.currency,
     lines: [

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -190,7 +190,7 @@ test('fresh FIFO consumes READY layers only and oldest layer first', () => {
     ],
   );
   assert.equal(plan.cogsTotal, 123.75);
-  assert.equal(plan.qboCogsJournalDraft?.docNumber, 'COGS-US-260501-260515-S1');
+  assert.equal(plan.qboCogsJournalDraft?.docNumber, 'C-US-260501-260515-S1');
   assert.equal(plan.qboCogsJournalDraft?.lines[0]?.accountName, 'COGS - Product FIFO');
   assert.equal(plan.qboCogsJournalDraft?.lines[1]?.accountName, 'Inventory Asset - Plutus');
 });


### PR DESCRIPTION
## Summary
- Promote #5485 to main
- Keeps fresh FIFO COGS QBO journal doc numbers within QBO's 21-character limit

## Verification
- PR #5485 build-test passed on dev
- Local: pnpm -C apps/plutus test
- Local: pnpm -C apps/plutus type-check
- Local: pnpm -C apps/plutus lint
- Local: pnpm -C apps/plutus build