### PR TITLE
promote: Caelum Star flicker fix

### DIFF
--- a/apps/website/src/app/cs/components/CsRegionLayout.tsx
+++ b/apps/website/src/app/cs/components/CsRegionLayout.tsx
@@ -14,8 +14,6 @@ export function CsRegionLayout({
       <style
         dangerouslySetInnerHTML={{
           __html: `
-            body > header,
-            main#main-content + footer,
             a[href="#main-content"] {
               display: none;
             }

--- a/apps/website/src/app/cs/page.tsx
+++ b/apps/website/src/app/cs/page.tsx
@@ -56,8 +56,6 @@ export default function CaelumStarPage() {
       <style
         dangerouslySetInnerHTML={{
           __html: `
-            body > header,
-            main#main-content + footer,
             a[href="#main-content"] {
               display: none;
             }

--- a/apps/website/src/app/globals.css
+++ b/apps/website/src/app/globals.css
@@ -30,6 +30,12 @@ body {
   letter-spacing: -0.01em;
 }
 
+html[data-standalone-product-site='true'] body > header,
+html[data-standalone-product-site='true'] main#main-content + footer,
+html[data-standalone-product-site='true'] a[href='#main-content'] {
+  display: none;
+}
+
 /* Smooth, Apple-ish tap highlights */
 * {
   -webkit-tap-highlight-color: transparent;

--- a/apps/website/src/app/layout.tsx
+++ b/apps/website/src/app/layout.tsx
@@ -4,6 +4,40 @@ import { site } from '@/content/site';
 import { Header } from '@/components/Header';
 import { Footer } from '@/components/Footer';
 import { SkipLink } from '@/components/SkipLink';
+import { StandaloneProductSiteMarker } from '@/components/StandaloneProductSiteMarker';
+
+const standaloneProductSiteScript = `
+(() => {
+  const hosts = ['caelumstar.co.uk', 'www.caelumstar.co.uk'];
+  const routes = ['/cs'];
+  let standalone = false;
+
+  for (const host of hosts) {
+    if (window.location.hostname === host) {
+      standalone = true;
+      break;
+    }
+  }
+
+  if (!standalone) {
+    for (const route of routes) {
+      if (window.location.pathname === route) {
+        standalone = true;
+        break;
+      }
+
+      if (window.location.pathname.startsWith(route + '/')) {
+        standalone = true;
+        break;
+      }
+    }
+  }
+
+  if (standalone) {
+    document.documentElement.dataset.standaloneProductSite = 'true';
+  }
+})();
+`;
 
 export const metadata: Metadata = {
   metadataBase: new URL(`https://${site.domain}`),
@@ -37,7 +71,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: standaloneProductSiteScript }} />
+      </head>
       <body>
+        <StandaloneProductSiteMarker />
         <SkipLink />
         <Header />
         <main id="main-content">{children}</main>

--- a/apps/website/src/components/Footer.tsx
+++ b/apps/website/src/components/Footer.tsx
@@ -1,6 +1,10 @@
+'use client';
+
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { site } from '@/content/site';
 import { Container } from '@/components/Container';
+import { isStandaloneProductRoute } from '@/lib/standaloneProductRoutes';
 
 const footerLinks = {
   Explore: [
@@ -19,7 +23,12 @@ const footerLinks = {
 };
 
 export function Footer() {
+  const pathname = usePathname();
   const year = new Date().getFullYear();
+
+  if (isStandaloneProductRoute(pathname)) {
+    return null;
+  }
 
   return (
     <footer className="border-t border-white/10 bg-black text-white">

--- a/apps/website/src/components/Header.tsx
+++ b/apps/website/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { Menu, X } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { site } from '@/content/site';
 import { Container } from '@/components/Container';
+import { isStandaloneProductRoute } from '@/lib/standaloneProductRoutes';
 
 const productNavLinks = [
   { label: 'US', href: '/cs/us' },
@@ -51,6 +52,10 @@ export function Header() {
     window.addEventListener('scroll', onScroll, { passive: true });
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
+
+  if (isStandaloneProductRoute(pathname)) {
+    return null;
+  }
 
   return (
     <header

--- a/apps/website/src/components/StandaloneProductSiteMarker.tsx
+++ b/apps/website/src/components/StandaloneProductSiteMarker.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import { isStandaloneProductHost, isStandaloneProductRoute } from '@/lib/standaloneProductRoutes';
+
+const standaloneProductSiteAttribute = 'standaloneProductSite';
+
+export function StandaloneProductSiteMarker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    let isStandalone = isStandaloneProductHost(window.location.hostname);
+
+    if (!isStandalone) {
+      isStandalone = isStandaloneProductRoute(pathname);
+    }
+
+    if (isStandalone) {
+      document.documentElement.dataset[standaloneProductSiteAttribute] = 'true';
+      return;
+    }
+
+    delete document.documentElement.dataset[standaloneProductSiteAttribute];
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/website/src/lib/standaloneProductRoutes.ts
+++ b/apps/website/src/lib/standaloneProductRoutes.ts
@@ -1,0 +1,26 @@
+const standaloneProductRouteRoots = ['/cs'];
+const standaloneProductHosts = ['caelumstar.co.uk', 'www.caelumstar.co.uk'];
+
+export function isStandaloneProductHost(hostname: string) {
+  for (const standaloneHost of standaloneProductHosts) {
+    if (hostname === standaloneHost) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isStandaloneProductRoute(pathname: string) {
+  for (const routeRoot of standaloneProductRouteRoots) {
+    if (pathname === routeRoot) {
+      return true;
+    }
+
+    if (pathname.startsWith(`${routeRoot}/`)) {
+      return true;
+    }
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
Promotes the Caelum Star standalone-site flicker fix from `dev` to `main`.

## Included change
- PR #5534: prevent global Targon header/footer from first-paint flashing on `caelumstar.co.uk` and `/cs` standalone routes.

## Verification
- PR #5534 CI passed on `dev`.
