### PR TITLE
[codex] Route Caelum Star domain root

### DIFF
--- a/apps/website/src/app/cs/components/Header.tsx
+++ b/apps/website/src/app/cs/components/Header.tsx
@@ -9,9 +9,9 @@ export function CaelumStarHeader({ region }: { region: 'us' | 'uk' }) {
       <div className={styles.contentWrap}>
         <div className={styles.headerTopRow}>
           <div className="flex items-center gap-4">
-            <Link href="/" className="opacity-50 transition-opacity hover:opacity-100">
+            <a href="https://targonglobal.com" className="opacity-50 transition-opacity hover:opacity-100">
               <Image src="/brand/logo-inverted.svg" alt="Targon" width={107} height={28} className="h-5 w-auto sm:h-7" />
-            </Link>
+            </a>
             <span className="text-white/20 text-lg">|</span>
             <Link href="/cs" className={styles.brandWrap}>
               <Image src="/logos/caelum-star-white.png" alt="Caelum Star logo" width={124} height={28} priority className="h-6 w-auto sm:h-7" />

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const CAELUM_STAR_HOSTS = new Set(['caelumstar.co.uk', 'www.caelumstar.co.uk']);
+const CAELUM_STAR_ROOT_REDIRECT_PATHS = new Set(['/cs', '/cs/', '/cs/uk']);
+
+function getHostname(request: NextRequest) {
+  const host = request.headers.get('host');
+
+  if (!host) {
+    return null;
+  }
+
+  return host.split(':')[0].toLowerCase();
+}
+
+function isCaelumStarHost(request: NextRequest) {
+  const hostname = getHostname(request);
+
+  if (!hostname) {
+    return false;
+  }
+
+  return CAELUM_STAR_HOSTS.has(hostname);
+}
+
+export function middleware(request: NextRequest) {
+  if (!isCaelumStarHost(request)) {
+    return NextResponse.next();
+  }
+
+  const { pathname } = request.nextUrl;
+
+  if (pathname === '/') {
+    const url = request.nextUrl.clone();
+    url.pathname = '/cs/uk';
+    return NextResponse.rewrite(url);
+  }
+
+  if (CAELUM_STAR_ROOT_REDIRECT_PATHS.has(pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
+
+  if (pathname.startsWith('/cs/uk/')) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\..*).*)']
+};


### PR DESCRIPTION
## Summary
- Add host-based middleware so `caelumstar.co.uk` and `www.caelumstar.co.uk` serve the Caelum Star UK page at `/`.
- Redirect legacy Caelum Star subpaths like `/cs/uk` back to `/` on the Caelum Star domain.
- Point the Targon logo inside the Caelum Star header to `https://targonglobal.com` so the brand-domain root does not loop back to itself.

## Why
Caelum Star should load as its own domain at the root URL, while Targon keeps its existing homepage. This keeps the live design and avoids publishing the experimental Raulde redesign.

## Validation
- `pnpm --filter @targon/website type-check`
- `pnpm --filter @targon/website lint`
- `curl --resolve caelumstar.co.uk:3010:127.0.0.1 http://caelumstar.co.uk:3010/` returned `x-middleware-rewrite: /cs/uk` and title `Caelum Star UK · Targon`.
- `curl --resolve targonglobal.com:3010:127.0.0.1 http://targonglobal.com:3010/` returned title `Targon`.
- Chrome Codex connector rendered the host-forced local Caelum route through a local proxy and verified title `Caelum Star UK · Targon`, `DUST SHEET PACKS` content, and no Targon purpose content.
- Chrome Codex connector verified normal local Targon root remains title `Targon` and has no Raulde text.
