### PR TITLE
Promote dev to main

### DIFF
--- a/apps/plutus/lib/plutus/fresh-start-fifo-cogs.ts
+++ b/apps/plutus/lib/plutus/fresh-start-fifo-cogs.ts
@@ -87,6 +87,10 @@ function normalizeSku(value: string): string {
   return normalized;
 }
 
+function isPrincipalSaleRow(description: string): boolean {
+  return description.trim().startsWith('Amazon Sales - Principal');
+}
+
 function roundMoney(value: number): number {
   return Math.round(value * 100) / 100;
 }
@@ -120,6 +124,7 @@ export function deriveSoldUnitsFromSettlementAuditRows(
 
   for (const row of rows) {
     if (row.quantity <= 0) continue;
+    if (!isPrincipalSaleRow(row.description)) continue;
     const sku = normalizeSku(row.sku);
     totalsBySku.set(sku, (totalsBySku.get(sku) ?? 0) + row.quantity);
   }

--- a/apps/plutus/scripts/plutus-fresh-cogs-audit.ts
+++ b/apps/plutus/scripts/plutus-fresh-cogs-audit.ts
@@ -9,6 +9,10 @@ function cents(value: number): number {
   return Math.round(value * 100);
 }
 
+function numericValue(value: bigint | number | null): number {
+  return Number(value ?? 0);
+}
+
 function requireOneAccountByName<T extends { Name: string; Active?: boolean }>(
   accounts: T[],
   name: string,
@@ -67,7 +71,7 @@ async function main() {
   ]);
 
   const plutusRemainingInventoryAssetCents = layerRows.reduce(
-    (sum, row) => sum + Number(row.remainingValueCents ?? 0),
+    (sum, row) => sum + numericValue(row.remainingValueCents),
     0,
   );
   const qboInventoryAssetPlutusCents = cents(
@@ -90,10 +94,16 @@ async function main() {
           deltaCents: qboInventoryAssetPlutusCents - plutusRemainingInventoryAssetCents,
           ok: qboInventoryAssetPlutusCents === plutusRemainingInventoryAssetCents,
         },
-        plutusRemainingInventoryAssetSupport: layerRows,
-        cogsPostingConsumptionTieout: postingRows.map((row) => ({
+        plutusRemainingInventoryAssetSupport: layerRows.map((row) => ({
           ...row,
-          ok: Number(row.postingCents ?? 0) === Number(row.consumptionCents ?? 0),
+          remainingValueCents: numericValue(row.remainingValueCents),
+        })),
+        cogsPostingConsumptionTieout: postingRows.map((row) => ({
+          marketplace: row.marketplace,
+          settlementId: row.settlementId,
+          postingCents: numericValue(row.postingCents),
+          consumptionCents: numericValue(row.consumptionCents),
+          ok: numericValue(row.postingCents) === numericValue(row.consumptionCents),
         })),
       },
       null,

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -238,7 +238,7 @@ test('fresh FIFO blocks when sold SKU has no enough READY quantity', () => {
   assert.equal(plan.qboCogsJournalDraft, null);
 });
 
-test('COGS sold-unit derivation uses positive shipment quantities only', () => {
+test('COGS sold-unit derivation uses principal sale quantities only', () => {
   assert.deepEqual(
     deriveSoldUnitsFromSettlementAuditRows([
       {
@@ -255,9 +255,19 @@ test('COGS sold-unit derivation uses positive shipment quantities only', () => {
         invoiceId: 'US-260501-260515-S1',
         market: 'us',
         date: '2026-05-02',
+        orderId: 'ORDER-REMOVAL',
+        sku: 'B09HXC3NL8',
+        quantity: 1,
+        description: 'Amazon Sales - Removal Shipment Revenue',
+        net: 75,
+      },
+      {
+        invoiceId: 'US-260501-260515-S1',
+        market: 'us',
+        date: '2026-05-02',
         orderId: 'ORDER-1',
         sku: 'cs-007',
-        quantity: 0,
+        quantity: 2,
         description: 'Amazon FBA Fees - FBA Per Unit Fulfilment Fee',
         net: 500,
       },

--- a/apps/website/src/app/cs/components/Header.tsx
+++ b/apps/website/src/app/cs/components/Header.tsx
@@ -9,9 +9,9 @@ export function CaelumStarHeader({ region }: { region: 'us' | 'uk' }) {
       <div className={styles.contentWrap}>
         <div className={styles.headerTopRow}>
           <div className="flex items-center gap-4">
-            <Link href="/" className="opacity-50 transition-opacity hover:opacity-100">
+            <a href="https://targonglobal.com" className="opacity-50 transition-opacity hover:opacity-100">
               <Image src="/brand/logo-inverted.svg" alt="Targon" width={107} height={28} className="h-5 w-auto sm:h-7" />
-            </Link>
+            </a>
             <span className="text-white/20 text-lg">|</span>
             <Link href="/cs" className={styles.brandWrap}>
               <Image src="/logos/caelum-star-white.png" alt="Caelum Star logo" width={124} height={28} priority className="h-6 w-auto sm:h-7" />

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const CAELUM_STAR_HOSTS = new Set(['caelumstar.co.uk', 'www.caelumstar.co.uk']);
+const CAELUM_STAR_ROOT_REDIRECT_PATHS = new Set(['/cs', '/cs/', '/cs/uk']);
+
+function getHostname(request: NextRequest) {
+  const host = request.headers.get('host');
+
+  if (!host) {
+    return null;
+  }
+
+  return host.split(':')[0].toLowerCase();
+}
+
+function isCaelumStarHost(request: NextRequest) {
+  const hostname = getHostname(request);
+
+  if (!hostname) {
+    return false;
+  }
+
+  return CAELUM_STAR_HOSTS.has(hostname);
+}
+
+export function middleware(request: NextRequest) {
+  if (!isCaelumStarHost(request)) {
+    return NextResponse.next();
+  }
+
+  const { pathname } = request.nextUrl;
+
+  if (pathname === '/') {
+    const url = request.nextUrl.clone();
+    url.pathname = '/cs/uk';
+    return NextResponse.rewrite(url);
+  }
+
+  if (CAELUM_STAR_ROOT_REDIRECT_PATHS.has(pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
+
+  if (pathname.startsWith('/cs/uk/')) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|.*\\..*).*)']
+};


### PR DESCRIPTION
## Summary
- promote current dev to main
- includes Plutus historical FIFO replay support from PR #5495
- includes current dev route changes already merged before this replay branch

## Plutus replay verification
- historical Plutus DB replay applied from existing QBO COGS journals: 21 COGS postings, 67 consumption rows, ,167.58 replayed COGS
- QBO Inventory Asset - Plutus ,770.48 equals Plutus remaining layer value ,770.48, delta /bin/zsh.00

## Verification
- PR #5495 build-test-github-hosted passed
- pnpm -C apps/plutus test -- --runInBand
- pnpm -C apps/plutus lint
- pnpm -C apps/plutus type-check
- pnpm -C apps/plutus inventory:fresh:audit
- pnpm -C apps/plutus build