### PR TITLE
fix(plutus): clarify inventory flow screens

### DIFF
--- a/apps/plutus/app/cogs-batches/page.tsx
+++ b/apps/plutus/app/cogs-batches/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function CogsBatchesRedirectPage() {
-  redirect('/purchase-orders?tab=cogs');
-}

--- a/apps/plutus/app/inventory-ledger/page.tsx
+++ b/apps/plutus/app/inventory-ledger/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function InventoryLedgerRedirectPage() {
-  redirect('/purchase-orders?tab=ledger');
-}

--- a/apps/plutus/app/purchase-orders/page.tsx
+++ b/apps/plutus/app/purchase-orders/page.tsx
@@ -57,12 +57,21 @@ type CogsPostingRow = {
   id: string;
   marketplace: string;
   settlementId: string;
+  sku: string;
+  poNumber: string;
+  qtyConsumed: number;
+  unitCost: number;
   txnDate: string;
   currency: string;
   qboJournalId: string | null;
   qboDocNumber: string | null;
-  consumptionCount: bigint;
-  cogsAmountCents: bigint | null;
+  cogsAmountCents: number;
+};
+
+type InventoryFlowStep = {
+  label: string;
+  title: string;
+  description: string;
 };
 
 async function getPurchaseOrderRows(): Promise<PurchaseOrderRow[]> {
@@ -115,20 +124,21 @@ async function getInventoryLayers(): Promise<InventoryLayerRow[]> {
 async function getCogsPostings(): Promise<CogsPostingRow[]> {
   return db.$queryRawUnsafe<CogsPostingRow[]>(`
     SELECT
-      posting."id",
-      posting."marketplace",
-      posting."settlementId",
-      posting."txnDate",
-      posting."currency",
-      posting."qboJournalId",
+      consumption."id",
+      consumption."marketplace",
+      consumption."settlementId",
+      consumption."sku",
+      consumption."poNumber",
+      consumption."qtyConsumed",
+      consumption."unitCost",
+      COALESCE(posting."txnDate", '') AS "txnDate",
+      consumption."currency",
+      COALESCE(posting."qboJournalId", consumption."qboJournalId") AS "qboJournalId",
       posting."qboDocNumber",
-      COUNT(consumption."id") AS "consumptionCount",
-      COALESCE(SUM(consumption."cogsAmountCents"), 0) AS "cogsAmountCents"
-    FROM "SettlementPosting" posting
-    LEFT JOIN "CogsConsumption" consumption ON consumption."settlementPostingId" = posting."id"
-    WHERE posting."postingType" = 'COGS'
-    GROUP BY posting."id"
-    ORDER BY posting."txnDate" DESC, posting."settlementId" DESC
+      consumption."cogsAmountCents"
+    FROM "CogsConsumption" consumption
+    LEFT JOIN "SettlementPosting" posting ON posting."id" = consumption."settlementPostingId"
+    ORDER BY COALESCE(posting."txnDate", '') DESC, consumption."settlementId" DESC, consumption."poNumber" ASC, consumption."sku" ASC
     LIMIT 500
   `);
 }
@@ -172,11 +182,106 @@ function tabHref(tab: InventoryTab): string {
   return `${appBasePath}/purchase-orders`;
 }
 
+function connectionKey(poNumber: string, sku: string, marketplace: string) {
+  return (
+    <Box>
+      <Typography sx={{ fontWeight: 650 }}>{poNumber}</Typography>
+      <Typography sx={{ mt: 0.25, fontSize: '0.78rem', color: 'text.secondary' }}>
+        {sku} · {marketplace}
+      </Typography>
+    </Box>
+  );
+}
+
+function stackedMetric(label: string, value: string) {
+  return (
+    <Box>
+      <Typography sx={{ fontSize: '0.72rem', color: 'text.secondary' }}>{label}</Typography>
+      <Typography sx={{ fontWeight: 600 }}>{value}</Typography>
+    </Box>
+  );
+}
+
+function InventoryFlow() {
+  const steps: InventoryFlowStep[] = [
+    {
+      label: '1',
+      title: 'QBO PO line',
+      description: 'Native purchase evidence creates the PO/SKU layer key.',
+    },
+    {
+      label: '2',
+      title: 'FIFO layer',
+      description: 'READY layers hold remaining quantity and landed value.',
+    },
+    {
+      label: '3',
+      title: 'COGS journal',
+      description: 'Settlement units consume READY layers and post QBO COGS.',
+    },
+    {
+      label: '4',
+      title: 'Sellerboard export',
+      description: 'The same PO/SKU consumption totals support Sellerboard.',
+    },
+  ];
+
+  return (
+    <Box
+      sx={{
+        mt: 2.5,
+        display: 'grid',
+        gridTemplateColumns: { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' },
+        gap: 1,
+      }}
+    >
+      {steps.map((step) => (
+        <Box
+          key={step.title}
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: '28px 1fr',
+            gap: 1,
+            alignItems: 'start',
+            border: 1,
+            borderColor: 'divider',
+            bgcolor: 'background.paper',
+            px: 1.25,
+            py: 1,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'grid',
+              placeItems: 'center',
+              width: 24,
+              height: 24,
+              borderRadius: '50%',
+              bgcolor: 'action.hover',
+              color: 'text.secondary',
+              fontSize: '0.75rem',
+              fontWeight: 700,
+            }}
+          >
+            {step.label}
+          </Box>
+          <Box>
+            <Typography sx={{ fontSize: '0.82rem', fontWeight: 700 }}>{step.title}</Typography>
+            <Typography sx={{ mt: 0.25, fontSize: '0.76rem', color: 'text.secondary', lineHeight: 1.35 }}>
+              {step.description}
+            </Typography>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
 function InventoryTabs({ activeTab }: { activeTab: InventoryTab }) {
   const tabs: Array<{ value: InventoryTab; label: string }> = [
-    { value: 'purchase-orders', label: 'Purchase Orders' },
-    { value: 'inventory-ledger', label: 'Inventory Ledger' },
-    { value: 'cogs-postings', label: 'COGS Postings' },
+    { value: 'purchase-orders', label: '1. PO Source' },
+    { value: 'inventory-ledger', label: '2. FIFO Ledger' },
+    { value: 'cogs-postings', label: '3. COGS Posted' },
   ];
 
   return (
@@ -211,35 +316,25 @@ function PurchaseOrderSummaryTable({ rows }: { rows: PurchaseOrderRow[] }) {
         <Table size="small" sx={{ minWidth: 1120 }}>
           <TableHead>
             <TableRow>
-              <TableCell>PO</TableCell>
-              <TableCell>SKU</TableCell>
-              <TableCell>Marketplace</TableCell>
+              <TableCell>PO / SKU</TableCell>
               <TableCell>Status</TableCell>
-              <TableCell>QBO PO</TableCell>
-              <TableCell align="right">Qty Received</TableCell>
-              <TableCell align="right">Live Qty</TableCell>
-              <TableCell align="right">In Transit Qty</TableCell>
+              <TableCell>QBO Source</TableCell>
+              <TableCell align="right">Quantity</TableCell>
               <TableCell align="right">Unit Cost</TableCell>
-              <TableCell align="right">Landed Total</TableCell>
-              <TableCell align="right">Live Value</TableCell>
-              <TableCell align="right">In Transit Value</TableCell>
+              <TableCell align="right">Value</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {rows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={12}>
+                <TableCell colSpan={6}>
                   <EmptyState title="No purchase-order layers" description="Opening layers and locked native QBO PO/SKU layers appear here." />
                 </TableCell>
               </TableRow>
             )}
             {rows.map((row) => (
               <TableRow key={`${row.marketplace}:${row.poNumber}:${row.sku}`}>
-                <TableCell>
-                  <Typography sx={{ fontWeight: 650 }}>{row.poNumber}</Typography>
-                </TableCell>
-                <TableCell>{row.sku}</TableCell>
-                <TableCell>{row.marketplace}</TableCell>
+                <TableCell>{connectionKey(row.poNumber, row.sku, row.marketplace)}</TableCell>
                 <TableCell>
                   <Chip
                     label={statusLabel(row)}
@@ -249,13 +344,21 @@ function PurchaseOrderSummaryTable({ rows }: { rows: PurchaseOrderRow[] }) {
                   />
                 </TableCell>
                 <TableCell>{row.qboPurchaseOrderId ?? 'OPENING'}</TableCell>
-                <TableCell align="right">{Number(row.qtyReceived ?? 0n).toLocaleString('en-US')}</TableCell>
-                <TableCell align="right">{Number(row.liveQtyRemaining ?? 0n).toLocaleString('en-US')}</TableCell>
-                <TableCell align="right">{Number(row.inTransitQtyRemaining ?? 0n).toLocaleString('en-US')}</TableCell>
+                <TableCell align="right">
+                  <Box sx={{ display: 'grid', gap: 0.75 }}>
+                    {stackedMetric('Received', Number(row.qtyReceived ?? 0n).toLocaleString('en-US'))}
+                    {stackedMetric('READY', Number(row.liveQtyRemaining ?? 0n).toLocaleString('en-US'))}
+                    {stackedMetric('NOT_READY', Number(row.inTransitQtyRemaining ?? 0n).toLocaleString('en-US'))}
+                  </Box>
+                </TableCell>
                 <TableCell align="right">{row.unitCost === null ? '-' : Number(row.unitCost).toFixed(2)}</TableCell>
-                <TableCell align="right">{formatUsdCents(row.landedTotalCents)}</TableCell>
-                <TableCell align="right">{formatUsdCents(row.liveValueCents)}</TableCell>
-                <TableCell align="right">{formatUsdCents(row.inTransitValueCents)}</TableCell>
+                <TableCell align="right">
+                  <Box sx={{ display: 'grid', gap: 0.75 }}>
+                    {stackedMetric('Landed', formatUsdCents(row.landedTotalCents))}
+                    {stackedMetric('Inventory Asset - Plutus', formatUsdCents(row.liveValueCents))}
+                    {stackedMetric('Inventory in Transit - Plutus', formatUsdCents(row.inTransitValueCents))}
+                  </Box>
+                </TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -272,14 +375,11 @@ function InventoryLedgerTable({ rows }: { rows: InventoryLayerRow[] }) {
         <Table size="small" sx={{ minWidth: 1040 }}>
           <TableHead>
             <TableRow>
-              <TableCell>PO</TableCell>
-              <TableCell>SKU</TableCell>
-              <TableCell>Marketplace</TableCell>
+              <TableCell>PO / SKU</TableCell>
               <TableCell>Status</TableCell>
               <TableCell>Control Account</TableCell>
-              <TableCell align="right">Qty Received</TableCell>
-              <TableCell align="right">Qty Remaining</TableCell>
-              <TableCell align="right">Landed Total</TableCell>
+              <TableCell align="right">Quantity</TableCell>
+              <TableCell align="right">Layer Value</TableCell>
               <TableCell align="right">Unit Cost</TableCell>
               <TableCell>Receipt</TableCell>
             </TableRow>
@@ -287,7 +387,7 @@ function InventoryLedgerTable({ rows }: { rows: InventoryLayerRow[] }) {
           <TableBody>
             {rows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={10}>
+                <TableCell colSpan={7}>
                   <EmptyState
                     title="No cost layers"
                     description="Opening layers and locked QBO PO/SKU layers will appear here."
@@ -297,17 +397,17 @@ function InventoryLedgerTable({ rows }: { rows: InventoryLayerRow[] }) {
             )}
             {rows.map((row) => (
               <TableRow key={row.id}>
-                <TableCell>
-                  <Typography sx={{ fontWeight: 650 }}>{row.poNumber}</Typography>
-                </TableCell>
-                <TableCell>{row.sku}</TableCell>
-                <TableCell>{row.marketplace}</TableCell>
+                <TableCell>{connectionKey(row.poNumber, row.sku, row.marketplace)}</TableCell>
                 <TableCell>
                   <Chip label={row.status} size="small" variant="outlined" />
                 </TableCell>
                 <TableCell>{controlAccount(row.status)}</TableCell>
-                <TableCell align="right">{row.qtyReceived.toLocaleString('en-US')}</TableCell>
-                <TableCell align="right">{row.qtyRemaining.toLocaleString('en-US')}</TableCell>
+                <TableCell align="right">
+                  <Box sx={{ display: 'grid', gap: 0.75 }}>
+                    {stackedMetric('Received', row.qtyReceived.toLocaleString('en-US'))}
+                    {stackedMetric('Remaining', row.qtyRemaining.toLocaleString('en-US'))}
+                  </Box>
+                </TableCell>
                 <TableCell align="right">
                   {formatCurrencyCents(row.landedTotalCents, row.currency)}
                 </TableCell>
@@ -329,36 +429,41 @@ function CogsPostingsTable({ rows }: { rows: CogsPostingRow[] }) {
         <Table size="small" sx={{ minWidth: 960 }}>
           <TableHead>
             <TableRow>
+              <TableCell>PO / SKU</TableCell>
               <TableCell>Settlement</TableCell>
-              <TableCell>Marketplace</TableCell>
               <TableCell>Date</TableCell>
               <TableCell>QBO Doc</TableCell>
               <TableCell>QBO JE</TableCell>
-              <TableCell align="right">Lines</TableCell>
+              <TableCell align="right">Qty</TableCell>
+              <TableCell align="right">Unit Cost</TableCell>
               <TableCell align="right">COGS</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {rows.length === 0 && (
               <TableRow>
-                <TableCell colSpan={7}>
+                <TableCell colSpan={8}>
                   <EmptyState
                     title="No COGS postings"
-                    description="FIFO COGS journals will appear here after settlement posting."
+                    description="Posted FIFO COGS consumption lines will appear here by PO and SKU."
                   />
                 </TableCell>
               </TableRow>
             )}
             {rows.map((row) => (
               <TableRow key={row.id}>
+                <TableCell>{connectionKey(row.poNumber, row.sku, row.marketplace)}</TableCell>
                 <TableCell>
                   <Typography sx={{ fontWeight: 650 }}>{row.settlementId}</Typography>
+                  <Typography sx={{ mt: 0.25, fontSize: '0.78rem', color: 'text.secondary' }}>
+                    {row.marketplace}
+                  </Typography>
                 </TableCell>
-                <TableCell>{row.marketplace}</TableCell>
                 <TableCell>{row.txnDate}</TableCell>
                 <TableCell>{row.qboDocNumber ?? '-'}</TableCell>
                 <TableCell>{row.qboJournalId ?? '-'}</TableCell>
-                <TableCell align="right">{Number(row.consumptionCount)}</TableCell>
+                <TableCell align="right">{row.qtyConsumed.toLocaleString('en-US')}</TableCell>
+                <TableCell align="right">{Number(row.unitCost).toFixed(2)}</TableCell>
                 <TableCell align="right">
                   {formatCurrencyCents(row.cogsAmountCents, row.currency)}
                 </TableCell>
@@ -374,11 +479,9 @@ function CogsPostingsTable({ rows }: { rows: CogsPostingRow[] }) {
 export default async function PurchaseOrdersPage({ searchParams }: { searchParams?: SearchParams } = {}) {
   const resolvedSearchParams = searchParams === undefined ? {} : await searchParams;
   const activeTab = parseInventoryTab(resolvedSearchParams.tab);
-  const [purchaseOrderRows, inventoryLayerRows, cogsPostingRows] = await Promise.all([
-    getPurchaseOrderRows(),
-    getInventoryLayers(),
-    getCogsPostings(),
-  ]);
+  const purchaseOrderRows = activeTab === 'purchase-orders' ? await getPurchaseOrderRows() : [];
+  const inventoryLayerRows = activeTab === 'inventory-ledger' ? await getInventoryLayers() : [];
+  const cogsPostingRows = activeTab === 'cogs-postings' ? await getCogsPostings() : [];
 
   return (
     <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
@@ -397,6 +500,7 @@ export default async function PurchaseOrdersPage({ searchParams }: { searchParam
         }
       />
 
+      <InventoryFlow />
       <InventoryTabs activeTab={activeTab} />
       {activeTab === 'purchase-orders' ? <PurchaseOrderSummaryTable rows={purchaseOrderRows} /> : null}
       {activeTab === 'inventory-ledger' ? <InventoryLedgerTable rows={inventoryLayerRows} /> : null}

--- a/apps/plutus/app/settlement-mapping/page.tsx
+++ b/apps/plutus/app/settlement-mapping/page.tsx
@@ -245,7 +245,7 @@ export default function SettlementMappingPage() {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['setup-settlement-mapping'] });
-      enqueueSnackbar('Saved settlement mappings', { variant: 'success' });
+      enqueueSnackbar('Saved settlement rules', { variant: 'success' });
     },
     onError: (error) => {
       enqueueSnackbar(error instanceof Error ? error.message : String(error), { variant: 'error' });
@@ -281,8 +281,8 @@ export default function SettlementMappingPage() {
       const memoCount = Object.keys(data.memoMappings).length;
       const taxCount = Object.keys(data.taxCodeMappings).length;
       const message = taxEngineEnabled
-        ? `Imported ${memoCount} memo mappings + ${taxCount} tax mappings from QBO`
-        : `Imported ${memoCount} memo mappings from QBO`;
+        ? `Imported ${memoCount} category rules + ${taxCount} tax rules from QBO`
+        : `Imported ${memoCount} category rules from QBO`;
       enqueueSnackbar(message, { variant: 'success' });
     },
     onError: (error) => {
@@ -291,7 +291,7 @@ export default function SettlementMappingPage() {
   });
 
   if (!isCheckingConnection && connectionStatus?.connected === false) {
-    return <NotConnectedScreen title="Settlement Mappings" canConnect={connectionStatus.canConnect} error={connectionStatus.error} />;
+    return <NotConnectedScreen title="Settlement Rules" canConnect={connectionStatus.canConnect} error={connectionStatus.error} />;
   }
 
   const isLoading =
@@ -306,18 +306,18 @@ export default function SettlementMappingPage() {
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2, flexWrap: 'wrap' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
             <PageHeader
-              title="Settlement Mappings"
+              title="Settlement Rules"
               variant="accent"
             />
             <Tooltip
               title={
                 <>
-                  <div>1) Import while your historical US settlements still exist in QBO.</div>
-                  <div style={{ marginTop: 4 }}>2) Plutus will fail if a memo is missing from the mapping (to prevent mis-posts).</div>
+                  <div>1) Import while your historical settlements still exist in QBO.</div>
+                  <div style={{ marginTop: 4 }}>2) Plutus blocks posting when an Amazon category has no QBO account rule.</div>
                   <div style={{ marginTop: 4 }}>
                     {taxEngineEnabled
-                      ? '3) Tax code mapping mirrors TaxCodeRef used on historical settlement JEs (import first, then edit if needed).'
-                      : '3) QBO sales tax is disabled, so settlement postings omit TaxCodeRef and tax mapping stays hidden.'}
+                      ? '3) Tax code rules mirror TaxCodeRef used on historical settlement journals.'
+                      : '3) QBO sales tax is disabled, so settlement postings omit TaxCodeRef.'}
                   </div>
                   <div style={{ marginTop: 4 }}>4) Settlement cash always balances through Plutus Settlement Control.</div>
                 </>
@@ -390,9 +390,9 @@ export default function SettlementMappingPage() {
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 2 }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, minWidth: 0 }}>
                   <Typography sx={{ fontSize: '0.875rem', fontWeight: 600, color: 'text.primary' }}>
-                    {region} Transaction Categories
+                    {region} Amazon Category Rules
                   </Typography>
-                  <Tooltip title="Every settlement line memo must map to a QBO account. Import from QBO to mirror existing postings, then review/update existing rows if needed." arrow>
+                  <Tooltip title="Every Amazon settlement category must map to a QBO account. Import from QBO to mirror existing postings, then review/update existing rows if needed." arrow>
                     <InfoOutlinedIcon sx={{ fontSize: 16, color: 'text.secondary', cursor: 'help' }} />
                   </Tooltip>
                 </Box>
@@ -400,7 +400,7 @@ export default function SettlementMappingPage() {
                   <TextField
                     value={search}
                     onChange={(e) => setSearch(e.target.value)}
-                    placeholder="Search memos…"
+                    placeholder="Search categories…"
                     size="small"
                     sx={{ width: 220 }}
                   />
@@ -429,10 +429,10 @@ export default function SettlementMappingPage() {
                     }}
                   >
                     <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary' }}>
-                      Transaction Category
+                      Amazon Category
                     </Typography>
                     <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary', display: { xs: 'none', md: 'block' } }}>
-                      Account Name
+                      QBO Account
                     </Typography>
                     {taxEngineEnabled && (
                       <Typography sx={{ fontSize: '0.625rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: 'text.secondary', display: { xs: 'none', md: 'block' } }}>

--- a/apps/plutus/components/app-header.tsx
+++ b/apps/plutus/components/app-header.tsx
@@ -8,9 +8,6 @@ import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import Drawer from '@mui/material/Drawer';
 import FormControl from '@mui/material/FormControl';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
@@ -21,7 +18,6 @@ import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
 import ReportProblemIcon from '@mui/icons-material/ReportProblem';
 import MenuIcon from '@mui/icons-material/Menu';
 import CloseIcon from '@mui/icons-material/Close';
-import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import { QboStatusIndicator } from '@/components/qbo-status-indicator';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { type Marketplace, useMarketplaceStore } from '@/lib/store/marketplace';
@@ -126,9 +122,6 @@ function isActivePath(pathname: string, href: string): boolean {
 export function AppHeader() {
   const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [moreAnchor, setMoreAnchor] = useState<HTMLElement | null>(null);
-  const moreOpen = Boolean(moreAnchor);
-  const secondaryActive = SECONDARY_NAV_ITEMS.some((item) => isActivePath(pathname, item.href));
 
   return (
     <Box
@@ -183,7 +176,7 @@ export function AppHeader() {
 
           {/* Desktop nav */}
           <Box component="nav" sx={{ display: { xs: 'none', lg: 'flex' }, alignItems: 'center', gap: 0.25 }}>
-            {PRIMARY_NAV_ITEMS.map((item) => {
+            {ALL_NAV_ITEMS.map((item) => {
               const Icon = item.icon;
               const isActive = isActivePath(pathname, item.href);
               return (
@@ -228,82 +221,6 @@ export function AppHeader() {
                 </Link>
               );
             })}
-            <Box sx={{ position: 'relative' }}>
-              <IconButton
-                aria-label="More Plutus sections"
-                aria-controls={moreOpen ? 'plutus-more-menu' : undefined}
-                aria-haspopup="menu"
-                aria-expanded={moreOpen ? 'true' : undefined}
-                onClick={(event) => setMoreAnchor(event.currentTarget)}
-                size="small"
-                sx={{
-                  ml: 0.25,
-                  width: 34,
-                  height: 34,
-                  borderRadius: 2,
-                  color: secondaryActive ? '#008f87' : 'text.secondary',
-                  bgcolor: secondaryActive ? 'rgba(0, 194, 185, 0.08)' : 'transparent',
-                  '&:hover': { bgcolor: 'action.hover', color: 'text.primary' },
-                }}
-              >
-                <MoreHorizIcon sx={{ fontSize: 19 }} />
-              </IconButton>
-              {secondaryActive && (
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    bottom: -12,
-                    left: 8,
-                    right: 8,
-                    height: 2,
-                    borderRadius: 1,
-                    bgcolor: '#00C2B9',
-                  }}
-                />
-              )}
-            </Box>
-            <Menu
-              id="plutus-more-menu"
-              anchorEl={moreAnchor}
-              open={moreOpen}
-              onClose={() => setMoreAnchor(null)}
-              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-              transformOrigin={{ vertical: 'top', horizontal: 'right' }}
-              slotProps={{
-                paper: {
-                  sx: {
-                    mt: 1,
-                    minWidth: 230,
-                    border: 1,
-                    borderColor: 'divider',
-                    boxShadow: '0 14px 40px rgba(2, 12, 27, 0.18)',
-                  },
-                },
-              }}
-            >
-              {SECONDARY_NAV_ITEMS.map((item) => {
-                const Icon = item.icon;
-                const isActive = isActivePath(pathname, item.href);
-                return (
-                  <MenuItem
-                    key={item.href}
-                    component={Link}
-                    href={item.href}
-                    selected={isActive}
-                    onClick={() => setMoreAnchor(null)}
-                    sx={{ gap: 1, py: 1 }}
-                  >
-                    <ListItemIcon sx={{ minWidth: 30 }}>
-                      <Icon sx={{ fontSize: 17, color: isActive ? '#00A59E' : 'text.secondary' }} />
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={item.label}
-                      primaryTypographyProps={{ fontSize: 13, fontWeight: isActive ? 650 : 500 }}
-                    />
-                  </MenuItem>
-                );
-              })}
-            </Menu>
           </Box>
         </Box>
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -449,9 +449,7 @@ test('settlement cash lines use settlement control wording', () => {
 test('fresh-start pages read new layer/allocation/consumption tables', () => {
   for (const path of [
     'app/purchase-orders/page.tsx',
-    'app/inventory-ledger/page.tsx',
     'app/landed-cost-allocations/page.tsx',
-    'app/cogs-batches/page.tsx',
     'app/sellerboard-export/page.tsx',
     'app/api/plutus/purchase-orders/route.ts',
     'app/api/plutus/inventory-ledger/route.ts',
@@ -469,16 +467,57 @@ test('fresh-start pages read new layer/allocation/consumption tables', () => {
   );
   assert.equal(read('app/purchase-orders/page.tsx').includes('tab=ledger'), true);
   assert.equal(read('app/purchase-orders/page.tsx').includes('tab=cogs'), true);
-  assert.equal(read('app/purchase-orders/page.tsx').includes('Live Value'), true);
-  assert.equal(read('app/purchase-orders/page.tsx').includes('In Transit Value'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('PO / SKU'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('QBO PO line'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('FIFO layer'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('COGS journal'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('Sellerboard export'), true);
   assert.equal(read('app/purchase-orders/page.tsx').includes('Inventory in Transit - Plutus'), true);
-  assert.equal(read('app/inventory-ledger/page.tsx').includes("redirect('/purchase-orders?tab=ledger')"), true);
-  assert.equal(read('app/cogs-batches/page.tsx').includes("redirect('/purchase-orders?tab=cogs')"), true);
+  assertDeleted('app/inventory-ledger/page.tsx');
+  assertDeleted('app/cogs-batches/page.tsx');
   assert.equal(
     read('app/api/plutus/landed-cost-allocations/route.ts').includes('LandedCostAllocation'),
     true,
   );
-  assert.equal(read('app/purchase-orders/page.tsx').includes('JOIN "CogsConsumption"'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('FROM "CogsConsumption"'), true);
+});
+
+test('inventory tables avoid repeating connection columns', () => {
+  const source = read('app/purchase-orders/page.tsx');
+  for (const forbidden of [
+    '<TableCell>PO</TableCell>',
+    '<TableCell>SKU</TableCell>',
+    '<TableCell>Marketplace</TableCell>',
+    '<TableCell>QBO PO</TableCell>',
+    '<TableCell align="right">Live Qty</TableCell>',
+    '<TableCell align="right">In Transit Qty</TableCell>',
+    '<TableCell align="right">Live Value</TableCell>',
+    '<TableCell align="right">In Transit Value</TableCell>',
+  ]) {
+    assert.equal(source.includes(forbidden), false, `${forbidden} should not be repeated as a standalone column`);
+  }
+});
+
+test('settlement mapping is framed as category to QBO account rules', () => {
+  const source = read('app/settlement-mapping/page.tsx');
+  for (const required of [
+    'Settlement Rules',
+    'Amazon Category',
+    'QBO Account',
+    'Every Amazon settlement category must map to a QBO account',
+  ]) {
+    assert.equal(source.includes(required), true, `${required} should be visible on settlement rules`);
+  }
+
+  for (const forbidden of [
+    'Settlement Mappings',
+    'Search memos',
+    'memo mappings',
+    'Transaction Category',
+    'Account Name',
+  ]) {
+    assert.equal(source.includes(forbidden), false, `${forbidden} should not be visible settlement-rule wording`);
+  }
 });
 
 test('fresh-start UI displays unit costs at two decimals', () => {

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -57,6 +57,7 @@ test('Plutus nav exposes fresh-start bridge surfaces only', () => {
   ]) {
     assert.equal(source.includes(href), true, `${href} should be in nav`);
   }
+  assert.equal(source.includes('{ALL_NAV_ITEMS.map((item)'), true, 'desktop nav should expose every Plutus section');
 
   for (const forbidden of [
     "href: '/products'",
@@ -66,6 +67,9 @@ test('Plutus nav exposes fresh-start bridge surfaces only', () => {
     "href: '/cogs-batches'",
     "href: '/sellerboard-export'",
     "href: '/settings'",
+    'More Plutus sections',
+    'MoreHorizIcon',
+    'plutus-more-menu',
   ]) {
     assert.equal(source.includes(forbidden), false, `${forbidden} should not be in nav`);
   }


### PR DESCRIPTION
## Summary
- Make Purchase Orders the canonical inventory surface and delete the old inventory-ledger/cogs-batches redirect pages
- Add an explicit QBO PO line -> FIFO layer -> COGS journal -> Sellerboard export flow strip
- Collapse repeated PO/SKU/marketplace columns into one PO / SKU key and show COGS consumption lines by PO/SKU
- Rename settlement mapping UI copy to Settlement Rules with Amazon Category -> QBO Account language
- Remove the desktop More menu so rule/audit pages are direct nav items

## Verification
- pnpm --dir apps/plutus test
- pnpm --dir apps/plutus lint
- pnpm --dir apps/plutus type-check
- pnpm --dir apps/plutus build
- Browser preview on http://localhost:4318/plutus/purchase-orders and related tabs