### PR TITLE
Revamp Plutus landed cost allocation workflow

### DIFF
--- a/apps/plutus/app/landed-cost-allocations/page.tsx
+++ b/apps/plutus/app/landed-cost-allocations/page.tsx
@@ -7,7 +7,11 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 
-import { AllocationCreateForm } from '@/components/landed-cost-allocations/allocation-create-form';
+import {
+  AllocationWorkbench,
+  type AllocationLayerOption,
+  type AllocationWorkbenchLine,
+} from '@/components/landed-cost-allocations/allocation-create-form';
 import { PageHeader } from '@/components/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
 import { db } from '@/lib/db';
@@ -29,20 +33,8 @@ type AllocationRow = {
   sourceNote: string | null;
 };
 
-type UnallocatedBillLine = {
-  qboBillId: string;
-  qboBillLineId: string;
-  billDate: string;
-  vendor: string;
-  docNumber: string;
-  account: string;
-  description: string;
-  amountCents: number;
-  currency: string;
-};
-
 type UnallocatedBillLineResult =
-  | { status: 'ok'; lines: UnallocatedBillLine[] }
+  | { status: 'ok'; lines: AllocationWorkbenchLine[] }
   | { status: 'not_connected'; message: string }
   | { status: 'error'; message: string };
 
@@ -51,6 +43,27 @@ async function getAllocations(): Promise<AllocationRow[]> {
     orderBy: [{ qboBillId: 'asc' }, { qboBillLineId: 'asc' }, { sku: 'asc' }],
     take: 1000,
   });
+}
+
+async function getLayerOptions(): Promise<AllocationLayerOption[]> {
+  return db.$queryRawUnsafe<AllocationLayerOption[]>(`
+    SELECT
+      "id",
+      "marketplace",
+      "poNumber",
+      "qboPurchaseOrderId",
+      "qboPurchaseOrderLineId",
+      "qboItemId",
+      "sku",
+      "qtyReceived",
+      "qtyRemaining",
+      "status"
+    FROM "CostLayer"
+    WHERE "qboPurchaseOrderId" IS NOT NULL
+      AND "status" = 'NOT_READY'
+    ORDER BY "poNumber" ASC, "sku" ASC, "receiptDate" ASC NULLS LAST
+    LIMIT 1000
+  `);
 }
 
 const landedCostAccountMatchers = ['freight', 'duty', 'custom', 'box', 'packaging', 'broker'];
@@ -80,9 +93,14 @@ async function getUnallocatedBillLines(
     return { status: 'not_connected', message: 'QBO connection is required to list bill lines.' };
   }
 
