### PR TITLE
[codex] fix Plutus inventory tab blink

### DIFF
--- a/apps/plutus/app/purchase-orders/inventory-tabs.tsx
+++ b/apps/plutus/app/purchase-orders/inventory-tabs.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+
+export type InventoryTab = 'purchase-orders' | 'inventory-ledger' | 'cogs-postings';
+
+type InventoryTabsClientProps = {
+  initialActiveTab: InventoryTab;
+  purchaseOrdersPanel: ReactNode;
+  ledgerPanel: ReactNode;
+  cogsPanel: ReactNode;
+};
+
+const tabs: Array<{ value: InventoryTab; label: string; queryValue: string | null }> = [
+  { value: 'purchase-orders', label: '1. PO Source', queryValue: null },
+  { value: 'inventory-ledger', label: '2. FIFO Ledger', queryValue: 'ledger' },
+  { value: 'cogs-postings', label: '3. COGS Posted', queryValue: 'cogs' },
+];
+
+function inventoryTabFromSearch(search: string): InventoryTab {
+  const value = new URLSearchParams(search).get('tab');
+  if (value === null) return 'purchase-orders';
+  if (value === 'po') return 'purchase-orders';
+  if (value === 'ledger') return 'inventory-ledger';
+  if (value === 'cogs') return 'cogs-postings';
+  throw new Error(`Unsupported inventory tab: ${value}`);
+}
+
+function updateInventoryTabUrl(tab: InventoryTab) {
+  const url = new URL(window.location.href);
+  const tabConfig = tabs.find((candidate) => candidate.value === tab);
+  if (tabConfig === undefined) {
+    throw new Error(`Unsupported inventory tab: ${tab}`);
+  }
+
+  if (tabConfig.queryValue === null) {
+    url.searchParams.delete('tab');
+  } else {
+    url.searchParams.set('tab', tabConfig.queryValue);
+  }
+
+  window.history.pushState({ plutusInventoryTab: tab }, '', `${url.pathname}${url.search}${url.hash}`);
+}
+
+export function InventoryTabsClient({
+  initialActiveTab,
+  purchaseOrdersPanel,
+  ledgerPanel,
+  cogsPanel,
+}: InventoryTabsClientProps) {
+  const [activeTab, setActiveTab] = useState<InventoryTab>(initialActiveTab);
+
+  useEffect(() => {
+    const handlePopState = () => {
+      setActiveTab(inventoryTabFromSearch(window.location.search));
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, []);
+
+  const panels: Record<InventoryTab, ReactNode> = {
+    'purchase-orders': purchaseOrdersPanel,
+    'inventory-ledger': ledgerPanel,
+    'cogs-postings': cogsPanel,
+  };
+
+  return (
+    <>
+      <Box role="tablist" aria-label="Inventory sections" sx={{ mt: 2.5, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        {tabs.map((tab) => {
+          const active = tab.value === activeTab;
+          return (
+            <Button
+              key={tab.value}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              aria-controls={`inventory-panel-${tab.value}`}
+              id={`inventory-tab-${tab.value}`}
+              variant={active ? 'contained' : 'outlined'}
+              size="small"
+              onClick={() => {
+                if (active) return;
+                setActiveTab(tab.value);
+                updateInventoryTabUrl(tab.value);
+              }}
+              sx={{
+                borderRadius: 2,
+                textTransform: 'none',
+                bgcolor: active ? '#00C2B9' : undefined,
+                '&:hover': active ? { bgcolor: '#00a89f' } : undefined,
+              }}
+            >
+              {tab.label}
+            </Button>
+          );
+        })}
+      </Box>
+
+      {tabs.map((tab) => (
+        <Box
+          key={tab.value}
+          role="tabpanel"
+          id={`inventory-panel-${tab.value}`}
+          aria-labelledby={`inventory-tab-${tab.value}`}
+          hidden={activeTab !== tab.value}
+        >
+          {panels[tab.value]}
+        </Box>
+      ))}
+    </>
+  );
+}

--- a/apps/plutus/app/purchase-orders/page.tsx
+++ b/apps/plutus/app/purchase-orders/page.tsx
@@ -12,6 +12,8 @@ import { PageHeader } from '@/components/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
 import { db } from '@/lib/db';
 
+import { InventoryTabsClient, type InventoryTab } from './inventory-tabs';
+
 export const dynamic = 'force-dynamic';
 
 const appBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
@@ -20,7 +22,6 @@ if (appBasePath === undefined) {
 }
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>;
-type InventoryTab = 'purchase-orders' | 'inventory-ledger' | 'cogs-postings';
 
 type PurchaseOrderRow = {
   poNumber: string;
@@ -172,14 +173,9 @@ function parseInventoryTab(raw: string | string[] | undefined): InventoryTab {
   const value = Array.isArray(raw) ? raw[0] : raw;
   if (value === 'ledger') return 'inventory-ledger';
   if (value === 'cogs') return 'cogs-postings';
-  if (value === undefined || value === 'po') return 'purchase-orders';
+  if (value === undefined) return 'purchase-orders';
+  if (value === 'po') return 'purchase-orders';
   throw new Error(`Unsupported inventory tab: ${value}`);
-}
-
-function tabHref(tab: InventoryTab): string {
-  if (tab === 'inventory-ledger') return `${appBasePath}/purchase-orders?tab=ledger`;
-  if (tab === 'cogs-postings') return `${appBasePath}/purchase-orders?tab=cogs`;
-  return `${appBasePath}/purchase-orders`;
 }
 
 function connectionKey(poNumber: string, sku: string, marketplace: string) {
@@ -273,38 +269,6 @@ function InventoryFlow() {
           </Box>
         </Box>
       ))}
-    </Box>
-  );
-}
-
-function InventoryTabs({ activeTab }: { activeTab: InventoryTab }) {
-  const tabs: Array<{ value: InventoryTab; label: string }> = [
-    { value: 'purchase-orders', label: '1. PO Source' },
-    { value: 'inventory-ledger', label: '2. FIFO Ledger' },
-    { value: 'cogs-postings', label: '3. COGS Posted' },
-  ];
-
-  return (
-    <Box sx={{ mt: 2.5, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-      {tabs.map((tab) => {
-        const active = tab.value === activeTab;
-        return (
-          <Button
-            key={tab.value}
-            href={tabHref(tab.value)}
-            variant={active ? 'contained' : 'outlined'}
-            size="small"
-            sx={{
-              borderRadius: 2,
-              textTransform: 'none',
-              bgcolor: active ? '#00C2B9' : undefined,
-              '&:hover': active ? { bgcolor: '#00a89f' } : undefined,
-            }}
-          >
-            {tab.label}
-          </Button>
-        );
-      })}
     </Box>
   );
 }
@@ -479,9 +443,11 @@ function CogsPostingsTable({ rows }: { rows: CogsPostingRow[] }) {
 export default async function PurchaseOrdersPage({ searchParams }: { searchParams?: SearchParams } = {}) {
   const resolvedSearchParams = searchParams === undefined ? {} : await searchParams;
   const activeTab = parseInventoryTab(resolvedSearchParams.tab);
-  const purchaseOrderRows = activeTab === 'purchase-orders' ? await getPurchaseOrderRows() : [];
-  const inventoryLayerRows = activeTab === 'inventory-ledger' ? await getInventoryLayers() : [];
-  const cogsPostingRows = activeTab === 'cogs-postings' ? await getCogsPostings() : [];
+  const [purchaseOrderRows, inventoryLayerRows, cogsPostingRows] = await Promise.all([
+    getPurchaseOrderRows(),
+    getInventoryLayers(),
+    getCogsPostings(),
+  ]);
 
   return (
     <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
@@ -501,10 +467,12 @@ export default async function PurchaseOrdersPage({ searchParams }: { searchParam
       />
 
       <InventoryFlow />
-      <InventoryTabs activeTab={activeTab} />
-      {activeTab === 'purchase-orders' ? <PurchaseOrderSummaryTable rows={purchaseOrderRows} /> : null}
-      {activeTab === 'inventory-ledger' ? <InventoryLedgerTable rows={inventoryLayerRows} /> : null}
-      {activeTab === 'cogs-postings' ? <CogsPostingsTable rows={cogsPostingRows} /> : null}
+      <InventoryTabsClient
+        initialActiveTab={activeTab}
+        purchaseOrdersPanel={<PurchaseOrderSummaryTable rows={purchaseOrderRows} />}
+        ledgerPanel={<InventoryLedgerTable rows={inventoryLayerRows} />}
+        cogsPanel={<CogsPostingsTable rows={cogsPostingRows} />}
+      />
     </Box>
   );
 }

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -453,6 +453,7 @@ test('settlement cash lines use settlement control wording', () => {
 test('fresh-start pages read new layer/allocation/consumption tables', () => {
   for (const path of [
     'app/purchase-orders/page.tsx',
+    'app/purchase-orders/inventory-tabs.tsx',
     'app/landed-cost-allocations/page.tsx',
     'app/sellerboard-export/page.tsx',
     'app/api/plutus/purchase-orders/route.ts',
@@ -469,8 +470,14 @@ test('fresh-start pages read new layer/allocation/consumption tables', () => {
     read('app/api/plutus/purchase-orders/route.ts').includes('"status" = \'NOT_READY\''),
     true,
   );
-  assert.equal(read('app/purchase-orders/page.tsx').includes('tab=ledger'), true);
-  assert.equal(read('app/purchase-orders/page.tsx').includes('tab=cogs'), true);
+  assert.equal(read('app/purchase-orders/inventory-tabs.tsx').includes("'use client'"), true);
+  assert.equal(read('app/purchase-orders/inventory-tabs.tsx').includes("queryValue: 'ledger'"), true);
+  assert.equal(read('app/purchase-orders/inventory-tabs.tsx').includes("queryValue: 'cogs'"), true);
+  assert.equal(read('app/purchase-orders/inventory-tabs.tsx').includes('window.history.pushState'), true);
+  assert.equal(read('app/purchase-orders/inventory-tabs.tsx').includes('hidden={activeTab !== tab.value}'), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('Promise.all(['), true);
+  assert.equal(read('app/purchase-orders/page.tsx').includes('href={tabHref(tab.value)}'), false);
+  assert.equal(read('app/purchase-orders/page.tsx').includes("activeTab === 'purchase-orders'"), false);
   assert.equal(read('app/purchase-orders/page.tsx').includes('PO / SKU'), true);
   assert.equal(read('app/purchase-orders/page.tsx').includes('QBO PO line'), true);
   assert.equal(read('app/purchase-orders/page.tsx').includes('FIFO layer'), true);


### PR DESCRIPTION
Fixes the inventory tab blink on /plutus/purchase-orders.\n\nRoot cause: the PO Source / FIFO Ledger / COGS Posted controls were href-backed server route navigations, and the page only fetched/rendered the active tab. Every tab click remounted the server route.\n\nChange:\n- Move inventory tab switching into a client component.\n- Fetch all three inventory panels once on the server.\n- Keep panels mounted and hide inactive panels.\n- Sync ?tab=ledger / ?tab=cogs via history.pushState without triggering Next navigation.\n\nVerification:\n- pnpm --dir apps/plutus test\n- pnpm --dir apps/plutus lint\n- pnpm --dir apps/plutus type-check\n- pnpm --dir apps/plutus build\n- Chrome preview on localhost:4319 confirmed tab clicks update selected tab and URL without a server GET.