### PR TITLE
fix(plutus): split ready and in-transit inventory audit

### DIFF
--- a/apps/plutus/app/api/plutus/inventory-ledger/route.ts
+++ b/apps/plutus/app/api/plutus/inventory-ledger/route.ts
@@ -19,6 +19,12 @@ type InventoryLayerRow = {
   receiptDate: Date | null;
 };
 
+function controlAccount(status: string): 'Inventory Asset - Plutus' | 'Inventory in Transit - Plutus' {
+  if (status === 'READY') return 'Inventory Asset - Plutus';
+  if (status === 'NOT_READY') return 'Inventory in Transit - Plutus';
+  throw new Error(`Unsupported cost layer status: ${status}`);
+}
+
 export async function GET() {
   try {
     const rows = await db.$queryRawUnsafe<InventoryLayerRow[]>(`
@@ -51,6 +57,7 @@ export async function GET() {
         unitCost: Number(row.unitCost),
         currency: row.currency,
         status: row.status,
+        controlAccount: controlAccount(row.status),
         receiptDate: row.receiptDate === null ? null : row.receiptDate.toISOString(),
       })),
     });

--- a/apps/plutus/app/api/plutus/purchase-orders/route.ts
+++ b/apps/plutus/app/api/plutus/purchase-orders/route.ts
@@ -11,8 +11,11 @@ type PurchaseOrderRow = {
   marketplace: string;
   layerCount: bigint;
   readyLayerCount: bigint;
-  remainingQty: bigint | null;
-  remainingValueCents: bigint | null;
+  notReadyLayerCount: bigint;
+  liveQtyRemaining: bigint | null;
+  inTransitQtyRemaining: bigint | null;
+  liveValueCents: bigint | null;
+  inTransitValueCents: bigint | null;
 };
 
 export async function GET() {
@@ -24,8 +27,11 @@ export async function GET() {
         "marketplace",
         COUNT("id") AS "layerCount",
         COUNT(*) FILTER (WHERE "status" = 'READY') AS "readyLayerCount",
-        COALESCE(SUM("qtyRemaining"), 0) AS "remainingQty",
-        COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)), 0) AS "remainingValueCents"
+        COUNT(*) FILTER (WHERE "status" = 'NOT_READY') AS "notReadyLayerCount",
+        COALESCE(SUM("qtyRemaining") FILTER (WHERE "status" = 'READY'), 0) AS "liveQtyRemaining",
+        COALESCE(SUM("qtyRemaining") FILTER (WHERE "status" = 'NOT_READY'), 0) AS "inTransitQtyRemaining",
+        COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)) FILTER (WHERE "status" = 'READY'), 0) AS "liveValueCents",
+        COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)) FILTER (WHERE "status" = 'NOT_READY'), 0) AS "inTransitValueCents"
       FROM "CostLayer"
       GROUP BY "poNumber", "marketplace"
       ORDER BY "poNumber" ASC
@@ -39,8 +45,11 @@ export async function GET() {
         marketplace: row.marketplace,
         layerCount: Number(row.layerCount),
         readyLayerCount: Number(row.readyLayerCount),
-        remainingQty: Number(row.remainingQty ?? 0n),
-        remainingValueCents: Number(row.remainingValueCents ?? 0n),
+        notReadyLayerCount: Number(row.notReadyLayerCount),
+        liveQtyRemaining: Number(row.liveQtyRemaining ?? 0n),
+        inTransitQtyRemaining: Number(row.inTransitQtyRemaining ?? 0n),
+        liveValueCents: Number(row.liveValueCents ?? 0n),
+        inTransitValueCents: Number(row.inTransitValueCents ?? 0n),
       })),
     });
   } catch (error) {

--- a/apps/plutus/app/inventory-ledger/page.tsx
+++ b/apps/plutus/app/inventory-ledger/page.tsx
@@ -56,6 +56,12 @@ function formatDate(value: Date | null): string {
   return value.toISOString().slice(0, 10);
 }
 
+function controlAccount(status: string): 'Inventory Asset - Plutus' | 'Inventory in Transit - Plutus' {
+  if (status === 'READY') return 'Inventory Asset - Plutus';
+  if (status === 'NOT_READY') return 'Inventory in Transit - Plutus';
+  throw new Error(`Unsupported cost layer status: ${status}`);
+}
+
 export default async function InventoryLedgerPage() {
   const rows = await getInventoryLayers();
 
@@ -74,6 +80,7 @@ export default async function InventoryLedgerPage() {
                 <TableCell>SKU</TableCell>
                 <TableCell>Marketplace</TableCell>
                 <TableCell>Status</TableCell>
+                <TableCell>Control Account</TableCell>
                 <TableCell align="right">Qty Received</TableCell>
                 <TableCell align="right">Qty Remaining</TableCell>
                 <TableCell align="right">Landed Total</TableCell>
@@ -84,7 +91,7 @@ export default async function InventoryLedgerPage() {
             <TableBody>
               {rows.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={9}>
+                  <TableCell colSpan={10}>
                     <EmptyState
                       title="No cost layers"
                       description="Opening layers and locked QBO PO/SKU layers will appear here."
@@ -102,6 +109,7 @@ export default async function InventoryLedgerPage() {
                   <TableCell>
                     <Chip label={row.status} size="small" variant="outlined" />
                   </TableCell>
+                  <TableCell>{controlAccount(row.status)}</TableCell>
                   <TableCell align="right">{row.qtyReceived.toLocaleString('en-US')}</TableCell>
                   <TableCell align="right">{row.qtyRemaining.toLocaleString('en-US')}</TableCell>
                   <TableCell align="right">

--- a/apps/plutus/app/purchase-orders/page.tsx
+++ b/apps/plutus/app/purchase-orders/page.tsx
@@ -26,10 +26,13 @@ type PurchaseOrderRow = {
   sku: string;
   layerCount: bigint;
   readyLayerCount: bigint;
+  notReadyLayerCount: bigint;
   qtyReceived: bigint | null;
-  remainingQty: bigint | null;
+  liveQtyRemaining: bigint | null;
+  inTransitQtyRemaining: bigint | null;
   landedTotalCents: bigint | null;
-  remainingValueCents: bigint | null;
+  liveValueCents: bigint | null;
+  inTransitValueCents: bigint | null;
   unitCost: number | null;
 };
 
@@ -47,10 +50,13 @@ async function getPurchaseOrderRows(): Promise<PurchaseOrderRow[]> {
       "sku",
       COUNT("id") AS "layerCount",
       COUNT(*) FILTER (WHERE "status" = 'READY') AS "readyLayerCount",
+      COUNT(*) FILTER (WHERE "status" = 'NOT_READY') AS "notReadyLayerCount",
       COALESCE(SUM("qtyReceived"), 0) AS "qtyReceived",
-      COALESCE(SUM("qtyRemaining"), 0) AS "remainingQty",
+      COALESCE(SUM("qtyRemaining") FILTER (WHERE "status" = 'READY'), 0) AS "liveQtyRemaining",
+      COALESCE(SUM("qtyRemaining") FILTER (WHERE "status" = 'NOT_READY'), 0) AS "inTransitQtyRemaining",
       COALESCE(SUM("landedTotalCents"), 0) AS "landedTotalCents",
-      COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)), 0) AS "remainingValueCents",
+      COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)) FILTER (WHERE "status" = 'READY'), 0) AS "liveValueCents",
+      COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)) FILTER (WHERE "status" = 'NOT_READY'), 0) AS "inTransitValueCents",
       CASE
         WHEN COALESCE(SUM("qtyReceived"), 0) = 0 THEN NULL
         ELSE (SUM("landedTotalCents")::numeric / 100) / SUM("qtyReceived")
@@ -72,6 +78,10 @@ async function getPurchaseOrderCounts(): Promise<PurchaseOrderCounts> {
 
 function formatCents(value: bigint | null): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(Number(value ?? 0n) / 100);
+}
+
+function statusLabel(row: PurchaseOrderRow): 'READY' | 'NOT_READY' {
+  return Number(row.notReadyLayerCount) === 0 ? 'READY' : 'NOT_READY';
 }
 
 export default async function PurchaseOrdersPage() {
@@ -105,16 +115,18 @@ export default async function PurchaseOrdersPage() {
                 <TableCell>Status</TableCell>
                 <TableCell>QBO PO</TableCell>
                 <TableCell align="right">Qty Received</TableCell>
-                <TableCell align="right">Qty Remaining</TableCell>
+                <TableCell align="right">Live Qty</TableCell>
+                <TableCell align="right">In Transit Qty</TableCell>
                 <TableCell align="right">Unit Cost</TableCell>
                 <TableCell align="right">Landed Total</TableCell>
-                <TableCell align="right">Remaining Value</TableCell>
+                <TableCell align="right">Live Value</TableCell>
+                <TableCell align="right">In Transit Value</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
               {rows.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={10}>
+                  <TableCell colSpan={12}>
                     <EmptyState title="No purchase-order layers" description="Opening layers and locked native QBO PO/SKU layers appear here." />
                   </TableCell>
                 </TableRow>
@@ -128,18 +140,20 @@ export default async function PurchaseOrdersPage() {
                   <TableCell>{row.marketplace}</TableCell>
                   <TableCell>
                     <Chip
-                      label={Number(row.readyLayerCount) === Number(row.layerCount) ? 'READY' : 'NOT_READY'}
+                      label={statusLabel(row)}
                       size="small"
                       variant="outlined"
-                      color={Number(row.readyLayerCount) === Number(row.layerCount) ? 'success' : 'warning'}
+                      color={statusLabel(row) === 'READY' ? 'success' : 'warning'}
                     />
                   </TableCell>
                   <TableCell>{row.qboPurchaseOrderId ?? 'OPENING'}</TableCell>
                   <TableCell align="right">{Number(row.qtyReceived ?? 0n).toLocaleString('en-US')}</TableCell>
-                  <TableCell align="right">{Number(row.remainingQty ?? 0n).toLocaleString('en-US')}</TableCell>
+                  <TableCell align="right">{Number(row.liveQtyRemaining ?? 0n).toLocaleString('en-US')}</TableCell>
+                  <TableCell align="right">{Number(row.inTransitQtyRemaining ?? 0n).toLocaleString('en-US')}</TableCell>
                   <TableCell align="right">{row.unitCost === null ? '-' : Number(row.unitCost).toFixed(6)}</TableCell>
                   <TableCell align="right">{formatCents(row.landedTotalCents)}</TableCell>
-                  <TableCell align="right">{formatCents(row.remainingValueCents)}</TableCell>
+                  <TableCell align="right">{formatCents(row.liveValueCents)}</TableCell>
+                  <TableCell align="right">{formatCents(row.inTransitValueCents)}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/apps/plutus/scripts/plutus-fresh-cogs-audit.ts
+++ b/apps/plutus/scripts/plutus-fresh-cogs-audit.ts
@@ -1,5 +1,5 @@
 import { db } from '@/lib/db';
-import { fetchAccounts } from '@/lib/qbo/api';
+import { fetchAccounts, type QboAccount } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import { loadSharedPlutusEnv } from './shared-env';
 
@@ -26,6 +26,13 @@ function requireOneAccountByName<T extends { Name: string; Active?: boolean }>(
   return matches[0]!;
 }
 
+function accountBalanceCents(account: QboAccount): number {
+  if (account.CurrentBalanceWithSubAccounts === undefined) {
+    throw new Error(`QBO account ${account.Name} is missing CurrentBalanceWithSubAccounts`);
+  }
+  return cents(Number(account.CurrentBalanceWithSubAccounts));
+}
+
 async function main() {
   let connection = await getQboConnection();
   if (connection === null) {
@@ -41,11 +48,23 @@ async function main() {
     accountResult.accounts,
     'Inventory Asset - Plutus',
   );
+  const inventoryInTransitPlutusAccount = requireOneAccountByName(
+    accountResult.accounts,
+    'Inventory in Transit - Plutus',
+  );
 
-  const [layerRows, postingRows] = await Promise.all([
+  const [readyLayerRows, notReadyLayerRows, postingRows] = await Promise.all([
     db.$queryRaw<Array<{ marketplace: string; remainingValueCents: bigint | number | null }>>`
       SELECT "marketplace", COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)), 0) AS "remainingValueCents"
       FROM "CostLayer"