-  const allocatedRefs = new Set(
-    allocations.map((allocation) => `${allocation.qboBillId}:${allocation.qboBillLineId}`),
-  );
+  const allocatedCentsByRef = new Map<string, number>();
+  for (const allocation of allocations) {
+    const ref = `${allocation.qboBillId}:${allocation.qboBillLineId}`;
+    allocatedCentsByRef.set(
+      ref,
+      (allocatedCentsByRef.get(ref) ?? 0) + allocation.allocatedAmountCents,
+    );
+  }
 
   try {
     const result = await fetchBills(connection, {
@@ -93,12 +111,15 @@ async function getUnallocatedBillLines(
       await saveServerQboConnection(result.updatedConnection);
     }
 
-    const lines: UnallocatedBillLine[] = [];
+    const lines: AllocationWorkbenchLine[] = [];
     for (const bill of result.bills) {
       for (const line of bill.Line ?? []) {
         if (line.Amount <= 0) continue;
         if (!isLandedCostBillLine(line)) continue;
-        if (allocatedRefs.has(`${bill.Id}:${line.Id}`)) continue;
+        const amountCents = Math.round(line.Amount * 100);
+        const allocatedCents = allocatedCentsByRef.get(`${bill.Id}:${line.Id}`) ?? 0;
+        const remainingCents = amountCents - allocatedCents;
+        if (remainingCents <= 0) continue;
 
         lines.push({
           qboBillId: bill.Id,
@@ -112,7 +133,9 @@ async function getUnallocatedBillLines(
             line.ItemBasedExpenseLineDetail?.ItemRef?.name ??
             '-',
           description: line.Description ?? '-',
-          amountCents: Math.round(line.Amount * 100),
+          amountCents,
+          allocatedCents,
+          remainingCents,
           currency: billLineCurrency(bill),
         });
       }
@@ -141,7 +164,7 @@ function formatCents(value: number, currency: string): string {
 }
 
 export default async function LandedCostAllocationsPage() {
-  const rows = await getAllocations();
+  const [rows, layerOptions] = await Promise.all([getAllocations(), getLayerOptions()]);
   const unallocatedBillLines = await getUnallocatedBillLines(rows);
 
   return (
@@ -150,7 +173,13 @@ export default async function LandedCostAllocationsPage() {
         title="Landed Cost Allocations"
         kicker="Freight, duty, boxes, broker lines assigned to PO/SKU"
       />
-      <AllocationCreateForm />
+      {unallocatedBillLines.status !== 'ok' ? (
+        <Alert severity={unallocatedBillLines.status === 'not_connected' ? 'warning' : 'error'}>
+          {unallocatedBillLines.message}
+        </Alert>
+      ) : (
+        <AllocationWorkbench lines={unallocatedBillLines.lines} layerOptions={layerOptions} />
+      )}
 
       <Box
         sx={{
@@ -163,62 +192,9 @@ export default async function LandedCostAllocationsPage() {
       >
         <Box sx={{ px: 2, py: 1.5, borderBottom: 1, borderColor: 'divider' }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-            Unallocated QBO landed-cost bill lines
+            Existing landed-cost allocations
           </Typography>
         </Box>
-        {unallocatedBillLines.status !== 'ok' ? (
-          <Alert severity={unallocatedBillLines.status === 'not_connected' ? 'warning' : 'error'}>
-            {unallocatedBillLines.message}
-          </Alert>
-        ) : (
-          <Box sx={{ overflowX: 'auto' }}>
-            <Table size="small" sx={{ minWidth: 1120 }}>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Date</TableCell>
-                  <TableCell>Vendor</TableCell>
-                  <TableCell>Doc</TableCell>
-                  <TableCell>QBO Bill</TableCell>
-                  <TableCell>Line</TableCell>
-                  <TableCell>Account</TableCell>
-                  <TableCell>Description</TableCell>
-                  <TableCell align="right">Amount</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {unallocatedBillLines.lines.length === 0 && (
-                  <TableRow>
-                    <TableCell colSpan={8}>
-                      <EmptyState
-                        title="No unallocated landed-cost bill lines"
-                        description="No matching current QBO bill lines remain after allocation filtering."
-                      />
-                    </TableCell>
-                  </TableRow>
-                )}
-                {unallocatedBillLines.lines.map((line) => (
-                  <TableRow key={`${line.qboBillId}:${line.qboBillLineId}`}>
-                    <TableCell>{line.billDate}</TableCell>
-                    <TableCell>{line.vendor}</TableCell>
-                    <TableCell>{line.docNumber}</TableCell>
-                    <TableCell>{line.qboBillId}</TableCell>
-                    <TableCell>{line.qboBillLineId}</TableCell>
-                    <TableCell>{line.account}</TableCell>
-                    <TableCell>{line.description}</TableCell>
-                    <TableCell align="right">
-                      {formatCents(line.amountCents, line.currency)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </Box>
-        )}
-      </Box>
-
-      <Box
-        sx={{ overflow: 'hidden', border: 1, borderColor: 'divider', bgcolor: 'background.paper' }}
-      >
         <Box sx={{ overflowX: 'auto' }}>
           <Table size="small" sx={{ minWidth: 1040 }}>
             <TableHead>

--- a/apps/plutus/components/landed-cost-allocations/allocation-create-form.tsx
+++ b/apps/plutus/components/landed-cost-allocations/allocation-create-form.tsx
@@ -1,48 +1,76 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
 import MenuItem from '@mui/material/MenuItem';
 import Paper from '@mui/material/Paper';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 
-import {
-  LANDED_COST_CURRENCIES,
-  LANDED_COST_TYPES,
-} from '@/lib/plutus/landed-cost-allocation-rules';
+import { EmptyState } from '@/components/ui/empty-state';
+import { LANDED_COST_TYPES } from '@/lib/plutus/landed-cost-allocation-rules';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
 if (basePath === undefined) {
   throw new Error('NEXT_PUBLIC_BASE_PATH is required');
 }
 
-type FormState = {
+export type AllocationWorkbenchLine = {
   qboBillId: string;
   qboBillLineId: string;
+  billDate: string;
+  vendor: string;
+  docNumber: string;
+  account: string;
+  description: string;
+  amountCents: number;
+  allocatedCents: number;
+  remainingCents: number;
+  currency: string;
+};
+
+export type AllocationLayerOption = {
+  id: string;
+  marketplace: string;
+  poNumber: string;
   qboPurchaseOrderId: string;
-  qboPurchaseOrderLineId: string;
+  qboPurchaseOrderLineId: string | null;
+  qboItemId: string | null;
   sku: string;
+  qtyReceived: number;
+  qtyRemaining: number;
+  status: string;
+};
+
+type AllocationWorkbenchProps = {
+  lines: AllocationWorkbenchLine[];
+  layerOptions: AllocationLayerOption[];
+};
+
+type FormState = {
+  selectedLineKey: string;
+  selectedLayerId: string;
   costType: string;
   amount: string;
-  currency: string;
   sourceNote: string;
 };
 
-const initialState: FormState = {
-  qboBillId: '',
-  qboBillLineId: '',
-  qboPurchaseOrderId: '',
-  qboPurchaseOrderLineId: '',
-  sku: '',
-  costType: 'FREIGHT',
-  amount: '',
-  currency: 'USD',
-  sourceNote: '',
-};
+function lineKey(line: AllocationWorkbenchLine): string {
+  return `${line.qboBillId}:${line.qboBillLineId}`;
+}
+
+function centsToInput(value: number): string {
+  return (value / 100).toFixed(2);
+}
 
 function amountToCents(value: string): number {
   const normalized = value.trim();
@@ -52,11 +80,72 @@ function amountToCents(value: string): number {
   return Math.round(amount * 100);
 }
 
-export function AllocationCreateForm() {
+function formatCurrency(value: number, currency: string): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency }).format(value / 100);
+}
+
+function initialForm(lines: AllocationWorkbenchLine[], layerOptions: AllocationLayerOption[]): FormState {
+  const firstLine = lines[0];
+  return {
+    selectedLineKey: firstLine ? lineKey(firstLine) : '',
+    selectedLayerId: layerOptions[0]?.id ?? '',
+    costType: 'FREIGHT',
+    amount: firstLine ? centsToInput(firstLine.remainingCents) : '',
+    sourceNote: '',
+  };
+}
+
+export function AllocationWorkbench({ lines, layerOptions }: AllocationWorkbenchProps) {
   const router = useRouter();
-  const [form, setForm] = useState<FormState>(initialState);
+  const [form, setForm] = useState<FormState>(() => initialForm(lines, layerOptions));
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  const selectedLine = useMemo(
+    () => lines.find((line) => lineKey(line) === form.selectedLineKey) ?? null,
+    [form.selectedLineKey, lines],
+  );
+  const selectedLayer = useMemo(
+    () => layerOptions.find((layer) => layer.id === form.selectedLayerId) ?? null,
+    [form.selectedLayerId, layerOptions],
+  );
+
+  useEffect(() => {
+    if (lines.length === 0) {
+      setForm((current) => ({ ...current, selectedLineKey: '', amount: '' }));
+      return;
+    }
+
+    const currentLine = lines.find((line) => lineKey(line) === form.selectedLineKey);
+    if (currentLine === undefined) {
+      const nextLine = lines[0];
+      setForm((current) => ({
+        ...current,
+        selectedLineKey: lineKey(nextLine),
+        amount: centsToInput(nextLine.remainingCents),
+      }));
+    }
+  }, [form.selectedLineKey, lines]);
+
+  useEffect(() => {
+    if (layerOptions.length === 0) {
+      setForm((current) => ({ ...current, selectedLayerId: '' }));
+      return;
+    }
+
+    if (!layerOptions.some((layer) => layer.id === form.selectedLayerId)) {
+      setForm((current) => ({ ...current, selectedLayerId: layerOptions[0]?.id ?? '' }));
+    }
+  }, [form.selectedLayerId, layerOptions]);
+
+  const selectLine = (line: AllocationWorkbenchLine) => {
+    setError(null);
+    setForm((current) => ({
+      ...current,
+      selectedLineKey: lineKey(line),
+      amount: centsToInput(line.remainingCents),
+    }));
+  };
 
   const setField = (field: keyof FormState, value: string) => {
     setForm((current) => ({ ...current, [field]: value }));
@@ -64,20 +153,35 @@ export function AllocationCreateForm() {
 
   const handleSubmit = async () => {
     setError(null);
+    if (selectedLine === null) {
+      setError('Select a QBO bill line first');
+      return;
+    }
+    if (selectedLayer === null) {
+      setError('Select a PO/SKU layer first');
+      return;
+    }
+
+    const allocatedAmountCents = amountToCents(form.amount);
+    if (allocatedAmountCents > selectedLine.remainingCents) {
+      setError('Allocation amount cannot exceed the bill line remaining amount');
+      return;
+    }
+
     setSaving(true);
     try {
       const res = await fetch(`${basePath}/api/plutus/landed-cost-allocations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          qboBillId: form.qboBillId,
-          qboBillLineId: form.qboBillLineId,
-          qboPurchaseOrderId: form.qboPurchaseOrderId,
-          qboPurchaseOrderLineId: form.qboPurchaseOrderLineId,
-          sku: form.sku,
+          qboBillId: selectedLine.qboBillId,
+          qboBillLineId: selectedLine.qboBillLineId,
+          qboPurchaseOrderId: selectedLayer.qboPurchaseOrderId,
+          qboPurchaseOrderLineId: selectedLayer.qboPurchaseOrderLineId ?? '',
+          sku: selectedLayer.sku,
           costType: form.costType,
-          allocatedAmountCents: amountToCents(form.amount),
-          currency: form.currency,
+          allocatedAmountCents,
+          currency: selectedLine.currency,
           sourceNote: form.sourceNote,
         }),
       });
@@ -85,7 +189,7 @@ export function AllocationCreateForm() {
       if (!res.ok) {
         throw new Error(data.details ?? data.error ?? 'Failed to save allocation');
       }
-      setForm(initialState);
+      setForm((current) => ({ ...current, sourceNote: '' }));
       router.refresh();
     } catch (submitError) {
       setError(submitError instanceof Error ? submitError.message : String(submitError));
@@ -95,97 +199,232 @@ export function AllocationCreateForm() {
   };
 
   return (
-    <Paper variant="outlined" sx={{ mb: 2, p: 2 }}>
-      <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
-        Add landed-cost allocation
-      </Typography>
+    <Paper variant="outlined" sx={{ mb: 2, overflow: 'hidden' }}>
       <Box
         sx={{
-          mt: 1.5,
           display: 'grid',
-          gap: 1.5,
-          gridTemplateColumns: { xs: '1fr', md: 'repeat(4, minmax(0, 1fr))' },
+          gridTemplateColumns: { xs: '1fr', lg: 'minmax(0, 1.25fr) minmax(360px, 0.75fr)' },
+          minHeight: 420,
         }}
       >
-        <TextField
-          label="QBO Bill ID"
-          size="small"
-          value={form.qboBillId}
-          onChange={(e) => setField('qboBillId', e.target.value)}
-        />
-        <TextField
-          label="QBO Bill Line ID"
-          size="small"
-          value={form.qboBillLineId}
-          onChange={(e) => setField('qboBillLineId', e.target.value)}
-        />
-        <TextField
-          label="QBO PO ID"
-          size="small"
-          value={form.qboPurchaseOrderId}
-          onChange={(e) => setField('qboPurchaseOrderId', e.target.value)}
-        />
-        <TextField
-          label="QBO PO Line ID"
-          size="small"
-          value={form.qboPurchaseOrderLineId}
-          onChange={(e) => setField('qboPurchaseOrderLineId', e.target.value)}
-        />
-        <TextField
-          label="SKU"
-          size="small"
-          value={form.sku}
-          onChange={(e) => setField('sku', e.target.value)}
-        />
-        <TextField
-          select
-          label="Cost Type"
-          size="small"
-          value={form.costType}
-          onChange={(e) => setField('costType', e.target.value)}
-        >
-          {LANDED_COST_TYPES.map((costType) => (
-            <MenuItem key={costType} value={costType}>
-              {costType}
-            </MenuItem>
-          ))}
-        </TextField>
-        <TextField
-          label="Amount"
-          size="small"
-          value={form.amount}
-          onChange={(e) => setField('amount', e.target.value)}
-          slotProps={{ htmlInput: { inputMode: 'decimal' } }}
-        />
-        <TextField
-          select
-          label="Currency"
-          size="small"
-          value={form.currency}
-          onChange={(e) => setField('currency', e.target.value)}
-        >
-          {LANDED_COST_CURRENCIES.map((currency) => (
-            <MenuItem key={currency} value={currency}>
-              {currency}
-            </MenuItem>
-          ))}
-        </TextField>
-        <TextField
-          label="Source Note"
-          size="small"
-          value={form.sourceNote}
-          onChange={(e) => setField('sourceNote', e.target.value)}
-          sx={{ gridColumn: { md: 'span 3' } }}
-        />
-        <Button variant="contained" disabled={saving} onClick={handleSubmit}>
-          Save Allocation
-        </Button>
+        <Box sx={{ borderRight: { lg: 1 }, borderColor: 'divider', minWidth: 0 }}>
+          <Box
+            sx={{
+              alignItems: 'center',
+              borderBottom: 1,
+              borderColor: 'divider',
+              display: 'flex',
+              gap: 1,
+              px: 2,
+              py: 1.5,
+            }}
+          >
+            <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+              QBO bill line queue
+            </Typography>
+            <Chip label={`${lines.length} open`} size="small" variant="outlined" />
+          </Box>
+          <Box sx={{ overflowX: 'auto' }}>
+            <Table size="small" sx={{ minWidth: 980 }}>
+              <TableHead>
+                <TableRow>
+                  <TableCell>Date</TableCell>
+                  <TableCell>Vendor</TableCell>
+                  <TableCell>Doc</TableCell>
+                  <TableCell>Account</TableCell>
+                  <TableCell>Description</TableCell>
+                  <TableCell align="right">Bill Amount</TableCell>
+                  <TableCell align="right">Allocated</TableCell>
+                  <TableCell align="right">Remaining</TableCell>
+                  <TableCell>Action</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {lines.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={9}>
+                      <EmptyState
+                        title="No unallocated landed-cost bill lines"
+                        description="No matching current QBO bill lines remain after allocation filtering."
+                      />
+                    </TableCell>
+                  </TableRow>
+                )}
+                {lines.map((line) => {
+                  const selected = selectedLine !== null && lineKey(line) === lineKey(selectedLine);
+                  return (
+                    <TableRow key={lineKey(line)} hover selected={selected}>
+                      <TableCell>{line.billDate}</TableCell>
+                      <TableCell>{line.vendor}</TableCell>
+                      <TableCell>{line.docNumber}</TableCell>
+                      <TableCell>{line.account}</TableCell>
+                      <TableCell>{line.description}</TableCell>
+                      <TableCell align="right">
+                        {formatCurrency(line.amountCents, line.currency)}
+                      </TableCell>
+                      <TableCell align="right">
+                        {formatCurrency(line.allocatedCents, line.currency)}
+                      </TableCell>
+                      <TableCell align="right">
+                        {formatCurrency(line.remainingCents, line.currency)}
+                      </TableCell>
+                      <TableCell>
+                        <Button
+                          size="small"
+                          variant={selected ? 'contained' : 'outlined'}
+                          onClick={() => selectLine(line)}
+                        >
+                          {selected ? 'Selected' : 'Assign'}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </Box>
+        </Box>
+
+        <Box sx={{ minWidth: 0 }}>
+          <Box sx={{ borderBottom: 1, borderColor: 'divider', px: 2, py: 1.5 }}>
+            <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+              Allocation
+            </Typography>
+          </Box>
+          <Box sx={{ display: 'grid', gap: 1.5, p: 2 }}>
+            {selectedLine === null ? (
+              <Alert severity="info">Select a bill line from the queue.</Alert>
+            ) : (
+              <Box
+                sx={{
+                  border: 1,
+                  borderColor: 'divider',
+                  display: 'grid',
+                  gap: 1,
+                  p: 1.5,
+                }}
+              >
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    QBO Bill
+                  </Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 650 }}>
+                    {selectedLine.qboBillId}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    QBO Bill Line
+                  </Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 650 }}>
+                    {selectedLine.qboBillLineId}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Remaining
+                  </Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 650 }}>
+                    {formatCurrency(selectedLine.remainingCents, selectedLine.currency)}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+
+            <TextField
+              select
+              label="PO/SKU layer"
+              size="small"
+              value={form.selectedLayerId}
+              onChange={(event) => setField('selectedLayerId', event.target.value)}
+              disabled={layerOptions.length === 0}
+            >
+              {layerOptions.map((layer) => (
+                <MenuItem key={layer.id} value={layer.id}>
+                  {layer.poNumber} · {layer.sku} · {layer.marketplace}
+                </MenuItem>
+              ))}
+            </TextField>
+
+            {selectedLayer !== null && (
+              <Box
+                sx={{
+                  border: 1,
+                  borderColor: 'divider',
+                  display: 'grid',
+                  gap: 1,
+                  p: 1.5,
+                }}
+              >
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    QBO PO
+                  </Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 650 }}>
+                    {selectedLayer.qboPurchaseOrderId}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    QBO PO Line
+                  </Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 650 }}>
+                    {selectedLayer.qboPurchaseOrderLineId ?? '-'}
+                  </Typography>
+                </Box>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', gap: 1 }}>
+                  <Typography variant="caption" color="text.secondary">
+                    Qty Remaining
+                  </Typography>
+                  <Typography variant="caption" sx={{ fontWeight: 650 }}>
+                    {selectedLayer.qtyRemaining.toLocaleString('en-US')}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+
+            <TextField
+              select
+              label="Cost Type"
+              size="small"
+              value={form.costType}
+              onChange={(event) => setField('costType', event.target.value)}
+            >
+              {LANDED_COST_TYPES.map((costType) => (
+                <MenuItem key={costType} value={costType}>
+                  {costType}
+                </MenuItem>
+              ))}
+            </TextField>
+            <TextField
+              label="Amount"
+              size="small"
+              value={form.amount}
+              onChange={(event) => setField('amount', event.target.value)}
+              slotProps={{ htmlInput: { inputMode: 'decimal' } }}
+            />
+            <TextField
+              label="Source Note"
+              size="small"
+              value={form.sourceNote}
+              onChange={(event) => setField('sourceNote', event.target.value)}
+            />
+            <Button
+              variant="contained"
+              disabled={saving || selectedLine === null || selectedLayer === null}
+              onClick={handleSubmit}
+            >
+              Save Allocation
+            </Button>
+            {layerOptions.length === 0 && (
+              <Alert severity="warning">
+                No NOT_READY native QBO PO/SKU layers are available for landed-cost assignment.
+              </Alert>
+            )}
+            {error !== null && <Alert severity="error">{error}</Alert>}
+          </Box>
+        </Box>
       </Box>
-      {error !== null && (
-        <Alert severity="error" sx={{ mt: 1.5 }}>
-          {error}
-        </Alert>
-      )}
     </Paper>
   );
 }

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -500,6 +500,46 @@ test('fresh-start pages read new layer/allocation/consumption tables', () => {
   assert.equal(read('app/purchase-orders/page.tsx').includes('FROM "CogsConsumption"'), true);
 });
 
+test('landed-cost allocation page uses selected QBO bill lines instead of raw ID entry', () => {
+  const page = read('app/landed-cost-allocations/page.tsx');
+  const form = read('components/landed-cost-allocations/allocation-create-form.tsx');
+
+  for (const required of [
+    'AllocationWorkbench',
+    'getLayerOptions',
+    'FROM "CostLayer"',
+    '"qboPurchaseOrderId" IS NOT NULL',
+    '"status" = \'NOT_READY\'',
+    'allocatedCents',
+    'remainingCents',
+    'Existing landed-cost allocations',
+  ]) {
+    assert.equal(page.includes(required), true, `${required} should be part of landed-cost page`);
+  }
+
+  for (const required of [
+    'QBO bill line queue',
+    'PO/SKU layer',
+    'selectedLine.qboBillId',
+    'selectedLine.qboBillLineId',
+    'selectedLayer.qboPurchaseOrderId',
+    'selectedLayer.qboPurchaseOrderLineId',
+    'Allocation amount cannot exceed the bill line remaining amount',
+  ]) {
+    assert.equal(form.includes(required), true, `${required} should be part of allocation workbench`);
+  }
+
+  for (const forbidden of [
+    'label="QBO Bill ID"',
+    'label="QBO Bill Line ID"',
+    'label="QBO PO ID"',
+    'label="QBO PO Line ID"',
+    'LANDED_COST_CURRENCIES',
+  ]) {
+    assert.equal(form.includes(forbidden), false, `${forbidden} should not remain in raw-entry form`);
+  }
+});
+
 test('inventory tables expose operational fields as standalone columns', () => {
   const source = read('app/purchase-orders/page.tsx');
   for (const required of [


### PR DESCRIPTION
## Summary
- replace the raw landed-cost ID entry box with a selected QBO bill-line allocation workbench
- show remaining bill-line amount after partial allocations instead of hiding any touched line
- target only NOT_READY native QBO PO/SKU layers for landed-cost assignment

## Verification
- pnpm --dir apps/plutus test
- pnpm --dir apps/plutus lint
- pnpm --dir apps/plutus type-check
- pnpm --dir apps/plutus build
- Chrome local preview: http://localhost:4321/plutus/landed-cost-allocations