### PR TITLE
Combine Plutus exceptions and QBO audit

### DIFF
--- a/apps/plutus/app/exceptions/page.tsx
+++ b/apps/plutus/app/exceptions/page.tsx
@@ -8,6 +8,7 @@ import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 
 import { PageHeader } from '@/components/page-header';
+import { QboAuditSection } from '@/components/subledger/qbo-audit-page';
 import { EmptyState } from '@/components/ui/empty-state';
 import { db } from '@/lib/db';
 
@@ -55,51 +56,65 @@ export default async function ExceptionsPage() {
 
   return (
     <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
-      <PageHeader title="Exceptions" kicker="Posting blockers" />
+      <PageHeader title="Exceptions" kicker="Posting blockers and QBO audit" />
 
-      <Box sx={tableWrapSx}>
-        <Box sx={{ overflowX: 'auto' }}>
-          <Table size="small" sx={{ minWidth: 1040 }}>
-            <TableHead>
-              <TableRow>
-                <TableCell>Code</TableCell>
-                <TableCell>Scope</TableCell>
-                <TableCell>Marketplace</TableCell>
-                <TableCell>Severity</TableCell>
-                <TableCell>Status</TableCell>
-                <TableCell>Message</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.length === 0 && (
-                <TableRow>
-                  <TableCell colSpan={6}>
-                    <EmptyState
-                      title="No open exceptions"
-                      description="Blocked settlements, missing SKU aliases, and unmatched QBO source lines will appear here."
-                    />
-                  </TableCell>
-                </TableRow>
-              )}
-              {rows.map((row) => (
-                <TableRow key={row.id}>
-                  <TableCell>
-                    <Typography sx={{ fontWeight: 650 }}>{row.code}</Typography>
-                  </TableCell>
-                  <TableCell>
-                    {row.scopeType} {row.scopeId}
-                  </TableCell>
-                  <TableCell>{row.marketplace ?? '-'}</TableCell>
-                  <TableCell>{row.severity}</TableCell>
-                  <TableCell>
-                    <Chip label={row.status} size="small" variant="outlined" />
-                  </TableCell>
-                  <TableCell>{row.message}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+      <Box sx={{ display: 'grid', gap: 3 }}>
+        <Box sx={{ display: 'grid', gap: 1.5 }}>
+          <Box>
+            <Typography variant="h2" sx={{ fontSize: '1.05rem', fontWeight: 700 }}>
+              Open exceptions
+            </Typography>
+            <Typography sx={{ mt: 0.25, color: 'text.secondary', fontSize: '0.8125rem' }}>
+              Current posting blockers and operator-required fixes.
+            </Typography>
+          </Box>
+          <Box sx={tableWrapSx}>
+            <Box sx={{ overflowX: 'auto' }}>
+              <Table size="small" sx={{ minWidth: 1040 }}>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Code</TableCell>
+                    <TableCell>Scope</TableCell>
+                    <TableCell>Marketplace</TableCell>
+                    <TableCell>Severity</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell>Message</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={6}>
+                        <EmptyState
+                          title="No open exceptions"
+                          description="Blocked settlements, missing SKU aliases, and unmatched QBO source lines will appear here."
+                        />
+                      </TableCell>
+                    </TableRow>
+                  )}
+                  {rows.map((row) => (
+                    <TableRow key={row.id}>
+                      <TableCell>
+                        <Typography sx={{ fontWeight: 650 }}>{row.code}</Typography>
+                      </TableCell>
+                      <TableCell>
+                        {row.scopeType} {row.scopeId}
+                      </TableCell>
+                      <TableCell>{row.marketplace ?? '-'}</TableCell>
+                      <TableCell>{row.severity}</TableCell>
+                      <TableCell>
+                        <Chip label={row.status} size="small" variant="outlined" />
+                      </TableCell>
+                      <TableCell>{row.message}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          </Box>
         </Box>
+
+        <QboAuditSection />
       </Box>
     </Box>
   );

--- a/apps/plutus/app/qbo-audit/page.tsx
+++ b/apps/plutus/app/qbo-audit/page.tsx
@@ -1,3 +1,5 @@
-import { QboAuditPage } from '@/components/subledger/qbo-audit-page';
+import { redirect } from 'next/navigation';
 
-export default QboAuditPage;
+export default function QboAuditRedirectPage() {
+  redirect('/exceptions');
+}

--- a/apps/plutus/components/app-header.tsx
+++ b/apps/plutus/components/app-header.tsx
@@ -11,7 +11,6 @@ import FormControl from '@mui/material/FormControl';
 import MenuItem from '@mui/material/MenuItem';
 import Select from '@mui/material/Select';
 import type { SelectChangeEvent } from '@mui/material/Select';
-import FactCheckIcon from '@mui/icons-material/FactCheck';
 import Inventory2Icon from '@mui/icons-material/Inventory2';
 import MapIcon from '@mui/icons-material/Map';
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong';
@@ -110,7 +109,6 @@ const PRIMARY_NAV_ITEMS: NavItem[] = [
 
 const SECONDARY_NAV_ITEMS: NavItem[] = [
   { href: '/settlement-mapping', label: 'Settlement Rules', icon: MapIcon },
-  { href: '/qbo-audit', label: 'QBO Audit', icon: FactCheckIcon },
 ];
 
 const ALL_NAV_ITEMS = [...PRIMARY_NAV_ITEMS, ...SECONDARY_NAV_ITEMS];

--- a/apps/plutus/components/subledger/qbo-audit-page.tsx
+++ b/apps/plutus/components/subledger/qbo-audit-page.tsx
@@ -12,7 +12,6 @@ import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 
-import { PageHeader } from '@/components/page-header';
 import { EmptyState } from '@/components/ui/empty-state';
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH;
@@ -72,7 +71,6 @@ type QboAuditResponse = {
 };
 
 const tableWrapSx = {
-  mt: 2,
   overflow: 'hidden',
   border: 1,
   borderColor: 'divider',
@@ -179,7 +177,7 @@ function LineSummary({ lineCount, lines }: { lineCount: number; lines: LineFinge
   );
 }
 
-export function QboAuditPage() {
+export function QboAuditSection() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['plutus-qbo-audit'],
     queryFn: fetchQboAudit,
@@ -189,9 +187,15 @@ export function QboAuditPage() {
   const postings = data ? data.postings : [];
 
   return (
-    <Box component="main" sx={{ mx: 'auto', maxWidth: 1280, px: { xs: 2, sm: 3, lg: 4 }, py: 3 }}>
-      <PageHeader title="QBO Audit" kicker="Exact cost subledger" />
-
+    <Box sx={{ display: 'grid', gap: 1.5 }}>
+      <Box>
+        <Typography variant="h2" sx={{ fontSize: '1.05rem', fontWeight: 700 }}>
+          QBO posting audit
+        </Typography>
+        <Typography sx={{ mt: 0.25, color: 'text.secondary', fontSize: '0.8125rem' }}>
+          Posted QBO objects, line drift, and attachment status.
+        </Typography>
+      </Box>
       <Box sx={tableWrapSx}>
         <Box sx={{ overflowX: 'auto' }}>
           <Table size="small" sx={{ minWidth: 1120 }}>

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -53,7 +53,6 @@ test('Plutus nav exposes fresh-start bridge surfaces only', () => {
     "href: '/purchase-orders'",
     "href: '/exceptions'",
     "href: '/settlement-mapping'",
-    "href: '/qbo-audit'",
   ]) {
     assert.equal(source.includes(href), true, `${href} should be in nav`);
   }
@@ -67,12 +66,23 @@ test('Plutus nav exposes fresh-start bridge surfaces only', () => {
     "href: '/cogs-batches'",
     "href: '/sellerboard-export'",
     "href: '/settings'",
+    "href: '/qbo-audit'",
+    'QBO Audit',
     'More Plutus sections',
     'MoreHorizIcon',
     'plutus-more-menu',
   ]) {
     assert.equal(source.includes(forbidden), false, `${forbidden} should not be in nav`);
   }
+});
+
+test('QBO audit is part of Exceptions instead of a separate nav surface', () => {
+  const exceptionsPage = read('app/exceptions/page.tsx');
+  const qboAuditRoute = read('app/qbo-audit/page.tsx');
+
+  assert.equal(exceptionsPage.includes('QboAuditSection'), true);
+  assert.equal(exceptionsPage.includes('Posting blockers and QBO audit'), true);
+  assert.equal(qboAuditRoute.includes("redirect('/exceptions')"), true);
 });
 
 test('useless settings route is deleted because QBO controls live in the header', () => {


### PR DESCRIPTION
## Summary
- show QBO posting audit inside the Exceptions page
- remove QBO Audit from top-level Plutus nav
- redirect /qbo-audit to /exceptions to avoid a duplicate UI surface

## Verification
- pnpm --dir apps/plutus test
- pnpm --dir apps/plutus lint
- pnpm --dir apps/plutus type-check
- pnpm --dir apps/plutus build
- Chrome local verification at /plutus/exceptions and /plutus/qbo-audit