+      WHERE "status" = 'READY'
+      GROUP BY "marketplace"
+      ORDER BY "marketplace" ASC
+    `,
+    db.$queryRaw<Array<{ marketplace: string; remainingValueCents: bigint | number | null }>>`
+      SELECT "marketplace", COALESCE(SUM(ROUND("qtyRemaining" * "unitCost" * 100)), 0) AS "remainingValueCents"
+      FROM "CostLayer"
+      WHERE "status" = 'NOT_READY'
       GROUP BY "marketplace"
       ORDER BY "marketplace" ASC
     `,
@@ -70,17 +89,16 @@ async function main() {
     `,
   ]);
 
-  const plutusRemainingInventoryAssetCents = layerRows.reduce(
+  const plutusReadyInventoryAssetCents = readyLayerRows.reduce(
     (sum, row) => sum + numericValue(row.remainingValueCents),
     0,
   );
-  const qboInventoryAssetPlutusCents = cents(
-    Number(
-      inventoryAssetPlutusAccount.CurrentBalanceWithSubAccounts ??
-        inventoryAssetPlutusAccount.CurrentBalance ??
-        0,
-    ),
+  const plutusNotReadyInventoryTransitCents = notReadyLayerRows.reduce(
+    (sum, row) => sum + numericValue(row.remainingValueCents),
+    0,
   );
+  const qboInventoryAssetPlutusCents = accountBalanceCents(inventoryAssetPlutusAccount);
+  const qboInventoryInTransitPlutusCents = accountBalanceCents(inventoryInTransitPlutusAccount);
 
   process.stdout.write(
     JSON.stringify(
@@ -89,12 +107,37 @@ async function main() {
           accountId: inventoryAssetPlutusAccount.Id,
           balanceCents: qboInventoryAssetPlutusCents,
         },
-        plutusRemainingInventoryAssetCents,
-        inventoryAssetTieout: {
-          deltaCents: qboInventoryAssetPlutusCents - plutusRemainingInventoryAssetCents,
-          ok: qboInventoryAssetPlutusCents === plutusRemainingInventoryAssetCents,
+        qboInventoryInTransitPlutus: {
+          accountId: inventoryInTransitPlutusAccount.Id,
+          balanceCents: qboInventoryInTransitPlutusCents,
         },
-        plutusRemainingInventoryAssetSupport: layerRows.map((row) => ({
+        plutusReadyInventoryAssetCents,
+        plutusNotReadyInventoryTransitCents,
+        inventoryAssetTieout: {
+          deltaCents: qboInventoryAssetPlutusCents - plutusReadyInventoryAssetCents,
+          ok: qboInventoryAssetPlutusCents === plutusReadyInventoryAssetCents,
+        },
+        inventoryInTransitTieout: {
+          deltaCents: qboInventoryInTransitPlutusCents - plutusNotReadyInventoryTransitCents,
+          ok: qboInventoryInTransitPlutusCents === plutusNotReadyInventoryTransitCents,
+        },
+        combinedInventoryTieout: {
+          qboCombinedCents: qboInventoryAssetPlutusCents + qboInventoryInTransitPlutusCents,
+          plutusCombinedCents:
+            plutusReadyInventoryAssetCents + plutusNotReadyInventoryTransitCents,
+          deltaCents:
+            qboInventoryAssetPlutusCents +
+            qboInventoryInTransitPlutusCents -
+            (plutusReadyInventoryAssetCents + plutusNotReadyInventoryTransitCents),
+          ok:
+            qboInventoryAssetPlutusCents + qboInventoryInTransitPlutusCents ===
+            plutusReadyInventoryAssetCents + plutusNotReadyInventoryTransitCents,
+        },
+        plutusReadyInventoryAssetSupport: readyLayerRows.map((row) => ({
+          ...row,
+          remainingValueCents: numericValue(row.remainingValueCents),
+        })),
+        plutusNotReadyInventoryTransitSupport: notReadyLayerRows.map((row) => ({
           ...row,
           remainingValueCents: numericValue(row.remainingValueCents),
         })),

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -394,6 +394,14 @@ test('fresh-start pages read new layer/allocation/consumption tables', () => {
 
   assert.equal(read('app/api/plutus/inventory-ledger/route.ts').includes('FROM "CostLayer"'), true);
   assert.equal(read('app/api/plutus/purchase-orders/route.ts').includes('FROM "CostLayer"'), true);
+  assert.equal(read('app/api/plutus/purchase-orders/route.ts').includes('"status" = \'READY\''), true);
+  assert.equal(
+    read('app/api/plutus/purchase-orders/route.ts').includes('"status" = \'NOT_READY\''),
+    true,
+  );
+  assert.equal(read('app/purchase-orders/page.tsx').includes('Live Value'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('In Transit Value'), true);
+  assert.equal(read('app/inventory-ledger/page.tsx').includes('Inventory in Transit - Plutus'), true);
   assert.equal(
     read('app/api/plutus/landed-cost-allocations/route.ts').includes('LandedCostAllocation'),
     true,
@@ -414,6 +422,16 @@ test('COGS posting uses direct FIFO journal accounts and no QtyDiff path', () =>
   assert.equal(source.includes('createJournalEntry'), true);
   assert.equal(source.includes('InventoryAdjustment'), false);
   assert.equal(source.includes('QtyDiff'), false);
+});
+
+test('fresh FIFO audit ties READY and NOT_READY layers to separate QBO control accounts', () => {
+  const source = read('scripts/plutus-fresh-cogs-audit.ts');
+  assert.equal(source.includes("'Inventory Asset - Plutus'"), true);
+  assert.equal(source.includes("'Inventory in Transit - Plutus'"), true);
+  assert.equal(source.includes('WHERE "status" = \'READY\''), true);
+  assert.equal(source.includes('WHERE "status" = \'NOT_READY\''), true);
+  assert.equal(source.includes('inventoryInTransitTieout'), true);
+  assert.equal(source.includes('combinedInventoryTieout'), true);
 });
 
 test('settlement processing creates FIFO COGS journal support rows', () => {


### PR DESCRIPTION
## Summary
- Split Plutus fresh FIFO audit into READY inventory asset and NOT_READY in-transit tieouts.
- Show live vs in-transit quantities/values on purchase orders and expose each inventory ledger row's QBO control account.
- Add regression coverage so fresh-start audit and PO APIs keep READY/NOT_READY separated.

## Verification
- `pnpm --dir apps/plutus test`
- `pnpm --dir apps/plutus lint`
- `pnpm --dir apps/plutus type-check`
- `pnpm --dir apps/plutus build`
- `pnpm --dir apps/plutus inventory:fresh:audit`

## Live QBO Audit Result
- `Inventory Asset - Plutus` account `316`: `$43,306.98`
- Plutus READY layer value: `$43,306.98`
- `Inventory in Transit - Plutus` account `318`: `$33,463.50`
- Plutus NOT_READY layer value: `$33,463.50`
- Combined delta: `$0.00`
