### PR TITLE
Fix Plutus historical FIFO replay audit

### DIFF
--- a/apps/plutus/lib/plutus/fresh-start-fifo-cogs.ts
+++ b/apps/plutus/lib/plutus/fresh-start-fifo-cogs.ts
@@ -87,6 +87,10 @@ function normalizeSku(value: string): string {
   return normalized;
 }
 
+function isPrincipalSaleRow(description: string): boolean {
+  return description.trim().startsWith('Amazon Sales - Principal');
+}
+
 function roundMoney(value: number): number {
   return Math.round(value * 100) / 100;
 }
@@ -120,6 +124,7 @@ export function deriveSoldUnitsFromSettlementAuditRows(
 
   for (const row of rows) {
     if (row.quantity <= 0) continue;
+    if (!isPrincipalSaleRow(row.description)) continue;
     const sku = normalizeSku(row.sku);
     totalsBySku.set(sku, (totalsBySku.get(sku) ?? 0) + row.quantity);
   }

--- a/apps/plutus/scripts/plutus-fresh-cogs-audit.ts
+++ b/apps/plutus/scripts/plutus-fresh-cogs-audit.ts
@@ -9,6 +9,10 @@ function cents(value: number): number {
   return Math.round(value * 100);
 }
 
+function numericValue(value: bigint | number | null): number {
+  return Number(value ?? 0);
+}
+
 function requireOneAccountByName<T extends { Name: string; Active?: boolean }>(
   accounts: T[],
   name: string,
@@ -67,7 +71,7 @@ async function main() {
   ]);
 
   const plutusRemainingInventoryAssetCents = layerRows.reduce(
-    (sum, row) => sum + Number(row.remainingValueCents ?? 0),
+    (sum, row) => sum + numericValue(row.remainingValueCents),
     0,
   );
   const qboInventoryAssetPlutusCents = cents(
@@ -90,10 +94,16 @@ async function main() {
           deltaCents: qboInventoryAssetPlutusCents - plutusRemainingInventoryAssetCents,
           ok: qboInventoryAssetPlutusCents === plutusRemainingInventoryAssetCents,
         },
-        plutusRemainingInventoryAssetSupport: layerRows,
-        cogsPostingConsumptionTieout: postingRows.map((row) => ({
+        plutusRemainingInventoryAssetSupport: layerRows.map((row) => ({
           ...row,
-          ok: Number(row.postingCents ?? 0) === Number(row.consumptionCents ?? 0),
+          remainingValueCents: numericValue(row.remainingValueCents),
+        })),
+        cogsPostingConsumptionTieout: postingRows.map((row) => ({
+          marketplace: row.marketplace,
+          settlementId: row.settlementId,
+          postingCents: numericValue(row.postingCents),
+          consumptionCents: numericValue(row.consumptionCents),
+          ok: numericValue(row.postingCents) === numericValue(row.consumptionCents),
         })),
       },
       null,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -238,7 +238,7 @@ test('fresh FIFO blocks when sold SKU has no enough READY quantity', () => {
   assert.equal(plan.qboCogsJournalDraft, null);
 });
 
-test('COGS sold-unit derivation uses positive shipment quantities only', () => {
+test('COGS sold-unit derivation uses principal sale quantities only', () => {
   assert.deepEqual(
     deriveSoldUnitsFromSettlementAuditRows([
       {
@@ -255,9 +255,19 @@ test('COGS sold-unit derivation uses positive shipment quantities only', () => {
         invoiceId: 'US-260501-260515-S1',
         market: 'us',
         date: '2026-05-02',
+        orderId: 'ORDER-REMOVAL',
+        sku: 'B09HXC3NL8',
+        quantity: 1,
+        description: 'Amazon Sales - Removal Shipment Revenue',
+        net: 75,
+      },
+      {
+        invoiceId: 'US-260501-260515-S1',
+        market: 'us',
+        date: '2026-05-02',
         orderId: 'ORDER-1',
         sku: 'cs-007',
-        quantity: 0,
+        quantity: 2,
         description: 'Amazon FBA Fees - FBA Per Unit Fulfilment Fee',
         net: 500,
       },


### PR DESCRIPTION
## Summary
- count only Amazon principal sale rows when deriving FIFO sold units, excluding removal shipment revenue and fee rows with quantities
- make fresh FIFO COGS audit output serialize raw SQL numeric values so live QBO tieout can run
- add regression coverage for principal-sale-only COGS quantity derivation

## Historical Replay Applied
- backfilled Plutus DB from existing QBO historical COGS journals: 21 COGS postings, 67 consumption rows, ,167.58 replayed COGS
- expanded original received quantities/value on PO-18-PDS and PO-19-PDS layers while preserving current qty remaining
- verified Inventory Asset - Plutus control: QBO ,770.48 = Plutus remaining layer value ,770.48, delta /bin/zsh.00

## Verification
- pnpm -C apps/plutus test -- --runInBand
- pnpm -C apps/plutus lint
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus inventory:fresh:audit
- pnpm -C apps/plutus build