### PR TITLE
fix(website): route UK selector to canonical domain

### DIFF
--- a/apps/website/next.config.mjs
+++ b/apps/website/next.config.mjs
@@ -1,3 +1,5 @@
+const CAELUM_STAR_UK_URL = 'https://caelumstar.co.uk/';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -40,27 +42,27 @@ const nextConfig = {
       },
       {
         source: '/cs/uk/packs',
-        destination: '/cs/uk',
+        destination: CAELUM_STAR_UK_URL,
         permanent: false,
       },
       {
         source: '/cs/uk/packs/:slug',
-        destination: '/cs/uk',
+        destination: CAELUM_STAR_UK_URL,
         permanent: false,
       },
       {
         source: '/cs/uk/where-to-buy',
-        destination: '/cs/uk',
+        destination: CAELUM_STAR_UK_URL,
         permanent: false,
       },
       {
         source: '/cs/uk/support',
-        destination: '/cs/uk',
+        destination: CAELUM_STAR_UK_URL,
         permanent: false,
       },
       {
         source: '/cs/uk/about',
-        destination: '/cs/uk',
+        destination: CAELUM_STAR_UK_URL,
         permanent: false,
       },
     ]

--- a/apps/website/public/llms.txt
+++ b/apps/website/public/llms.txt
@@ -29,10 +29,8 @@ Preferred interpretation:
 
 ## United Kingdom
 - [UK Site](https://caelumstar.co.uk/): Dust sheet packs, reference prices, coverage, durability, and Amazon buy links.
-- [UK Targon URL](https://www.targonglobal.com/cs/uk): Same UK pack selector on the Targon domain when not using the UK custom domain.
 - [UK 6 Pack Light Amazon](https://www.amazon.co.uk/dp/B09HXC3NL8): Direct Amazon UK listing for the 6 Pack light plastic dust sheet variant.
 - [UK 6 Pack Strong Amazon](https://www.amazon.co.uk/dp/B0DHDTPGGP): Direct Amazon UK listing for the 6 Pack strong plastic dust sheet variant.
 - [UK 1 Pack Strong Amazon](https://www.amazon.co.uk/dp/B0FLKJ7WWM): Direct Amazon UK listing for the 1 Pack strong plastic dust sheet variant.
 - [UK 3 Pack Strong Amazon](https://www.amazon.co.uk/dp/B0CR1GSBQ9): Direct Amazon UK listing for the 3 Pack strong plastic dust sheet variant.
 - [UK 3 Pack Light Amazon](https://www.amazon.co.uk/dp/B0C7ZQ3VZL): Direct Amazon UK listing for the 3 Pack light plastic dust sheet variant.
-- [UK 10 Pack Light Amazon](https://www.amazon.co.uk/dp/B0CR1H3VSF): Direct Amazon UK listing for the 10 Pack light plastic dust sheet variant.

--- a/apps/website/src/app/cs/page.tsx
+++ b/apps/website/src/app/cs/page.tsx
@@ -14,7 +14,7 @@ const regions = [
   {
     flag: '\u{1F1EC}\u{1F1E7}',
     title: 'United Kingdom',
-    href: '/cs/uk'
+    href: 'https://caelumstar.co.uk/'
   }
 ];
 

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -8,7 +8,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { url: baseUrl, lastModified: new Date() },
     { url: `${baseUrl}/cs`, lastModified: new Date() },
     { url: `${baseUrl}/cs/us`, lastModified: new Date() },
-    { url: `${baseUrl}/cs/uk`, lastModified: new Date() },
+    { url: 'https://caelumstar.co.uk/', lastModified: new Date() },
     { url: `${baseUrl}/legal/privacy`, lastModified: new Date() },
     { url: `${baseUrl}/legal/terms`, lastModified: new Date() }
   ];

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -7,7 +7,7 @@ const footerLinks = {
     { label: 'Home', href: '/' },
     { label: 'Caelum Star', href: '/cs' },
     { label: 'US site', href: '/cs/us' },
-    { label: 'UK site', href: '/cs/uk' }
+    { label: 'UK site', href: 'https://caelumstar.co.uk/' }
   ],
   Company: [
     { label: 'Contact', href: `mailto:${site.contactEmail}` }

--- a/apps/website/src/components/Header.tsx
+++ b/apps/website/src/components/Header.tsx
@@ -11,7 +11,7 @@ import { Container } from '@/components/Container';
 
 const productNavLinks = [
   { label: 'US', href: '/cs/us' },
-  { label: 'UK', href: '/cs/uk' }
+  { label: 'UK', href: 'https://caelumstar.co.uk/' }
 ];
 
 const homeNavLinks = [

--- a/apps/website/src/content/products.ts
+++ b/apps/website/src/content/products.ts
@@ -98,7 +98,6 @@ const AMAZON_US_12PK = 'https://www.amazon.com/dp/B0FP66CWQ6?th=1';
 const AMAZON_UK_1PK = 'https://www.amazon.co.uk/dp/B0FLKJ7WWM';
 const AMAZON_UK_3PK = 'https://www.amazon.co.uk/dp/B0CR1GSBQ9';
 const AMAZON_UK_6PK = 'https://www.amazon.co.uk/dp/B09HXC3NL8';
-const AMAZON_UK_12PK = 'https://www.amazon.co.uk/dp/B0FP66CWQ6';
 
 /**
  * Product set:
@@ -453,42 +452,6 @@ export const productsUK: Product[] = [
       { src: '/images/amazon/applications.webp', alt: 'Applications: moving, painting, renovating', variant: 'square' }
     ],
     amazonUrl: AMAZON_UK_3PK
-  },
-  {
-    slug: '10pk-light',
-    name: '10 Pack',
-    packLabel: '10 PK',
-    thicknessLabel: 'Light',
-    coverageLabel: '1080 sq ft',
-    price: '£13.99',
-    tagline: 'Pro coverage for multi-room renovations.',
-    description: 'More sheets for bigger rooms, repeat work, and bigger prep.',
-    longDescription: [
-      'Pro coverage for multi-room renovations.',
-      'Light durability, universal protection.',
-      '55% recycled plastic, globally certified.'
-    ],
-    highlights: ['12ft × 9ft per sheet', 'Light durability', '55% recycled plastic (GRS)'],
-    specs: [
-      { label: 'Pack', value: '10 sheets' },
-      { label: 'Total coverage', value: '1080 sq ft (≈100 m²)' },
-      { label: 'Sheet size', value: '3.6m × 2.7m (12ft × 9ft) each' },
-      { label: 'Durability', value: 'Light' },
-      { label: 'Material', value: 'LDPE (plastic sheeting)' }
-    ],
-    image: { src: '/images/products/UK-products/10pk-light.png', alt: 'CS 10 Pack Extra Large Dust Sheets — Light by Caelum Star' },
-    gallery: [
-      {
-        src: '/images/amazon/uk/12pk-light-lifestyle.webp',
-        alt: 'Pro coverage — perfect for multi-room projects (10 pack)',
-        variant: 'square'
-      },
-      { src: '/images/amazon/multi-room-projects.webp', alt: 'Ideal for multi-room projects: pro coverage', variant: 'square' },
-      { src: '/images/amazon/light-durability.webp', alt: 'Light durability: universal protection', variant: 'square' },
-      { src: '/images/amazon/fit-coverage.webp', alt: 'Find your perfect fit: pack-to-coverage comparison', variant: 'wide' },
-      { src: '/images/amazon/applications.webp', alt: 'Applications: moving, painting, renovating', variant: 'square' }
-    ],
-    amazonUrl: AMAZON_UK_12PK
   }
 ];
 

--- a/apps/website/src/middleware.ts
+++ b/apps/website/src/middleware.ts
@@ -1,8 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 const CAELUM_STAR_UK_HOSTS = new Set(['caelumstar.co.uk', 'www.caelumstar.co.uk']);
+const TARGON_HOSTS = new Set(['targonglobal.com', 'www.targonglobal.com']);
 const CAELUM_STAR_UK_ROOT = '/cs/uk';
 const CAELUM_STAR_UK_ROOT_REDIRECT_PATHS = new Set(['/cs', '/cs/', CAELUM_STAR_UK_ROOT]);
+const CAELUM_STAR_UK_URL = 'https://caelumstar.co.uk/';
 const TARGON_US_PATH = '/cs/us';
 const TARGON_US_URL = 'https://www.targonglobal.com/cs/us';
 
@@ -26,6 +28,16 @@ function isCaelumStarUkHost(request: NextRequest) {
   return CAELUM_STAR_UK_HOSTS.has(hostname);
 }
 
+function isTargonHost(request: NextRequest) {
+  const hostname = getHostname(request);
+
+  if (!hostname) {
+    return false;
+  }
+
+  return TARGON_HOSTS.has(hostname);
+}
+
 function isAtOrUnderPath(pathname: string, rootPath: string) {
   if (pathname === rootPath) {
     return true;
@@ -42,11 +54,15 @@ function redirectToRoot(request: NextRequest) {
 }
 
 export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (isTargonHost(request) && isAtOrUnderPath(pathname, CAELUM_STAR_UK_ROOT)) {
+    return NextResponse.redirect(CAELUM_STAR_UK_URL);
+  }
+
   if (!isCaelumStarUkHost(request)) {
     return NextResponse.next();
   }
-
-  const { pathname } = request.nextUrl;
 
   if (pathname === '/') {
     const url = request.nextUrl.clone();


### PR DESCRIPTION
## Summary
- route Caelum Star UK selector/header/footer links to https://caelumstar.co.uk/
- redirect Targon-host /cs/uk routes and old UK subroutes straight to the UK custom domain
- remove stale UK 10-pack public/catalog references

## Verification
- pnpm -C apps/website type-check
- pnpm -C apps/website build
- local production header checks: /cs/uk and /cs/uk/packs on www.targonglobal.com redirect to https://caelumstar.co.uk/
- browser check: /cs UK card href is https://caelumstar.co.uk/