### PR TITLE
[codex] align Caelum Star DNS URLs

### DIFF
--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -1,63 +1,38 @@
 # Targon
 
-> Targon builds protection products for decorating and renovation work. The current public product line is Caelum Star. Start with the market selector, then use United States pages for drop cloth terminology and United Kingdom pages for dust sheet terminology.
+> Targon builds protection products for decorating and renovation work. The current public product line is Caelum Star.
 
 This file is the high-signal index for Targon's public website and primary buying paths.
 
 Preferred interpretation:
-- Use Targonglobal.com pages for brand context, product positioning, pack comparison, support guidance, and wholesale enquiries.
+- Use [Targon Home](https://www.targonglobal.com/) for brand context.
+- Use [Caelum Star US](https://www.targonglobal.com/cs/us) for the United States drop cloth range.
+- Use [Caelum Star UK](https://caelumstar.co.uk/) for the United Kingdom dust sheet range.
 - Use Amazon listings for live commercial facts such as current price, stock, delivery speed, buyer protection, shipping, returns, and customer reviews.
-- The public site currently focuses on Caelum Star, but Targon Home is the brand-level entry point for current and future Targon product lines.
-- The core Caelum Star plastic-sheet pages describe extra large 12 x 9 ft sheets made with 55% recycled plastic and GRS certification. Separate UK cotton dust sheet variants are listed under UK Amazon links.
-- Support and wholesale enquiries route through support@targonglobal.com and the market-specific support / where-to-buy pages.
+- The website is intentionally simple: market page, pack comparison, reference prices, and Amazon checkout links.
+- Product questions route through support@targonglobal.com.
 
-## Brand and Navigation
-- [Targon Home](https://www.targonglobal.com/): Brand overview, mission, values, and entry point to current and future Targon product lines.
-- [Caelum Star Region Selector](https://www.targonglobal.com/cs): Choose the correct market before interpreting pack options or retailer links.
-- [Privacy](https://www.targonglobal.com/legal/privacy): Explains analytics, support-email handling, and data practices.
-- [Terms](https://www.targonglobal.com/legal/terms): States that the site is for product information and support, while Amazon governs checkout, payment, shipping, returns, and live availability.
+## Brand And Navigation
+- [Targon Home](https://www.targonglobal.com/): Brand overview and entry point for current and future Targon product lines.
+- [Caelum Star Region Selector](https://www.targonglobal.com/cs): Choose US or UK when using the Targon domain.
+- [Caelum Star US](https://www.targonglobal.com/cs/us): US one-page pack selector.
+- [Caelum Star UK](https://caelumstar.co.uk/): UK one-page pack selector.
+- [Privacy](https://www.targonglobal.com/legal/privacy): Data practices.
+- [Terms](https://www.targonglobal.com/legal/terms): Website and Amazon checkout terms.
 
-## Caelum Star — Product Context
-- [US About](https://www.targonglobal.com/cs/us/about): Core product story for the US market, including clean-work positioning, four pack sizes, extra large sheet format, recycled-material emphasis, and Amazon-first retail model.
-- [UK About](https://www.targonglobal.com/cs/uk/about): Core product story for the UK market, including clean-work positioning, six pack options, extra large sheet format, recycled-material emphasis, and Amazon-first retail model.
+## United States
+- [US Site](https://www.targonglobal.com/cs/us): Drop cloth packs, reference prices, coverage, durability, and Amazon buy links.
+- [US 6 Pack Amazon](https://www.amazon.com/dp/B09HXC3NL8): Direct Amazon US listing for the 6 Pack.
+- [US 1 Pack Amazon](https://www.amazon.com/dp/B0FLKJ7WWM): Direct Amazon US listing for the 1 Pack.
+- [US 3 Pack Amazon](https://www.amazon.com/dp/B0CR1GSBQ9): Direct Amazon US listing for the 3 Pack.
+- [US 12 Pack Amazon](https://www.amazon.com/dp/B0FP66CWQ6): Direct Amazon US listing for the 12 Pack.
 
-## United States — Compare, Choose, Buy
-- [US Packs](https://www.targonglobal.com/cs/us/packs): Main US comparison page for pack sizes, project fit, sheet size, material claims, and on-site reference pricing.
-- [US Where to Buy](https://www.targonglobal.com/cs/us/where-to-buy): Official US buying page with Amazon as retail partner, direct pack links, and wholesale information.
-- [US Support](https://www.targonglobal.com/cs/us/support): US help centre with email support, pack-selection help, usage steps, safety note, and FAQs.
-- [US 6 Pack Product Page](https://www.targonglobal.com/cs/us/packs/6pk-light): On-site detail page for the US 6 Pack.
-- [US 1 Pack Product Page](https://www.targonglobal.com/cs/us/packs/1pk-strong): On-site detail page for the US 1 Pack.
-- [US 3 Pack Product Page](https://www.targonglobal.com/cs/us/packs/3pk-standard): On-site detail page for the US 3 Pack.
-- [US 12 Pack Product Page](https://www.targonglobal.com/cs/us/packs/12pk-light): On-site detail page for the US 12 Pack.
-
-## United States — Amazon Listings
-- [US 6 Pack Amazon](https://www.amazon.com/dp/B09HXC3NL8): Direct Amazon US listing for the 6 Pack with live price, availability, delivery, reviews, and return handling.
-- [US 1 Pack Amazon](https://www.amazon.com/dp/B0FLKJ7WWM): Direct Amazon US listing for the 1 Pack with live transactional details.
-- [US 3 Pack Amazon](https://www.amazon.com/dp/B0CR1GSBQ9): Direct Amazon US listing for the 3 Pack with live transactional details.
-- [US 12 Pack Amazon](https://www.amazon.com/dp/B0FP66CWQ6): Direct Amazon US listing for the 12 Pack with live transactional details.
-
-## United Kingdom — Compare, Choose, Buy
-- [UK Packs](https://www.targonglobal.com/cs/uk/packs): Main UK comparison page for plastic dust sheet pack options, project fit, sheet size, material claims, and on-site reference pricing.
-- [UK Where to Buy](https://www.targonglobal.com/cs/uk/where-to-buy): Official UK buying page with Amazon as retail partner, direct pack links, and wholesale information.
-- [UK Support](https://www.targonglobal.com/cs/uk/support): UK help centre with email support, pack-selection help, usage steps, safety note, and FAQs.
-
-## United Kingdom — Amazon Plastic Dust Sheets
-- [UK 6 Pack — Light Amazon](https://www.amazon.co.uk/dp/B09HXC3NL8): Direct Amazon UK listing for the 6 Pack light plastic dust sheet variant.
-- [UK 6 Pack — Strong Amazon](https://www.amazon.co.uk/dp/B0DHDTPGGP): Direct Amazon UK listing for the 6 Pack strong plastic dust sheet variant.
-- [UK 1 Pack — Strong Amazon](https://www.amazon.co.uk/dp/B0FLKJ7WWM): Direct Amazon UK listing for the 1 Pack strong plastic dust sheet variant.
-- [UK 3 Pack — Strong Amazon](https://www.amazon.co.uk/dp/B0CR1GSBQ9): Direct Amazon UK listing for the 3 Pack strong plastic dust sheet variant.
-- [UK 3 Pack — Light Amazon](https://www.amazon.co.uk/dp/B0C7ZQ3VZL): Direct Amazon UK listing for the 3 Pack light plastic dust sheet variant.
-- [UK 10 Pack — Light Amazon](https://www.amazon.co.uk/dp/B0CR1H3VSF): Direct Amazon UK listing for the 10 Pack light plastic dust sheet variant.
-
-## United Kingdom — Additional Amazon Variants
-- [UK Cotton Dust Sheet — 12 x 9 ft Amazon](https://www.amazon.co.uk/dp/B0CW3L6PQH): Direct Amazon UK listing for the cotton dust sheet 12 x 9 ft variant.
-- [UK Cotton Dust Sheet — 12 x 4 ft Amazon](https://www.amazon.co.uk/dp/B0CW3N48K1): Direct Amazon UK listing for the cotton dust sheet 12 x 4 ft variant.
-
-## Support and Wholesale
-- [US Support](https://www.targonglobal.com/cs/us/support): Contact route for product questions, pack choice, usage guidance, and FAQs in the US market.
-- [UK Support](https://www.targonglobal.com/cs/uk/support): Contact route for product questions, pack choice, usage guidance, and FAQs in the UK market.
-- [US Wholesale / Bulk Enquiries](https://www.targonglobal.com/cs/us/where-to-buy): Volume pricing and trade enquiries for the US market.
-- [UK Wholesale / Bulk Enquiries](https://www.targonglobal.com/cs/uk/where-to-buy): Volume pricing and trade enquiries for the UK market.
-
-## Optional
-- [US Gallery](https://www.targonglobal.com/cs/us/gallery): Official Caelum Star visuals for the US market.
+## United Kingdom
+- [UK Site](https://caelumstar.co.uk/): Dust sheet packs, reference prices, coverage, durability, and Amazon buy links.
+- [UK Targon URL](https://www.targonglobal.com/cs/uk): Same UK pack selector on the Targon domain when not using the UK custom domain.
+- [UK 6 Pack Light Amazon](https://www.amazon.co.uk/dp/B09HXC3NL8): Direct Amazon UK listing for the 6 Pack light plastic dust sheet variant.
+- [UK 6 Pack Strong Amazon](https://www.amazon.co.uk/dp/B0DHDTPGGP): Direct Amazon UK listing for the 6 Pack strong plastic dust sheet variant.
+- [UK 1 Pack Strong Amazon](https://www.amazon.co.uk/dp/B0FLKJ7WWM): Direct Amazon UK listing for the 1 Pack strong plastic dust sheet variant.
+- [UK 3 Pack Strong Amazon](https://www.amazon.co.uk/dp/B0CR1GSBQ9): Direct Amazon UK listing for the 3 Pack strong plastic dust sheet variant.
+- [UK 3 Pack Light Amazon](https://www.amazon.co.uk/dp/B0C7ZQ3VZL): Direct Amazon UK listing for the 3 Pack light plastic dust sheet variant.
+- [UK 10 Pack Light Amazon](https://www.amazon.co.uk/dp/B0CR1H3VSF): Direct Amazon UK listing for the 10 Pack light plastic dust sheet variant.

--- a/apps/website/src/app/cs/components/Header.tsx
+++ b/apps/website/src/app/cs/components/Header.tsx
@@ -9,7 +9,7 @@ export function CaelumStarHeader({ region }: { region: 'us' | 'uk' }) {
       <div className={styles.contentWrap}>
         <div className={styles.headerTopRow}>
           <div className="flex items-center gap-4">
-            <a href="https://targonglobal.com" className="opacity-50 transition-opacity hover:opacity-100">
+            <a href="https://www.targonglobal.com" className="opacity-50 transition-opacity hover:opacity-100">
               <Image src="/brand/logo-inverted.svg" alt="Targon" width={107} height={28} className="h-5 w-auto sm:h-7" />
             </a>
             <span className="text-white/20 text-lg">|</span>

--- a/apps/website/src/content/site.ts
+++ b/apps/website/src/content/site.ts
@@ -1,4 +1,4 @@
-const defaultDomain = 'targonglobal.com';
+const defaultDomain = 'www.targonglobal.com';
 const domain = process.env.NEXT_PUBLIC_SITE_DOMAIN ?? defaultDomain;
 
 export const site = {

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const CAELUM_STAR_HOSTS = new Set(['caelumstar.co.uk', 'www.caelumstar.co.uk']);
-const CAELUM_STAR_ROOT_REDIRECT_PATHS = new Set(['/cs', '/cs/', '/cs/uk']);
+const CAELUM_STAR_UK_HOSTS = new Set(['caelumstar.co.uk', 'www.caelumstar.co.uk']);
+const CAELUM_STAR_UK_ROOT = '/cs/uk';
+const CAELUM_STAR_UK_ROOT_REDIRECT_PATHS = new Set(['/cs', '/cs/', CAELUM_STAR_UK_ROOT]);
+const TARGON_US_PATH = '/cs/us';
+const TARGON_US_URL = 'https://www.targonglobal.com/cs/us';
 
 function getHostname(request: NextRequest) {
   const host = request.headers.get('host');
@@ -13,18 +16,33 @@ function getHostname(request: NextRequest) {
   return host.split(':')[0].toLowerCase();
 }
 
-function isCaelumStarHost(request: NextRequest) {
+function isCaelumStarUkHost(request: NextRequest) {
   const hostname = getHostname(request);
 
   if (!hostname) {
     return false;
   }
 
-  return CAELUM_STAR_HOSTS.has(hostname);
+  return CAELUM_STAR_UK_HOSTS.has(hostname);
+}
+
+function isAtOrUnderPath(pathname: string, rootPath: string) {
+  if (pathname === rootPath) {
+    return true;
+  }
+
+  return pathname.startsWith(`${rootPath}/`);
+}
+
+function redirectToRoot(request: NextRequest) {
+  const url = request.nextUrl.clone();
+  url.pathname = '/';
+  url.search = '';
+  return NextResponse.redirect(url);
 }
 
 export function middleware(request: NextRequest) {
-  if (!isCaelumStarHost(request)) {
+  if (!isCaelumStarUkHost(request)) {
     return NextResponse.next();
   }
 
@@ -32,22 +50,20 @@ export function middleware(request: NextRequest) {
 
   if (pathname === '/') {
     const url = request.nextUrl.clone();
-    url.pathname = '/cs/uk';
+    url.pathname = CAELUM_STAR_UK_ROOT;
     return NextResponse.rewrite(url);
   }
 
-  if (CAELUM_STAR_ROOT_REDIRECT_PATHS.has(pathname)) {
-    const url = request.nextUrl.clone();
-    url.pathname = '/';
-    url.search = '';
-    return NextResponse.redirect(url);
+  if (CAELUM_STAR_UK_ROOT_REDIRECT_PATHS.has(pathname)) {
+    return redirectToRoot(request);
   }
 
-  if (pathname.startsWith('/cs/uk/')) {
-    const url = request.nextUrl.clone();
-    url.pathname = '/';
-    url.search = '';
-    return NextResponse.redirect(url);
+  if (isAtOrUnderPath(pathname, TARGON_US_PATH)) {
+    return NextResponse.redirect(TARGON_US_URL);
+  }
+
+  if (pathname.startsWith(`${CAELUM_STAR_UK_ROOT}/`)) {
+    return redirectToRoot(request);
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- Route caelumstar.co.uk as the UK-only custom root.
- Keep US canonical URL on www.targonglobal.com/cs/us until an owned US domain exists.
- Clean up public URL metadata and Targon logo domain.

## Validation
- pnpm -C apps/website type-check
- git diff --check -- apps/website
- rg scan for stale caelumstar.com and legacy /packs routes in touched URL files
- curl host-header checks for caelumstar.co.uk root, /cs/uk, /cs/us, and Targon US URL