### PR TITLE
Show FIFO COGS on settlement detail

### DIFF
--- a/apps/plutus/app/api/plutus/settlements/[region]/[settlementId]/route.ts
+++ b/apps/plutus/app/api/plutus/settlements/[region]/[settlementId]/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { createLogger } from '@targon/logger';
 
+import { db } from '@/lib/db';
 import { QboAuthError } from '@/lib/qbo/api';
 import { getQboConnection, saveServerQboConnection } from '@/lib/qbo/connection-store';
 import { getCurrentUser } from '@/lib/current-user';
@@ -70,6 +71,52 @@ function buildHistory(parent: Awaited<ReturnType<typeof fetchSettlementParentDet
   return events.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 }
 
+async function fetchCogsConsumptions(input: {
+  marketplace: string;
+  settlementIds: string[];
+}) {
+  const distinctSettlementIds = Array.from(new Set(input.settlementIds));
+  if (distinctSettlementIds.length === 0) return [];
+
+  const rows = await db.cogsConsumption.findMany({
+    where: {
+      marketplace: input.marketplace,
+      settlementId: { in: distinctSettlementIds },
+    },
+    include: {
+      settlementPosting: {
+        select: {
+          txnDate: true,
+          qboDocNumber: true,
+          qboJournalId: true,
+        },
+      },
+    },
+    orderBy: [
+      { settlementId: 'asc' },
+      { poNumber: 'asc' },
+      { sku: 'asc' },
+      { createdAt: 'asc' },
+    ],
+  });
+
+  return rows.map((row) => ({
+    id: row.id,
+    settlementId: row.settlementId,
+    marketplace: row.marketplace,
+    sku: row.sku,
+    poNumber: row.poNumber,
+    costLayerId: row.costLayerId,
+    qtyConsumed: row.qtyConsumed,
+    unitCost: Number(row.unitCost),
+    cogsAmountCents: row.cogsAmountCents,
+    currency: row.currency,
+    qboJournalId: row.settlementPosting?.qboJournalId ?? row.qboJournalId,
+    qboDocNumber: row.settlementPosting?.qboDocNumber ?? null,
+    txnDate: row.settlementPosting?.txnDate ?? null,
+  }));
+}
+
 export async function GET(_req: NextRequest, context: RouteContext) {
   try {
     const connection = await getQboConnection();
@@ -94,6 +141,23 @@ export async function GET(_req: NextRequest, context: RouteContext) {
     const invoiceResolutions = await resolveAuditInvoicesForSettlementChildren(
       detail.parent.children,
     );
+    const cogsSettlementIds = new Set<string>([detail.parent.sourceSettlementId]);
+    for (const child of detail.parent.children) {
+      const invoiceResolution = invoiceResolutions.get(child.qboJournalEntryId);
+      if (invoiceResolution?.status === 'resolved') {
+        cogsSettlementIds.add(invoiceResolution.invoiceId);
+      }
+      if (child.processing !== null) {
+        cogsSettlementIds.add(child.processing.invoiceId);
+      }
+      if (child.rollback !== null) {
+        cogsSettlementIds.add(child.rollback.invoiceId);
+      }
+    }
+    const cogsConsumptions = await fetchCogsConsumptions({
+      marketplace: detail.parent.marketplace.id,
+      settlementIds: Array.from(cogsSettlementIds),
+    });
 
     return NextResponse.json({
       settlement: {
@@ -122,6 +186,7 @@ export async function GET(_req: NextRequest, context: RouteContext) {
           invoiceResolutionMessage: formatAuditInvoiceResolutionMessage(invoiceResolution),
         };
       }),
+      cogsConsumptions,
       history: buildHistory(detail.parent),
     });
   } catch (error) {

--- a/apps/plutus/app/settlements/[region]/[settlementId]/page.tsx
+++ b/apps/plutus/app/settlements/[region]/[settlementId]/page.tsx
@@ -7,6 +7,11 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Chip from '@mui/material/Chip';
 import Skeleton from '@mui/material/Skeleton';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
 import Typography from '@mui/material/Typography';
 
 import { BackButton } from '@/components/back-button';
@@ -110,6 +115,21 @@ type ParentSettlementDetailResponse = {
         };
     invoiceResolutionMessage: string;
   }>;
+  cogsConsumptions: Array<{
+    id: string;
+    settlementId: string;
+    marketplace: string;
+    sku: string;
+    poNumber: string;
+    costLayerId: string;
+    qtyConsumed: number;
+    unitCost: number;
+    cogsAmountCents: number;
+    currency: string;
+    qboJournalId: string | null;
+    qboDocNumber: string | null;
+    txnDate: string | null;
+  }>;
   history: Array<{
     id: string;
     timestamp: string;
@@ -189,6 +209,119 @@ function PlutusPill({
       variant="outlined"
       sx={{ borderColor: 'rgba(34, 197, 94, 0.45)', color: 'success.dark' }}
     />
+  );
+}
+
+function formatMoney(amount: number, currency: string): string {
+  const formatted = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(Math.abs(amount));
+
+  if (amount < 0) return `(${formatted})`;
+  return formatted;
+}
+
+function formatInteger(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function SettlementCogsSection({
+  rows,
+  currency,
+}: {
+  rows: ParentSettlementDetailResponse['cogsConsumptions'];
+  currency: string;
+}) {
+  const totalCents = rows.reduce((sum, row) => sum + row.cogsAmountCents, 0);
+
+  return (
+    <Box
+      component="section"
+      sx={{
+        display: 'grid',
+        gap: 1.5,
+        py: 2,
+        borderTop: '1px solid',
+        borderColor: 'divider',
+      }}
+    >
+      <Box
+        component="header"
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          gap: 2,
+          flexWrap: 'wrap',
+        }}
+      >
+        <Box sx={{ display: 'grid', gap: 0.35 }}>
+          <Typography sx={{ fontSize: '0.95rem', fontWeight: 700 }}>FIFO COGS</Typography>
+          <Typography sx={{ fontSize: '0.8rem', color: 'text.secondary' }}>
+            PO/SKU consumption support for this settlement
+          </Typography>
+        </Box>
+        <Box sx={{ display: 'grid', justifyItems: 'end', gap: 0.35 }}>
+          <Typography
+            sx={{
+              fontSize: '0.72rem',
+              textTransform: 'uppercase',
+              letterSpacing: '0.04em',
+              color: 'text.secondary',
+            }}
+          >
+            COGS total
+          </Typography>
+          <Typography sx={{ fontSize: '0.95rem', fontWeight: 700 }}>
+            {formatMoney(totalCents / 100, currency)}
+          </Typography>
+        </Box>
+      </Box>
+
+      <Box sx={{ overflowX: 'auto' }}>
+        <Table size="small" sx={{ minWidth: 980 }}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Support Settlement</TableCell>
+              <TableCell>PO</TableCell>
+              <TableCell>SKU</TableCell>
+              <TableCell>QBO COGS Doc</TableCell>
+              <TableCell>QBO JE</TableCell>
+              <TableCell align="right">Qty</TableCell>
+              <TableCell align="right">Unit Cost</TableCell>
+              <TableCell align="right">COGS</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={8}>
+                  <Typography sx={{ py: 2, fontSize: '0.875rem', color: 'text.secondary' }}>
+                    No FIFO COGS consumption rows are posted for this settlement.
+                  </Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              rows.map((row) => (
+                <TableRow key={row.id}>
+                  <TableCell>{row.settlementId}</TableCell>
+                  <TableCell>{row.poNumber}</TableCell>
+                  <TableCell>{row.sku}</TableCell>
+                  <TableCell>{row.qboDocNumber ?? '-'}</TableCell>
+                  <TableCell>{row.qboJournalId ?? '-'}</TableCell>
+                  <TableCell align="right">{formatInteger(row.qtyConsumed)}</TableCell>
+                  <TableCell align="right">{formatMoney(row.unitCost, row.currency)}</TableCell>
+                  <TableCell align="right">
+                    {formatMoney(row.cogsAmountCents / 100, row.currency)}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </Box>
+    </Box>
   );
 }
 
@@ -467,7 +600,17 @@ export default function ParentSettlementDetailPage() {
               </Typography>
             )}
 
-            <Box component="section" sx={{ display: 'grid', gap: 0 }}>
+            <Box component="section" sx={{ display: 'grid', gap: 0.5 }}>
+              <Typography
+                sx={{
+                  fontSize: '0.8rem',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                  color: 'text.secondary',
+                }}
+              >
+                Regular Settlement Posting
+              </Typography>
               {ledgerSections.map((section) => {
                 const child = childByJournalEntryId.get(section.qboJournalEntryId);
                 if (child === undefined) {
@@ -484,6 +627,11 @@ export default function ParentSettlementDetailPage() {
                 );
               })}
             </Box>
+
+            <SettlementCogsSection
+              rows={data.cogsConsumptions}
+              currency={data.settlement.marketplace.currency}
+            />
 
             <Box component="section" sx={{ display: 'grid', gap: 0.5 }}>
               <Typography

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -510,6 +510,31 @@ test('fresh-start pages read new layer/allocation/consumption tables', () => {
   assert.equal(read('app/purchase-orders/page.tsx').includes('FROM "CogsConsumption"'), true);
 });
 
+test('settlement detail page shows regular posting and FIFO COGS support together', () => {
+  const page = read('app/settlements/[region]/[settlementId]/page.tsx');
+  const route = read('app/api/plutus/settlements/[region]/[settlementId]/route.ts');
+
+  for (const required of [
+    'Regular Settlement Posting',
+    'SettlementCogsSection',
+    'FIFO COGS',
+    'PO/SKU consumption support for this settlement',
+    'data.cogsConsumptions',
+  ]) {
+    assert.equal(page.includes(required), true, `${required} should be visible on settlement detail`);
+  }
+
+  for (const required of [
+    'db.cogsConsumption.findMany',
+    'settlementId: { in: distinctSettlementIds }',
+    'cogsConsumptions',
+    'detail.parent.sourceSettlementId',
+    'invoiceResolution.invoiceId',
+  ]) {
+    assert.equal(route.includes(required), true, `${required} should be fetched by settlement detail API`);
+  }
+});
+
 test('landed-cost allocation page uses selected QBO bill lines instead of raw ID entry', () => {
   const page = read('app/landed-cost-allocations/page.tsx');
   const form = read('components/landed-cost-allocations/allocation-create-form.tsx');


### PR DESCRIPTION
## Summary
- add FIFO COGS consumption rows to the parent settlement detail API
- render regular settlement posting and FIFO COGS support on the same settlement detail page
- add regression coverage for settlement detail COGS visibility

## Verification
- pnpm --dir apps/plutus test
- pnpm --dir apps/plutus lint
- pnpm --dir apps/plutus type-check
- pnpm --dir apps/plutus build
- Chrome local preview: http://localhost:4328/plutus/settlements/UK/EG-RFyYct6Pu_jz5F3tUAw1odmuDOt7PomUyPjVV5X7kpk