### PR TITLE
promote(plutus): display unit costs at two decimals

### DIFF
--- a/apps/plutus/app/inventory-ledger/page.tsx
+++ b/apps/plutus/app/inventory-ledger/page.tsx
@@ -115,7 +115,7 @@ export default async function InventoryLedgerPage() {
                   <TableCell align="right">
                     {formatCents(row.landedTotalCents, row.currency)}
                   </TableCell>
-                  <TableCell align="right">{Number(row.unitCost).toFixed(6)}</TableCell>
+                  <TableCell align="right">{Number(row.unitCost).toFixed(2)}</TableCell>
                   <TableCell>{formatDate(row.receiptDate)}</TableCell>
                 </TableRow>
               ))}

--- a/apps/plutus/app/purchase-orders/page.tsx
+++ b/apps/plutus/app/purchase-orders/page.tsx
@@ -150,7 +150,7 @@ export default async function PurchaseOrdersPage() {
                   <TableCell align="right">{Number(row.qtyReceived ?? 0n).toLocaleString('en-US')}</TableCell>
                   <TableCell align="right">{Number(row.liveQtyRemaining ?? 0n).toLocaleString('en-US')}</TableCell>
                   <TableCell align="right">{Number(row.inTransitQtyRemaining ?? 0n).toLocaleString('en-US')}</TableCell>
-                  <TableCell align="right">{row.unitCost === null ? '-' : Number(row.unitCost).toFixed(6)}</TableCell>
+                  <TableCell align="right">{row.unitCost === null ? '-' : Number(row.unitCost).toFixed(2)}</TableCell>
                   <TableCell align="right">{formatCents(row.landedTotalCents)}</TableCell>
                   <TableCell align="right">{formatCents(row.liveValueCents)}</TableCell>
                   <TableCell align="right">{formatCents(row.inTransitValueCents)}</TableCell>

--- a/apps/plutus/app/sellerboard-export/page.tsx
+++ b/apps/plutus/app/sellerboard-export/page.tsx
@@ -87,7 +87,7 @@ export default async function SellerboardExportPage() {
                   <TableCell>{row.poNumber}</TableCell>
                   <TableCell>{row.marketplace}</TableCell>
                   <TableCell align="right">{row.qtyConsumed.toLocaleString('en-US')}</TableCell>
-                  <TableCell align="right">{Number(row.unitCost).toFixed(6)}</TableCell>
+                  <TableCell align="right">{Number(row.unitCost).toFixed(2)}</TableCell>
                   <TableCell align="right">{formatCents(row.cogsAmountCents, row.currency)}</TableCell>
                   <TableCell>{row.qboJournalId ?? '-'}</TableCell>
                 </TableRow>

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -409,6 +409,18 @@ test('fresh-start pages read new layer/allocation/consumption tables', () => {
   assert.equal(read('app/sellerboard-export/page.tsx').includes('FROM "CogsConsumption"'), true);
 });
 
+test('fresh-start UI displays unit costs at two decimals', () => {
+  for (const path of [
+    'app/purchase-orders/page.tsx',
+    'app/inventory-ledger/page.tsx',
+    'app/sellerboard-export/page.tsx',
+  ]) {
+    const source = read(path);
+    assert.equal(source.includes('toFixed(2)'), true, `${path} should display unit cost at two decimals`);
+    assert.equal(source.includes('toFixed(6)'), false, `${path} should not display six-decimal unit cost`);
+  }
+});
+
 test('COGS posting uses direct FIFO journal accounts and no QtyDiff path', () => {
   const source = read('scripts/plutus-post-fresh-cogs-to-qbo.ts');
   assert.equal(


### PR DESCRIPTION
## Summary
- Promote two-decimal Plutus unit-cost display from dev to main.
- Unit costs now render at two decimals on purchase orders, inventory ledger, and Sellerboard export.
- Underlying FIFO unit-cost precision remains unchanged.

## Verification
- Dev PR #5501 checks passed.
- Local checks passed: test, lint, type-check, build.
