### PR TITLE
Harden settlement COGS detail rows

### DIFF
--- a/apps/plutus/app/settlements/[region]/[settlementId]/page.tsx
+++ b/apps/plutus/app/settlements/[region]/[settlementId]/page.tsx
@@ -115,7 +115,7 @@ type ParentSettlementDetailResponse = {
         };
     invoiceResolutionMessage: string;
   }>;
-  cogsConsumptions: Array<{
+  cogsConsumptions?: Array<{
     id: string;
     settlementId: string;
     marketplace: string;
@@ -154,6 +154,8 @@ type ParentPreviewResponse = {
     };
   }>;
 };
+
+type SettlementCogsRows = NonNullable<ParentSettlementDetailResponse['cogsConsumptions']>;
 
 function formatPeriod(start: string | null, end: string | null): string {
   if (start === null || end === null) return '—';
@@ -226,11 +228,18 @@ function formatInteger(value: number): string {
   return value.toLocaleString('en-US');
 }
 
+function normalizeCogsRows(
+  rows: ParentSettlementDetailResponse['cogsConsumptions'],
+): SettlementCogsRows {
+  if (rows === undefined) return [];
+  return rows;
+}
+
 function SettlementCogsSection({
   rows,
   currency,
 }: {
-  rows: ParentSettlementDetailResponse['cogsConsumptions'];
+  rows: SettlementCogsRows;
   currency: string;
 }) {
   const totalCents = rows.reduce((sum, row) => sum + row.cogsAmountCents, 0);
@@ -629,7 +638,7 @@ export default function ParentSettlementDetailPage() {
             </Box>
 
             <SettlementCogsSection
-              rows={data.cogsConsumptions}
+              rows={normalizeCogsRows(data.cogsConsumptions)}
               currency={data.settlement.marketplace.currency}
             />
 

--- a/apps/plutus/tests/run.ts
+++ b/apps/plutus/tests/run.ts
@@ -519,7 +519,7 @@ test('settlement detail page shows regular posting and FIFO COGS support togethe
     'SettlementCogsSection',
     'FIFO COGS',
     'PO/SKU consumption support for this settlement',
-    'data.cogsConsumptions',
+    'normalizeCogsRows(data.cogsConsumptions)',
   ]) {
     assert.equal(page.includes(required), true, `${required} should be visible on settlement detail`);
   }


### PR DESCRIPTION
## Summary
- avoid a runtime crash if the settlement detail client sees an older cached response without cogsConsumptions
- keep the FIFO COGS section visible and empty in that case
- update regression coverage to assert the normalized COGS rows path

## Verification
- pnpm --dir apps/plutus test
- pnpm --dir apps/plutus lint
- pnpm --dir apps/plutus type-check
- pnpm --dir apps/plutus build
- Chrome local preview: http://localhost:4328/plutus/settlements/UK/EG-RFyYct6Pu_jz5F3tUAw1odmuDOt7PomUyPjVV5X7kpk